### PR TITLE
Picker support for store_kwargs

### DIFF
--- a/resources/common/th/th_picker.py
+++ b/resources/common/th/th_picker.py
@@ -8,7 +8,7 @@
 from gnr.web.gnrwebpage import BaseComponent
 from gnr.web.gnrwebstruct import struct_method
 from gnr.core.gnrbag import Bag
-from gnr.core.gnrdecorator import public_method
+from gnr.core.gnrdecorator import public_method, extract_kwargs
 from gnr.core.gnrdict import dictExtract
 from gnr.web.gnrwebpage import GnrMissingResourceException
 
@@ -68,6 +68,7 @@ class THPicker(BaseComponent):
         title = title or tblobj.name_long
         treepicker = tblobj.attributes.get('hierarchical') and not viewResource
         condition_kwargs = dictExtract(picker_kwargs,'condition_',pop=True,slice_prefix=not treepicker)
+        store_kwargs = dictExtract(picker_kwargs,'store_',pop=True, slice_prefix=False)
         if treepicker:
             palette = pane.palettePane(paletteCode=paletteCode,dockButton=dockButton,title=title,
                             width=width or '400px',height=height or '600px')
@@ -85,7 +86,7 @@ class THPicker(BaseComponent):
                                                 dragValues['text/plain'] = treeItem.attr.caption;
                                                 dragValues['%s'] = treeItem.attr;
                                             }""" %paletteCode,
-                            condition=condition,checkbox=checkbox,subtable=subtable,**tree_kwargs)
+                            condition=condition,checkbox=checkbox,subtable=subtable,**tree_kwargs,**store_kwargs)
         else:
             palette = pane.paletteGridPicker(grid=grid,table=table,relation_field=many,
                                             paletteCode=paletteCode,viewResource=viewResource,
@@ -95,7 +96,7 @@ class THPicker(BaseComponent):
                                             subtable=subtable,
                                             checkbox=checkbox,structure_field = structure_field or picker_kwargs.get('structure_field'),
                                             uniqueRow=picker_kwargs.get('uniqueRow',True),
-                                            top_height=picker_kwargs.get('top_height'),structure_kwargs = dictExtract(picker_kwargs,'structure_'),**kwargs)
+                                            top_height=picker_kwargs.get('top_height'),structure_kwargs = dictExtract(picker_kwargs,'structure_'),**store_kwargs,**kwargs)
 
         if grid is not None:
             grid.attributes.update(dropTargetCb_picker='return this.form?!this.form.isDisabled():true')
@@ -118,14 +119,15 @@ class THPicker(BaseComponent):
     
 
 
+    @extract_kwargs(store=True)
     @struct_method
     def pk_paletteGridPicker(self,pane,grid=None,table=None,relation_field=None,paletteCode=None,
                                 viewResource=None,searchOn=True,multiSelect=True,
                                 title=None,dockButton=True,
                                 height=None,width=None,condition=None,condition_kwargs=None,
                                 structure_field=None,uniqueRow=True,top_height=None,
-                                checkbox=None,structure_kwargs=None,subtable=None,
-                                **kwargs):
+                                checkbox=None,structure_kwargs=None,subtable=None, 
+                                store_kwargs=True, **kwargs):
         many = relation_field 
         if viewResource is True:
             viewResource = 'ViewPicker'
@@ -212,7 +214,9 @@ class THPicker(BaseComponent):
                                         sourcegrid=paletteth.view.grid.js_widget,
                                         pickerset='=.grid.sets.pickerset',
                                         destgrid=grid)
-
+        
+        if store_kwargs:
+            paletteth.view.store.attributes.update(**store_kwargs)
         if condition:
             paletteth.view.store.attributes.update(condition=condition,subtable=subtable,**condition_kwargs)
         if not condition_kwargs:

--- a/resources/common/th/th_picker.py
+++ b/resources/common/th/th_picker.py
@@ -127,7 +127,7 @@ class THPicker(BaseComponent):
                                 height=None,width=None,condition=None,condition_kwargs=None,
                                 structure_field=None,uniqueRow=True,top_height=None,
                                 checkbox=None,structure_kwargs=None,subtable=None, 
-                                store_kwargs=True, **kwargs):
+                                store_kwargs=None, **kwargs):
         many = relation_field 
         if viewResource is True:
             viewResource = 'ViewPicker'


### PR DESCRIPTION
### **User description**
Closes #214


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for `store_kwargs` parameter in picker components

- Extract and apply store-related parameters to palette grid picker

- Enable passing store configuration options through picker methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Picker Method Call"] --> B["Extract store_kwargs"]
  B --> C["Pass to Tree Picker"]
  B --> D["Pass to Grid Picker"]
  D --> E["Apply to Store Attributes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>th_picker.py</strong><dd><code>Enhanced picker methods with store_kwargs support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/common/th/th_picker.py

<ul><li>Import <code>extract_kwargs</code> decorator for parameter extraction<br> <li> Extract <code>store_kwargs</code> from picker parameters using <code>dictExtract</code><br> <li> Pass <code>store_kwargs</code> to both tree and grid picker components<br> <li> Add <code>@extract_kwargs(store=True)</code> decorator to <code>pk_paletteGridPicker</code> <br>method<br> <li> Apply <code>store_kwargs</code> to palette view store attributes when provided</ul>


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/215/files#diff-73a825fca2f80731e32afa8a1fcea715034d3ec86f6cc2fc08b84daabfd6db4c">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

