### PR TITLE
re-added main_repo_name for instance path in docker image.

### DIFF
--- a/gnrpy/gnr/app/cli/gnrdockerize.py
+++ b/gnrpy/gnr/app/cli/gnrdockerize.py
@@ -76,6 +76,9 @@ class MultiStageDockerImageBuilder:
         image_labels = {"gnr_app_dockerize_on": str(now)}
         entry_dir = os.getcwd()
 
+        main_repo_url = self.builder.git_url_from_path(self.instance.instanceFolder)
+        self.main_repo_name = self.builder.git_repo_name_from_url(main_repo_url)
+        
         os.chdir(self.build_context_dir)
         self.dockerfile_path = os.path.join(self.build_context_dir, "Dockerfile")
         with open(self.dockerfile_path, 'w') as dockerfile:


### PR DESCRIPTION
fix: during last refactor, the main_repo_name went missing and not found by linter
due to f-string usage. Put it back in place, and verified against a new deployment.