### PR TITLE
Fix Sphinx export: TOC roots, regular pages, and theme handling

### DIFF
--- a/projects/gnrcore/packages/docu/resources/tables/handbook/th_handbook.py
+++ b/projects/gnrcore/packages/docu/resources/tables/handbook/th_handbook.py
@@ -5,7 +5,6 @@
 # Copyright (c) 2011 Softwell. All rights reserved.
 
 from gnr.web.gnrbaseclasses import BaseComponent
-from gnr.core.gnrdecorator import public_method
 
 class View(BaseComponent):
     def th_struct(self,struct):
@@ -40,9 +39,8 @@ class Form(BaseComponent):
         tc = form.center.tabContainer(datapath='.record')
         self.handbookInfo(tc.contentPane(title='!![en]Info'))
         self.handbookDocRoot(tc.contentPane(title='!![en]Documentation', hidden='^.docroot_id?=!#v'))
-        tc.contentPane(title='!![en]Preview', hidden='==(handbook_url || local)', 
-                    handbook_url='^.handbook_url?=!#v', local='^.is_local_handbook').remote(
-                    self.handbookPreview, _if='handbook_url', handbook_url='^.handbook_url?=!#v')
+        self.handbookPreview(tc.borderContainer(title='!![en]Preview', hidden='==(handbook_url || local)',
+                    handbook_url='^.handbook_url?=!#v', local='^.is_local_handbook'))
         self.handbookZip(tc.contentPane(title='!![en]Zip', hidden='^.is_local_handbook?=#v!=true'))
 
     def handbookInfo(self, main):
@@ -55,8 +53,10 @@ class Form(BaseComponent):
         fb.field('name', validate_notnull=True)
         fb.field('is_local_handbook', lbl='', label='!![en]Is local handbook')
         fb.field('title', validate_notnull=True)
-        fb.div('^.sphinx_path', lbl='!![en]Sphinx path', hidden='==(handbook_url || local)', 
-                                                handbook_url='^.handbook_url?=!#v', local='^.is_local_handbook')
+        fb.div('^.sphinx_path', lbl='!![en]Sphinx path', hidden='==(handbook_url || local)',
+                        _virtual_column='sphinx_path',
+                        handbook_url='^.handbook_url?=!#v',
+                        local='^.is_local_handbook')
         fb.field('docroot_id', hasDownArrow=True, validate_notnull=True, tag='hdbselect', folderSelectable=True)
         fb.checkBoxText(value='^.toc_roots',
                         table='docu.documentation', popup=True, cols=4,lbl='!![en]TOC roots',
@@ -115,13 +115,11 @@ class Form(BaseComponent):
                 docroot_id='=#FORM.record.docroot_id',
                 _if='docroot_id', _delay=1)
 
-    @public_method
-    def handbookPreview(self, frame, **kwargs):
-        frame_bc = frame.borderContainer()
-        frame_bc.contentPane(region='top', height='30px', overflow='hidden').formbuilder(margin='2px').a(
-                            '^.handbook_url', lbl='!![en]Doc url:', href='^.handbook_url', 
+    def handbookPreview(self, bc, **kwargs):
+        bc.contentPane(region='top', height='30px', overflow='hidden').formbuilder(margin='2px').a(
+                            '^.handbook_url', lbl='!![en]Doc url:', href='^.handbook_url',
                             target='_blank', hidden='^.handbook_url?=!#v')
-        frame_bc.contentPane(region='center', overflow='hidden').htmlIframe(src='^.handbook_url', width='100%', height='100%')
+        bc.contentPane(region='center', overflow='hidden').htmlIframe(src='^.handbook_url', width='100%', height='100%')
     
     def handbookZip(self, frame):
         frame_bc = frame.borderContainer()


### PR DESCRIPTION
## Summary

This PR fixes multiple issues in the DOCU Sphinx export functionality, ensuring proper handling of TOC structure, theme fallback, and UI preview.

## Changes

### 1. TOC Structure Fix (Closes #289)

**Problem:**
- Export only processed documents in `toc_roots`, ignoring regular published pages
- No check on `publish_date` for toc_root documents
- Unpublished toc_roots were included in export

**Solution:**
- Iterate over ALL direct children of docroot (not just toc_roots)
- Check `publish_date` for each document
- Separate into two groups:
  - **Regular pages**: have `publish_date` but NOT in `toc_roots` → appear as regular TOC entries
  - **TOC sections**: in `toc_roots` AND have `publish_date` → appear as sections with captions
- Build main TOC: regular pages first, then TOC sections
- Unpublished documents excluded regardless of toc_roots membership

**Example result:**
```
Given structure:
- introduction (publish_date ✓, toc_roots ✗) → included as regular page
- draft (publish_date ✗, toc_roots ✗) → excluded
- google (publish_date ✓, toc_roots ✓) → included as TOC section
- social (publish_date ✗, toc_roots ✓) → excluded

Generated TOC:
.. toctree::
   introduction

.. toctree::
   :caption: Google
   google/...
```

### 2. Theme Handling

**Problem:**
- Export failed when configured theme didn't exist locally
- Common scenario: DB has `genropy_rtd_theme` from production, local env doesn't have it

**Solution:**
- Check theme existence before using configured value
- Fallback to `sphinx_rtd_theme` if theme not found
- Log warning when fallback occurs
- Export succeeds instead of failing

### 3. Handbook Theme Preferences

**Problem:**
- `TypeError: 'NoneType' object is not subscriptable` when `handbooks_theme_pref` not configured

**Solution:**
- Default to empty dict: `handbooks_theme_pref = ... or {}`
- Use `.get()` for all preference access (logo, copyright, display_version, etc.)
- Export succeeds even without theme preferences

### 4. Preview Tab Fix

**Problem:**
- Handbook preview iframe not rendering correctly in form

**Solution:**
- Remove `@public_method` decorator
- Change from `.remote()` call to direct method invocation
- Accept `borderContainer` directly instead of creating nested one
- Add `_virtual_column='sphinx_path'` to sphinx_path div for proper virtual column handling

### 5. Debug Logging

Added logging for HTML build move operation to help troubleshoot deployment:
```python
logger.info(f"Moving HTML build from {source} to {destination}")
logger.info(f"Move completed. Published doc available at: {path}")
```

## Files Changed

- `export_to_sphinx.py`: TOC logic, theme handling, preferences handling, logging
- `th_handbook.py`: Preview tab fix, remove unused import

## Testing

✅ Tested with handbook having:
- Regular published pages (not in toc_roots)
- TOC sections (in toc_roots with publish_date)
- Unpublished documents (excluded correctly)
- Missing theme (fallback works)
- No theme preferences (no error)

## Related

- Closes #289
- Related to broader DOCU refactoring (#337)