### PR TITLE
Improvements in attachmanager to correctly manage images.  #150

### DIFF
--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -989,25 +989,29 @@ dojo.declare("gnr.widgets.iframe", gnr.widgets.baseHtml, {
             }
             v = genro.addParamsToUrl(v,src_kwargs);   
                 if(sourceNode.attr.documentClasses){
-                    let useViewer = true;
-                    try {
-                    let parsed = parseURL(v);
+                    let useViewer = false;
                     let ext = '';
-                    if (parsed.file && parsed.file.includes('.')) {
-                        ext = parsed.file.split('.').pop().toLowerCase();
-                        console.log(ext)
-                    }
-                    let extList = (this._default_ext || '').toLowerCase().split(',').filter(e => e !== 'pdf');
-                    if (ext && extList.includes(ext)) {
-                        useViewer = false;
-                    }
-                    } catch(e) {
-                        useViewer = true;
-                    }
+                    genro.dom.removeClass(domnode,'emptyIframe');
+                    genro.dom.addClass(domnode,'waiting');
+                    try {
+                        let parsed = parseURL(v);
+                        if (parsed.file && parsed.file.includes('.')) {
+                            ext = parsed.file.split('.').pop().toLowerCase();
+                        }
+                    } catch(e) {}
     
-            if(useViewer){
-                v = genro.dom.detectPdfViewer(v,sourceNode.attr.jsPdfViewer);
-            }
+                    let extList = (this._default_ext || '').toLowerCase().split(',').filter(e => e !== 'pdf');
+                    useViewer = !ext || !extList.includes(ext);
+    
+                    if (useViewer) {
+                        v = genro.dom.detectPdfViewer(v, sourceNode.attr.jsPdfViewer);
+                    } else if (ext && ext.match(/^(jpe?g|png|gif)$/)) {
+                        domnode.removeAttribute('src');
+                        domnode.setAttribute('srcdoc', `<html><body style="margin:0;padding:0;display:flex;align-items:center;justify-content:center;background:#f9f9f9;">
+                            <img src="${v}" style="max-width:100%;display:block;cursor:zoom-in;" onclick="genro.openBrowserTab(this.src, {target:'_blank'})" />
+                        </body></html>`);
+                        return;
+                    }
                 }
             var doset = this.initContentHtml(domnode,v);
             if (doset){

--- a/resources/common/gnrcomponents/attachmanager/attachmanager.py
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.py
@@ -19,8 +19,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 
-import hashlib
-import os
+import hashlib, os
 
 from gnr.core.gnrdict import dictExtract
 from gnr.web.gnrbaseclasses import BaseComponent
@@ -37,6 +36,7 @@ class ViewAtcMobile(BaseComponent):
         r = struct.view().rows()
         r.fieldcell('fileurl',width='100%', 
                     template='<div class="atc_iframe_wrapper"><iframe src="#" width="100%" height="100%" class="atc_iframe_resizer" frameBorder="0"></iframe><div>')
+
 
 class ViewAtcMobileNoPreview(BaseComponent):
     def th_struct(self,struct):
@@ -126,6 +126,7 @@ class AttachGalleryView(AttachManagerViewBase):
             return dict(gallerycell='<div class="gallerybox"" ><div class="gallerybox_caption" >%s</div><img style="height:90px;max-width:100%%;" border=0 draggable="false" src="%s" /></div>' % (row['description'],url))
         selection.apply(apply_gallerycell)
 
+
 class Form(BaseComponent):
     
     def th_form(self, form):
@@ -151,8 +152,7 @@ class Form(BaseComponent):
                      onUploadingMethod=None,onUploadedMethod=None,**kwargs):
         sc = parent.stackContainer(**kwargs)
         bc = sc.borderContainer(title='!![en]Viewer')
-        bc.attachmentPreviewViewer(src='^.fileurl',selectedPage='^#FORM.viewerMode',region='center',overflow='hidden',
-                                   currentPreviewZoom='^#FORM.currentPreviewZoom')
+        bc.attachmentPreviewViewer(src='^.fileurl',selectedPage='^#FORM.viewerMode',region='center')
         da = sc.contentPane(title='!![en]Uploader').div(position='absolute',top='10px',left='10px',right='10px',bottom='10px',
             text_align='center',border='3px dotted #999',rounded=8)
         upload_message = '!!Drag here or double click to upload' if not self.isMobile else "!!Double click to upload"
@@ -183,6 +183,7 @@ class Form(BaseComponent):
         if newrecord:
             record['id'] = self.db.table(record.tablename).newPkeyValue()
 
+
 class FormPlaceholder(BaseComponent):
     py_requires = 'gnrcomponents/attachmanager/attachmanager:Form'
 
@@ -194,10 +195,10 @@ class FormPlaceholder(BaseComponent):
         fattr = form.attributes
         askMetadata = fattr.pop('askMetadata',None)
         self._atc_viewerStack(bc,region='center',askMetadata=askMetadata,
-                               attachment_table=fattr['table'],
-                            frameCode = fattr['frameCode'],
-                            onUploadingMethod=self.onUploadingAttachmentUpd,
-                            onUploadedMethod=self.onUploadedAttachment)
+                                attachment_table=fattr['table'],
+                                frameCode = fattr['frameCode'],
+                                onUploadingMethod=self.onUploadingAttachmentUpd,
+                                onUploadedMethod=self.onUploadedAttachment)
     
     def _atc_stackSwitcher(self,parent,sc):
         parent.dataController("sc.switchPage(fileurl?0:1)",fileurl='^#FORM.record.fileurl',sc=sc.js_widget)
