### PR TITLE
Refactor contentEditor to support multiple text editors

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -28,7 +28,10 @@ Enhancements
 * 'gnr app checkdep -i' installation process now have better control
   over subprocess execution to collect errors and provide useful
   informations to debug issues (#343)
-
+* new contentEditor in docu_components which supports multiple text
+  editors. (#344)
+  
+  
 Deprecations
 ------------
 
@@ -37,6 +40,8 @@ Deprecations
 * getVolumeService() and legacy volumes configuration have been
   deprecated in favor of section 'services'
 * the subdomain concept from wsgisite and gnrwebpage has been dropped (#334)
+* contentText component in docu_components has been deprecated by
+  contentEditor which supports multiple text editors.
 
 Fixes
 -----

--- a/projects/gnrcore/packages/docu/model/content.py
+++ b/projects/gnrcore/packages/docu/model/content.py
@@ -7,13 +7,14 @@ class Table(object):
                         name_plural='!!Contents', caption_field='title')
         self.sysFields(tbl)
 
-        tbl.column('title', name_long='!!Title',indexed=True, validate_notnull=True)
+        tbl.column('title', name_long='!!Title', validate_notnull=True)
         tbl.column('headline', name_long='!!Headline')
         tbl.column('abstract', name_long='!!Abstract')
         tbl.column('text', name_long='!!Text')
         tbl.column('html', name_long='!!HTML')
-
         tbl.column('tplbag', dtype='X', name_long='!!Template')
+        
+        tbl.formulaColumn('calc_text', "COALESCE($html,$text)", name_long='!!Calculated Text')
 
     def trigger_onInserted(self, record):
         self.db.table('docu.content_history').makeNewVersionFromContent(record)

--- a/projects/gnrcore/packages/docu/resources/docu_components.py
+++ b/projects/gnrcore/packages/docu/resources/docu_components.py
@@ -494,16 +494,59 @@ class DocumentationViewer(BaseComponent):
 class ContentsComponent(BaseComponent):
     js_requires='docu_components'
     
-    def contentEditor(self, pane, mode='text', value=None, htmlpath=None, textpath=None, initialEditType='wysiwyg', **kwargs):
-        "Supported modes: html,rst"
-        if mode=='rst':
-            pane.MDEditor(value=value, htmlpath=htmlpath, nodeId='contentMd', height='100%', previewStyle='vertical',
-                        initialEditType=initialEditType, **kwargs)
-        elif mode=='html':
-            pane.tinyMce(value=value, textpath=textpath, nodeId='contentHtml', height='100%', **kwargs)
+    @struct_method
+    def contentEditor(self, pane, mode=None, **kwargs):
+        """
+        Unified content editor supporting multiple editor types.
+
+        Supported modes:
+        - 'html': WYSIWYG HTML editor (tinyMce or ckeditor based on sys stylingPreferences)
+            Edits .html field, optionally saves plain text to .text
+        - 'md': Markdown editor with preview (MDEditor)
+            Edits .text field, optionally renders HTML to .html
+        - 'text': Simple textarea fallback
+            Edits .text field
+        - 'template': Template chunk editor
+            Edits .tplbag field
+
+        Args:
+            pane: Container pane for the editor
+            mode: Editor mode ('html', 'md', 'text', 'template')
+            **kwargs: Additional arguments passed to underlying editor
+                     (e.g., initialEditType for MDEditor)
+        """
+        if mode == 'html':
+            self.contentEditor_html(pane, **kwargs)
+        elif mode == 'md':
+            self.contentEditor_md(pane, **kwargs)
+        elif mode == 'template':
+            self.contentEditor_template(pane, **kwargs)
         else:
-            pane.simpleTextArea(value=value, nodeId='contentText', height='100%', **kwargs)
+            self.contentEditor_text(pane, **kwargs)
     
+    def contentEditor_html(self, pane, **kwargs):
+        "Chooses html editor after checking sys stylingPreferences for tinymce_beta (True=tinyMce, False=ckeditor)"
+        use_tinymce = self.getPreference('theme.tinymce_beta', pkg='sys') 
+        if use_tinymce:
+            pane.tinyMce(value='^.html', textpath='.text', nodeId='contentHtml',
+                        height='100%', **kwargs)
+        else:
+            pane.ckeditor(value='^.html', nodeId='contentHtml', height='100%', **kwargs)
+    
+    def contentEditor_md(self, pane, initialEditType='wysiwyg', previewStyle='vertical', **kwargs):
+        "Markdown editor with preview. Default initialEditType to 'wysiwyg' if not provided"
+        pane.MDEditor(value='^.text', htmlpath='.html', nodeId='contentMd_',
+                        height='100%', initialEditType=initialEditType, previewStyle=previewStyle, **kwargs)
+        
+    def contentEditor_text(self, pane, **kwargs):
+        "Simple textarea fallback"
+        pane.simpleTextArea(value='^.text', nodeId='contentText', height='100%', **kwargs)
+        
+    def contentEditor_template(self, pane, **kwargs):
+        "Simple template chunk editor"
+        pane.templateChunk(template='^.tplbag', editable=True, height='100%', margin='5px', overflow='hidden',
+                                                table='docu.content', selfsubscribe_onChunkEdit='this.form.save();')
+                
     @customizable    
     def contentData(self, pane, **kwargs):
         fb = pane.formbuilder(cols=1, width='600px', border_spacing='4px', **kwargs)
@@ -535,32 +578,6 @@ class ContentsComponent(BaseComponent):
                                                     delrow=True,
                                                     configurable=False, 
                                                     **kwargs)
-    
-    @struct_method
-    def contentText(self, pane, mode='text', convertText=False, convertHtml=True, **kwargs):
-        """Supported modes: text,html,rst. 
-            Text (default) is edited with a textarea, Html with tinyMce, rst with MDEditor.
-            convertText: when mode is html, if convertText is True, the plain text version is saved in the 'text' field
-            convertHtml: when mode is rst, if convertHtml is True, the html version is saved in the 'html' field
-        """
-        if mode=='html':
-            # TinyMCE edits HTML, saves HTML in value and optionally plain text in textpath
-            value = '^.html'
-            textpath = '^.text' if convertText else None
-            self.contentEditor(pane, value=value, mode=mode, textpath=textpath, **kwargs)
-        elif mode=='rst':
-            # MDEditor edits Markdown, saves Markdown in value and HTML in htmlpath
-            value = '^.text'
-            htmlpath = '^.html' if convertHtml else None
-            self.contentEditor(pane, value=value, mode=mode, htmlpath=htmlpath, **kwargs)
-        else:
-            # Plain text mode
-            value = '^.text'
-            self.contentEditor(pane, value=value, mode=mode, **kwargs)
-
-    def contentTemplate(self, pane):
-        pane.templateChunk(template='^.tplbag', editable=True, height='100%', margin='5px', overflow='hidden',
-                                                table='docu.content', selfsubscribe_onChunkEdit='this.form.save();')
 
     def contentAttachments(self, pane):
         pane.attachmentMultiButtonFrame()

--- a/projects/gnrcore/packages/docu/resources/docu_components.py
+++ b/projects/gnrcore/packages/docu/resources/docu_components.py
@@ -582,8 +582,22 @@ class ContentsComponent(BaseComponent):
     def contentAttachments(self, pane):
         pane.attachmentMultiButtonFrame()
 
-    def contentVersions(self, bc, **kwargs):
-        bc.contentPane(region='center').plainTableHandler(relation='@versions', formResource='FormDiff', configurable=False)
-        bc.contentPane(region='bottom', closable='close', closable_label='!![en]Differences', height='50%').simpleTextArea(
-                                                    '^.diff', overflow='hidden', height='100%', width='100%', 
+    def contentVersions(self, bc, table=None, condition=None, relation=None, **kwargs):
+        "Please provide either table or relation"
+        historyth_params = dict(formResource='FormDiff' or kwargs.pop('formResource', None),
+                                viewResource='ViewFromContent' or kwargs.pop('viewResource', None),
+                                configurable=False or kwargs.pop('configurable', False))
+        if table:
+            historyth_params['table'] = table 
+        elif relation:
+            historyth_params['relation'] = relation
+        else:
+            raise GnrException('Please provide either table or relation to contentVersions')
+        if condition:
+            historyth_params['condition'] = condition
+        bc.contentPane(region='center').plainTableHandler(**historyth_params, **kwargs)
+        bc.contentPane(region='bottom', closable='close', closable_label='!![en]Differences', 
+                                                    height='50%').simpleTextArea(
+                                                    '^.diff', overflow='hidden', 
+                                                    height='100%', width='100%', 
                                                     editor=True, readOnly=True)

--- a/projects/gnrcore/packages/docu/resources/docu_components.py
+++ b/projects/gnrcore/packages/docu/resources/docu_components.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import warnings
 from gnr.web.gnrbaseclasses import BaseComponent
 from gnr.web.gnrwebstruct import struct_method
 from gnr.core.gnrdecorator import public_method,customizable
@@ -515,15 +516,24 @@ class ContentsComponent(BaseComponent):
             **kwargs: Additional arguments passed to underlying editor
                      (e.g., initialEditType for MDEditor)
         """
-        if mode == 'html':
-            self.contentEditor_html(pane, **kwargs)
-        elif mode == 'md':
-            self.contentEditor_md(pane, **kwargs)
-        elif mode == 'template':
-            self.contentEditor_template(pane, **kwargs)
-        else:
-            self.contentEditor_text(pane, **kwargs)
-    
+        getattr(self, f"contentEditor_{mode}", self.contentEditor_text)(pane, **kwargs)
+
+    @struct_method
+    def contentText(self, pane, mode=None, **kwargs):
+        """
+        DEPRECATED: Use contentEditor() instead.
+
+        This method is deprecated and will be removed in a future release.
+        Please update your code to use contentEditor() with the appropriate mode parameter.
+        """
+        warnings.warn(
+            "contentText() is deprecated and will be removed in a future release. "
+            "Please use contentEditor() instead.",
+            FutureWarning,
+            stacklevel=2
+        )
+        self.contentEditor(pane, mode=mode, **kwargs)
+
     def contentEditor_html(self, pane, **kwargs):
         "Chooses html editor after checking sys stylingPreferences for tinymce_beta (True=tinyMce, False=ckeditor)"
         use_tinymce = self.getPreference('theme.tinymce_beta', pkg='sys') 

--- a/projects/gnrcore/packages/docu/resources/tables/content/th_content.py
+++ b/projects/gnrcore/packages/docu/resources/tables/content/th_content.py
@@ -91,8 +91,9 @@ class FormReview(Form):
     def th_form(self, form):
         tc = form.center.tabContainer(tabPosition='left-h')
         tc.contentPane(title='!!Text', region='center',overflow='hidden',
-                                          datapath='.record').contentEditor(mode='md')
-        self.contentVersions(tc.borderContainer(title='!!Versions', region='center'), value='^.text')
+                                datapath='.record').contentEditor(mode='md')
+        self.contentVersions(tc.borderContainer(title='!!Versions', region='center'),
+                                relation='@versions')
         return tc
         
     def th_options(self):

--- a/projects/gnrcore/packages/docu/resources/tables/content/th_content.py
+++ b/projects/gnrcore/packages/docu/resources/tables/content/th_content.py
@@ -8,10 +8,9 @@ class View(BaseComponent):
 
     def th_struct(self,struct):
         r = struct.view().rows()
-        r.fieldcell('title')
-        r.fieldcell('headline')
-        r.fieldcell('abstract')
-        r.fieldcell('text')
+        r.fieldcell('title', width='20em')
+        r.fieldcell('headline', width='40em')
+        r.fieldcell('abstract', width='auto')
 
     def th_order(self):
         return 'title'
@@ -60,10 +59,11 @@ class Form(BaseComponent):
         self.contentAttributes(top.borderContainer(title='!!Content Attributes', region='right', width='500px'))
         self.contentMain(bc.tabContainer(region='center'))
     
-    @customizable
     def contentMain(self, tc):
-        self.contentText(tc.contentPane(title='!!Text', datapath='.record', overflow='hidden'))
-        self.contentTemplate(tc.contentPane(title='!!Template', datapath='.record'))
+        tc.contentPane(title='!!Text', datapath='.record', overflow='hidden').contentEditor(mode='text')
+        tc.contentPane(title='!!Markdown', datapath='.record', overflow='hidden').contentEditor(mode='md')
+        tc.contentPane(title='!!HTML', datapath='.record', overflow='hidden').contentEditor(mode='html')
+        tc.contentPane(title='!!Template', datapath='.record', overflow='hidden').contentEditor(mode='template')
         self.contentAttachments(tc.contentPane(title='!!Attachments'))
         return tc
     
@@ -77,7 +77,7 @@ class FormEmbed(Form):
 
     def th_form(self, form):
         bc = form.record
-        self.contentEditor(bc.contentPane(region='center',overflow='hidden',datapath='.record'), value='^.text',htmlpath='.html')
+        bc.contentPane(region='center',overflow='hidden',datapath='.record').contentEditor()
         
     def th_options(self):
         return dict(autoSave=True, showtoolbar=False)
@@ -90,8 +90,8 @@ class FormReview(Form):
     @customizable
     def th_form(self, form):
         tc = form.center.tabContainer(tabPosition='left-h')
-        self.contentEditor(tc.contentPane(title='!!Text', region='center',overflow='hidden', 
-                                          datapath='.record'), value='^.text',htmlpath='.html')
+        tc.contentPane(title='!!Text', region='center',overflow='hidden',
+                                          datapath='.record').contentEditor(mode='md')
         self.contentVersions(tc.borderContainer(title='!!Versions', region='center'), value='^.text')
         return tc
         

--- a/projects/gnrcore/packages/docu/resources/tables/content_history/th_content_history.py
+++ b/projects/gnrcore/packages/docu/resources/tables/content_history/th_content_history.py
@@ -26,6 +26,17 @@ class View(BaseComponent):
                             """, 
                             old_version='^.grid.selectedId?text', 
                             new_version='=#FORM.record.text', _if='old_version')
+        
+
+class ViewFromContent(View):
+    
+    def th_struct(self, struct):
+        r = struct.view().rows()
+        r.fieldcell('version', width='3em')
+        r.fieldcell('__ins_user', width='auto')
+        r.fieldcell('__ins_ts', width='9em')
+        r.fieldcell('text', hidden=True)
+
 
 class Form(BaseComponent):
 


### PR DESCRIPTION
## Overview
Closes #339

This PR refactors the `contentEditor` component in `docu_components` to provide a unified, clean interface for switching between different text editors available in the Genro framework.

## Changes

### Architecture
The refactoring splits the monolithic `contentEditor` method into a clean dispatcher pattern with dedicated methods for each editor type:

- **`contentEditor(pane, mode, **kwargs)`**: Main dispatcher method using `getattr` pattern for extensibility
- **`contentEditor_html(pane, **kwargs)`**: HTML WYSIWYG editors (tinyMce/ckeditor)
- **`contentEditor_md(pane, **kwargs)`**: Markdown editor with preview (MDEditor)
- **`contentEditor_text(pane, **kwargs)`**: Simple textarea fallback
- **`contentEditor_template(pane, **kwargs)`**: Template chunk editor
- **`contentText(pane, mode, **kwargs)`**: Deprecated wrapper (emits FutureWarning)

### Dispatcher Implementation
The main `contentEditor` method uses a dynamic dispatch pattern for better maintainability:
```python
getattr(self, f"contentEditor_{mode}", self.contentEditor_text)(pane, **kwargs)
```
This avoids updating an if-elif chain when new editor modes are added.

### Deprecation Strategy
The legacy `contentText` method is now **deprecated but not removed**. It emits a `FutureWarning` and delegates to `contentEditor`, allowing dependent packages time to migrate without forcing immediate breaking changes.

### Supported Modes
- **`mode='html'`**: WYSIWYG HTML editor
  - Checks `sys.stylingPreferences.tinymce_beta` to switch between tinyMce (default) and ckeditor
  - Edits `.html` field, saves plain text to `.text`
- **`mode='md'`**: Markdown/RST editor with live preview
  - Edits `.text` field, renders HTML to `.html`
- **`mode='text'`**: Simple textarea for plain text
  - Edits `.text` field
- **`mode='template'`**: Template chunk editor
  - Edits `.tplbag` field

### Key Improvements

1. **Clean signature**: `contentEditor(pane, mode, **kwargs)` - no need to specify `value`, `htmlpath`, or `textpath` externally
2. **Automatic field mapping**: The method determines which fields to use based on mode
3. **Proper path handling**: Output paths (`htmlpath`, `textpath`) are relative (without `^`) as they're write-only, not reactive
4. **Extensible dispatcher**: Using `getattr` pattern makes adding new editor modes straightforward
5. **Backward compatibility**: `contentText` remains available with deprecation warning
6. **All comments in English**: Following Genropy standards

### Model Changes
Added `calc_text` formula column to `docu.content` table:
```python
tbl.formulaColumn('calc_text', "COALESCE($html,$text)", name_long='!!Calculated Text')
```

## Usage Examples

### Recommended (new contentEditor)
```python
self.contentEditor(pane, mode='html')
self.contentEditor(pane, mode='md')
self.contentEditor(pane, mode='text')
self.contentEditor(pane, mode='template')
```

### Legacy (deprecated contentText)
```python
# Still works but emits FutureWarning
self.contentText(pane, mode='html')
self.contentText(pane, mode='md')
```

## Migration Path

Applications using `contentText` will see deprecation warnings in logs. To migrate:
- Replace `self.contentText(pane, mode='html')` → `self.contentEditor(pane, mode='html')`
- Replace `self.contentText(pane, mode='rst')` → `self.contentEditor(pane, mode='md')`
- Replace `self.contentText(pane, mode='text')` → `self.contentEditor(pane, mode='text')`

## Testing
- [x] Syntax validation passed
- [x] MDEditor working with correct `htmlpath` (relative path)
- [x] Multiple editor modes tested in `th_content.py`
- [x] Deprecation warning working correctly

## Files Modified
- `projects/gnrcore/packages/docu/resources/docu_components.py` - Main refactoring
- `projects/gnrcore/packages/docu/resources/tables/content/th_content.py` - Updated calls
- `projects/gnrcore/packages/docu/model/content.py` - Added calc_text column