### PR TITLE
Set capture = 'environment' in the image input  widget to use the rear camera

### DIFF
--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -1204,7 +1204,8 @@ dojo.declare("gnr.widgets.video", gnr.widgets.baseHtml, {
     startCapture:function(sourceNode,capture_kw){
         var onErrorGetUserMedia = objectPop(capture_kw,'onReject');
         var onAccept = objectPop(capture_kw,'onAccept');
-        let capture_enviroment= sourceNode.attr.capture === 'environment';
+let capture_environment = sourceNode.attr.capture === 'environment';
+let video = capture_environment ? {facingMode: "environment"} : true
         let video = capture_enviroment ? {facingMode: "environment"} : true
         navigator.mediaDevices.getUserMedia({ video: video, audio: false })
         .then(function(stream) {

--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -1204,7 +1204,9 @@ dojo.declare("gnr.widgets.video", gnr.widgets.baseHtml, {
     startCapture:function(sourceNode,capture_kw){
         var onErrorGetUserMedia = objectPop(capture_kw,'onReject');
         var onAccept = objectPop(capture_kw,'onAccept');
-        navigator.mediaDevices.getUserMedia({ video: true, audio: false })
+        let capture_enviroment= sourceNode.attr.capture === 'environment';
+        let video = capture_enviroment ? {facingMode: "environment"} : true
+        navigator.mediaDevices.getUserMedia({ video: video, audio: false })
         .then(function(stream) {
             if(onAccept){
                 funcApply(onAccept,{},sourceNode);
@@ -5114,7 +5116,7 @@ dojo.declare("gnr.widgets.uploadable", gnr.widgets.baseHtml, {
         var that = this;
         if(objectNotEmpty(crop)){
             crop = objectUpdate({text_align:'center',overflow:'hidden'},crop);
-            var innerImage=objectExtract(attr,'src,src_back,placeholder,height,width,edit,upload_maxsize,upload_folder,upload_filename,upload_ext,zoomWindow,format,mask,border,takePicture,nodeId');
+            var innerImage=objectExtract(attr,'src,src_back,placeholder,height,width,edit,upload_maxsize,upload_folder,upload_filename,upload_ext,zoomWindow,format,mask,border,takePicture,nodeId,capture');
             if (innerImage.placeholder===true){
                 innerImage.placeholder = '/_gnr/11/css/icons/placeholder_img_dflt.png'
             }
@@ -5197,6 +5199,7 @@ dojo.declare("gnr.widgets.uploadable", gnr.widgets.baseHtml, {
                         this.domNode.value = null;
                     }
                 });
+                if (attr.capture){sourceNode.attr.capture=attr.capture};
                 var uploadhandler_key = genro.isMobile? 'connect_onclick':'connect_ondblclick';
 
                 attr[uploadhandler_key] = function(){
@@ -5342,7 +5345,9 @@ dojo.declare("gnr.widgets.uploadable", gnr.widgets.baseHtml, {
         let clientHeight = sourceNode.domNode.clientHeight;
         var dlg = genro.dlg.quickDialog(_T('Take picture'),{_showParent:true,_workspace:true,closable:true,width:videoWidth+22+'px',
                         connect_show:function(){
-                            genro.nodeById(videoNodeId).publish('startCapture');
+                            let videoNode = genro.nodeById(videoNodeId)
+                            if (sourceNode.attr.capture){videoNode.attr.capture=sourceNode.attr.capture};
+                            videoNode.publish('startCapture');
                         }});
         var sc = dlg.center._('StackContainer',{height:videoHeight+42+'px',nodeId:frameCode,selectedPage:'^#WORKSPACE.selectedPage'});
         let video = sc._('contentPane',{pageName:'video'});

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1134,7 +1134,7 @@ class GnrWsgiSite(object):
         pass
 
     @metadata(beacon=True)
-def onClosedPage(self, page_id=None, **kwargs):
+    def onClosedPage(self, page_id=None, **kwargs):
         "Drops page when closing"
         self.register.drop_page(page_id)
 

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1134,7 +1134,7 @@ class GnrWsgiSite(object):
         pass
 
     @metadata(beacon=True)
-    def onClosedPage(self, page_id=None, **kwargs):
+    def onClosedPage(self, page_id=None, *args, **kwargs):
         "Drops page when closing"
         self.register.drop_page(page_id)
 

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1134,7 +1134,7 @@ class GnrWsgiSite(object):
         pass
 
     @metadata(beacon=True)
-    def onClosedPage(self, page_id=None, *args, **kwargs):
+def onClosedPage(self, page_id=None, **kwargs):
         "Drops page when closing"
         self.register.drop_page(page_id)
 


### PR DESCRIPTION
example:

# -*- coding: utf-8 -*-
from gnr.core.gnrdecorator import public_method


class GnrCustomWebPage(object):
    py_requires = 'th/th:TableHandler'

    def main(self,pane,**kwargs):
        gb = pane.gridbox(columns=1,gap='5px', datapath='main')
        div = gb.img(src='^.img_targa',id='div',
                    lbl='Fotografia',
                    lbl_side='top',
                    crop_height='100px',
                    crop_width='100px',
                    capture='environment',
                    # crop_border='2px dotted silver',
                    # crop_rounded=6,
                    edit=True,
                    placeholder=True,
                    takePicture=True,
                    )