### PR TITLE
l'rpc non parte; _onStart risolve

### DIFF
--- a/resources/common/th/th_tree.py
+++ b/resources/common/th/th_tree.py
@@ -99,7 +99,7 @@ class HTableTree(BaseComponent):
                         childname='store',caption=caption,dbstore=dbstore,
                         columns=columns,related_kwargs=related_kwargs,
                         nodeId=nodeId,
-                        subtable=subtable,resolved=resolved,**storekw)
+                        subtable=subtable,resolved=resolved,_onStart=True,**storekw)
             treeNode._hstore = d
             d.addCallback("""
                 var selectedIdentifier;


### PR DESCRIPTION
### **User description**
La vista principale di una tabella gerarchica deve poter essere filtrata tramite l'opzione tree_condition ma, in sua presenza, l'if che la gestisce (riga 88) rende al client un dataRpc che non viene mai lanciato.

Dovrebbe chiamare tblobj.getHierarchicalData per generare l'albero (almeno il nodo corrente) ma a video non appare nulla.

Ho provato a aggiungere _onStart=True , come da diff, e tutto ha preso a funzionare: il dataRpc viene chiamato e genera l'abero ANCHE in presenza di tree_condition

Non so se sia la soluzione migliore.

PS: altro discorso è la fruibilità della tree_condition . Nella query che viene generata in "getConditionPkeys" c'è anche "AND $child_count=0", quindi la condition viene applicata solo i nodi finali, gli altri vengono esclusi. Ad esempio: filtrare per descrizione=PIPPO fa apparire le foglie che si chiamano PIPPO ma quando viene aggiunto un sotto-nodo con nome PLUTO quest'ultimo non appare, manche il padre che si chiama PIPPO scompare! 
Probabilmente filtrare sui campi hierarchical_xx può funzionare secondo le attese


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes hierarchical table view not loading with tree_condition set

- Ensures dataRpc is triggered by adding _onStart=True

- Resolves issue where hierarchical data was not displayed


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>th_tree.py</strong><dd><code>Enable dataRpc on start for hierarchical table view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/common/th/th_tree.py

<li>Adds _onStart=True to dataRpc call for hierarchical table view<br> <li> Ensures dataRpc is executed even when tree_condition is present


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/186/files#diff-e92e81083eef434561f36b6a4189e3b498f57a5776ff0b8afb29fa44cfaf1876">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>