### PR TITLE
Feature/viewmobile messages

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase.css
+++ b/gnrjs/gnr_d11/css/gnrbase.css
@@ -11,6 +11,11 @@ input:focus { outline: none; }
 * a:hover{
     text-decoration:underline !important;
 }
+
+body {
+    --primary-color: #1E3055;
+}
+
 #protection_shield{
     background: rgba(200, 200, 200, 0.4) url(icons/pageWaiting.gif) no-repeat center center;
     z-index: 10000000;
@@ -4615,7 +4620,10 @@ p {
     width: 10px;
 }
 
-
+/*Mobile bar styles*/
+.mobile_bar.slotbar_toolbar_standard{
+    background:white;
+}
 
 .mobile_bar .multibutton_container{
     color:var(--root-dark);
@@ -4623,8 +4631,10 @@ p {
 
 .mobile_bar .multibutton_selected.multibutton, .mobile_bar .multibutton:active{
     background: none;
+    font-weight: bold;
     border-bottom:2px solid var(--root-dark);
 }
+
 .mobile_bar .multibutton {
     position: relative;
     font-variant: normal;
@@ -4639,11 +4649,11 @@ p {
     background-color: transparent;
 }
 
-
 .mobile_bar .multibutton:first-child{
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     border-left: 0px;
+    margin-left:10px;
 }
 
 .mobile_bar .multibutton:last-child {
@@ -4651,6 +4661,7 @@ p {
     border-bottom-right-radius: 0;
     border-left: 0px;
     border-right: 0px;
+    margin-right: 10px;
 }
 
 .mobile_bar .multibutton_container.singleChildMultibutton{
@@ -4666,6 +4677,28 @@ p {
         padding-right: 6px;
     }
 }
+
+/*Mobile button styles*/
+.mobile_button_container{
+    display: flex;
+    flex-flow: column;
+    justify-content: space-around;
+    align-content: center;
+    align-items: center;
+}
+
+.mobile_button{
+    background: var(--primary-color);
+    color: white;
+    width:80%;
+    font-size: 1.1em;
+    text-align: center;
+    cursor: pointer;
+    padding:10px;
+    margin:5px;
+    border-radius: 20px;
+}
+
 /* @end */
 
 .framecloserIcon{

--- a/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
@@ -67,6 +67,8 @@ class MacroExpander(BaseMacroExpander):
         channel_code = m.group('querycode') or 'current'
         sqlparams = self.querycompiler.sqlparams
         tsquery_params = sqlparams.get(f'tsquery_{channel_code}',{})
+        if not tsquery_params:
+            return "''"
         query_param = tsquery_params.get("querystring",'')  # The search text parameter (e.g., :querystring)
         language_param = tsquery_params.get("language",'simple')  # Default language to 'simple'
         config = m.group("config") or "StartSel=<mark>, StopSel=</mark>, MaxWords=20, MinWords=5, MaxFragments=99, FragmentDelimiter=<hr/>"

--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -50,12 +50,21 @@ class Table(object):
         tbl.column('error_msg', name_long='Error message')
         tbl.column('error_ts', name_long='Error Timestamp')
         tbl.column('connection_retry', dtype='L')
+        tbl.column('read', dtype='B', name_long='!!Read')
 
+        tbl.joinColumn('dest_user_id', name_long='!!Destination user').relation('adm.user.id', 
+                                            cnd='@dest_user_id.email=$to_address', relation_name='received_messages')
         tbl.formulaColumn('sent','$send_date IS NOT NULL', name_long='!!Sent')
         tbl.formulaColumn('plain_text', """regexp_replace($body, '<[^>]*>', '', 'g')""")
         tbl.formulaColumn('abstract', """LEFT(REPLACE($plain_text,'&nbsp;', ''),300)""", name_long='!![en]Abstract')
         tbl.formulaColumn('delta_send',"CAST( EXTRACT(EPOCH FROM ($send_date-$__ins_ts)) AS INTEGER)",dtype='L')
+        tbl.formulaColumn('show_read', """CASE WHEN $read IS NOT TRUE THEN '<div style="border-radius\\:10px;background\\:var(--primary-color);height\\:10px;width\\:10px"></div>'
+                                                ELSE NULL END""", name_long='!!Show read')
+        tbl.pyColumn('full_external_url', name_long='Full external url')
 
+    def pyColumn_full_external_url(self,record,field):
+        return self.db.application.site.externalUrl('/index', menucode='messages')
+    
     def defaultValues(self):
         return dict(account_id=self.db.currentEnv.get('current_account_id'))
 
@@ -322,6 +331,12 @@ class Table(object):
         self.db.commit()
         return 
 
+    @public_method
+    def markAsRead(self, pkey):
+        with self.recordToUpdate(pkey) as message_rec:
+            message_rec['read'] = True
+        self.db.commit()
+        
     def atc_getAttachmentPath(self,pkey):
         return self.folderPath(self.recordAs(pkey))
 

--- a/projects/gnrcore/packages/email/resources/tables/message/tpl/msg_preview.xml
+++ b/projects/gnrcore/packages/email/resources/tables/message/tpl/msg_preview.xml
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<GenRoBag><metadata><email><subject _T="NN"></subject>
+<to_address _T="NN"></to_address>
+<from_address _T="NN"></from_address>
+<cc_address _T="NN"></cc_address>
+<bcc_address _T="NN"></bcc_address>
+<attachments _T="NN"></attachments></email>
+<email_compiled _T="BAG"></email_compiled></metadata>
+<content>&lt;div&gt;
+	A: $a&lt;/div&gt;
+&lt;div&gt;
+	Data: $data_invio&lt;/div&gt;
+&lt;div&gt;
+	Oggetto: &lt;strong&gt;$oggetto&lt;/strong&gt;&lt;/div&gt;
+&lt;div&gt;
+	&amp;nbsp;&lt;/div&gt;
+&lt;div&gt;
+	&lt;hr /&gt;
+&lt;/div&gt;
+&lt;div&gt;
+	$corpo&lt;/div&gt;
+</content>
+<content_css _T="NN"></content_css>
+<varsbag><gtdjidzlvl _pkey="gtdjidzlvl"><fieldpath dtype="::NN">body</fieldpath>
+<dtype dtype="::NN">T</dtype>
+<fieldname dtype="::NN">Corpo</fieldname>
+<varname dtype="::NN">corpo</varname>
+<virtual_column _T="NN"></virtual_column>
+<required_columns _T="NN" dtype="::NN"></required_columns>
+<df_template _T="NN" dtype="::NN"></df_template>
+<format _T="NN" dtype="::NN"></format>
+<mask _T="NN" dtype="::NN"></mask>
+<editable _T="NN" dtype="::NN"></editable></gtdjidzlvl>
+<gtdjifmw4x _pkey="gtdjifmw4x"><fieldpath dtype="::NN">subject</fieldpath>
+<dtype dtype="::NN">T</dtype>
+<fieldname dtype="::NN">Oggetto</fieldname>
+<varname dtype="::NN">oggetto</varname>
+<virtual_column _T="NN"></virtual_column>
+<required_columns _T="NN" dtype="::NN"></required_columns>
+<df_template _T="NN" dtype="::NN"></df_template>
+<format _T="NN" dtype="::NN"></format>
+<mask _T="NN" dtype="::NN"></mask>
+<editable _T="NN" dtype="::NN"></editable></gtdjifmw4x>
+<gtdjigcf49 _pkey="gtdjigcf49"><fieldpath dtype="::NN">send_date</fieldpath>
+<dtype dtype="::NN">DH</dtype>
+<fieldname dtype="::NN">Data invio</fieldname>
+<varname dtype="::NN">data_invio</varname>
+<virtual_column _T="NN"></virtual_column>
+<required_columns _T="NN" dtype="::NN"></required_columns>
+<df_template _T="NN" dtype="::NN"></df_template>
+<format _T="NN" dtype="::NN"></format>
+<mask _T="NN" dtype="::NN"></mask>
+<editable _T="NN" dtype="::NN"></editable></gtdjigcf49>
+<gtdjiipkpd _pkey="gtdjiipkpd"><fieldpath dtype="::NN">to_address</fieldpath>
+<dtype dtype="::NN">T</dtype>
+<fieldname dtype="::NN">A</fieldname>
+<varname dtype="::NN">a</varname>
+<virtual_column _T="NN"></virtual_column>
+<required_columns _T="NN" dtype="::NN"></required_columns>
+<df_template _T="NN" dtype="::NN"></df_template>
+<format _T="NN" dtype="::NN"></format>
+<mask _T="NN" dtype="::NN"></mask>
+<editable _T="NN" dtype="::NN"></editable></gtdjiipkpd></varsbag>
+<parametersbag _T="NN"></parametersbag>
+<email><attached_reports _T="BAG"></attached_reports></email>
+<compiled><main maintable="email.message" locale="it-IT" virtual_columns="" columns="$body,$subject,$send_date,$to_address" formats="{}::JS" masks="{}::JS" editcols="{}::JS" df_templates="{}::JS" dtypes='{"corpo": "T", "oggetto": "T", "data_invio": "DH", "a": "T"}::JS'>&lt;div&gt;
+	A: $to_address&lt;/div&gt;
+&lt;div&gt;
+	Data: $send_date&lt;/div&gt;
+&lt;div&gt;
+	Oggetto: &lt;strong&gt;$subject&lt;/strong&gt;&lt;/div&gt;
+&lt;div&gt;
+	&amp;nbsp;&lt;/div&gt;
+&lt;div&gt;
+	&lt;hr /&gt;
+&lt;/div&gt;
+&lt;div&gt;
+	$body&lt;/div&gt;
+</main></compiled></GenRoBag>

--- a/resources/common/themes/mimi.css
+++ b/resources/common/themes/mimi.css
@@ -1,5 +1,8 @@
 /*vico*/
 
+body {
+    --primary-color: #1E3055;
+}
 
 body.tundra.mimi {
     font:14px "SF Pro Text","Myriad Set Pro","SF Pro Icons","Apple Legacy Chevron","Helvetica Neue","Helvetica","Arial",sans-serif;


### PR DESCRIPTION
### **User description**
Closes #138


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a `ViewMobile` class for mobile-friendly email message views.
  - Introduced a new row template for mobile message display.
  - Added filtering and reading state sections for mobile messages.

- Enhanced database schema for email messages.
  - Added `read` column to track message read status.
  - Added `markAsRead` method to update read status.

- Improved CSS for mobile styling.
  - Defined primary color and mobile-specific styles.
  - Added styles for mobile buttons and bars.

- Fixed potential error in `_expand_TSHEADLINE` by returning an empty string for missing `tsquery` parameters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_gnrbasepostgresadapter.py</strong><dd><code>Fix `_expand_TSHEADLINE` for missing `tsquery` parameters</code></dd></summary>
<hr>

gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py

<li>Fixed potential error in <code>_expand_TSHEADLINE</code> by returning an empty <br>string for missing <code>tsquery</code> parameters.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/139/files#diff-797257b16d5883fcff9f539388b550c42387d86e0e9a8326a717142ea4702a4d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message.py</strong><dd><code>Enhance email message schema and add read tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

projects/gnrcore/packages/email/model/message.py

<li>Added <code>read</code> column to track message read status.<br> <li> Added <code>markAsRead</code> method to update read status.<br> <li> Added <code>show_read</code> formula column for UI display.<br> <li> Added <code>full_external_url</code> Python column for external URL generation.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/139/files#diff-43d51f50fd02f277a01d808d809f7f6896d76c3ba047fbac871b5c10073ee7e4">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>th_message.py</strong><dd><code>Add mobile-friendly views and forms for messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

projects/gnrcore/packages/email/resources/tables/message/th_message.py

<li>Added <code>ViewMobile</code> class for mobile-friendly message views.<br> <li> Introduced filtering and reading state sections for mobile messages.<br> <li> Added <code>FormMobile</code> class for mobile-specific message forms.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/139/files#diff-fedeee72dac5c965bdad525fd7715540e0d094be1fed0b5c26162fd08dbdc12f">+103/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gnrbase.css</strong><dd><code>Add and improve mobile-specific CSS styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrjs/gnr_d11/css/gnrbase.css

<li>Added primary color definition.<br> <li> Added styles for mobile bars and buttons.<br> <li> Improved mobile-specific styling for better user experience.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/139/files#diff-98e6c62f189c40bcb9fe467d2cf5f610b898eb79d8819b666817d3e8a8f4b460">+35/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mimi.css</strong><dd><code>Add primary color to theme CSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/common/themes/mimi.css

- Added primary color definition for the theme.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/139/files#diff-1333879abb666a0cf5dee1cf98790a6e429c5ca49c02bdfa1c4d1e5374ba8ec6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>msg_preview.xml</strong><dd><code>Add XML template for message previews</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

projects/gnrcore/packages/email/resources/tables/message/tpl/msg_preview.xml

<li>Added a new XML template for message previews.<br> <li> Included fields like subject, send date, and body.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/139/files#diff-66635b850e7902179b941de9a937e264e1e0714ed0235a9d5c11802a20787211">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>