### PR TITLE
feat: add double-click to lock buttons in MultiButton for mobile (#306)

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase.css
+++ b/gnrjs/gnr_d11/css/gnrbase.css
@@ -4542,6 +4542,13 @@ p {
 .multibutton_selected.multibutton:hover{
 	text-decoration:none;
 }
+
+/* Locked button style (double-click to lock/unlock for multivalue selection) */
+.multibutton[data-locked="true"] .multibutton_caption{
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
 .multibutton_selected.multibutton[disabled='true']{
     opacity: 1;
     cursor: not-allowed;

--- a/projects/gnrcore/packages/test/webpages/components/multibutton.py
+++ b/projects/gnrcore/packages/test/webpages/components/multibutton.py
@@ -3,17 +3,21 @@
 class GnrCustomWebPage(object):
 
     py_requires="gnrcomponents/testhandler:TestHandlerFull,th/th:TableHandler"
-    
-    def windowTitle(self):
-        return 'Multibutton test'
         
     def test_0_multibutton_base(self,pane):
+        "Multibutton base"
         pane.multibutton(value='^.base',values='pippo:Pippo,paperino:Paperino')
         pane.textbox(value='^.base')
         pane.dataController("genro.bp(true)",v='^.base')
 
     def test_1_itemsMaxWidth(self,pane):
+        "Multibutton itemsMaxWidth"
         pane.textbox(value='^.base',lbl='Curr selected')
         pane.textbox(value='^.values',lbl='Curr values',default='pippo:Pippo,pluto:Pluto,paperino:Paperino,mario:Mario,l:luca,c:Cesare,p:Pancrazio,o:Ortensia,a:Antonella,b:Brigitta')
         pane.div(height='20px')
         pane.div(_class='mobile_bar').multibutton(value='^.base',values='^.values',itemsMaxWidth='300px',content_max_width='40px')
+        
+    def test_2_multivalue(self, pane):
+        "Multivalue: shift+click to select multiple values."
+        pane.multibutton(value='^.base',values='pippo:Pippo,paperino:Paperino', multivalue=True)
+        pane.textbox(value='^.base')


### PR DESCRIPTION
## Summary

Fixes #306 - MultiButton requires shift+click for multiple selection, impossible on mobile

### Problem
The MultiButton widget supports multiple selection but requires `shift+click`, which is not available on mobile/touch devices.

### Solution
Implemented **double-tap to "lock" buttons**:
- Double click on a button makes it "sticky" (locked)
- Locked buttons remain selected even when clicking on other buttons
- Another double click unlocks the button
- Visual indicator: **underlined text** for locked buttons

## Changes

- `gnrjs/gnr_d11/js/genro_components.js`: 
  - Added `getLockedCodes()` function to get codes of locked buttons
  - Added `btn_dblaction` handler for toggling `data-locked` attribute
  - Modified `btn_action` to include locked buttons in selection

- `gnrjs/gnr_d11/css/gnrbase.css`:
  - Added style for buttons with `data-locked="true"` (text-decoration: underline)

## Test plan

@fporcari could you please test this?

- [ ] Verify that double click on a button locks it (underlined)
- [ ] Verify that locked buttons remain selected when clicking on others
- [ ] Verify that another double click unlocks the button
- [ ] Test on mobile/touch device