### PR TITLE
closes #133

### DIFF
--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -466,6 +466,13 @@ class Server(object):
             os.environ["WERKZEUG_SERVER_FD"] = str(srv.fileno())
 
             if self.reloader:
+                
+                # werkzeug reloader expects sys.argv without
+                # spaces for the reloader on python3.8
+                if " " in sys.argv[0]:
+                    cmd_name = sys.argv.pop(0).split()
+                    sys.argv = cmd_name + sys.argv
+
                 run_with_reloader(
                     srv.serve_forever,
                     #extra_files=extra_files,


### PR DESCRIPTION
### **User description**
werkzeug autoreloader on python3.8 expects sys.argv[0] to be without spaces, which is the trick that it's used on GNR cli to implement subcommands.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed `gnr web serve` command issue on Python 3.8.

- Adjusted `sys.argv` handling to remove spaces for Werkzeug reloader.

- Ensured compatibility with Python 3.8's autoreloader expectations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serverwsgi.py</strong><dd><code>Adjust `sys.argv` handling for Werkzeug reloader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/gnr/web/serverwsgi.py

<li>Added logic to handle <code>sys.argv</code> without spaces for Python 3.8.<br> <li> Modified <code>serve</code> method to adjust <code>sys.argv</code> for Werkzeug reloader.<br> <li> Ensured compatibility with Python 3.8 autoreloader behavior.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/152/files#diff-d3c2c6d4e7122bf9ec5cc68b4285db0e75248972f25f4f2ea141b7c568dd8735">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>