### PR TITLE
Fixes #112, fixes #99

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmigration.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration.py
@@ -707,6 +707,7 @@ class SqlMigrator():
         sqltablename = self.tableSqlName(item)
         substatements = []
         if not item['columns']:
+            #without columns avoid table creation
             return
         for col in item['columns'].values():
             substatements.append(self.columnSql(col).strip())

--- a/gnrpy/gnr/sql/gnrsqlmigration.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration.py
@@ -633,7 +633,7 @@ class SqlMigrator():
             handler(**kw)
 
     def missing_handler_cb(self,**kwargs):
-        raise NotImplementedError
+        return f'missing {kwargs}'
  
     def prepareStructures(self):
         self.application_schemas = self.db.getApplicationSchemas()

--- a/gnrpy/gnr/sql/gnrsqlmigration.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration.py
@@ -629,9 +629,11 @@ class SqlMigrator():
             item = kw['item']
             if item.get('schema_name') in self.readOnly_schemas:
                 continue
-            handler = getattr(self, f'{evt}_{kw["entity"]}' ,'missing_handler')
+            handler = getattr(self, f'{evt}_{kw["entity"]}' ,self.missing_handler_cb)
             handler(**kw)
 
+    def missing_handler_cb(self,**kwargs):
+        raise NotImplementedError
  
     def prepareStructures(self):
         self.application_schemas = self.db.getApplicationSchemas()
@@ -704,6 +706,8 @@ class SqlMigrator():
     def added_table(self, item=None,**kwargs):
         sqltablename = self.tableSqlName(item)
         substatements = []
+        if not item['columns']:
+            return
         for col in item['columns'].values():
             substatements.append(self.columnSql(col).strip())
         if item["attributes"]["pkeys"]:
@@ -853,19 +857,7 @@ class SqlMigrator():
         elif changed_attribute == 'unique':
             # Handle changes to the UNIQUE constraint
             if newvalue:
-                columns = [column_name]
-                constraint_name = hashed_name(schema=item['schema_name'],table=item['table_name'],columns=columns,obj_type='cst')
-                sql = self.db.adapter.struct_constraint_sql(
-                    constraint_type='UNIQUE',
-                    constraint_name=constraint_name,
-                    columns=columns,
-                    schema_name=item['schema_name'],
-                    table_name=item['table_name']
-                )
-                constraints_dict = table_dict['constraints']
-                constraints_dict[constraint_name] = {
-                    "command": f'ADD {sql}'
-                }
+                self.addColumnUniqueConstraint(item)
             else:
                 columns = [column_name]
                 constraints_dict = table_dict['constraints']
@@ -878,6 +870,22 @@ class SqlMigrator():
                 constraints_dict[constraint_name] = {"command":sql}
         elif changed_attribute in ('generated_expression','extra_sql'):
             return
+
+    def addColumnUniqueConstraint(self,col):
+        table_dict = self.schema_tables(col['schema_name'])[col['table_name']]
+        columns = [col['entity_name']]
+        constraint_name = hashed_name(schema=col['schema_name'],table=col['table_name'],columns=columns,obj_type='cst')
+        sql = self.db.adapter.struct_constraint_sql(
+            constraint_type='UNIQUE',
+            constraint_name=constraint_name,
+            columns=columns,
+            schema_name=col['schema_name'],
+            table_name=col['table_name']
+        )
+        constraints_dict = table_dict['constraints']
+        constraints_dict[constraint_name] = {
+            "command": f'ADD {sql}'
+        }
 
     def changed_index(self, item=None,changed_attribute=None,oldvalue=None,newvalue=None, **kwargs):
         """
@@ -986,10 +994,11 @@ class SqlMigrator():
     def columnSql(self, col):
         """Return the statement string for creating a table's column"""
         colattr = col['attributes']
+        if colattr.get('unique'):
+            self.addColumnUniqueConstraint(col)
         return self.db.adapter.columnSqlDefinition(col['entity_name'],
                                                    dtype=colattr['dtype'], size=colattr.get('size'),
                                                    notnull=colattr.get('notnull', False),
-                                                    unique=colattr.get('unique'),
                                                     default=colattr.get('sqldefault'),
                                                     extra_sql=colattr.get('extra_sql'),
                                                     generated_expression=colattr.get('generated_expression'))
@@ -1101,6 +1110,7 @@ class SqlMigrator():
         if build_commands:
             # FIXME: why the manager is not used in this case?
             self.db.adapter.execute(build_commands,autoCommit=True)
+        
 
 
     #jsonorm = OrmExtractor(GnrApp('dbsetup_tester').db).get_json_struct()

--- a/gnrpy/tests/sql/test_gnrsqlmigration.py
+++ b/gnrpy/tests/sql/test_gnrsqlmigration.py
@@ -69,8 +69,9 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
         self.db.startup()
         self.migrator.prepareMigrationCommands()
         if apply_only:
+            changes = self.migrator.getChanges()
             self.migrator.applyChanges()
-            return
+            return changes
         if expected_value == '?':
             expected_changes = self.migrator.getChanges()
             print('Expected value:', expected_changes)
@@ -147,6 +148,16 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
         check_value = 'CREATE TABLE "alfa"."alfa_restaurant"(\n "id" serial8 NOT NULL,\n "name" character varying(45),\n "country" character(2),\n "vat_number" character varying(30),\n PRIMARY KEY (id),\n CONSTRAINT "cst_703bf76b" UNIQUE ("country", "vat_number")\n);'
         self.checkChanges(check_value)
 
