### PR TITLE
175 pypdf deprecation pymupdf adoption

### DIFF
--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
 	     "paste",
 	     "psutil",
 	     "pymupdf",
-	     "PyPDF2",
 	     "pypdftk",
 	     "pyro4",
 	     "python-dateutil",

--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 	     "paramiko", # gnr.core.gnrssh
 	     "paste",
 	     "psutil",
+	     "pymupdf",
 	     "pyro4",
 	     "python-dateutil",
 	     "pytz",

--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 	     "paste",
 	     "psutil",
 	     "pymupdf",
+	     "pypdftk",
 	     "pyro4",
 	     "python-dateutil",
 	     "pytz",

--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 	     "paste",
 	     "psutil",
 	     "pymupdf",
+	     "PyPDF2",
 	     "pypdftk",
 	     "pyro4",
 	     "python-dateutil",

--- a/projects/gnrcore/packages/sys/requirements.txt
+++ b/projects/gnrcore/packages/sys/requirements.txt
@@ -1,6 +1,3 @@
-requests
-PyPDF2
 pdf2image
 watchdog
-redbaron
-WebOb
+

--- a/resources/common/services/pdf/pypdf.py
+++ b/resources/common/services/pdf/pypdf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from io import BytesIO
+import warnings
 
 from gnr.lib.services.pdf import PdfService
 from gnr.core.gnrdecorator import extract_kwargs
@@ -27,12 +28,14 @@ class Service(PdfService):
         :param pdf_list: TODO
         :param output_filepath: TODO"""
         
-        if HAS_PYPDF:
-            return self.joinPdf_PYPDF(pdf_list, output_filepath)
-        
         if HAS_FITZ:
             return self.joinPdf_FITZ(pdf_list, output_filepath)
-        raise self.parent.exception('Missing pyPdf in this installation')
+
+        if HAS_PYPDF:
+            warnings.warn("PyPDF is deprecated, please update your codebase")
+            return self.joinPdf_PYPDF(pdf_list, output_filepath)
+        
+        raise self.parent.exception('Missing pdf library in this installation')
     
     def joinPdf_PYPDF(self,pdf_list, output_filepath):
         output_pdf = PdfWriter()

--- a/resources/common/services/pdfform/pdftk/service.py
+++ b/resources/common/services/pdfform/pdftk/service.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env pythonw
 # -*- coding: utf-8 -*-
 
-
+import pypdftk
 from gnr.lib.services.pdfform import PdfFormService
-try:
-    import pypdftk
-except:
-    from gnr.core.gnrlang import GnrException
-    raise GnrException('Missing pypdftk library. Please install it or disable pdf forms in preferences')
 
 class Service(PdfFormService):
 

--- a/resources/common/services/pdfform/pdftk/service.py
+++ b/resources/common/services/pdfform/pdftk/service.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env pythonw
 # -*- coding: utf-8 -*-
+import shutil
 
 import pypdftk
+
+from gnr.core.gnrlang import GnrException
 from gnr.lib.services.pdfform import PdfFormService
+
+if shutil.which(pypdftk.PDFTK_PATH) is None:
+    raise GnrException('Missing pypdftk library. Please install it or disable pdf forms in preferences')
+
 
 class Service(PdfFormService):
 

--- a/resources/common/services/pdfform/pdftk/service.py
+++ b/resources/common/services/pdfform/pdftk/service.py
@@ -8,7 +8,7 @@ from gnr.core.gnrlang import GnrException
 from gnr.lib.services.pdfform import PdfFormService
 
 if shutil.which(pypdftk.PDFTK_PATH) is None:
-    raise GnrException('Missing pypdftk library. Please install it or disable pdf forms in preferences')
+    raise GnrException('Missing pdftk tool, see http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/  - Please install it or disable pdf forms in preferences')
 
 
 class Service(PdfFormService):


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Adopted `pymupdf` as the preferred PDF library, deprecating `pypdf`.
  - Added `pymupdf` to framework dependencies.
  - Updated PDF joining logic to use `pymupdf` if available.
  - Issued deprecation warnings when `pypdf` is used.

- Improved error handling and dependency checks for PDF form services.
  - Added `pypdftk` as a dependency and checked for its executable.
  - Enhanced error messages with installation guidance.

- Cleaned up and updated dependency lists.
  - Removed `PyPDF2` from sys package requirements.
  - Added `pypdftk` to framework dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pypdf.py</strong><dd><code>Prefer pymupdf over pypdf and add deprecation warning</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/common/services/pdf/pypdf.py

<li>Prioritized <code>pymupdf</code> (<code>fitz</code>) for PDF joining if available.<br> <li> Issued deprecation warning when using <code>pypdf</code>.<br> <li> Improved error message for missing PDF libraries.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/181/files#diff-b39053b9ba1dea9da323cb0bf59f12eb9ada376ed98a0b3d00c645f474aaf629">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Require pypdftk and check for pdftk tool presence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/common/services/pdfform/pdftk/service.py

<li>Added <code>pypdftk</code> import as a required dependency.<br> <li> Checked for the presence of the <code>pdftk</code> executable.<br> <li> Improved error message with installation tips.<br> <li> Removed runtime import check for <code>pypdftk</code>.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/181/files#diff-8e2032abc3978a86bf7248af708c87ba9d4b7f1e078e73c7d184410386d7e4a3">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add pymupdf and pypdftk to framework dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/pyproject.toml

- Added `pymupdf` and `pypdftk` to framework dependencies.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/181/files#diff-d762847663d5e2a81034875a1f6b4db37b0155f5209b02c0eb8e1d8db0596b99">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Remove PyPDF2 and redundant dependencies from sys requirements</code></dd></summary>
<hr>

projects/gnrcore/packages/sys/requirements.txt

<li>Removed <code>PyPDF2</code> and other duplicate dependencies from sys requirements.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/181/files#diff-98e6b309daa182302e1bb4182733ce352b566d08ab7e2c379333b11531305d55">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>