@@ -208,7 +209,6 @@ class FormPlaceholder(BaseComponent):
 
  
 
-
 class ViewPalette(BaseComponent):
     def th_struct(self,struct):
         r = struct.view().rows()
@@ -218,32 +218,14 @@ class ViewPalette(BaseComponent):
     def th_view(self,view):
         view.top.popNode('bar')
 
+
 class FormPalette(Form):
     pass
+
 
 class UploaderViewerPane(BaseComponent):
     js_requires='gnrcomponents/attachmanager/attachmanager'
     css_requires = 'gnrcomponents/attachmanager/attachmanager'
-
-    @struct_method
-    def upv_viewerStack(self,parent,src=None,currentPreviewZoom=None,**kwargs):
-        sc = parent.stackContainer(**kwargs)
-        sc.contentPane(pageName='document').iframe(src=src,height='100%',
-                                  avoidCache=True,width='100%',border='0px',documentClasses=True)
-        sc.contentPane(pageName='image').img(src=src,zoom=currentPreviewZoom)
-        sc.contentPane(pageName='video').video(src=src,height='100%',width='100%',
-                                    border=0,controls=True)
-        parent.dataController("""
-        let ext = src.split("?")[0].split('.').pop()
-        SET .$ext = src.split("?")[0].split('.').pop();
-        if(['jpg','jpeg','png','svg','webp'].includes(ext)){
-            sc.switchPage(1);
-        }else if(['mp4','avi','mpg','mpeg'].includes(ext)){
-            sc.switchPage(2);
-        }else{
-            sc.switchPage(0);
-        }
-        """,src=src,_if='src',sc=sc.js_widget)
 
     @extract_kwargs(uploader=True)
     @struct_method
@@ -263,6 +245,7 @@ class UploaderViewerPane(BaseComponent):
                         _class='attachmentDropUploader',
                         **uploader_kwargs)
         bc.dataController("""sc.switchPage(fileurl?0:1)""",fileurl=fileurl,sc=sc.js_widget)
+
 
 class AttachManager(BaseComponent):
     py_requires = 'gnrcomponents/attachmanager/attachmanager:UploaderViewerPane'
