### PR TITLE
getBody customizable method allows content replacements. #194

### DIFF
--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -327,6 +327,8 @@ class Table(object):
     
     def getBody(self, message=None, **kwargs):
         "Customizable method to return the body of the email. Default is to return the actual 'body' field."
+        if not message:
+            return ""
         return message['body']
     
     @public_method

--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -63,10 +63,11 @@ class Table(object):
         tbl.formulaColumn('show_read', """CASE WHEN $read IS NOT TRUE THEN '<div style="border-radius\\:10px;background\\:var(--primary-color);height\\:10px;width\\:10px"></div>'
                                                 ELSE NULL END""", name_long='!!Show read')
         tbl.pyColumn('full_external_url', name_long='Full external url')
-
+        tbl.pyColumn('compiled_body', py_method='getBody')
+        
     def pyColumn_full_external_url(self,record,field):
         return self.db.application.site.externalUrl('/index', menucode='messages')
-    
+        
     def defaultValues(self):
         return dict(account_id=self.db.currentEnv.get('current_account_id'))
 
@@ -299,7 +300,7 @@ class Table(object):
             try:
                 mail_handler.sendmail(to_address = message['to_address'],
                                 account_id = account_id,
-                                body=message['body'], subject=message['subject'],
+                                body=self.getBody(message), subject=message['subject'],
                                 cc_address=message['cc_address'], bcc_address=bcc_address,
                                 from_address=message['from_address'] or mp['from_address'],
                                 attachments=attachments, 
@@ -323,6 +324,10 @@ class Table(object):
                 message['sending_attempt'].child('attempt', ts=ts, error= error_msg)
         self.db.commit()
         return message
+    
+    def getBody(self, message=None, **kwargs):
+        "Customizable method to return the body of the email. Default is to return the actual 'body' field."
+        return message['body']
     
     @public_method
     def clearErrors(self, pkey):

--- a/projects/gnrcore/packages/email/resources/tables/message/tpl/msg_preview.xml
+++ b/projects/gnrcore/packages/email/resources/tables/message/tpl/msg_preview.xml
@@ -5,7 +5,8 @@
 <cc_address _T="NN"></cc_address>
 <bcc_address _T="NN"></bcc_address>
 <attachments _T="NN"></attachments></email>
-<email_compiled _T="BAG"></email_compiled></metadata>
+<email_compiled _T="BAG"></email_compiled>
+<default_letterhead _T="NN"></default_letterhead></metadata>
 <content>&lt;div&gt;
 	A: $a&lt;/div&gt;
 &lt;div&gt;
@@ -18,20 +19,9 @@
 	&lt;hr /&gt;
 &lt;/div&gt;
 &lt;div&gt;
-	$corpo&lt;/div&gt;
-</content>
+	$corpo&lt;/div&gt;</content>
 <content_css _T="NN"></content_css>
-<varsbag><gtdjidzlvl _pkey="gtdjidzlvl"><fieldpath dtype="::NN">body</fieldpath>
-<dtype dtype="::NN">T</dtype>
-<fieldname dtype="::NN">Corpo</fieldname>
-<varname dtype="::NN">corpo</varname>
-<virtual_column _T="NN"></virtual_column>
-<required_columns _T="NN" dtype="::NN"></required_columns>
-<df_template _T="NN" dtype="::NN"></df_template>
-<format _T="NN" dtype="::NN"></format>
-<mask _T="NN" dtype="::NN"></mask>
-<editable _T="NN" dtype="::NN"></editable></gtdjidzlvl>
-<gtdjifmw4x _pkey="gtdjifmw4x"><fieldpath dtype="::NN">subject</fieldpath>
+<varsbag><gtdjifmw4x _pkey="gtdjifmw4x"><fieldpath dtype="::NN">subject</fieldpath>
 <dtype dtype="::NN">T</dtype>
 <fieldname dtype="::NN">Oggetto</fieldname>
 <varname dtype="::NN">oggetto</varname>
@@ -60,10 +50,20 @@
 <df_template _T="NN" dtype="::NN"></df_template>
 <format _T="NN" dtype="::NN"></format>
 <mask _T="NN" dtype="::NN"></mask>
-<editable _T="NN" dtype="::NN"></editable></gtdjiipkpd></varsbag>
+<editable _T="NN" dtype="::NN"></editable></gtdjiipkpd>
+<h920ldn0nd _pkey="h920ldn0nd"><fieldpath dtype="::NN">compiled_body</fieldpath>
+<dtype dtype="::NN">T</dtype>
+<fieldname dtype="::NN">compiled_body</fieldname>
+<varname dtype="::NN">corpo</varname>
+<virtual_column _T="B">True</virtual_column>
+<required_columns _T="NN" dtype="::NN"></required_columns>
+<df_template _T="NN" dtype="::NN"></df_template>
+<format _T="NN" dtype="::NN"></format>
+<mask _T="NN" dtype="::NN"></mask>
+<editable _T="NN" dtype="::NN"></editable></h920ldn0nd></varsbag>
 <parametersbag _T="NN"></parametersbag>
 <email><attached_reports _T="BAG"></attached_reports></email>
-<compiled><main maintable="email.message" locale="it-IT" virtual_columns="" columns="$body,$subject,$send_date,$to_address" formats="{}::JS" masks="{}::JS" editcols="{}::JS" df_templates="{}::JS" dtypes='{"corpo": "T", "oggetto": "T", "data_invio": "DH", "a": "T"}::JS'>&lt;div&gt;
+<compiled><main maintable="email.message" locale="it-IT" virtual_columns="compiled_body" columns="$subject,$send_date,$to_address,$compiled_body" formats="{}::JS" masks="{}::JS" editcols="{}::JS" df_templates="{}::JS" dtypes='{"oggetto": "T", "data_invio": "DH", "a": "T", "corpo": "T"}::JS'>&lt;div&gt;
 	A: $to_address&lt;/div&gt;
 &lt;div&gt;
 	Data: $send_date&lt;/div&gt;
@@ -75,5 +75,4 @@
 	&lt;hr /&gt;
 &lt;/div&gt;
 &lt;div&gt;
-	$body&lt;/div&gt;
-</main></compiled></GenRoBag>
+	$compiled_body&lt;/div&gt;</main></compiled></GenRoBag>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added customizable `getBody` method for email content processing

- Replaced direct body field usage with compiled body column

- Updated email preview template to use compiled body


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Direct body field"] --> B["getBody method"]
  B --> C["compiled_body column"]
  C --> D["Email preview template"]
  B --> E["sendMessage method"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message.py</strong><dd><code>Add customizable getBody method and compiled_body column</code>&nbsp; </dd></summary>
<hr>

projects/gnrcore/packages/email/model/message.py

<li>Added <code>compiled_body</code> pyColumn that calls <code>getBody</code> method<br> <li> Modified <code>sendMessage</code> to use <code>getBody(message)</code> instead of direct body <br>access<br> <li> Implemented customizable <code>getBody</code> method that returns message body by <br>default


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/195/files#diff-43d51f50fd02f277a01d808d809f7f6896d76c3ba047fbac871b5c10073ee7e4">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>msg_preview.xml</strong><dd><code>Update template to use compiled_body field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

projects/gnrcore/packages/email/resources/tables/message/tpl/msg_preview.xml

<li>Added <code>default_letterhead</code> metadata field<br> <li> Replaced direct <code>$body</code> reference with <code>$compiled_body</code> in template<br> <li> Updated varsbag to use <code>compiled_body</code> field instead of <code>body</code><br> <li> Modified compiled section to include <code>compiled_body</code> in virtual columns


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/195/files#diff-66635b850e7902179b941de9a937e264e1e0714ed0235a9d5c11802a20787211">+17/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>