### PR TITLE
Fix potential mutation of readOnlyAttrs dictionary in addPackage

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -1029,9 +1029,9 @@ class GnrApp(object):
             attrs['path'] = self.realPath(attrs['path'])
         apppkg = GnrPackage(pkgid, self, **attrs)
         apppkg.content = pkgcontent or Bag()
-        readOnlyAttrs = {'readOnly':True} if attrs.get('readOnly') else None
+        readOnlyAttrs = {'readOnly':True} if attrs.get('readOnly') else dict()
         for reqpkgid in apppkg.required_packages():
-            self.addPackage(reqpkgid,pkgattrs=readOnlyAttrs)
+            self.addPackage(reqpkgid,pkgattrs=dict(readOnlyAttrs))
         self.packagesIdByPath[os.path.realpath(apppkg.packageFolder)] = pkgid
         self.packages[pkgid] = apppkg
 


### PR DESCRIPTION
## Summary
- Fix dictionary mutation issue when passing `readOnlyAttrs` to `addPackage` during required_packages iteration
- Create a copy of the dictionary with `dict(readOnlyAttrs)` to prevent cross-contamination between package configurations
- Initialize `readOnlyAttrs` as empty dict instead of None to ensure `dict()` always works

## Test plan
- [x] Existing tests pass
- [x] Verify that packages with `readOnly=True` propagate the attribute correctly to required packages
- [x] Verify that modifications to `pkgattrs` in `addPackage` don't affect other iterations