### PR TITLE
Fix to picker condition applied even if picker is disabled (picker Fa…

### DIFF
--- a/resources/common/th/th.py
+++ b/resources/common/th/th.py
@@ -129,22 +129,21 @@ class TableHandler(BaseComponent):
             if addrow is not True:
                 addrow_defaults = addrow
 
-        if picker or picker_kwargs:
+        if picker:
             top_slots.append('thpicker')
-            if picker is True:
-                picker = tblobj.pkey
-                picker_kwargs['table'] = table
-                if picker_kwargs.pop('exclude_assigned',None):
-                    picker_base_condition = '$%(_fkey_name)s IS NULL' %condition_kwargs 
-                else:
-                    picker_base_condition = '$%(_fkey_name)s IS NULL OR $%(_fkey_name)s!=:fkey' %condition_kwargs 
-                picker_custom_condition = picker_kwargs.get('condition')
-                picker_kwargs['condition'] = picker_base_condition if not picker_custom_condition else '(%s) AND (%s)' %(picker_base_condition,picker_custom_condition)
-                for k,v in list(condition_kwargs.items()):
-                    picker_kwargs['condition_%s' %k] = v
-                if delrow:
-                    tblname = tblattr.get('name_plural') or tblattr.get('name_one') or tblobj.name
-                    unlinkdict = dict(one_name=tblname.lower(),
+            picker = tblobj.pkey
+            picker_kwargs['table'] = table
+            if picker_kwargs.pop('exclude_assigned',None):
+                picker_base_condition = '$%(_fkey_name)s IS NULL' %condition_kwargs 
+            else:
+                picker_base_condition = '$%(_fkey_name)s IS NULL OR $%(_fkey_name)s!=:fkey' %condition_kwargs 
+            picker_custom_condition = picker_kwargs.get('condition')
+            picker_kwargs['condition'] = picker_base_condition if not picker_custom_condition else '(%s) AND (%s)' %(picker_base_condition,picker_custom_condition)
+            for k,v in list(condition_kwargs.items()):
+                picker_kwargs['condition_%s' %k] = v
+            if delrow:
+                tblname = tblattr.get('name_plural') or tblattr.get('name_one') or tblobj.name
+                unlinkdict = dict(one_name=tblname.lower(),
                                     field=condition_kwargs['_fkey_name'])
             picker_kwargs['relation_field'] = picker
 


### PR DESCRIPTION
### **User description**
Closes #222


___

### **PR Type**
Bug fix


___

### **Description**
- Fix picker condition logic when picker is disabled

- Remove unnecessary picker_kwargs check in condition

- Ensure picker configuration only applies when enabled


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Picker Check"] --> B["Picker Enabled?"]
  B -->|Yes| C["Apply Picker Configuration"]
  B -->|No| D["Skip Picker Logic"]
  C --> E["Set Conditions & Parameters"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>th.py</strong><dd><code>Fix picker condition logic when disabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/common/th/th.py

<ul><li>Simplified picker condition check from <code>if picker or picker_kwargs:</code> to <br><code>if picker:</code><br> <li> Removed nested <code>if picker is True:</code> condition block<br> <li> Moved picker configuration logic to execute only when picker is <br>enabled<br> <li> Fixed indentation for picker-related code block</ul>


</details>


  </td>
  <td><a href="https://github.com/genropy/genropy/pull/223/files#diff-ca99c6fedda46c0f98bc508eac4d559941c456a11a99bd353fd28c6bf2b51813">+14/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

