### PR TITLE
added "--inspect" option  to 'gnr db migrate', which generates a zip …

### DIFF
--- a/gnrpy/gnr/db/cli/gnrmigrate.py
+++ b/gnrpy/gnr/db/cli/gnrmigrate.py
@@ -130,8 +130,11 @@ def inspect(migrator, options):
         for filename in dump_files:
             zipf.write(filename)
             logger.info("Added %s to inspection archive", filename)
-            os.remove(filename)
-            logger.debug("Removed temp file %s", filename)
+
+    # Remove temporary files after successful zip creation
+    for filename in dump_files:
+        os.remove(filename)
+        logger.debug("Removed temp file %s", filename)
     print(f"Inspection archive {zip_name} created.")
     
 def check_db(migrator, options):

--- a/gnrpy/gnr/db/cli/gnrmigrate.py
+++ b/gnrpy/gnr/db/cli/gnrmigrate.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+import datetime
 import sys
 import os
 import glob
+import zipfile
+import json
 
 from gnr.db import logger
 from gnr.core.gnrsys import expandpath
 from gnr.core.gnrconfig import getGnrConfig
 from gnr.core.cli import GnrCliArgParse
+from gnr.core.gnrbag import Bag
 from gnr.app.gnrapp import GnrApp
 from gnr.sql.gnrsqlmigration import SqlMigrator
 from gnr.sql import AdapterCapabilities
@@ -94,6 +98,42 @@ def get_app(options):
     return GnrApp(os.getcwd()), storename
 
 
+def inspect(migrator, options):
+    # dump the information from the migrator, and generates a zip file
+    # useful for inspection/debug
+    logger.info("Creating migration inspection archive")
+    now = datetime.datetime.now().strftime("%Y%m%d%H%M")
+    dump_files = []
+    
+    to_dump = [
+        ("db_struct", migrator.sqlStructure),
+        ("orm_struct", migrator.ormStructure),
+        ("changes", migrator.getChanges)
+    ]
+
+    for dump_item in to_dump:
+        filename = f"{options.instance}_{dump_item[0]}_{now}.json"
+        with open(filename, "w") as wfp:
+            if callable(dump_item[1]):
+                wfp.write(json.dumps(dump_item[1]()))
+            else:
+                wfp.write(json.dumps(dump_item[1]))
+        dump_files.append(filename)
+    orig_db_dump = f"{options.instance}_cur_db_struct_{now}"
+    dump_files.append(migrator.db.dump(orig_db_dump,
+                                       options=Bag(plain_text=True,
+                                                   schema_only=True)
+                                       )
+                      )
+    zip_name = f"{options.instance}_migrate_inspection_{now}.zip"
+    with zipfile.ZipFile(zip_name, "w") as zipf:
+        for filename in dump_files:
+            zipf.write(filename)
+            logger.info("Added %s to inspection archive", filename)
+            os.remove(filename)
+            logger.debug("Removed temp file %s", filename)
+    print(f"Inspection archive {zip_name} created.")
+    
 def check_db(migrator, options):
     dbname = migrator.db.currentEnv.get('storename')
     dbname = dbname or 'Main'
@@ -151,6 +191,10 @@ def main():
                         dest='remove_relations_only',
                         action='store_true',
                         help="Remove relations")
+    parser.add_argument('--inspect',
+                        dest='inspect',
+                        action='store_true',
+                        help='Create a dump file with configuration for inspection')
     
     parser.add_argument('-i', '--instance',
                         dest='instance',
@@ -206,6 +250,9 @@ def main():
             check_db(migrator, options)
         elif options.import_file:
             import_db(options.import_file, options)
+        elif options.inspect:
+
+            inspect(migrator, options)
         else:
             changes = check_db(migrator, options)
             if changes:


### PR DESCRIPTION
### **User description**
…file

contaning:
* the dump of the current sql schema structure
* dump of the current db structure in JSON format
* dump of the ORM structure in JSON format
* a list of changes that the migrator wants to apply, in SQL format

The rationale is to provide users a simple tool to create a dump of all the useful informations needed to debug the new migrate tool, like attaching the zip file to a ticket.


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new `--inspect` option to the `gnr db migrate` CLI.

- Generates a zip file containing database and ORM structure dumps.

- Includes a list of migration changes for debugging purposes.

- Automatically removes temporary files after creating the zip archive.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gnrmigrate.py</strong><dd><code>Add inspection and debugging support to migration CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/gnr/db/cli/gnrmigrate.py

<li>Introduced <code>--inspect</code> CLI option for migration inspection.<br> <li> Added functionality to dump database and ORM structures to JSON.<br> <li> Created a zip archive containing inspection-related files.<br> <li> Implemented temporary file cleanup after zip creation.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/156/files#diff-58dddd5d56a8b28f1393656c5d17e79de0568cf4c83e0c8368f8ede180ee24c6">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>