+
+    def test_04d_add_unique_column(self):
+        """Tests adding a new column to an existing table."""
+        pkg = self.src.package('alfa')
+        tbl = pkg.table('recipe')
+        tbl.column('testuniquecol',unique=True,size=':10')
+        check_value = 'ALTER TABLE "alfa"."alfa_recipe"\nADD COLUMN "testuniquecol" character varying(10);\nALTER TABLE "alfa"."alfa_recipe"\nADD CONSTRAINT "cst_f797d32c" UNIQUE ("testuniquecol");'
+        self.checkChanges(check_value)
+
+
     def test_05a_create_table_withpkey(self):
         """Tests creating a table with a primary key column."""
         pkg = self.src.package('alfa')
@@ -174,13 +185,23 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
         check_value = 'CREATE TABLE "alfa"."alfa_recipe_row" ("recipe_code" character varying(12) NOT NULL , "recipe_line" bigint NOT NULL , "description" text , "ingredient_id" bigint , PRIMARY KEY (recipe_code,recipe_line));'
         self.checkChanges(check_value)
 
-    def test_05a_create_table_with_pkey_explicit_unique(self):
+    def test_05d_create_table_with_pkey_explicit_unique(self):
         """Tests creating a table with a primary key column."""
         pkg = self.src.package('alfa')
         tbl = pkg.table('company', pkey='code')
         tbl.column('code', size=':30',unique=True)
         tbl.column('description')
         check_value = 'CREATE TABLE "alfa"."alfa_company"(\n "code" character varying(30) NOT NULL,\n "description" text,\n PRIMARY KEY (code)\n);'
+        self.checkChanges(check_value)
+
+    def test_05e_create_table_with_pkey_and_unique_col(self):
+        """Tests creating a table with a primary key column."""
+        pkg = self.src.package('alfa')
+        tbl = pkg.table('test_table_with_uniquecol', pkey='code')
+        tbl.column('code', size=':30',unique=True)
+        tbl.column('description')
+        tbl.column('uniquecol',unique=True,size='10')
+        check_value = 'CREATE TABLE "alfa"."alfa_test_table_with_uniquecol"(\n "code" character varying(30) NOT NULL,\n "description" text,\n "uniquecol" character(10),\n PRIMARY KEY (code)\n);\nALTER TABLE "alfa"."alfa_test_table_with_uniquecol"\nADD CONSTRAINT "cst_9bbd2120" UNIQUE ("uniquecol");'
         self.checkChanges(check_value)
 
     def test_06_prepare_table(self):
@@ -308,7 +329,7 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
     def test_08c_modify_column_remove_unique(self):
         pkg = self.src.package('alfa')
         tbl = pkg.table('author')
-        tbl.column('tax_code',unique=False)
+        tbl.column('tax_code').attributes.pop('unique')
         check_value = 'ALTER TABLE "alfa"."alfa_author"\nDROP CONSTRAINT IF EXISTS "cst_99206169";'
         self.checkChanges(check_value)  
 
@@ -324,6 +345,17 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
         pkg.table('author')['columns'].pop('foo')
         check_value = 'ALTER TABLE "alfa"."alfa_author" \n DROP COLUMN "foo";'
         self.checkChanges(check_value)
+
+
+    def test_10a_empty_table_creation(self):
+        pkg = self.src.package('alfa')
+        tbl = pkg.table('my_empty_table')
+        self.checkChanges(apply_only=True)
+        tbl.attributes.update(pkey='id')
+        tbl.column('id',size='22')
+        self.checkChanges('CREATE TABLE "alfa"."alfa_my_empty_table"(\n "id" character(22) NOT NULL,\n PRIMARY KEY (id)\n);')
+
+
 
     #def test_09b_remove_relation(self):
     #    pkg = self.src.package('alfa')
@@ -353,6 +385,7 @@ class TestGnrSqlMigration_postgres(BaseGnrSqlMigration):
             password=cls.pg_conf.get("password")
         )
 
+ 
 @pytest.mark.skipif(gnrpostgres3.SqlDbAdapter.not_capable(Capabilities.MIGRATIONS),
                     reason="Adapter doesn't support migrations")
 class TestGnrSqlMigration_postgres3(BaseGnrSqlMigration):
@@ -419,3 +452,11 @@ class ToDo:
         tbl.drop_constraint('unique_code')
         check_value = 'ALTER TABLE "alfa"."alfa_recipe" DROP CONSTRAINT unique_code;'
         self.checkChanges(check_value)
+
+
+
+    def test_10b_change_pkey(self):
+        """Not implemented feature"""
+        pass
+
+


### PR DESCRIPTION
### **User description**
column unique constraint is no longer declared with inline syntax in order to set it with an identifier


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed handling of unique constraints with a dedicated method.

- Added new tests for unique constraints and empty table creation.

- Improved error handling for missing handlers in migration commands.

- Enhanced logic to skip processing empty column lists in table creation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gnrsqlmigration.py</strong><dd><code>Refactor unique constraint handling and error management</code>&nbsp; </dd></summary>
<hr>

gnrpy/gnr/sql/gnrsqlmigration.py

<li>Replaced inline unique constraint handling with a dedicated method.<br> <li> Added <code>missing_handler_cb</code> for better error handling.<br> <li> Skipped processing empty column lists in table creation.<br> <li> Refactored unique constraint logic into <code>addColumnUniqueConstraint</code>.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/153/files#diff-1da6c903993af7f57379ed4d95e4284644a2330c0c855a072b76208114b71ef9">+25/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gnrsqlmigration.py</strong><dd><code>Add tests for unique constraints and table creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/tests/sql/test_gnrsqlmigration.py

<li>Added tests for unique constraints on columns and composite columns.<br> <li> Introduced test for empty table creation.<br> <li> Enhanced test coverage for modifying and dropping unique constraints.<br> <li> Added placeholder test for changing primary keys.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/153/files#diff-4e5fac1b8a40a842c0f252b0e7d27f06d559dd125f0a8310b1bc168f0b176edb">+44/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>