### PR TITLE
Refactor column width calculation in ThResourceMaker (-g option)

### DIFF
--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -831,10 +831,10 @@ class SqlQueryCompiler(object):
         high_field = m.group(3)
 
         result = f"""
-                (({low_field} IS NULL AND {high_field} IS NOT NULL AND {value_field}<{high_field}) OR
+                (({low_field} IS NULL AND {high_field} IS NOT NULL AND {value_field}<={high_field}) OR
                 ({low_field} IS NOT NULL AND {high_field} IS NULL AND {value_field}>={low_field}) OR
                 ({low_field} IS NOT NULL AND {high_field} IS NOT NULL AND
-                    {value_field} >= {low_field} AND {value_field} < {high_field}) OR
+                    {value_field} >= {low_field} AND {value_field} <= {high_field}) OR
                 ({low_field} IS NULL AND {high_field} IS NULL))
             """
         #TODO: verificare se inclusivo o meno su intervallo superiore

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -92,7 +92,27 @@ def configurePackage(pkg):
     movie.column('description', name_short='Dsc', name_long='Movie description')
 
     dvd = pkg.table('dvd', name_short='Dvd', name_long='Dvd', pkey='code')
-    dvd_id = dvd.column('code', 'L')
+    dvd.column('code', 'L')
     dvd.column('movie_id', 'L',name_short='Mid', name_long='Movie id').relation('movie.id')
     dvd.column('purchasedate', 'D', name_short='Pdt', name_long='Purchase date')
     dvd.column('available', name_short='Avl', name_long='Available')
+
+    location = pkg.table('location',
+                         name_short='Loc',
+                         name_long='Location',
+                         pkey='id')
+    location.column('id', 'L')
+    location.column('name', name_short='Name', name_long='Name')
+    location.column('rating', 'I', name_short='Rt', name_long='Rating')
+
+    # loc_allocation = pkg.table('loc_allocation',
+    #                            name_short='Loc. Alloc',
+    #                            name_long='Location Allocation',
+    #                            pkey='id')
+    # loc_allocation.column('id', 'L')
+    # loc_allocation.column('location_id', 'L', name_short='Loc', name_long='Location'
+    #                         ).relation('location.id')
+    # loc_allocation.column('movie_id', 'L', name_short='Movie', name_long='Movie ID'
+    #                         ).relation('movie.id')
+    # loc_allocation.column('from_date', 'D', name_short='From', name_long='From Date')
+    # loc_allocation.column('to_date', 'D', name_short='To', name_long='To Date')

