### PR TITLE
Feature/deferred events

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -11,7 +11,8 @@ Enhancements
 * Package depencency installer ('gnr app checkdep') has a new '-n'
   option to disable package caching
 * Support for 'security.txt' and 'robots.txt' WKUs through instanceconfig
-  
+* Introduced 'deferAfterCommit' method in GnrSqlDb to executed
+  callables *after* a commit
 
 Version 25.04.10
 ================

--- a/gnrpy/tests/sql/d_table_test.py
+++ b/gnrpy/tests/sql/d_table_test.py
@@ -109,14 +109,18 @@ class BaseSql(BaseGnrSqlTest):
             results.append(item)
             
         PRE_OP = "pre_op_result"
+        POST_OP = "post_op_result"
         # WARNING: we need to execute a query in the current
         # connection otherwise the deferToCommit callback is not executed
         # due to the lack of an active connection.
         qs = self.db.query('video.movie', columns='$title').fetch()
         self.db.deferToCommit(update_res, PRE_OP)
+        self.db.deferAfterCommit(update_res, POST_OP)
         self.db.commit()
-        assert len(results) == 1
+        assert len(results) == 2
         assert PRE_OP in results
+        assert POST_OP in results
+        assert results.index(PRE_OP) < results.index(POST_OP)
 
     #------------table test-----------------------------------------
     def test_insert(self):


### PR DESCRIPTION
### **User description**
Introducing deferAfterCommit in GnrSqlDb in order to execute arbitrary callabled after the commit.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Added generic deferred queues to `GnrSqlDb` for commit hooks.
  - Introduced `deferAfterCommit` to schedule callables after commit.
  - Refactored deferred queue handling for flexibility.

- Updated tests to validate `deferAfterCommit` execution order.

- Documented new feature in release notes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gnrsql.py</strong><dd><code>Add generic deferred queues and after-commit hook to GnrSqlDb</code></dd></summary>
<hr>

gnrpy/gnr/sql/gnrsql.py

<li>Introduced generic deferred queues for commit-related callables.<br> <li> Added <code>deferAfterCommit</code> method to schedule post-commit actions.<br> <li> Refactored deferred call handling for flexibility and extensibility.<br> <li> Updated internal commit logic to support new after-commit queue.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/188/files#diff-de83fec9e43fc84fec968675352a798c58ce9557b3dc332d9f12f1e808f621fc">+42/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>d_table_test.py</strong><dd><code>Add and extend tests for deferAfterCommit functionality</code>&nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/tests/sql/d_table_test.py

<li>Added test for <code>deferAfterCommit</code> to ensure correct execution order.<br> <li> Extended existing test to check both pre- and post-commit callbacks.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/188/files#diff-09debe09ae98f2060bb2783cd4a3ef0b4c2790c693ff2ab4d1cd03e9729f1e78">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RELEASE_NOTES.rst</strong><dd><code>Document deferAfterCommit feature in release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gnrpy/RELEASE_NOTES.rst

<li>Documented the introduction of <code>deferAfterCommit</code> in enhancements <br>section.


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/188/files#diff-d7e9179f79c31d79ec753907830f2511ac4fa62aecad924e0f7a0dfd6ed059ad">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>