@@ -320,22 +303,28 @@ class AttachManager(BaseComponent):
     @struct_method
     def at_attachmentPreviewViewer(self,parent,src=None,currentPreviewZoom=None,**kwargs):
         sc = parent.stackContainer(_virtual_column='fileurl',**kwargs)
-        sc.contentPane(pageName='document').iframe(src=src,height='100%',
+        sc.contentPane(pageName='document', overflow='hidden').iframe(src=src,height='100%',
                                     avoidCache=True,width='100%',border='0px',documentClasses=True)
-        sc.contentPane(pageName='image').img(src=src,zoom=currentPreviewZoom)
-        sc.contentPane(pageName='video').video(src=src,height='100%',width='100%',
+        zoom = f'zoom:{currentPreviewZoom}' if currentPreviewZoom else None
+        img_style = 'max-width:100%;display:block;cursor:zoom-in;' if not zoom else None
+        sc.contentPane(pageName='image').img(src=src, zoom=zoom, style=img_style,
+                                    onclick="genro.openBrowserTab(this.src, {target:'_blank'})")
+        sc.contentPane(pageName='video', overflow='hidden').video(src=src,height='100%',width='100%',
                                     border=0,controls=True)
-        parent.dataController("""
-        let ext = src.split("?")[0].split('.').pop()
-        SET .$ext = src.split("?")[0].split('.').pop();
-        if(['jpg','jpeg','png','svg','webp'].includes(ext)){
-            sc.switchPage(1);
-        }else if(['mp4','avi','mpg','mpeg'].includes(ext)){
-            sc.switchPage(2);
+        parent.dataController("""       
+        let cleanSrc = src.split("?")[0].split("#")[0];
+        let filename = cleanSrc.substring(cleanSrc.lastIndexOf('/') + 1);
+        let ext = filename.includes('.') ? filename.split('.').pop().toLowerCase() : '';
+        SET .$ext = ext;
+        if(IMAGES_EXT.includes(`.${ext}`)){
+            sc.switchPage('image');
+        }else if(VIDEOS_EXT.includes(`.${ext}`)){
+            sc.switchPage('video');
         }else{
-            sc.switchPage(0);
+            sc.switchPage('document');
         }
-        """,src=src,_if='src',sc=sc.js_widget)
+        """,src=src,_if='src',sc=sc.js_widget,
+            IMAGES_EXT=IMAGES_EXT, VIDEOS_EXT=VIDEOS_EXT)
 
     @extract_kwargs(default=True,vpane=True,fpane=True)
     @struct_method


### PR DESCRIPTION
### **User description**
Ref. #149 and #150, when attachment is not a pdf we have to show a different object to show attachments correctly.
In case of images, we set a max-width of 100% and if image is zoomed, we open it in a different tab. Not very elegant solution but it works, still available for further improvements


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved handling of non-PDF attachments in the viewer.

- Added support for displaying images with zoom functionality.

- Enhanced attachment preview logic for better type detection.

- Refactored and cleaned up redundant or unused code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>genro_widgets.js</strong><dd><code>Enhance attachment viewer logic for images and type detection</code></dd></summary>
<hr>

gnrjs/gnr_d11/js/genro_widgets.js

<li>Updated logic to detect and handle non-PDF attachments.<br> <li> Added support for displaying images with zoom and open-in-tab <br>functionality.<br> <li> Improved type detection for attachments based on file extensions.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/151/files#diff-6f1709e2d6489f56cec2b2b93266173d949a648fcbf28b5c05c7ce9778ea2d32">+20/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>attachmanager.py</strong><dd><code>Refactor and enhance attachment preview handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/common/gnrcomponents/attachmanager/attachmanager.py

<li>Refactored attachment preview logic for better type handling.<br> <li> Removed redundant code for viewer stack switching.<br> <li> Improved handling of image and video previews in the attachment <br>viewer.<br> <li> Added constants for image and video extensions for cleaner logic.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/151/files#diff-2db4ee538a6b8ae7f6eaefbc9a477550f9297f481dac9224fa596307b85258f6">+30/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>