--- a/gnrpy/tests/sql/data/dbdata_base.xml
+++ b/gnrpy/tests/sql/data/dbdata_base.xml
@@ -1,97 +1,94 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <GenRoBag>
-      <people pkg='video'>
-      	<r id='0::L' name='Woody Allen' year='1935' nationality='USA' />
-      	<r id='1::L' name='Steven Spielberg' year='1946::L' nationality='USA' />
-      	<r id='2::L' name='Stanley Kubrick' year='1928::L' nationality='USA' />
-      	<r id='3::L' name='Brian De Palma' year='1940::L' nationality='USA' />
-      	<r id='4::L' name='Alfred Hitchcock' year='1899::L' nationality='UK' />
-      	<r id='5::L' name='Martin Scorsese' year='1942::L' nationality='USA' />
+	<people pkg='video'>
+		<r id='0::L' name='Woody Allen' year='1935' nationality='USA' />
+		<r id='1::L' name='Steven Spielberg' year='1946::L' nationality='USA' />
+		<r id='2::L' name='Stanley Kubrick' year='1928::L' nationality='USA' />
+		<r id='3::L' name='Brian De Palma' year='1940::L' nationality='USA' />
+		<r id='4::L' name='Alfred Hitchcock' year='1899::L' nationality='UK' />
+		<r id='5::L' name='Martin Scorsese' year='1942::L' nationality='USA' />
+	
+		<r id='6::L' name='Tom Hanks' year='1956' nationality='USA' />
+		<r id='7::L' name='Matt Damon' year='1970::L' nationality='USA' />
+		<r id='8::L' name='Leonardo DiCaprio' year='1974::L' nationality='USA' />
+		<r id='9::L' name='Cate Blanchett' year='1969::L' nationality='AU' />
+		<r id='10::L' name='Jonathan Rhys Meyers' year='1977::L' nationality='IR' />
+		<r id='11::L' name='Scarlett Johansson' year='1984::L' nationality='USA' />
+	
+		<r id='12::L' name='Hugh Jackman' year='1968' nationality='AU' />
+		<r id='13::L' name='Kevin Costner' year='1955::L' nationality='USA' />
+		<r id='14::L' name='Al Pacino' year='1940::L' nationality='USA' />
+		<r id='15::L' name='Michelle Pfeiffer' year='1958::L' nationality='AU' />
+		<r id='16::L' name='Anthony Perkins' year='1932::L' nationality='USA' />
+		<r id='17::L' name='Janet Leigh' year='1927::L' nationality='USA' />
+	
+		<r id='18::L' name='Ryan ONeal' year='1941' nationality='AU' />
+		<r id='19::L' name='Marisa Berenson' year='1947::L' nationality='USA' />
+		<r id='20::L' name='Tom Cruise' year='1962::L' nationality='USA' />
+		<r id='21::L' name='Nicole Kidman' year='1967::L' nationality='AU' />
+		<r id='22::L' name='Eric Bana' year='1968' nationality='AU' /> 
+		<r id='23::L' name='Daniel Craig ' year='1968' nationality='UK' /> 
+	</people>
+
+	<cast pkg='video'>
+		<r id='0::L' movie_id='0' person_id='0' role='director'  prizes='' />
+		<r id='1::L' movie_id='0' person_id='10' role='actor'  prizes='' />
+		<r id='2::L' movie_id='0' person_id='11' role='actor'  prizes='' />
    
-      	<r id='6::L' name='Tom Hanks' year='1956' nationality='USA' />
-      	<r id='7::L' name='Matt Damon' year='1970::L' nationality='USA' />
-      	<r id='8::L' name='Leonardo DiCaprio' year='1974::L' nationality='USA' />
-      	<r id='9::L' name='Cate Blanchett' year='1969::L' nationality='AU' />
-      	<r id='10::L' name='Jonathan Rhys Meyers' year='1977::L' nationality='IR' />
-      	<r id='11::L' name='Scarlett Johansson' year='1984::L' nationality='USA' />
+		<r id='3::L' movie_id='1' person_id='0' role='director'  prizes='' />
+		<r id='4::L' movie_id='1' person_id='12' role='actor'  prizes='' />
+		<r id='5::L' movie_id='1' person_id='11' role='actor'  prizes='' />
    
-      	<r id='12::L' name='Hugh Jackman' year='1968' nationality='AU' />
-      	<r id='13::L' name='Kevin Costner' year='1955::L' nationality='USA' />
-      	<r id='14::L' name='Al Pacino' year='1940::L' nationality='USA' />
-      	<r id='15::L' name='Michelle Pfeiffer' year='1958::L' nationality='AU' />
-      	<r id='16::L' name='Anthony Perkins' year='1932::L' nationality='USA' />
-      	<r id='17::L' name='Janet Leigh' year='1927::L' nationality='USA' />
+		<r id='6::L' movie_id='2' person_id='1' role='director'  prizes='' />
+		<r id='7::L' movie_id='2' person_id='16' role='actor'  prizes='' />
+		<r id='8::L' movie_id='2' person_id='17' role='actor'  prizes='' />
    
