### PR TITLE
titleCounter supports dict syntax

### DIFF
--- a/gnrpy/gnr/web/gnrmenu.py
+++ b/gnrpy/gnr/web/gnrmenu.py
@@ -310,10 +310,20 @@ class MenuResolver(BagResolver):
             except NotAllowedException:
                 continue
             self.setLabelClass(attributes)
-            if attributes.get('titleCounter') and menuTag!='tableBranch':
-                self._page.subscribeTable(attributes['table'],True,subscribeMode=True)
-                attributes['titleCounter_count'] = self._page.app.getRecordCount(table=attributes['table'],
-                                                                                 where=attributes.get('titleCounter_condition'))
+            titleCounter_val = attributes.get('titleCounter')
+            if titleCounter_val and menuTag != 'tableBranch':
+                titleCounter_attrs = {}
+                if isinstance(titleCounter_val, dict):
+                    titleCounter_attrs.update(titleCounter_val)
+                table = attributes.get('table') or titleCounter_attrs.get('table')
+                if not table:
+                    continue
+                self._page.subscribeTable(table, True, subscribeMode=True)
+                attributes['titleCounter_count'] = self._page.app.getRecordCount(
+                    table=table,
+                    where=attributes.get('titleCounter_condition'),
+                    **titleCounter_attrs
+                )
             result.setItem(node.label, value, attributes)
         return result
 


### PR DESCRIPTION
### **User description**
`titleCounter` supports dict of parameters to be passed to the getRecordCount method. 
This allows to specify `condition_kwargs` or other parameters (e.g. `subtable`), which previously were ignored.

Former syntax example:
`titleCounter=True,  titleCounter_condition='$da_valutare IS TRUE'`

New syntax example:
`titleCounter=dict(condition='$documento_da_approvare IS TRUE', subtable='*')`

Former compatibility is kept the same.


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for `titleCounter` to accept dictionary syntax.

- Enhanced flexibility by allowing additional parameters like `subtable`.

- Maintained backward compatibility with the previous syntax.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gnrmenu.py</strong><dd><code>Enhanced `titleCounter` to support dictionary syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/gnr/web/gnrmenu.py

<li>Modified <code>titleCounter</code> logic to accept dictionary syntax.<br> <li> Added handling for additional parameters like <code>subtable</code>.<br> <li> Ensured backward compatibility with the previous implementation.<br> <li> Improved error handling for missing <code>table</code> attribute.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/158/files#diff-268a54c5de4b8940bb8da13e0e3441b6348e4a1dd69cb02608d03ee580017978">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>