### PR TITLE
gnr db migrate inspect failure 

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -15,7 +15,9 @@ Enhancements
   color syntax plugin, hidden preview mode, and bag mode support to
   store mardown text into nested Bag structures.
 * TinyMCE is now the default editor (#219)
-  
+* Postgres database dump is now correctly monitored for runtime
+  errors, like server version mismatches
+
 Deprecations
 ------------
 


### PR DESCRIPTION
refs #323 

the PR monitor the execution of the external process to dump the postgres database during the inspection process, and stop the execution if any errors are raised, gaining more control on the execution.