-      	<r id='18::L' name='Ryan ONeal' year='1941' nationality='AU' />
-      	<r id='19::L' name='Marisa Berenson' year='1947::L' nationality='USA' />
-      	<r id='20::L' name='Tom Cruise' year='1962::L' nationality='USA' />
-      	<r id='21::L' name='Nicole Kidman' year='1967::L' nationality='AU' />
-      	<r id='22::L' name='Eric Bana' year='1968' nationality='AU' /> 
-      	<r id='23::L' name='Daniel Craig ' year='1968' nationality='UK' /> 
-      </people>
+		<r id='9::L' movie_id='3' person_id='1' role='director'  prizes='Oscar: Best director' />
+		<r id='10::L' movie_id='3' person_id='6' role='actor'  prizes='' />
+		<r id='11::L' movie_id='3' person_id='7' role='actor'  prizes='' />
    
+		<r id='12::L' movie_id='4' person_id='2' role='director'  prizes='' />
+		<r id='13::L' movie_id='4' person_id='20' role='actor'  prizes='' />
+		<r id='14::L' movie_id='4' person_id='21' role='actor'  prizes='' />
    
-      <cast pkg='video'>
-      	<r id='0::L' movie_id='0' person_id='0' role='director'  prizes='' />
-      	<r id='1::L' movie_id='0' person_id='10' role='actor'  prizes='' />
-      	<r id='2::L' movie_id='0' person_id='11' role='actor'  prizes='' />
+		<r id='15::L' movie_id='5' person_id='2' role='director'  prizes='' />
+		<r id='16::L' movie_id='5' person_id='18' role='actor'  prizes='' />
+		<r id='17::L' movie_id='5' person_id='19' role='actor'  prizes='' />
    
-      	<r id='3::L' movie_id='1' person_id='0' role='director'  prizes='' />
-      	<r id='4::L' movie_id='1' person_id='12' role='actor'  prizes='' />
-      	<r id='5::L' movie_id='1' person_id='11' role='actor'  prizes='' />
+		<r id='18::L' movie_id='6' person_id='3' role='director'  prizes='' />
+		<r id='19::L' movie_id='6' person_id='14' role='actor'  prizes='' />
+		<r id='20::L' movie_id='6' person_id='15' role='actor'  prizes='' />
    
-      	<r id='6::L' movie_id='2' person_id='1' role='director'  prizes='' />
-      	<r id='7::L' movie_id='2' person_id='16' role='actor'  prizes='' />
-      	<r id='8::L' movie_id='2' person_id='17' role='actor'  prizes='' />
+		<r id='21::L' movie_id='7' person_id='3' role='director'  prizes='' />
+		<r id='22::L' movie_id='7' person_id='13' role='actor'  prizes='' />
    
-      	<r id='9::L' movie_id='3' person_id='1' role='director'  prizes='Oscar: Best director' />
-      	<r id='10::L' movie_id='3' person_id='6' role='actor'  prizes='' />
-      	<r id='11::L' movie_id='3' person_id='7' role='actor'  prizes='' />
+		<r id='23::L' movie_id='8' person_id='4' role='director'  prizes='' />
+		<r id='24::L' movie_id='8' person_id='16' role='actor'  prizes='' />
+		<r id='25::L' movie_id='8' person_id='17' role='actor'  prizes='' />
    
+		<r id='23::L' movie_id='9' person_id='5' role='director'  prizes='' />
+		<r id='24::L' movie_id='9' person_id='8' role='actor'  prizes='' />
+		<r id='25::L' movie_id='9' person_id='9' role='actor'  prizes='' />
    
