### PR TITLE
Bag now saves internally template_kwargs if provided, to expand {VAR}…

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -705,8 +705,9 @@ class GnrApp(object):
                     packages.setItem(pkgid, n.value, n.attr)
                 config['packages']  = packages
             return config
+        
         instance_config_path = os.path.join(self.instanceFolder, 'instanceconfig.xml')
-        base_instance_config = normalizePackages(Bag(instance_config_path))
+        base_instance_config = normalizePackages(Bag(instance_config_path, _template_kwargs=os.environ))
         instance_config = normalizePackages(self.gnr_config['gnr.instanceconfig.default_xml']) or Bag()
         template = base_instance_config['instance?template']
         if template:

--- a/gnrpy/gnr/app/gnrconfig.py
+++ b/gnrpy/gnr/app/gnrconfig.py
@@ -181,7 +181,7 @@ def getGnrConfig(config_path=None, set_environment=False):
     config_path = config_path or gnrConfigPath()
     if not config_path or not os.path.isdir(config_path):
         raise Exception('Missing genro configuration')
-    gnr_config = Bag(config_path)
+    gnr_config = Bag(config_path, _template_kargs=os.environ)
     if set_environment:
         setEnvironment(gnr_config)
     return gnr_config

--- a/gnrpy/gnr/core/gnrbag.py
+++ b/gnrpy/gnr/core/gnrbag.py
@@ -454,6 +454,9 @@ class Bag(GnrObject):
         self._del_subscribers = {}
         self._modified = None
         self._rootattributes = None
+
+        self._template_kwargs = kwargs.get("_template_kwargs", {})
+        
         source=source or kwargs
         if source:
             self.fillFrom(source)
@@ -1959,6 +1962,9 @@ class Bag(GnrObject):
             #     else:
             #         source = source.decode()
             # source = source.format_map(AllowMissingDict(_template_kwargs))
+
+            if self._template_kwargs:
+                source = source.format_map(self._template_kwargs)
             return self._fromXml(source, fromFile)
         elif mode == 'xsd':
             return self._fromXsd(source, fromFile)

--- a/gnrpy/tests/core/gnrbag_test.py
+++ b/gnrpy/tests/core/gnrbag_test.py
@@ -34,6 +34,12 @@ class TestBasicBag(object):
         b = Bag("<name>John</name>")
         assert b['name'] == 'John'
 
+    def test_template_kwargs(self):
+        source = "<name>{TESTVAR}</name>"
+        test_kwargs = dict(TESTVAR="admin", TESTVAR2="admin2")
+        b = Bag(source, _template_kwargs=test_kwargs)
+        assert b['name'] == "admin"
+        
     def test_fillFromBag(self):
         c = Bag(self.mybag)
         assert c == self.mybag


### PR DESCRIPTION
… items in the source

file if values are presente. This is useful to have configuration items values defined in the process enviroment, like we do for docker.

When an instanceconfig/main configuration is loaded, we use os.environ as _template_kwargs.

Updated bag test accordingly