### PR TITLE
Support for singleFile, expanded delay

### DIFF
--- a/resources/common/gnrcomponents/attachmanager/attachmanager.py
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.py
@@ -540,6 +540,7 @@ class AttachManager(BaseComponent):
                 connect_onClose='FIRE .saveDescription;',
             ).div(padding='10px').formbuilder(cols=1,border_spacing='3px')
         fb.textbox(value='^.form.record.external_url',lbl='!!External url')
+        # FIXME: the delay has a an arbitrary value
         frame.dataController("""
             if(parentForm && frm.getParentForm().isNewRecord()){
                 frame.setHiderLayer(true,{message:newrecordmessage,background_color:'white'});

--- a/resources/common/gnrcomponents/attachmanager/attachmanager.py
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.py
@@ -497,7 +497,7 @@ class AttachManager(BaseComponent):
 
     @struct_method
     def at_attachmentMultiButtonFrame(self,pane,datapath='.attachments',formResource=None,parentForm=True,ask=None,
-                                      toolbarPosition=None,itemsMaxWidth=None,**kwargs):   
+                                      toolbarPosition=None,itemsMaxWidth=None,singleFile=False,**kwargs):   
         toolbarPosition = toolbarPosition or 'top'
         frame = pane.multiButtonForm(frameCode='attachmentPane_#',datapath=datapath,
                             relation='@atc_attachments',
@@ -515,7 +515,8 @@ class AttachManager(BaseComponent):
                             multibutton_deleteSelectedOnly=True,
                             toolbarPosition=toolbarPosition,
                             store_order_by='$_row_count')
-        frame.multiButtonView.item(code='add_atc',caption='+',frm=frame.form.js_form,
+        if not singleFile:
+            frame.multiButtonView.item(code='add_atc',caption='+',frm=frame.form.js_form,
                                     action='frm.newrecord();',
                 parentForm=parentForm,deleteAction=False,
                 disabled='==!_store || _store.len()==0 || (this.form?this.form.isDisabled():false)',
@@ -546,7 +547,8 @@ class AttachManager(BaseComponent):
                 frame.setHiderLayer(false);
                 frm.newrecord();
             }
-            """,store='^.store',_delay=100,newrecordmessage="!!Save record before upload attachments",
+            """,store='^.store',_delay=500,
+            newrecordmessage="!!Save record before upload attachments",
             _fired='^#FORM.controller.loaded',
             _if='!store || store.len()==0',
             parentForm=parentForm,


### PR DESCRIPTION
### **User description**
Added singleFileParameter to attachmentMultiButtonFrame to support single attachment files: sometimes you need to add only one attachment per record but you want to keep interface as well as attachment functionality, this way it is possible to do so in a simple way.

Expanded delay can guarantee that store is loaded in time, otherwise with more complicated interfaces it can happen that store is not present after loading yet, and this leads to incorrect behaviour of the component (newrecord interface is shown instead of the first existing record).


___

### **PR Type**
Enhancement


___

### **Description**
- Added `singleFile` parameter to support single attachment mode

- Disabled add button when `singleFile` is True

- Increased delay in dataController to ensure store readiness


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attachmanager.py</strong><dd><code>Add single file support and expand delay in attachment manager</code></dd></summary>
<hr>

resources/common/gnrcomponents/attachmanager/attachmanager.py

<li>Introduced <code>singleFile</code> parameter to <code>at_attachmentMultiButtonFrame</code><br> <li> Conditional rendering of add button based on <code>singleFile</code><br> <li> Increased <code>_delay</code> in dataController from 100 to 500


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/187/files#diff-2db4ee538a6b8ae7f6eaefbc9a477550f9297f481dac9224fa596307b85258f6">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>