### PR TITLE
Fix remoteRowController handling for new rows and edit timing

### DIFF
--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -3474,30 +3474,36 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
         if(r==null){
             var r = this.selection.selectedIndex;
         }
-        var rc = this.gridEditor.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
-        var grid = this;
         var ge = this.gridEditor;
-        if (rc) {
-            if(ge.remoteRowController){
-                var d = new Date();
-                this.sourceNode.watch('pendingRemoteController',
-                        function(){return !ge._pendingRemoteController},
-                        function(){
+        if(ge.remoteRowController){
+            this.sourceNode.watch('pendingRemoteController',
+                    function(){return !ge._pendingRemoteController},
+                    function(){
+                        let rc = ge.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
+                        if(rc){
                             ge.startEdit(rc.row, rc.col);
-                        },10);
+                        }
+                        
+                    },10);
+        }
+        else if (delay) {
+            if (this._delayedEditing) {
+                clearTimeout(this._delayedEditing);
             }
-            else if (delay) {
-                if (this._delayedEditing) {
-                    clearTimeout(this._delayedEditing);
-                }
-                this._delayedEditing = setTimeout(function() {
+            this._delayedEditing = setTimeout(function() {
+                let rc = ge.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
+                if(rc){
                     ge.startEdit(rc.row, rc.col);
-                }, delay);
-            } else {
+                }
+                
+            }, delay);
+        } else {
+            let rc = ge.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
+            if(rc){
                 ge.startEdit(rc.row, rc.col);
             }
-
         }
+
     },
 
     mixin_newBagRow: function(defaultArgs) {

--- a/gnrjs/gnr_d11/js/genro_wdg.js
+++ b/gnrjs/gnr_d11/js/genro_wdg.js
@@ -2299,8 +2299,13 @@ dojo.declare("gnr.GridChangeManager", null, {
             if(!rowEditor){
                 rowEditor = gridEditor.newRowEditor(kw.node);
                 let rowSelectedQueries = gridEditor.rowSelectedQueries(rowEditor.data);
-                if((gridEditor.remoteRowController || rowSelectedQueries.len(rowEditor.data)>0) && rowEditor.data.getItem(this.grid.masterEditColumn())!==null ){
-                    gridEditor.callRemoteController(kw.node,null,null,true);
+
+                const hasRemoteController = gridEditor.remoteRowController || rowSelectedQueries.len(rowEditor.data) > 0;
+                const hasMasterEditValue = rowEditor.data.getItem(this.grid.masterEditColumn()) !== null;
+                const hasDefaultController = gridEditor.remoteRowController_default;
+
+                if (hasRemoteController && (hasMasterEditValue || hasDefaultController)) {
+                    gridEditor.callRemoteController(kw.node, null, null, true);
                 }
             }
         }


### PR DESCRIPTION
Improved readability by extracting complex boolean conditions into well-named constants. More importantly, fixed a logic issue where remoteRowController was not being called for new rows when remoteRowController_default is configured.

The remoteRowController should be invoked when:
- A remoteRowController or rowSelectedQueries exist, AND
- Either the masterEditColumn has a value OR remoteRowController_default is configured

Previously, the condition only checked for masterEditColumn value, which meant that new rows with remoteRowController_default configured were incorrectly skipped. This fix ensures that when remoteRowController_default is set, the controller is properly called for new rows to initialize default values from the server.