### PR TITLE
Execute the GLBL data check and load on onDbUpgrade

### DIFF
--- a/gnrpy/gnr/app/gnrdbo.py
+++ b/gnrpy/gnr/app/gnrdbo.py
@@ -186,9 +186,10 @@ class GnrDboPackage(object):
                             tblobj.query().count()
                             )
                 tblobj.insertMany(recordsToInsert)
-        db.commit()
 
-        self.db.table('adm.preference').initPkgPref(self.name,s['preferences'])
+        if s['preferences']:
+            self.db.table('adm.preference').initPkgPref(self.name,s['preferences'])
+            
         db.commit()
         
         os.remove('%s.pik' %bagpath)

--- a/projects/gnr_it/packages/glbl/model/nazione.py
+++ b/projects/gnr_it/packages/glbl/model/nazione.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+from gnr.app import pkglog as logger
 
 class Table(object):
     def config_db(self, pkg):
@@ -12,7 +13,13 @@ class Table(object):
         tbl.column('code3', size='3', name_long='!![it]Code3')
         tbl.column('nmbr', size='3', name_long='!![it]Num.Code')
         tbl.column('nmbrunico', size='3', name_long='!![it]Num.Unico')
-        
+
+    def onDbUpgrade(self):
+        logger.info("Ensure GLBL data is loaded")
+        if not self.query().count():
+            logger.info("No data found, loading GLBL data")
+            self.db.package("glbl").loadStartupData()
+
     def populate(self):
         data = """
 AALAND ISLANDS                                  AX      ALA     248

--- a/projects/gnrcore/packages/adm/model/preference.py
+++ b/projects/gnrcore/packages/adm/model/preference.py
@@ -90,7 +90,9 @@ class Table(object):
 
     def setPreference(self, path=None, value=None, pkg='',_attributes=None,**kwargs):
         with self.db.tempEnv(connectionName='system',storename=self.db.rootstore):
-            with self.recordToUpdate(MAIN_PREFERENCE) as record:
+            with self.recordToUpdate(MAIN_PREFERENCE, ignoreMissing=True) as record:
+                if not record:
+                    return
                 l = ['data',pkg]
                 if path:
                     l.append(path)

--- a/projects/gnrcore/packages/adm/model/preference.py
+++ b/projects/gnrcore/packages/adm/model/preference.py
@@ -90,9 +90,7 @@ class Table(object):
 
     def setPreference(self, path=None, value=None, pkg='',_attributes=None,**kwargs):
         with self.db.tempEnv(connectionName='system',storename=self.db.rootstore):
-            with self.recordToUpdate(MAIN_PREFERENCE, ignoreMissing=True) as record:
-                if not record:
-                    return
+            with self.recordToUpdate(code=MAIN_PREFERENCE, insertMissing=True) as record:
                 l = ['data',pkg]
                 if path:
                     l.append(path)


### PR DESCRIPTION
Execute the GLBL data check and load on onDbUpgrade from the 'nazione' table,

since the simple upgrade script is not enough, since it's executed *after* the sys record creation, and the problematic relation is coming from a sys record.

The upgrade script is left there, just in case, to be used via `gnr db migrate -U`

We also had to tweak the adm.preference table and handle a case when the preference is missing: if we call the loadStartupData for a package, a record from adm.preferences is update, but since we're creating the database from scratch, it doesn't exist anymore. So we just skip the update if the record in adm.preference is missing. YMMV, please review

Still related to ticket #276 