### PR TITLE
added --remotedb to 'gnr web serve' command line, which works this way:

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -623,8 +623,9 @@ class GnrApp(object):
     >>> testgarden = GnrApp('testgarden')
     >>> testgarden.db.table('showcase.person').query().count()
     12"""
-    def __init__(self, instanceFolder=None,custom_config=None, forTesting=False, 
-                debug=False, restorepath=None,enabled_packages=None,**kwargs):
+    def __init__(self, instanceFolder=None, custom_config=None,
+                 forTesting=False, debug=False, restorepath=None,
+                 enabled_packages=None, **kwargs):
         self.aux_instances = {}
         self.gnr_config = getGnrConfig(set_environment=True)
         self.debug=debug
@@ -634,8 +635,8 @@ class GnrApp(object):
         self.project_packages_path = None
         self.enabled_packages = enabled_packages
         if instanceFolder:
-            if '@' in instanceFolder:
-                instanceFolder,self.remote_db  = instanceFolder.split('@',1)
+            if ':' in instanceFolder:
+                instanceFolder,self.remote_db  = instanceFolder.split(':',1)
             self.instanceFolder = self.instance_name_to_path(instanceFolder)
             self.instanceName = os.path.basename(self.instanceFolder)
             project_packages_path = os.path.normpath(os.path.join(self.instanceFolder, '..', '..', 'packages'))
@@ -662,14 +663,16 @@ class GnrApp(object):
         if custom_config:
             self.config.update(custom_config)
         if self.remote_db:
-            remote_db_node = self.config.getNode('remote_db.%s' %self.remote_db)
-            remotedbattr = remote_db_node.attr
-            if remotedbattr and 'ssh_host' in remotedbattr:
-                db_node = self.config.getNode('db')
-                sshattr = dict(db_node.attr)
-                sshattr.update(remotedbattr)
-                sshattr['forwarded_port'] = sshattr.pop('port',None)
-                db_node.attr['port'] = self.gnrdaemon.sshtunnel_port(**sshattr)
+            remote_db_node = self.config.getNode(f'remote_db.{self.remote_db}')
+            if remote_db_node:
+                remotedbattr = remote_db_node.attr
+                if remotedbattr:
+                    db_node = self.config.getNode('db')
+                    if 'ssh_host' in remotedbattr:
+                        sshattr = dict(db_node.attr)
+                        sshattr.update(remotedbattr)
+                        sshattr['forwarded_port'] = sshattr.pop('port',None)
+                        db_node.attr['port'] = self.gnrdaemon.sshtunnel_port(**sshattr)
         if 'menu' not in self.config:
             self.config['menu'] = Bag()
             #------ application instance customization-------
@@ -743,7 +746,14 @@ class GnrApp(object):
             if dbattrs.get('dbname') == '_dummydb':
                 pass
             elif self.remote_db:
-                dbattrs.update(self.config.getAttr('remote_db.%s' %self.remote_db))
+                rdb = self.config.get(f"remote_db")#.{self.remote_db}")
+                if rdb:
+                    rconf = rdb.getAttr(self.remote_db)
+                    if rconf:
+                        logger.info("Using remote db: %s", self.remote_db)
+                        dbattrs.update(rconf)
+                    else:
+                        logger.error("Remote db %s does not exists", self.remote_db)
             elif dbattrs and dbattrs.get('implementation') == 'sqlite':
                 dbname = dbattrs.pop('filename',None) or dbattrs['dbname']
                 if not os.path.isabs(dbname):

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -192,6 +192,9 @@ class GnrWsgiSite(object):
         abs_script_path = os.path.abspath(script_path)
         self.remote_db = ''
         self._register = None
+        if site_name and ':' in site_name:
+            _,self.remote_db = site_name.split(':',1)
+        
         if os.path.isfile(abs_script_path):
             self.site_name = os.path.basename(os.path.dirname(abs_script_path))
         else:
@@ -199,6 +202,7 @@ class GnrWsgiSite(object):
             if site_name and ':' in site_name:
                 site_name,self.remote_db = site_name.split(':',1)
             self.site_name = site_name
+            
         self.site_path = PathResolver().site_name_to_path(self.site_name)
         site_parent=(os.path.dirname(self.site_path))
         if site_parent.endswith('sites'):
@@ -1304,7 +1308,7 @@ class GnrWsgiSite(object):
  #           else:
  #               restorepath = None
         if self.remote_db:
-            instance_path = '%s@%s' %(instance_path,self.remote_db)
+            instance_path = '%s:%s' %(instance_path,self.remote_db)
         app = GnrWsgiWebApp(instance_path, site=self,restorepath=restorepath)
         self.config.setItem('instances.app', app, path=instance_path)
  #       for f in restorefiles:


### PR DESCRIPTION
* if no options is provided, do nothing
* if the option is provided without a value, search for the remote db having the same name of the instance
* the the option is provided with a value, use the value to search for the corresponding configured remote_db.

If the remote_db is not found, log the error and continue with the default db configuration.

The previous behaviour, 'gnr web server instance:remote_db_name' is left unchanged. If the value is provided, try to use it, otherwise log the error.