### PR TITLE
Avoid StopIteration error when importing empty sheets. Closes #176

### DIFF
--- a/gnrpy/gnr/core/gnrlist.py
+++ b/gnrpy/gnr/core/gnrlist.py
@@ -283,8 +283,11 @@ class XlsReader(object):
     def addSheet(self,sheetname):
         sheet = self.book.sheet_by_name(sheetname)
         linegen = self._sheetlines(sheet)
-        firstline = next(linegen)
-        headers = [slugify(firstline[c],sep='_') for c in range(sheet.ncols)]
+        try:
+            firstline = next(linegen)
+        except StopIteration:
+            firstline = []
+        headers = [slugify(firstline[c], sep='_') for c in range(sheet.ncols)] if firstline else []
         colindex = dict([(i,True)for i,h in enumerate(headers) if h])
         headers = [h for h in headers if h]
         index = dict()
@@ -299,7 +302,7 @@ class XlsReader(object):
                                    'colindex':colindex,
                                    'index':index,
                                     'ncols':len(headers),
-                                    'nrows':sheet.nrows - 1,
+                                    'nrows': max(sheet.nrows - 1, 0),
                                     'errors':errors,
                                     'linegen':linegen}
 

--- a/gnrpy/gnr/core/gnrlist.py
+++ b/gnrpy/gnr/core/gnrlist.py
@@ -287,7 +287,7 @@ class XlsReader(object):
             firstline = next(linegen)
         except StopIteration:
             firstline = []
-        headers = [slugify(firstline[c], sep='_') for c in range(sheet.ncols)] if firstline else []
+        headers = [slugify(firstline[c], sep='_') for c in range(min(len(firstline), sheet.ncols))] if firstline else []
         colindex = dict([(i,True)for i,h in enumerate(headers) if h])
         headers = [h for h in headers if h]
         index = dict()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Prevents StopIteration error when importing Excel files with empty sheets

- Skips header and row processing for empty sheets

- Ensures row count is non-negative for all sheets


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gnrlist.py</strong><dd><code>Handle empty Excel sheets gracefully during import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/gnr/core/gnrlist.py

<li>Wrapped header extraction in try/except to catch StopIteration<br> <li> Sets headers to empty if sheet is empty<br> <li> Ensures nrows is never negative by using max(sheet.nrows - 1, 0)<br> <li> Prevents processing of empty sheets, avoiding import errors


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/177/files#diff-1b614ac013cc034108dd6a85eb16eedd9cb475186751927b0e997ff30ee644f4">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>