### PR TITLE
262 multiple names in ingress endpoints

### DIFF
--- a/gnrpy/gnr/web/cli/gnrk8s.py
+++ b/gnrpy/gnr/web/cli/gnrk8s.py
@@ -18,9 +18,10 @@ def main():
                         dest="image",
                         help="Image name to be deployed")
     parser.add_argument('-f', '--fqdn',
+                        action="append",
                         required=True,
-                        dest="fqdn",
-                        help="The FQDN of the deployed service")
+                        dest="fqdns",
+                        help="One (or more) FQDN of the deployed service")
     parser.add_argument('-n', '--name',
                         dest="name",
                         help="The application name (default to instance name)")
@@ -55,7 +56,7 @@ def main():
     
     options = parser.parse_args()
     generator = GnrK8SGenerator(options.instance_name, options.image,
-                                options.fqdn,
+                                options.fqdns,
                                 deployment_name=options.name,
                                 split=options.split,
                                 env_file=options.env,

--- a/gnrpy/gnr/web/gnrk8s.py
+++ b/gnrpy/gnr/web/gnrk8s.py
@@ -11,7 +11,7 @@ from gnr.web import logger
 
 class GnrK8SGenerator(object):
     def __init__(self, instance_name, image,
-                 fqdn,
+                 fqdns,
                  deployment_name=None, split=False,
                  env_file=False, env_secrets=[],
                  container_port=8000,
@@ -23,7 +23,7 @@ class GnrK8SGenerator(object):
         if ":" not in self.image:
             self.image = f'{self.image}:latest'
         self.secret_name = secret_name
-        self.fqdn = fqdn
+        self.fqdns = fqdns
         self.container_port = container_port
         self.stack_name = deployment_name or instance_name
         self.application_name = f'{self.stack_name}-application'
@@ -59,7 +59,7 @@ class GnrK8SGenerator(object):
         self.env.append(dict(name='GNR_DAEMON_PORT', value=str(self.GNR_DAEMON_PORT)))
         # have gunicorn listen on all interfaces
         self.env.append(dict(name='GNR_GUNICORN_BIND', value='0.0.0.0'))
-        self.env.append(dict(name="GNR_EXTERNALHOST", value=f'https://{self.fqdn}'))
+        self.env.append(dict(name="GNR_EXTERNALHOST", value=f'https://{self.fqdns[0]}'))
 
     def get_pv(self):
         pv = {
@@ -376,7 +376,7 @@ class GnrK8SGenerator(object):
             "spec": {
                 "rules": [
                     {
-                        "host": self.fqdn,
+                        "host": fqdn,
                         "http": {
                             "paths": [
                                 {
@@ -394,12 +394,11 @@ class GnrK8SGenerator(object):
                             ]
                         }
                     }
+                    for fqdn in self.fqdns
                 ],
                 "tls": [
                     {
-                        "hosts": [
-                            self.fqdn
-                        ]
+                        "hosts": self.fqdns
                     },
                 ],
             }


### PR DESCRIPTION
- **feat: handle duplicate columns in file readers and improve documentation**
- **fix: ensure consistent slugification between CSV and Excel readers**
- **test: add SQL adapter compatibility tests for GnrNamedList**
- **support for multiple FQDN in traefik rule (for docker) and in ingress rules (k8s), allowing multiple name to retain compatibility with current deployment schemes.**
