### PR TITLE
Fix Sphinx export: handle TOC roots and regular pages correctly

### DIFF
--- a/projects/gnrcore/packages/docu/resources/tables/handbook/th_handbook.py
+++ b/projects/gnrcore/packages/docu/resources/tables/handbook/th_handbook.py
@@ -60,16 +60,22 @@ class Form(BaseComponent):
         fb.field('docroot_id', hasDownArrow=True, validate_notnull=True, tag='hdbselect', folderSelectable=True)
         fb.checkBoxText(value='^.toc_roots',
                         table='docu.documentation', popup=True, cols=4,lbl='!![en]TOC roots',
-                        condition='$parent_id = :docroot_id', condition_docroot_id='^.docroot_id' )
+                        condition='$parent_id=:docroot_id AND $sphinx_toc IS TRUE', 
+                        condition_docroot_id='^.docroot_id' )
         fb.field('language', validate_notnull=True)
         fb.field('version')
         fb.field('author')
+        # Check for available themes
         themesSn = self.site.storageNode('rsrc:pkg_docu','sphinx_env','themes')
+        themes = ''
         if themesSn.exists:
             themes = ','.join([s.basename for s in themesSn.children() if s.isdir and not s.basename.startswith('.')])
+
+        # Show theme selector if themes are available, otherwise show default theme
+        if themes:
             fb.field('theme', values=themes, tag='filteringSelect')
         else:
-            fb.textBox(value='Sphinx RTD standard theme', lbl='Theme', readOnly=True)
+            fb.textBox(value='Sphinx RTD standard theme', lbl='!![en]Theme', readOnly=True)
         
         fb.field('examples_site')
         fb.field('examples_directory')


### PR DESCRIPTION
## Summary

This PR fixes several issues with the Sphinx export functionality when using TOC roots:

- **TOC roots filtering**: Only exports TOC roots that have publish_date set
- **Regular pages inclusion**: Includes non-TOC root pages with publish_date in the main TOC
- **Docroot content**: Adds docroot textual content to the index page before the TOC menu
- **Content processing**: Applies image and link fixes to docroot content
- **Theme refactoring**: Simplifies theme selection logic in handbook form

## Changes

### export_to_sphinx.py
- Added docroot content extraction and processing in step_prepareRstDocs()
- Implemented two-phase processing: regular pages first, then TOC roots
- Added publish_date check for both regular pages and TOC roots
- Modified createFile() to place content before toctree

### th_handbook.py
- Refactored theme selection logic to handle empty theme directories
- Reduced nesting by checking theme availability first

## Behavior

**Before**: TOC roots were always included regardless of publication status, regular pages were ignored, docroot content was not included

**After**:
- Regular pages with publish_date appear in main TOC
- TOC roots with publish_date appear as captioned sections
- Unpublished items (no publish_date) are excluded
- Docroot content appears before the TOC menu

## Test Plan

Tested with handbook structure containing:
- Published regular page (introduction) → ✅ Included
- Unpublished page (draft) → ✅ Excluded
- Published TOC root (google) → ✅ Included
- Unpublished TOC root (social) → ✅ Excluded
- Docroot with content → ✅ Content included in index

Fixes #289