-      	<r id='12::L' movie_id='4' person_id='2' role='director'  prizes='' />
-      	<r id='13::L' movie_id='4' person_id='20' role='actor'  prizes='' />
-      	<r id='14::L' movie_id='4' person_id='21' role='actor'  prizes='' />
-   
-      	<r id='15::L' movie_id='5' person_id='2' role='director'  prizes='' />
-      	<r id='16::L' movie_id='5' person_id='18' role='actor'  prizes='' />
-      	<r id='17::L' movie_id='5' person_id='19' role='actor'  prizes='' />
-   
-      	<r id='18::L' movie_id='6' person_id='3' role='director'  prizes='' />
-      	<r id='19::L' movie_id='6' person_id='14' role='actor'  prizes='' />
-      	<r id='20::L' movie_id='6' person_id='15' role='actor'  prizes='' />
-   
-      	<r id='21::L' movie_id='7' person_id='3' role='director'  prizes='' />
-      	<r id='22::L' movie_id='7' person_id='13' role='actor'  prizes='' />
-   
-      	<r id='23::L' movie_id='8' person_id='4' role='director'  prizes='' />
-      	<r id='24::L' movie_id='8' person_id='16' role='actor'  prizes='' />
-      	<r id='25::L' movie_id='8' person_id='17' role='actor'  prizes='' />
-   
-      	<r id='23::L' movie_id='9' person_id='5' role='director'  prizes='' />
-      	<r id='24::L' movie_id='9' person_id='8' role='actor'  prizes='' />
-      	<r id='25::L' movie_id='9' person_id='9' role='actor'  prizes='' />
-   
-      	<r id='23::L' movie_id='9' person_id='5' role='director'  prizes='Oscar: Best director' />
-      	<r id='24::L' movie_id='9' person_id='8' role='actor'  prizes='' />
-      	<r id='25::L' movie_id='9' person_id='7' role='actor'  prizes='' />
-   
-      </cast>
-   
-      <movie pkg='video'>
-      	<r id='0::L' title='Match point' year='2005::L' nationality='USA,UK' genre='DRAMA'/>
-      	<r id='1::L' title='Scoop' year='2006::L' nationality='USA,UK' genre='COMEDY' />
-      	<r id='2::L' title='Munich' year='2005::L' nationality='USA' genre='DRAMA'/>
-      	<r id='3::L' title='Saving private Ryan' year='1998::L' nationality='USA' genre='WAR' />
-      	<r id='4::L' title='Eyes wide shut' year='1999::L' nationality='UK' genre='DRAMA' />
-      	<r id='5::L' title='Barry Lindon' year='1975::L' nationality='UK' genre='DRAMA' />
-      	<r id='6::L' title='Scarface' year='1983::L' nationality='USA' genre='CRIME' />
-      	<r id='7::L' title='The untouchables' year='1987::L' nationality='USA' genre='CRIME' />
-      	<r id='8::L' title='Psycho' year='1960::L' nationality='UK' genre='THRILLER' />
-      	<r id='9::L' title='The Aviator' year='2004::L' nationality='USA' genre='BIOGRAPHY'/>
-      	<r id='10::L' title='The Departed' year='2006::L' nationality='USA' genre='CRIME'/>
-      </movie>
- 
+		<r id='23::L' movie_id='9' person_id='5' role='director'  prizes='Oscar: Best director' />
+		<r id='24::L' movie_id='9' person_id='8' role='actor'  prizes='' />
+		<r id='25::L' movie_id='9' person_id='7' role='actor'  prizes='' />
+	</cast>
+
+	<movie pkg='video'>
+		<r id='0::L' title='Match point' year='2005::L' nationality='USA,UK' genre='DRAMA' />
+		<r id='1::L' title='Scoop' year='2006::L' nationality='USA,UK' genre='COMEDY' />
+		<r id='2::L' title='Munich' year='2005::L' nationality='USA' genre='DRAMA' />
+		<r id='3::L' title='Saving private Ryan' year='1998::L' nationality='USA' genre='WAR' />
+		<r id='4::L' title='Eyes wide shut' year='1999::L' nationality='UK' genre='DRAMA' />
+		<r id='5::L' title='Barry Lindon' year='1975::L' nationality='UK' genre='DRAMA' />
+		<r id='6::L' title='Scarface' year='1983::L' nationality='USA' genre='CRIME' />
+		<r id='7::L' title='The untouchables' year='1987::L' nationality='USA' genre='CRIME' />
+		<r id='8::L' title='Psycho' year='1960::L' nationality='UK' genre='THRILLER' />
+		<r id='9::L' title='The Aviator' year='2004::L' nationality='USA' genre='BIOGRAPHY' />
+		<r id='10::L' title='The Departed' year='2006::L' nationality='USA' genre='CRIME' />
+	</movie>
+
 	<dvd pkg='video'>
 		<r code='0::L' movie_id='0::L' purchasedate='2006-04-11::D' available='yes' />
 		<r code='1::L' movie_id='1::L' purchasedate='2006-03-02::D' available='no' />
