### PR TITLE
Feature/checking bug 77

### DIFF
--- a/gnrpy/gnr/sql/adapters/gnrpostgres.py
+++ b/gnrpy/gnr/sql/adapters/gnrpostgres.py
@@ -50,9 +50,6 @@ RE_SQL_PARAMS = re.compile(r":(\S\w*)(\W|$)")
 
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 
-import re
-
-import re
 
 class TsVectorCompiler:
     # Regex patterns for each macro with improved support for quoted identifiers

--- a/gnrpy/tests/sql/test_gnrsqlmigration.py
+++ b/gnrpy/tests/sql/test_gnrsqlmigration.py
@@ -311,6 +311,19 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
         check_value = 'ALTER TABLE "alfa"."alfa_ingredient" \n ALTER COLUMN "description" TYPE character varying(50);'
         self.checkChanges(check_value)
 
+
+    def test_08e_modify_column_from_text_to_bytea(self):
+        """Tests modifying the data type of an existing column."""
+        pkg = self.src.package('alfa')
+        tbl = pkg.table('ingredient')
+        foo_varchar = tbl.column('foo_varchar', size=':50')
+        self.checkChanges(apply_only=True)
+        foo_varchar.attributes['dtype'] = 'O'
+        foo_varchar.attributes.pop('size')
+        self.checkChanges('ALTER TABLE "alfa"."alfa_ingredient"\nDROP COLUMN "foo_varchar",\nADD COLUMN "foo_varchar" bytea;')
+
+
+
     def test_08b_modify_column_type(self):
         pkg = self.src.package('alfa')
         tbl = pkg.table('recipe_row_alternative')

--- a/gnrpy/tests/web/utils.py
+++ b/gnrpy/tests/web/utils.py
@@ -91,7 +91,7 @@ class ExternalProcess:
             stderr=subprocess.PIPE,
             preexec_fn=os.setsid
         )
-        time.sleep(0.5)  # Adjust if your process needs more time
+        time.sleep(2)  # Adjust if your process needs more time
 
     def stop(self):
         if self.process:


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Added a new test for modifying column type to `bytea`.

- Removed redundant imports in `gnrpostgres.py`.

- Improved test coverage for SQL migration scenarios.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gnrpostgres.py</strong><dd><code>Removed redundant imports in `gnrpostgres.py`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/gnr/sql/adapters/gnrpostgres.py

<li>Removed redundant <code>re</code> imports.<br> <li> Simplified import structure for better readability.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/157/files#diff-e083180674c0849d2d8696b738fbdb804f1c368340328293097c752bfc6d1860">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gnrsqlmigration.py</strong><dd><code>Added test for modifying column type to `bytea`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/tests/sql/test_gnrsqlmigration.py

<li>Added a new test <code>test_08e_modify_column_from_text_to_bytea</code>.<br> <li> Enhanced test coverage for column type modification scenarios.<br> <li> Verified behavior for altering column type to <code>bytea</code>.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/157/files#diff-4e5fac1b8a40a842c0f252b0e7d27f06d559dd125f0a8310b1bc168f0b176edb">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>