### PR TITLE
Use pdf viewer only if attachment might be a pdf

### DIFF
--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -988,9 +988,27 @@ dojo.declare("gnr.widgets.iframe", gnr.widgets.baseHtml, {
                 src_kwargs._nocache = genro.time36Id();
             }
             v = genro.addParamsToUrl(v,src_kwargs);   
-            if(sourceNode.attr.documentClasses){
+                if(sourceNode.attr.documentClasses){
+                    let useViewer = true;
+                    try {
+                    let parsed = parseURL(v);
+                    let ext = '';
+                    if (parsed.file && parsed.file.includes('.')) {
+                        ext = parsed.file.split('.').pop().toLowerCase();
+                        console.log(ext)
+                    }
+                    let extList = (this._default_ext || '').toLowerCase().split(',').filter(e => e !== 'pdf');
+                    if (ext && extList.includes(ext)) {
+                        useViewer = false;
+                    }
+                    } catch(e) {
+                        useViewer = true;
+                    }
+    
+            if(useViewer){
                 v = genro.dom.detectPdfViewer(v,sourceNode.attr.jsPdfViewer);
             }
+                }
             var doset = this.initContentHtml(domnode,v);
             if (doset){
                 sourceNode.watch('absurlUpdating',function(){


### PR DESCRIPTION
### **User description**
… not if the attachment is an image. Closes #149


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes PDF viewer to open only PDF attachments.

- Adds logic to detect and exclude non-PDF file extensions.

- Implements error handling for URL parsing failures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>genro_widgets.js</strong><dd><code>Enhance PDF viewer logic to handle file types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrjs/gnr_d11/js/genro_widgets.js

<li>Added logic to check file extension before using PDF viewer.<br> <li> Excluded non-PDF file extensions from triggering the PDF viewer.<br> <li> Added error handling for URL parsing issues.<br> <li> Adjusted logic to ensure compatibility with existing functionality.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/150/files#diff-6f1709e2d6489f56cec2b2b93266173d949a648fcbf28b5c05c7ce9778ea2d32">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>