### PR TITLE
Hotfix/local dbevents

### DIFF
--- a/gnrpy/gnr/web/gnrwebapp.py
+++ b/gnrpy/gnr/web/gnrwebapp.py
@@ -101,30 +101,38 @@ class GnrWsgiWebApp(GnrApp):
         super(GnrWsgiWebApp, self).onDbCommitted()
         dbeventKey = 'dbevents_%s' %self.db.connectionKey()
         dbeventsDict= self.db.currentEnv.pop(dbeventKey,None)
+        if not dbeventsDict:
+            return
         dbevent_reason = self.db.currentEnv.pop('dbevent_reason',None)
-        if dbeventsDict:
-            page = self.site.currentPage
-            tables = [k for k,v in list(dbeventsDict.items()) if v]
+        hidden_transaction = self.db.currentEnv.get('hidden_transaction')
+        
+        page = self.site.currentPage
+        page_id = None
+        pagename = None
+        if page:
+            page_id = page.page_id
+            pagename = page.pagename
+        tables = [k for k,v in list(dbeventsDict.items()) if v]
+        if hidden_transaction:
+            if not page_id:
+                return
+            subscribed_tables = self.site.register.page(page_id).get('subscribed_tables')
+        else:
             subscribed_tables = self.site.getSubscribedTables(tables)
-            if subscribed_tables:
-                for table in set(tables).difference(subscribed_tables):
-                    dbeventsDict.pop(table)         
-                for table,dbevents in list(dbeventsDict.items()):
-                    dbeventsDict[table] = self._compress_dbevents(dbevents)
-                page_id = None
-                pagename = None
-                if page:
-                    page_id = page.page_id
-                    pagename = page.pagename
-                if self.db.currentEnv.get('hidden_transaction'):
-                    page.notifyLocalDbEvents(dbeventsDict,register_name='page',
-                                                 origin_page_id=page_id,
-                                                 dbevent_reason=dbevent_reason or pagename)
-                else:
-                    self.site.register.notifyDbEvents(dbeventsDict,register_name='page',
-                                                 origin_page_id=page_id,
-                                                 dbevent_reason=dbevent_reason or pagename)
+        if not subscribed_tables:
+            return
+        for table in set(tables).difference(subscribed_tables):
+            dbeventsDict.pop(table)         
+        for table,dbevents in list(dbeventsDict.items()):
+            dbeventsDict[table] = self._compress_dbevents(dbevents)
 
+        if self.db.currentEnv.get('hidden_transaction'):
+            page.notifyLocalDbEvents(dbeventsDict,origin_page_id=page_id,
+                                            dbevent_reason=dbevent_reason or pagename)
+        else:
+            self.site.register.notifyDbEvents(dbeventsDict,register_name='page',
+                                            origin_page_id=page_id,
+                                            dbevent_reason=dbevent_reason or pagename)
             self.db.updateEnv(env_transaction_id= None,dbevents=None)
 
     def _compress_dbevents(self,dbevents):

--- a/gnrpy/gnr/web/gnrwebapp.py
+++ b/gnrpy/gnr/web/gnrwebapp.py
@@ -116,10 +116,15 @@ class GnrWsgiWebApp(GnrApp):
                 if page:
                     page_id = page.page_id
                     pagename = page.pagename
-                if not self.db.currentEnv.get('hidden_transaction'):
+                if self.db.currentEnv.get('hidden_transaction'):
+                    page.notifyLocalDbEvents(dbeventsDict,register_name='page',
+                                                 origin_page_id=page_id,
+                                                 dbevent_reason=dbevent_reason or pagename)
+                else:
                     self.site.register.notifyDbEvents(dbeventsDict,register_name='page',
                                                  origin_page_id=page_id,
                                                  dbevent_reason=dbevent_reason or pagename)
+
             self.db.updateEnv(env_transaction_id= None,dbevents=None)
 
     def _compress_dbevents(self,dbevents):

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -2020,6 +2020,18 @@ class GnrWebPage(GnrBaseWebPage):
         self.setInClientData_legacy(path, value=value, attributes=attributes, page_id=page_id or self.page_id, filters=filters,
                         fired=fired, reason=reason, replace=replace,public=public,**kwargs)
 
+    def notifyLocalDbEvents(self,dbeventsDict=None,origin_page_id=None,dbevent_reason=None):
+        for table,dbevents in list(dbeventsDict.items()):
+            if not dbevents:
+                continue
+            table_code = table.replace('.', '_')
+            self.addLocalDatachange('gnr.dbchanges.%s' %table_code, dbevents,attributes=dict(from_page_id=origin_page_id,dbevent_reason=dbevent_reason))
+
+
+    def addLocalDatachange(self, path, value=None, attributes=None, fired=False, reason=None, delete=False):
+        datachange = ClientDataChange(path, value, attributes=attributes, fired=fired,
+                                      reason=reason, delete=delete)
+        self.local_datachanges.append(datachange)
 
     def setInClientData_legacy(self, path, value=None, attributes=None, page_id=None, filters=None,
                         fired=False, reason=None, replace=False,public=None,**kwargs):


### PR DESCRIPTION
This PR addresses the issue within the hidden_transaction context in the database environment. Previously, DB changes were not being propagated, even to the page that generated the dbevents. With this modification, db_events are still not transmitted to the site register, but they are now correctly passed to the page that triggered them. This ensures that local event handling works as expected while maintaining isolation from the site register.”