### PR TITLE
External projects packages

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -1025,6 +1025,13 @@ class GnrApp(object):
                 path = os.path.join(project_path,'packages')
                 if not os.path.isdir(os.path.join(path, pkgid)):
                     path=None
+                    external_project_path = os.path.join(project_path,'external_projects.xml')
+                    if os.path.exists(external_project_path):
+                        external_projects = Bag(external_project_path)
+                        package_attrs = external_projects.getAttr(pkgid) or {}
+                        external_project = package_attrs.get('project')
+                        if external_project:
+                            return self.pkg_name_to_path(pkgid,external_project)
         else:
             path = self.package_path.get(pkgid)
             


### PR DESCRIPTION
This feature makes external projects path readable from an xml file such as:

```
<GenRoBag>
    <acube project='gnrpayments'/>
    <bnck project='gnrwork'/>
    <dem project='gnrcommunication'/>
    <edifact project='gnrexperiments'/>
    <electron project='gnrexperiments'/>
    <genrobot project='gnrcommunication'/>
    <gnrai project='gnrexperiments'/>
...
```

This is useful to avoid errors when projects are moved from their former path (e.g. `gnrextra` projects).

Feature has been tested and is approvable