### PR TITLE
fix creazione indice: alcuni nomi sono riservati e vanno virgolettati

### DIFF
--- a/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
@@ -743,9 +743,9 @@ class PostgresSqlDbBaseAdapter(SqlDbBaseAdapter):
         column_defs = []
         for column, order in columns.items():
             if order:
-                column_defs.append(f"{column} {order}")
+                column_defs.append(f'"{column}" {order}')
             else:
-                column_defs.append(f"{column}")  # Default sorting if not specified
+                column_defs.append(f'"{column}"')  # Default sorting if not specified
 
         # Join columns into a single string
         column_list = ", ".join(column_defs)


### PR DESCRIPTION
### **User description**
Alcuni nomi sono parole riservate di Postgres e non possono essere utilizzati "in chiaro".
Questo fix risolve la creazione degli indici su campi come "user", e altri (non li testati tutti: a memoria c'è "desc", forse "timestamp").

Esempio senza fix con indexed=True sul campo "user": la db migrate prova a generare l'indice utilizzando il nome senza virgolette
```
  CREATE INDEX idx_28ed0b1e ON "fatt"."fatt_fattura" USING btree (user);

  
  File "/home/eolo/venvs/gnr3/bin/gnr", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/eolo/frigel/genropy3/gnrpy/gnr/core/cli/gnr.py", line 215, in main
    cmd.run()
    ~~~~~~~^^
  File "/home/eolo/frigel/genropy3/gnrpy/gnr/core/cli/gnr.py", line 203, in run
    cmd_module.main()
    ~~~~~~~~~~~~~~~^^
  File "/home/eolo/frigel/genropy3/gnrpy/gnr/db/cli/gnrmigrate.py", line 263, in main
    migrator.applyChanges()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/eolo/frigel/genropy3/gnrpy/gnr/sql/gnrsqlmigration.py", line 1120, in applyChanges
    self.db.adapter.execute(build_commands,autoCommit=True)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eolo/frigel/genropy3/gnrpy/gnr/sql/adapters/_gnrbaseadapter.py", line 651, in execute
    cursor.execute(sql,sqlargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/eolo/frigel/genropy3/gnrpy/gnr/sql/adapters/gnrpostgres.py", line 401, in execute
    return super(GnrDictCursor, self).execute(query, vars)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
psycopg2.errors.InvalidObjectDefinition: functions in index expression must be marked IMMUTABLE
```


Con il fix funziona tutto:
```
CREATE INDEX idx_28ed0b1e ON "fatt"."fatt_fattura" USING btree ("user");
```

Testato solo su Postgresql


___

### **PR Type**
Bug fix


___

### **Description**
- Fix quoting of column names in index creation SQL

- Prevent errors with reserved Postgres keywords as column names


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_gnrbasepostgresadapter.py</strong><dd><code>Quote column names in index creation SQL statements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py

<li>Add double quotes around column names in index creation SQL<br> <li> Ensure columns with reserved names (e.g., "user") are handled <br>correctly<br> <li> Prevent SQL errors during index creation on reserved keywords


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/185/files#diff-797257b16d5883fcff9f539388b550c42387d86e0e9a8326a717142ea4702a4d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>