@@ -111,4 +108,27 @@
 		<r code='17::L' movie_id='8::L' purchasedate='2005-04-07::D' available='yes' />
 		<r code='18::L' movie_id='9::L' purchasedate='2006-04-18::D' available='yes' />
 	</dvd>
+
+	<location pkg='video'>
+		<r id='0::L' name='CineCittà (Italy)' rating='-3' />
+		<r id='1::L' name='Pinewood studios (UK)' rating='7' />
+		<r id='2::L' name='Universal studios Hollywood (USA)' rating='-1' />
+		<r id='3::L' name='Warner Bros studios Leavesden (UK)' rating='4' />
+		<r id='4::L' name='Paramount Pictures studios (USA)' rating='-6' />
+		<r id='5::L' name='Fox studios Australia (Australia)' rating='2' />
+		<r id='6::L' name='Babelsberg studio (Germania)' rating='-8' />
+		<r id='7::L' name='Raleigh studios (USA)' rating='5' />
+		<r id='8::L' name='Weta Workshop-Stone Street studios (New Zeland)' rating='0' />
+		<r id='9::L' name='Mel Cité du Cinéma (Canada)' rating='9' />
+		<r id='10::L' name='Shepperton studios (UK)' rating='-4' />
+	</location>
+
+	<!-- <loc_allocation pkg='video'>
+		<r id='0::L' location_id='0' movie_id='0' from_date='2004-02-01' to_date='2004-04-30' />
+		<r id='1::L' location_id='1' movie_id='0' from_date='2004-05-01' to_date='2004-05-15' />
+		<r id='2::L' location_id='2' movie_id='0' from_date='2004-06-01' to_date='2004-07-30' />
+		<r id='3::L' location_id='2' movie_id='1' from_date='2005-01-01' to_date='2005-03-30' />
+		<r id='4::L' location_id='0' movie_id='5' from_date='1974-06-01' to_date='1974-07-30' />
+		<r id='5::L' location_id='1' movie_id='5' from_date='1974-09-01' to_date='1974-10-15' />
+	</loc_allocation> -->
 </GenRoBag>

