### PR TITLE
fix: prevent duplicate service_name parameter in storage handler

### DIFF
--- a/projects/gnrcore/packages/sys/model/service.py
+++ b/projects/gnrcore/packages/sys/model/service.py
@@ -67,6 +67,14 @@ class Table(object):
             with site.register.globalStore() as gs:
                 gs.setItem('globalServices_lastChangedConfigTS.%(service_identifier)s' %record,datetime.now())
 
+    def trigger_onInserted(self, record):
+        self.serviceExpiredTs(record)
+        # Add to storage_handler params if this is a storage service
+        site = getattr(self.db.application, 'site', None)
+        if site and hasattr(site, 'storage_handler'):
+            if record.get('service_type') == 'storage':
+                site.storage_handler.updateStorageParams(record.get('service_name'))
+
     def trigger_onUpdated(self,record,old_record=None):
         self.serviceExpiredTs(record)
         # Update storage_handler params if this is a storage service


### PR DESCRIPTION
## Summary
- Add `trigger_onInserted` to `sys.service` model to update `storage_params` when a new storage service is added to the database
- Pop `service_name` from `service_params` before passing to `getService()` to avoid duplicate keyword argument error
- Add tests for service_name parameter handling

Fixes #357

## Test plan
- [x] Run existing storage handler tests
- [x] Add new tests for `service_name` parameter handling
- [x] Verify all 588 tests pass