### PR TITLE
Extended data retention policy, added the 'retention_extra_where' method

### DIFF
--- a/gnrpy/gnr/app/cli/gnrcleanup.py
+++ b/gnrpy/gnr/app/cli/gnrcleanup.py
@@ -31,7 +31,10 @@ def main():
     if options.policy:
         print("Current policy:")
         for table, conf in policy.items():
-            print(f"Table: {table} - Retention for {conf['retention_period']} days based on field '{conf['filter_column']}'")
+            mesg = f"Table: {table} - {conf['retention_period']} days on '{conf['filter_column']}'"
+            if conf['extra_where_filter']:
+                mesg += f" - extra filter: '{conf['extra_where_filter']}'"
+            print(mesg)
         sys.exit(3)
         
     summary = app.executeRetentionPolicy(dry_run=dry_run)

--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -1563,12 +1563,9 @@ class GnrApp(object):
 
         """
         policy = {
-            table.fullname: dict(filter_column=table.defaultRetentionPolicy[0],
-                                 retention_period_default=table.defaultRetentionPolicy[1],
-                                 retention_period=table.defaultRetentionPolicy[1])
+            table.fullname: table.defaultRetentionPolicy
             for table in self.db.tables if table.defaultRetentionPolicy
             }
-
         return policy
     
     @property

--- a/gnrpy/tests/app/gnrapp_test.py
+++ b/gnrpy/tests/app/gnrapp_test.py
@@ -180,4 +180,8 @@ class TestGnrApp(BaseGnrAppTest):
             assert p['sys.error']['retention_period_default'] == 60
             assert p['sys.error']['filter_column'] == '__ins_ts'
             assert p['sys.error']['retention_period'] == p['sys.error']['retention_period_default']
+            assert "extra_where_filter" in p['sys.error']
+            assert "extra_where_filter" in p['sys.task_execution']
+            assert p['sys.error']['extra_where_filter'] == None
+            assert p['sys.task_execution']['extra_where_filter'] == None
        


### PR DESCRIPTION
Extended data retention policy, added the 'retention_extra_where' method search, which
should return a where clause added in AND to the base retention policy table search.

This way, the table can provide a base retention policy on a datetime field and a cutoff period in days, but can also provide extra filtering by defining this method.

refs #249