--- a/gnrpy/tests/sql/data/dbstructure_base.xml
+++ b/gnrpy/tests/sql/data/dbstructure_base.xml
@@ -1,20 +1,50 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<GenRoBag><packages tag="package_list"><video name_short="video" comment="video package" name_full="video" tag="package" name_long="video"><tables tag="table_list"><people pkey="id" name_short="people" tag="table" pkg="video" rowcaption="name,year:%s (%s)" fullname="video.people" name_long="People"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
-<name _T="BAG" name_short="N." tag="column" name_long="Name"></name>
-<year _T="BAG" name_short="Yr" dtype="L" tag="column" name_long="Birth Year"></year>
-<nationality _T="BAG" name_short="Ntl" tag="column" name_long="Nationality"></nationality></columns></people>
-<cast pkey="id" name_short="cast" tag="table" pkg="video" rowcaption="" fullname="video.cast" name_long="Cast"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
-<movie_id name_short="Mid" dtype="L" tag="column" name_long="Movie id"><relation _T="BAG" related_column="movie.id" mode="relation"></relation></movie_id>
-<person_id name_short="Prs" dtype="L" tag="column" name_long="Person id"><relation _T="BAG" related_column="people.id" mode="relation"></relation></person_id>
-<role _T="BAG" name_short="Rl." tag="column" name_long="Role"></role>
-<prizes _T="BAG" name_short="Priz." tag="column" size="40" name_long="Prizes"></prizes></columns></cast>
-<movie pkey="id" name_short="Mv" tag="table" pkg="video" rowcaption="title" fullname="video.movie" name_long="Movie"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
-<title _T="BAG" name_short="Ttl." validate_case="capitalize" validate_len="3,40" tag="column" name_long="Title"></title>
-<genre _T="BAG" validate_case="upper" validate_len="3,10" name_short="Gnr" tag="column" indexed="y" name_long="Genre"></genre>
-<year _T="BAG" name_short="Yr" dtype="L" tag="column" indexed="y" name_long="Year"></year>
-<nationality _T="BAG" name_short="Ntl" tag="column" name_long="Nationality"></nationality>
-<description _T="BAG" name_short="Dsc" tag="column" name_long="Movie description"></description></columns></movie>
-<dvd pkey="code" name_short="Dvd" tag="table" pkg="video" fullname="video.dvd" name_long="Dvd"><columns tag="column_list"><code _T="BAG" dtype="L" tag="column"></code>
-<movie_id name_short="Mid" dtype="L" tag="column" name_long="Movie id"><relation _T="BAG" related_column="movie.id" mode="relation"></relation></movie_id>
-<purchasedate _T="BAG" name_short="Pdt" dtype="D" tag="column" name_long="Purchase date"></purchasedate>
-<available _T="BAG" name_short="Avl" tag="column" name_long="Available"></available></columns></dvd></tables></video></packages></GenRoBag>
+<GenRoBag>
+  <packages tag="package_list">
+    <video name_short="video" comment="video package" name_full="video" tag="package" name_long="video">
+      <tables tag="table_list">
+	<people pkey="id" name_short="people" tag="table" pkg="video" rowcaption="name,year:%s (%s)" fullname="video.people" name_long="People">
+	  <columns tag="column_list">
+	    <id _T="BAG" dtype="L" tag="column"></id>
+	    <name _T="BAG" name_short="N." tag="column" name_long="Name"></name>
+	    <year _T="BAG" name_short="Yr" dtype="L" tag="column" name_long="Birth Year"></year>
+	    <nationality _T="BAG" name_short="Ntl" tag="column" name_long="Nationality"></nationality>
+	  </columns>
+	</people>
+	<cast pkey="id" name_short="cast" tag="table" pkg="video" rowcaption="" fullname="video.cast" name_long="Cast">
+	  <columns tag="column_list">
+	    <id _T="BAG" dtype="L" tag="column"></id>
+	    <movie_id name_short="Mid" dtype="L" tag="column" name_long="Movie id">
+	      <relation _T="BAG" related_column="movie.id" mode="relation"></relation>
+	    </movie_id>
+	    <person_id name_short="Prs" dtype="L" tag="column" name_long="Person id">
+	      <relation _T="BAG" related_column="people.id" mode="relation"></relation>
+	    </person_id>
+	    <role _T="BAG" name_short="Rl." tag="column" name_long="Role"></role>
+	    <prizes _T="BAG" name_short="Priz." tag="column" size="40" name_long="Prizes"></prizes>
+	  </columns>
+	</cast>
+	<movie pkey="id" name_short="Mv" tag="table" pkg="video" rowcaption="title" fullname="video.movie" name_long="Movie">
+	  <columns tag="column_list">
+	    <id _T="BAG" dtype="L" tag="column"></id>
+	    <title _T="BAG" name_short="Ttl." validate_case="capitalize" validate_len="3,40" tag="column" name_long="Title"></title>
+	    <genre _T="BAG" validate_case="upper" validate_len="3,10" name_short="Gnr" tag="column" indexed="y" name_long="Genre"></genre>
+	    <year _T="BAG" name_short="Yr" dtype="L" tag="column" indexed="y" name_long="Year"></year>
+	    <nationality _T="BAG" name_short="Ntl" tag="column" name_long="Nationality"></nationality>
+	    <description _T="BAG" name_short="Dsc" tag="column" name_long="Movie description"></description>
+	  </columns>
+	</movie>
+	<dvd pkey="code" name_short="Dvd" tag="table" pkg="video" fullname="video.dvd" name_long="Dvd">
+	  <columns tag="column_list">
+	    <code _T="BAG" dtype="L" tag="column"></code>
+	    <movie_id name_short="Mid" dtype="L" tag="column" name_long="Movie id">
+	      <relation _T="BAG" related_column="movie.id" mode="relation"></relation>
+	    </movie_id>
+	    <purchasedate _T="BAG" name_short="Pdt" dtype="D" tag="column" name_long="Purchase date"></purchasedate>
+	    <available _T="BAG" name_short="Avl" tag="column" name_long="Available"></available>
+	  </columns>
+	</dvd>
+      </tables>
+    </video>
+  </packages>
+</GenRoBag>

