### PR TITLE
glbl package startup data auto-load

### DIFF
--- a/projects/gnr_it/packages/glbl/lib/upgrades/0001_ensure_data.py
+++ b/projects/gnr_it/packages/glbl/lib/upgrades/0001_ensure_data.py
@@ -1,0 +1,8 @@
+from gnr.app import pkglog as logger
+
+def main(db):
+    logger.info("Ensure GLBL data is loaded")
+    if not db.table("glbl.nazione").query().count():
+        logger.info("Loading GLBL data")
+        db.package("glbl").loadStartupData()
+    


### PR DESCRIPTION
added upgrade script for glbl package which automatically load the data if they're missing. For ease, only the 'nazione' table is checked.

This allows automatically deploy of new application images using the glbl package (like all erpy-based applications do), otherwise the '''gnr db migrate -u''' fails due to sys record being added by erpy.

refs #276