### PR TITLE
added minimal logging to ExternalProcess class handler

### DIFF
--- a/gnrpy/tests/web/gnrwsgisite_test.py
+++ b/gnrpy/tests/web/gnrwsgisite_test.py
@@ -71,7 +71,6 @@ class TestGnrWsgiSite(BaseGnrTest):
  
     def test_service_handler(self):
         # non existing service
-        print("UNO")
         with pytest.raises(KeyError) as excinfo:
             r = self.services_handler("foobar").configurations()
             
@@ -79,10 +78,7 @@ class TestGnrWsgiSite(BaseGnrTest):
         assert r is None
         r = self.site.getService("git", "gitpython")
         assert r is None
-        print(self.site.serviceList("git"))
-        print("DUE")
         assert "git" in self.services_handler.service_types
-        print("TRE")
 
     def test_auxinstances(self):
         with pytest.raises(Exception) as excinfo:


### PR DESCRIPTION
Added logging to external process manager and stdout/stdint capturing of the process, in order to debug the issue. 

Attempted 10 workflow run without the ability to reproduce the problem, so I'm merging this anyway waiting for future failure, hopefully there'll be enough information to understand the cause of the randoming test failures.