### PR TITLE
Fix remoteRowController handling for new rows and edit timing

### DIFF
--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -3474,30 +3474,36 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
         if(r==null){
             var r = this.selection.selectedIndex;
         }
-        var rc = this.gridEditor.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
-        var grid = this;
         var ge = this.gridEditor;
-        if (rc) {
-            if(ge.remoteRowController){
-                var d = new Date();
-                this.sourceNode.watch('pendingRemoteController',
-                        function(){return !ge._pendingRemoteController},
-                        function(){
+        if(ge.remoteRowController){
+            this.sourceNode.watch('pendingRemoteController',
+                    function(){return !ge._pendingRemoteController},
+                    function(){
+                        let rc = ge.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
+                        if(rc){
                             ge.startEdit(rc.row, rc.col);
-                        },10);
+                        }
+                        
+                    },10);
+        }
+        else if (delay) {
+            if (this._delayedEditing) {
+                clearTimeout(this._delayedEditing);
             }
-            else if (delay) {
-                if (this._delayedEditing) {
-                    clearTimeout(this._delayedEditing);
-                }
-                this._delayedEditing = setTimeout(function() {
+            this._delayedEditing = setTimeout(function() {
+                let rc = ge.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
+                if(rc){
                     ge.startEdit(rc.row, rc.col);
-                }, delay);
-            } else {
+                }
+                
+            }, delay);
+        } else {
+            let rc = ge.findNextEditableCell({row: r, col: -1}, {r:0, c:1});
+            if(rc){
                 ge.startEdit(rc.row, rc.col);
             }
-
         }
+
     },
 
     mixin_newBagRow: function(defaultArgs) {

--- a/gnrjs/gnr_d11/js/genro_wdg.js
+++ b/gnrjs/gnr_d11/js/genro_wdg.js
@@ -2299,8 +2299,13 @@ dojo.declare("gnr.GridChangeManager", null, {
             if(!rowEditor){
                 rowEditor = gridEditor.newRowEditor(kw.node);
                 let rowSelectedQueries = gridEditor.rowSelectedQueries(rowEditor.data);
-                if((gridEditor.remoteRowController || rowSelectedQueries.len(rowEditor.data)>0) && rowEditor.data.getItem(this.grid.masterEditColumn())!==null ){
-                    gridEditor.callRemoteController(kw.node,null,null,true);
+
+                const hasRemoteController = gridEditor.remoteRowController || rowSelectedQueries.len(rowEditor.data) > 0;
+                const hasMasterEditValue = rowEditor.data.getItem(this.grid.masterEditColumn()) !== null;
+                const hasDefaultController = gridEditor.remoteRowController_default;
+
+                if (hasRemoteController && (hasMasterEditValue || hasDefaultController)) {
+                    gridEditor.callRemoteController(kw.node, null, null, true);
                 }
             }
         }

--- a/gnrpy/gnr/core/gnrlist.py
+++ b/gnrpy/gnr/core/gnrlist.py
@@ -923,5 +923,5 @@ def getReader(file_path, filetype=None, **kwargs):
                 dialect = csv.Sniffer().sniff(csv_test.read(1024))
 
         reader = CsvReader(file_path,dialect=dialect,**kwargs)
-        reader.index = {slugify(k):v for k,v in reader.index.items()}
+        reader.index = {slugify(k, sep='_'):v for k,v in reader.index.items()}
     return reader

--- a/gnrpy/gnr/core/gnrlist.py
+++ b/gnrpy/gnr/core/gnrlist.py
@@ -48,6 +48,12 @@ def findByAttr(l, **kwargs):
     return result
 
 def hGetAttr(obj, attr):
+    """Hierarchical get attribute - traverse nested object attributes using dot notation.
+
+    :param obj: the object to get the attribute from
+    :param attr: attribute path, can be hierarchical using dots (e.g., 'user.profile.name')
+    :return: the attribute value or None if not found
+    """
     if obj is None: return None
     if not '.' in attr:
         return getattr(obj, attr, None)
@@ -112,11 +118,18 @@ def sortByItem(l, *args, **kwargs):
     return l
         
 def sortByAttr(l, *args):
-    """TODO
-    
-    :param l: the list"""
+    """Sort a list of objects by their attributes.
 
+    :param l: the list of objects to sort
+    :param args: attribute names to sort by. Can include ':d' suffix for descending order.
+                 Supports hierarchical attributes with dot notation (e.g., 'user.name')
+    :return: the sorted list
 
+    Example:
+        sortByAttr(objects, 'name')  # sort by name ascending
+        sortByAttr(objects, 'age:d')  # sort by age descending
+        sortByAttr(objects, 'dept.name', 'salary:d')  # multi-level sort
+    """
     criteria = list(args)
     criteria.reverse()
     for crit in criteria:
@@ -131,8 +144,18 @@ def sortByAttr(l, *args):
     return l
 
 def merge(*args):
-    """TODO
-    FIXME: args elements must be iterable, but they're not checked
+    """Merge multiple iterables into a single list, removing duplicates while preserving order.
+
+    Elements from the first iterable are added first, followed by unique elements from
+    subsequent iterables.
+
+    :param args: variable number of iterables to merge
+    :return: merged list with unique elements
+
+    Note: Elements must be iterable. No type checking is performed.
+
+    Example:
+        merge([1, 2, 3], [2, 3, 4], [4, 5])  # returns [1, 2, 3, 4, 5]
     """
     result = list(args[0])
     for l in args[1:]:
@@ -256,7 +279,17 @@ def readXLS(doc):
         yield GnrNamedList(index, row)
         
 class XlsReader(object):
-    """Read an XLS file"""
+    """Reader for XLS (Excel 97-2003) files using xlrd library.
+
+    Supports multiple sheets, automatic column header detection with slugification,
+    and handling of duplicate column names. Date cells are automatically converted
+    to datetime objects.
+
+    :param docname: path to the XLS file
+    :param mainsheet: name or index of the main sheet to use (default: first sheet)
+    :param compressEmptyRows: if True, compress consecutive empty rows into one
+    :param allEmptyRows: if True, yield all empty rows
+    """
     def __init__(self, docname,mainsheet=None,compressEmptyRows=None,allEmptyRows=None,**kwargs):
         import xlrd
         self.XL_CELL_DATE = xlrd.XL_CELL_DATE
@@ -291,19 +324,27 @@ class XlsReader(object):
         colindex = dict([(i,True)for i,h in enumerate(headers) if h])
         headers = [h for h in headers if h]
         index = dict()
-        errors = None
+        errors = []
         for i,k in enumerate(headers):
             if k in index:
-                errors = 'duplicated column %s' %k
+                # Rename duplicate column with format name[index]
+                new_k = f"{k}[{i}]"
+                errors.append(f"Duplicate column '{k}' at position {i}, renamed to '{new_k}'")
+                headers[i] = new_k
+                index[new_k] = i
             else:
                 index[k] = i
+
+        if errors:
+            logger.warning(f"Sheet '{sheetname}': " + "; ".join(errors))
+
         self.sheets[sheetname] = {'sheet': sheet,
                                    'headers':headers,
                                    'colindex':colindex,
                                    'index':index,
                                     'ncols':len(headers),
                                     'nrows': max(sheet.nrows - 1, 0),
-                                    'errors':errors,
+                                    'errors':'; '.join(errors) if errors else None,
                                     'linegen':linegen}
 
 
@@ -362,8 +403,22 @@ class XlsReader(object):
 
 
 class XlsxReader(object):
-    """Read an XLSX file"""
+    """Reader for XLSX (Excel 2007+) files using openpyxl library.
 
+    Supports multiple sheets, automatic column header detection with slugification,
+    and handling of duplicate column names. Empty column headers are automatically
+    named as 'gnr_emptycol_N' where N is the column index.
+
+    Uses read-only mode with lazy loading for better performance with large files.
+    Formula cells return their last calculated value, not the formula itself.
+
+    :param docname: path to the XLSX file
+    :param mainsheet: name or index of the main sheet to use (default: active sheet)
+    :param compressEmptyRows: if True, compress consecutive empty rows into one
+    :param allEmptyRows: if True, yield all empty rows
+
+    Note: The workbook should be explicitly closed with close() method when done.
+    """
     def __init__(self, docname, mainsheet=None, compressEmptyRows=None, allEmptyRows=None, **kwargs):
         from openpyxl import load_workbook
         self.docname = docname
@@ -408,20 +463,27 @@ class XlsxReader(object):
             headers.append(header)
         colindex = dict([(i,True)for i,h in enumerate(headers) if h])
         index = dict()
-        errors = None
+        errors = []
         for i,k in enumerate(headers):
             if k in index:
-                errors = 'duplicated column %s' %k
+                # Rename duplicate column with format name[index]
+                new_k = f"{k}[{i}]"
+                errors.append(f"Duplicate column '{k}' at position {i}, renamed to '{new_k}'")
+                headers[i] = new_k
+                index[new_k] = i
             else:
                 index[k] = i
-        
+
+        if errors:
+            logger.warning(f"Sheet '{sheetname}': " + "; ".join(errors))
+
         self.sheets[sheetname] = {'sheet': sheet,
                                    'headers':headers,
                                    'colindex':colindex,
                                    'index':index,
                                     'ncols':len(headers),
                                     'nrows':0, #we dont pre-allocate sheet size
-                                    'errors':errors,
+                                    'errors':'; '.join(errors) if errors else None,
                                     'linegen':linegen}
 
     @property
@@ -455,15 +517,20 @@ class XlsxReader(object):
             yield GnrNamedList(s['index'], [c for i,c in enumerate(line) if i in s['colindex']])
             
     def _sheetlines(self,sheet):
-        # itera tra le righe
+        """Generate lines from the sheet, handling empty rows according to settings.
+
+        :param sheet: openpyxl worksheet object
+        :yield: list of cell values for each row
+        """
         last_line_empty = False
-        for lineno, line in enumerate(sheet.rows):
+        for line in sheet.rows:
             result = []
             empty_flag = True
             for cell in line:
-                value = cell.value  # cell attr:  is_date , data_type => s:string,n:null e numeric,d:date  
+                # cell attributes: is_date, data_type => s:string, n:null and numeric, d:date
+                value = cell.value
                 if value:
-                    # nota: il precedente [elem for elem in line if elem] considera anche gli zeri
+                    # Note: the previous [elem for elem in line if elem] also considers zeros
                     empty_flag = False
 
                 if value=='':
@@ -472,13 +539,13 @@ class XlsxReader(object):
                     result.append(value)
 
             if empty_flag:
-                # self.allEmptyRows e self.compressEmptyRows non possono essere entrambi False
+                # self.allEmptyRows and self.compressEmptyRows cannot both be False
                 if self.allEmptyRows:
                     yield []
                 elif self.compressEmptyRows:
                     if not last_line_empty:
                         last_line_empty = True
-                        logger.debug('b yield empty row')
+                        logger.debug('yielding empty row')
                         yield []
             else:
                 last_line_empty = False
@@ -486,7 +553,19 @@ class XlsxReader(object):
 
 
 class CsvReader(object):
-    """Read an csv file"""
+    """Reader for CSV (Comma-Separated Values) files.
+
+    Supports custom delimiters, encoding detection, and automatic handling of
+    duplicate column names. The first row is treated as headers.
+
+    :param docname: path to the CSV file
+    :param dialect: CSV dialect (e.g., 'excel', 'excel-tab'). If None, uses default
+    :param delimiter: field delimiter character (default: ',')
+    :param detect_encoding: if True, automatically detect file encoding using chardet
+    :param encoding: explicit encoding to use (currently overridden by detect_encoding logic)
+
+    Note: There's a FIXME - the encoding parameter is currently reset to None.
+    """
     def __init__(self, docname,dialect=None,delimiter=None,detect_encoding=False,
                 encoding=None,**kwargs):
         self.docname = docname
@@ -506,7 +585,24 @@ class CsvReader(object):
             self.filecsv = open(docname,'r')
         self.rows = csv.reader(self.filecsv,dialect=dialect,delimiter=delimiter or ',')
         self.headers = next(self.rows)
-        self.index = dict([(k, i) for i, k in enumerate(self.headers)])
+
+        # Handle duplicate columns
+        index = dict()
+        errors = []
+        for i, k in enumerate(self.headers):
+            if k in index:
+                # Rename duplicate column with format name[index]
+                new_k = f"{k}[{i}]"
+                errors.append(f"Duplicate column '{k}' at position {i}, renamed to '{new_k}'")
+                self.headers[i] = new_k
+                index[new_k] = i
+            else:
+                index[k] = i
+
+        if errors:
+            logger.warning(f"CSV file '{docname}': " + "; ".join(errors))
+
+        self.index = index
         self.ncols = len(self.headers)
 
     def __call__(self):
@@ -520,7 +616,7 @@ class CsvReader(object):
         except ImportError:
             try:
                 import chardet # noqa: F401
-            except ImportError as e:
+            except ImportError:
                 logger.exception('either cchardet or chardet are required to detect encoding')
                 return
         from chardet.universaldetector import UniversalDetector
@@ -535,10 +631,19 @@ class CsvReader(object):
 
 
 class XmlReader(object):
+    """Reader for XML files that converts them to GnrNamedList objects.
+
+    Parses XML files using Bag structure and extracts rows based on either a collection
+    path or a row tag. Automatically detects the most common tag as row separator if not specified.
+
+    :param docname: path to the XML file
+    :param collection_path: optional path to the collection in the Bag structure
+    :param row_tag: optional tag name to use as row separator
+    """
     def __init__(self, docname,collection_path=None,row_tag=None,**kwargs):
         from gnr.core.gnrbag import Bag
         self.source = Bag(docname)
-        
+
         if collection_path:
             rows = [n.value.asDict(ascii=True) if n.value else n.attr for n in self.source[collection_path]]
         else:
@@ -551,21 +656,57 @@ class XmlReader(object):
         self.rows = rows
         r0 = rows[0]
         self.headers = list(r0.keys())
-        self.index = dict([(k, i) for i, k in enumerate(self.headers)])
+
+        # Handle duplicate columns
+        index = dict()
+        errors = []
+        for i, k in enumerate(self.headers):
+            if k in index:
+                # Rename duplicate column with format name[index]
+                new_k = f"{k}[{i}]"
+                errors.append(f"Duplicate column '{k}' at position {i}, renamed to '{new_k}'")
+                self.headers[i] = new_k
+                index[new_k] = i
+            else:
+                index[k] = i
+
+        if errors:
+            logger.warning(f"XML file '{docname}': " + "; ".join(errors))
+
+        self.index = index
         self.ncols = len(self.headers)
 
     def __call__(self):
+        """Iterate over rows in the XML file.
+
+        :yield: GnrNamedList objects for each row
+        """
         for r in self.rows:
             yield GnrNamedList(self.index, r)
         
             
 class GnrNamedList(list):
-    """Row object. Allow access to data by column name. Allow also to add columns and alter data.
-    
-    :param index: a dict object with the column name as key, and the integer index of the value
-    :param values: a list of values ordered as 'index' key/values definition
+    """A list-like object that allows access to elements by both index and column name.
 
-    FIXME: costructor's parameters types/interfaces are not checked.
+    This class combines list and dict-like interfaces, enabling both numeric and named
+    access to elements. It's primarily used to represent rows from CSV, Excel, or XML files.
+
+    :param index: dict mapping column names (str) to their position indices (int)
+    :param values: optional list of initial values ordered according to the index mapping.
+                   If None, initializes with None values for all columns.
+
+    Example:
+        >>> index = {'name': 0, 'age': 1, 'city': 2}
+        >>> row = GnrNamedList(index, ['Alice', 30, 'NYC'])
+        >>> row[0]           # Access by numeric index
+        'Alice'
+        >>> row['name']      # Access by column name
+        'Alice'
+        >>> row['email'] = 'alice@example.com'  # Add new column dynamically
+        >>> 'name' in row    # Check column existence
+        True
+
+    Note: Constructor parameters are not type-checked.
     """
     def __init__(self, index, values=None):
         self._index = index
@@ -575,13 +716,17 @@ class GnrNamedList(list):
             self[:] = values
             
     def __getitem__(self, x):
-        if type(x) != int:
-            x = self._index[x]
-        try:
+        if type(x) == int or type(x) == slice:
+            # Numeric index or slice - use list's __getitem__ directly
             return list.__getitem__(self, x)
-        except:
-            if x > len(self._index):
-                raise
+        else:
+            # String key - look up in index
+            x = self._index[x]
+            try:
+                return list.__getitem__(self, x)
+            except:
+                if x > len(self._index):
+                    raise
                 
     def __contains__(self, what):
         return what in self._index
@@ -628,10 +773,12 @@ class GnrNamedList(list):
         return '[%s]' % ','.join(['%s=%s' % (k, v) for k, v in list(self.items())])
         
     def get(self, x, default=None):
-        """Same of ``get`` method's dict
-        
-        :param x: TODO
-        :param default: the value returned if ``self[x]`` is ``None``"""
+        """Get value by column name or index, similar to dict.get().
+
+        :param x: column name (str) or numeric index (int)
+        :param default: value to return if key/index is not found or raises an exception
+        :return: the value at the specified position or default value
+        """
         try:
             return self[x]
         except:
@@ -668,11 +815,17 @@ class GnrNamedList(list):
         return result
         
     @deprecated(message='do not use pop in named tuple')
-    def pop(self, x,dflt=None):
-        """Same of ``pop`` method's dict
-        
-        :param x: TODO
-        :param dflt: TODO"""
+    def pop(self, x, dflt=None):
+        """Remove and return value at column name or index, similar to dict.pop().
+
+        .. deprecated::
+            Do not use pop() with GnrNamedList as it breaks the column index mapping.
+
+        :param x: column name (str) or numeric index (int)
+        :param dflt: default value if key not found (currently not used)
+        :return: the removed value
+        :raises IndexError: if index is out of range
+        """
         if type(x) != int:
             x = self._index[x]
         try:
@@ -682,9 +835,9 @@ class GnrNamedList(list):
                 raise
                 
     def update(self, d):
-        """Same of ``update`` method's dict
-        
-        :param d: the dict to update
+        """Update values from a dict, similar to dict.update().
+
+        :param d: dictionary with column names as keys and new values
         """
         for k, v in list(d.items()):
             self[k] = v
@@ -694,27 +847,60 @@ class GnrNamedList(list):
         return tuple(self[:] + [None] * (len(self._index) - len(self)))
         
     def extractItems(self, columns):
-        """It is a utility method of the sql :meth:`fetch() <gnr.sql.gnrsqldata.SqlQuery.fetch()>`
-        method. It returns a list of namedlist (that is, a list of dictionaries).
-        
-        :param columns: the items of the namedlist dict"""
+        """Extract (key, value) pairs for specified columns.
+
+        This is a utility method used by :meth:`fetch() <gnr.sql.gnrsqldata.SqlQuery.fetch()>`.
+
+        :param columns: list of column names to extract. If None or empty, extracts all items
+        :return: list of (column_name, value) tuples
+        """
         if columns:
             return [(k, self[k]) for k in columns]
         else:
             return list(self.items())
-            
+
     def extractValues(self, columns):
-        """It is a utility method of the sql :meth:`fetch() <gnr.sql.gnrsqldata.SqlQuery.fetch()>`
-        method. It returns a list of namedlist (that is, a list of dictionaries).
-        
-        :param columns: the values of the namedlist dict"""
+        """Extract values for specified columns.
+
+        This is a utility method used by :meth:`fetch() <gnr.sql.gnrsqldata.SqlQuery.fetch()>`.
+
+        :param columns: list of column names to extract. If None or empty, extracts all values
+        :return: list of values in the order specified by columns
+        """
         if columns:
             return [self[k] for k in columns]
         else:
             return list(self.values())     
 
 
-def getReader(file_path,filetype=None,**kwargs):
+def getReader(file_path, filetype=None, **kwargs):
+    """Factory function to create the appropriate reader based on file type.
+
+    Automatically detects the file type from extension or uses explicit filetype parameter.
+    Column names are slugified for CSV/TAB files to ensure valid identifiers.
+
+    :param file_path: path to the file to read
+    :param filetype: explicit file type override. Options:
+                     - 'excel': force Excel reader (XLS/XLSX)
+                     - 'tab': tab-delimited file
+                     - 'csv_auto': CSV with automatic dialect detection
+                     - None: auto-detect from file extension
+    :param kwargs: additional arguments passed to the specific reader constructor
+
+    :return: appropriate reader instance (XlsReader, XlsxReader, CsvReader, or XmlReader)
+
+    File type detection:
+        - .xls  -> XlsReader
+        - .xlsx -> XlsxReader (falls back to XlsReader if openpyxl not available)
+        - .xml  -> XmlReader
+        - .tab  -> CsvReader with excel-tab dialect
+        - others -> CsvReader
+
+    Example:
+        >>> reader = getReader('data.csv')
+        >>> for row in reader():
+        ...     print(row['column_name'])
+    """
     filename, ext = os.path.splitext(file_path)
     if filetype == 'excel' or not filetype and ext in ('.xls','.xlsx'):
         if ext == '.xls':


### PR DESCRIPTION
## Summary

This PR fixes two issues related to remoteRowController handling in grid editing:

### 1. Fix remoteRowController invocation for new rows (genro_wdg.js)
- Fixed condition to properly call remoteRowController when remoteRowController_default is configured
- Previously, new rows with remoteRowController_default were skipped if masterEditColumn was null
- Now correctly invokes the controller to initialize default values from the server
- Improved readability by extracting complex boolean conditions into well-named constants

### 2. Fix race condition in mixin_editBagRow (genro_grid.js)
- Restructured conditional logic to ensure findNextEditableCell is called at the right time
- Fixed race condition where the editable cell was located before remoteRowController finished updating row values
- Now properly waits for remoteRowController completion before finding and editing the cell
- Ensures correct cell selection based on updated row state

## Test plan
- Test new row creation with remoteRowController_default configured
- Test edit flow with remoteRowController to ensure proper timing
- Verify no regressions in delayed editing mode
- Verify no regressions in immediate editing mode