### PR TITLE
Align gnrdeploy template loader to gnrapp's one

### DIFF
--- a/gnrpy/gnr/app/gnrdeploy.py
+++ b/gnrpy/gnr/app/gnrdeploy.py
@@ -448,11 +448,14 @@ class PathResolver(object):
         instance_config = normalizePackages(self.gnr_config['gnr.instanceconfig.default_xml']) or Bag()
         template = base_instance_config['instance?template']
         if template:
-            template_config_path = os.path.join(self.instance_name_to_path(template),'config','instanceconfig.xml')
-            if os.path.exists(template_config_path):
-                instance_config.update(normalizePackages(Bag(template_config_path)) or Bag())
+            template_update = self.gnr_config['gnr.instanceconfig.%s_xml' % template]
+            if template_update:
+                instance_config.update(normalizePackages(template_update) or Bag())
             else:
-                instance_config.update(normalizePackages(self.gnr_config['gnr.instanceconfig.%s_xml' % template]) or Bag())
+                template_config_path = os.path.join(self.instance_name_to_path(template),'config','instanceconfig.xml')
+                if os.path.exists(template_config_path):
+                    instance_config.update(normalizePackages(Bag(template_config_path)) or Bag())
+                
         if 'instances' in self.gnr_config['gnr.environment_xml']:
             for path, instance_template in self.gnr_config.digest(
                     'gnr.environment_xml.instances:#a.path,#a.instance_template') or []:


### PR DESCRIPTION
The gnrapp template loader was updated in fd466285aad89d10fa7cabe60bd91edf09099b16 but gnrdeploy's share similar code (almost identical) which was left behind to the previous approach, re-rising the issue once again. This change align's the 2 loaders, as an hotfix waiting for a better refactoring and code reusage of the section