--- a/gnrpy/tests/sql/data/dbstructure_final.xml
+++ b/gnrpy/tests/sql/data/dbstructure_final.xml
@@ -1,22 +1,62 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<GenRoBag><packages tag="package_list"><video tag="package" comment="video package" name_short="video" name_long="video" name_full="video"><tables tag="table_list"><people name_short="people" name_long="People" pkey="id" rowcaption="name,year:%s (%s)" pkg="video" fullname="video.people" tag="table"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
-<name _T="BAG" name_short="N." name_long="Name" tag="column"></name>
-<year _T="BAG" dtype="L" name_short="Yr" name_long="Birth Year" tag="column"></year>
-<nationality _T="BAG" name_short="Ntl" name_long="Nationality" tag="column"></nationality>
-<foo _T="BAG" tag="column"></foo></columns></people>
-<cast name_short="cast" name_long="Cast" pkey="id" rowcaption="" pkg="video" fullname="video.cast" tag="table"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
-<movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column"><relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation></movie_id>
-<person_id dtype="L" name_short="Prs" name_long="Person id" tag="column"><relation _T="BAG" related_column="people.id" mode="relation" onUpdate_sql="cascade"></relation></person_id>
-<role _T="BAG" name_short="Rl." name_long="Role" tag="column"></role>
-<prizes _T="BAG" size="40" name_short="Priz." name_long="Prizes" tag="column"></prizes></columns></cast>
-<movie name_short="Mv" name_long="Movie" pkey="id" rowcaption="title" pkg="video" fullname="video.movie" tag="table"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
-<title _T="BAG" name_short="Ttl." name_long="Title" validate_case="capitalize" validate_len="3:40" tag="column"></title>
-<genre _T="BAG" name_short="Gnr" name_long="Genre" indexed="y" validate_case="upper" validate_len="3:10" tag="column"></genre>
-<year _T="BAG" dtype="L" name_short="Yr" name_long="Year" indexed="y" tag="column"></year>
-<nationality _T="BAG" name_short="Ntl" name_long="Nationality" tag="column"></nationality>
-<description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description></columns></movie>
-<dvd name_short="Dvd" name_long="Dvd" pkey="code" pkg="video" fullname="video.dvd" tag="table"><columns tag="column_list"><code _T="BAG" dtype="L" tag="column"></code>
-<movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column"><relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation></movie_id>
-<purchasedate _T="BAG" dtype="D" name_short="Pdt" name_long="Purchase date" tag="column"></purchasedate>
-<available _T="BAG" name_short="Avl" name_long="Available" tag="column"></available></columns></dvd>
-<actor name_short="act" name_long="actor" pkey="id" pkg="video" fullname="video.actor" tag="table"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id></columns></actor></tables></video></packages></GenRoBag>
+<GenRoBag>
+  <packages tag="package_list">
+    <video tag="package" comment="video package" name_short="video" name_long="video" name_full="video">
+      <tables tag="table_list">
+	
+	<people name_short="people" name_long="People" pkey="id" rowcaption="name,year:%s (%s)" pkg="video" fullname="video.people" tag="table">
+	  <columns tag="column_list">
+	    <id _T="BAG" dtype="L" tag="column"></id>
+	    <name _T="BAG" name_short="N." name_long="Name" tag="column"></name>
+	    <year _T="BAG" dtype="L" name_short="Yr" name_long="Birth Year" tag="column"></year>
+	    <nationality _T="BAG" name_short="Ntl" name_long="Nationality" tag="column"></nationality>
+	    <foo _T="BAG" tag="column"></foo>
+	  </columns>
+	</people>
+	
+	<cast name_short="cast" name_long="Cast" pkey="id" rowcaption="" pkg="video" fullname="video.cast" tag="table">
+	  <columns tag="column_list">
+	    <id _T="BAG" dtype="L" tag="column"></id>
+	    <movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column">
+	      <relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation>
+	    </movie_id>
+	    <person_id dtype="L" name_short="Prs" name_long="Person id" tag="column">
+	      <relation _T="BAG" related_column="people.id" mode="relation" onUpdate_sql="cascade"></relation>
+	    </person_id>
+	    <role _T="BAG" name_short="Rl." name_long="Role" tag="column"></role>
+	    <prizes _T="BAG" size="40" name_short="Priz." name_long="Prizes" tag="column"></prizes>
+	  </columns>
+	</cast>
+
+	<movie name_short="Mv" name_long="Movie" pkey="id" rowcaption="title" pkg="video" fullname="video.movie" tag="table">
+	  <columns tag="column_list">
+	    <id _T="BAG" dtype="L" tag="column"></id>
+	    <title _T="BAG" name_short="Ttl." name_long="Title" validate_case="capitalize" validate_len="3:40" tag="column"></title>
+	    <genre _T="BAG" name_short="Gnr" name_long="Genre" indexed="y" validate_case="upper" validate_len="3:10" tag="column"></genre>
+	    <year _T="BAG" dtype="L" name_short="Yr" name_long="Year" indexed="y" tag="column"></year>
+	    <nationality _T="BAG" name_short="Ntl" name_long="Nationality" tag="column"></nationality>
+	    <description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description>
+	  </columns>
+	</movie>
+	
+	<dvd name_short="Dvd" name_long="Dvd" pkey="code" pkg="video" fullname="video.dvd" tag="table">
+	  <columns tag="column_list">
+	    <code _T="BAG" dtype="L" tag="column"></code>
+	    <movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column">
+	      <relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation>
+	    </movie_id>
+	    <purchasedate _T="BAG" dtype="D" name_short="Pdt" name_long="Purchase date" tag="column"></purchasedate>
+	    <available _T="BAG" name_short="Avl" name_long="Available" tag="column"></available>
+	  </columns>
+	</dvd>
+	
+	<actor name_short="act" name_long="actor" pkey="id" pkg="video" fullname="video.actor" tag="table">
+	  <columns tag="column_list">
+	    <id _T="BAG" dtype="L" tag="column"></id>
+	  </columns>
+	</actor>
+	
+      </tables>
+    </video>
+  </packages>
+</GenRoBag>

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -131,9 +131,6 @@ class BaseSql(BaseGnrSqlTest):
         result = query.count()
         assert result == 9
 
-
-        
-
     def test_sqlparams_date(self):
         query = self.db.query('video.dvd',
                               columns='$purchasedate',
@@ -142,6 +139,13 @@ class BaseSql(BaseGnrSqlTest):
         result = query.selection().output('list')
         assert result[0][0] == datetime.date(2005, 4, 7)
 
+    def test_between_syntax(self):
+        query = self.db.query('video.dvd',
+                              columns='$purchasedate',
+                              where='#BETWEEN($purchasedate, :d1, :d2)',
+                              sqlparams={'d1': datetime.date(2005, 4, 1), 'd2': datetime.date(2005, 4, 30)})
+        result = query.selection().output('list')
+        assert result[0][0] == datetime.date(2005, 4, 7)
 
     def test_joinSimple(self):
         tbl = self.db.table('video.dvd')


### PR DESCRIPTION
Refactoring of wrong-working column width calculation in ThResourceMaker (launched with -g option).
Since the direct calculation of the width in "em" seems to be not so accurate, I've used a lookup table instead.
Not so elegant, but improves accuracy of the width calculation.

#110 