### PR TITLE
364 feature - bag editor cli

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -30,7 +30,9 @@ Enhancements
   informations to debug issues (#343)
 * new contentEditor in docu_components which supports multiple text
   editors. (#344)
-  
+* New 'gnr core bagedit' CLI tool which allows to manipulate
+  (get/add/set/update/delete) entities inside bag files using the
+  command line
   
 Deprecations
 ------------

--- a/gnrpy/gnr/core/cli/gnrbagedit.py
+++ b/gnrpy/gnr/core/cli/gnrbagedit.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+
+import sys
+import os.path
+import tempfile
+from pathlib import Path
+from gnr.core.cli import GnrCliArgParse
+from gnr.core.gnrbageditor import BagEditor
+from gnr.core.gnrconfig import getEnvironmentPath
+from gnr.core.gnrbag import Bag
+
+def get_default_file_paths():
+    """Get default file paths, returning None if environment is not configured."""
+    try:
+        env_path = getEnvironmentPath()
+        if env_path is None:
+            return None, None, None
+
+        environment_file = env_path
+        instance_file = os.path.join(os.path.dirname(env_path), "instanceconfig", "default.xml")
+        siteconfig_file = os.path.join(os.path.dirname(env_path), "siteconfig", "default.xml")
+        return environment_file, instance_file, siteconfig_file
+    except Exception:
+        return None, None, None
+
+
+def parse_attributes(attr_strings):
+    """Parse attribute strings like 'path="/foobar"' into a dictionary."""
+    attributes = {}
+    if not attr_strings:
+        return attributes
+
+    for attr_string in attr_strings:
+        if '=' not in attr_string:
+            print(f"Error: Invalid attribute format '{attr_string}'. Expected format: key=value", file=sys.stderr)
+            sys.exit(1)
+
+        key, value = attr_string.split('=', 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        attributes[key] = value
+
+    return attributes
+
+description = "Manipulate Bag entities via command line"
+
+def main():
+    parser = GnrCliArgParse(
+        description=description,
+        epilog='Examples:\n'
+               '  %(prog)s file.xml add projects.foobar.goober weight="1" --output result.xml\n'
+               '  cat file.xml | %(prog)s - add projects.test path="/foo" --output -\n'
+               '  %(prog)s --environment-default get projects.custom1'
+    )
+
+    parser.add_argument('file', nargs='?', help='XML file to modify (use "-" to read from stdin, optional if using --*-default flags)')
+    parser.add_argument('operation', choices=['add', 'delete', 'update', 'get', 'set'],
+                       help='Operation to perform (add creates if missing, update requires existing, get retrieves entity)')
+    parser.add_argument('entity_path', help='Dot-separated path to entity (e.g., projects.custom1)')
+    parser.add_argument('attributes', nargs='*', help='Attributes to set (format: key=value, not used for get)')
+    parser.add_argument('--indent', action='store_true', help='Pretty-print XML output with indentation')
+    parser.add_argument('-o', '--output', help='Output file path (use "-" for stdout, defaults to overwriting source file or stdout if reading from stdin)')
+
+    # Default file options
+    parser.add_argument('--environment-default', action='store_true',
+                       help='Use default environment configuration file')
+    parser.add_argument('--instance-default', action='store_true',
+                       help='Use default instance configuration file')
+    parser.add_argument('--siteconfig-default', action='store_true',
+                       help='Use default siteconfig configuration file')
+
+    args = parser.parse_args()
+
+    # Determine which file to use
+    default_flags = [args.environment_default, args.instance_default, args.siteconfig_default]
+    if sum(default_flags) > 1:
+        print("Error: Only one default flag can be specified at a time", file=sys.stderr)
+        sys.exit(1)
+
+    using_stdin = False
+    temp_file = None
+
+    if args.environment_default or args.instance_default or args.siteconfig_default:
+        if args.file is not None:
+            print("Error: Cannot specify both a file and a default flag", file=sys.stderr)
+            sys.exit(1)
+        # Get default file paths
+        environment_file, instance_file, siteconfig_file = get_default_file_paths()
+
+        if args.environment_default:
+            if environment_file is None:
+                print("Error: No Genro environment configured", file=sys.stderr)
+                sys.exit(1)
+            file_path = environment_file
+        elif args.instance_default:
+            if instance_file is None:
+                print("Error: No Genro environment configured", file=sys.stderr)
+                sys.exit(1)
+            file_path = instance_file
+        elif args.siteconfig_default:
+            if siteconfig_file is None:
+                print("Error: No Genro environment configured", file=sys.stderr)
+                sys.exit(1)
+            file_path = siteconfig_file
+    elif args.file == '-':
+        # Read from stdin
+        using_stdin = True
+        try:
+            stdin_content = sys.stdin.read()
+            if not stdin_content.strip():
+                print("Error: No input provided on stdin", file=sys.stderr)
+                sys.exit(1)
+
+            # Create a temporary file to load the XML
+            temp_fd, temp_file = tempfile.mkstemp(suffix='.xml', text=True)
+            with os.fdopen(temp_fd, 'w') as f:
+                f.write(stdin_content)
+            file_path = temp_file
+        except Exception as e:
+            print(f"Error reading from stdin: {e}", file=sys.stderr)
+            if temp_file:
+                Path(temp_file).unlink(missing_ok=True)
+            sys.exit(1)
+    elif args.file is not None:
+        # Regular file path provided
+        file_path = args.file
+    else:
+        # No file specified and no default flag
+        print("Error: Either specify a file or use one of the --*-default flags", file=sys.stderr)
+        sys.exit(1)
+
+    # Determine output destination
+    if args.output:
+        output_path = args.output
+    elif using_stdin:
+        # Default to stdout when reading from stdin
+        output_path = '-'
+    else:
+        # Default to overwriting source file
+        output_path = file_path
+
+    # Initialize BagEditor
+    editor = BagEditor()
+
+    # Load XML file
+    try:
+        editor.load(file_path)
+    except FileNotFoundError:
+        print(f"Error: File not found: {file_path}", file=sys.stderr)
+        if temp_file:
+            Path(temp_file).unlink(missing_ok=True)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        if temp_file:
+            Path(temp_file).unlink(missing_ok=True)
+        sys.exit(1)
+    finally:
+        # Clean up temp file after loading (we don't need it anymore)
+        if temp_file and Path(temp_file).exists():
+            Path(temp_file).unlink(missing_ok=True)
+
+    # Perform operation
+    try:
+        if args.operation == 'get':
+            # Handle get operation (read-only, no save needed)
+            if args.attributes:
+                print("Warning: Attributes are ignored for get operation", file=sys.stderr)
+
+            entity = editor.get_entity(args.entity_path)
+            if entity is None:
+                print(f"Error: Entity not found: {args.entity_path}", file=sys.stderr)
+                sys.exit(1)
+
+            # Display entity information
+            print(f"Entity: {args.entity_path}")
+            print(f"Value: {entity['value']}")
+            if entity['attributes']:
+                print("Attributes:")
+                for key, value in entity['attributes'].items():
+                    print(f"  {key}: {value}")
+            else:
+                print("Attributes: (none)")
+        else:
+            # Parse attributes for add/update operations
+            attributes = parse_attributes(args.attributes)
+
+            if args.operation == 'add':
+                editor.add_entity(args.entity_path, attributes)
+            if args.operation == 'set':
+                editor.set_entity(args.entity_path, attributes)
+            elif args.operation == 'delete':
+                if args.attributes:
+                    print("Warning: Attributes are ignored for delete operation", file=sys.stderr)
+                editor.delete_entity(args.entity_path)
+            elif args.operation == 'update':
+                editor.update_entity(args.entity_path, attributes)
+
+            # Save the result
+            if output_path == '-':
+                # Write to stdout
+                xml_content = editor.bag.toXml(autocreate=False, encoding='UTF-8')
+                sys.stdout.write(xml_content)
+                sys.stdout.flush()
+            else:
+                # Save to file
+                editor.save(output_path)
+                if output_path != file_path:
+                    print(f"Successfully {args.operation}ed entity: {args.entity_path} (saved to {output_path})", file=sys.stderr)
+                else:
+                    print(f"Successfully {args.operation}ed entity: {args.entity_path}", file=sys.stderr)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/gnrpy/gnr/core/cli/gnrbagedit.py
+++ b/gnrpy/gnr/core/cli/gnrbagedit.py
@@ -198,16 +198,25 @@ def main():
             # Save the result
             if output_path == '-':
                 # Write to stdout
-                xml_content = editor.bag.toXml(autocreate=False, encoding='UTF-8')
+                xml_content = editor.bag.toXml(autocreate=False, encoding='UTF-8', pretty=args.indent)
                 sys.stdout.write(xml_content)
                 sys.stdout.flush()
             else:
                 # Save to file
-                editor.save(output_path)
+                # Map operation to past tense for success message
+                operation_past_tense = {
+                    'add': 'added',
+                    'update': 'updated',
+                    'delete': 'deleted',
+                    'set': 'set'
+                }
+                operation_text = operation_past_tense.get(args.operation, args.operation)
+
+                editor.save(output_path, indent=args.indent)
                 if output_path != file_path:
-                    print(f"Successfully {args.operation}ed entity: {args.entity_path} (saved to {output_path})", file=sys.stderr)
+                    print(f"Successfully {operation_text} entity: {args.entity_path} (saved to {output_path})", file=sys.stderr)
                 else:
-                    print(f"Successfully {args.operation}ed entity: {args.entity_path}", file=sys.stderr)
+                    print(f"Successfully {operation_text} entity: {args.entity_path}", file=sys.stderr)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/gnrpy/gnr/core/cli/gnrbagedit.py
+++ b/gnrpy/gnr/core/cli/gnrbagedit.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from gnr.core.cli import GnrCliArgParse
 from gnr.core.gnrbageditor import BagEditor
 from gnr.core.gnrconfig import getEnvironmentPath
-from gnr.core.gnrbag import Bag
 
 def get_default_file_paths():
     """Get default file paths, returning None if environment is not configured."""

--- a/gnrpy/gnr/core/gnrbageditor.py
+++ b/gnrpy/gnr/core/gnrbageditor.py
@@ -1,0 +1,225 @@
+"""
+BagEditor class for manipulating XML files using Genropy Bag.
+Provides methods to add, set, update, and delete entities in Bag structures.
+"""
+from pathlib import Path
+
+from gnr.core.gnrbag import Bag
+
+class BagEditor:
+    """Editor for XML files using Genropy Bag."""
+
+    def __init__(self, file_path=None):
+        """
+        Initialize BagEditor.
+
+        Args:
+            file_path: Path to XML file. If provided, loads the file.
+        """
+        self.file_path = file_path
+        self.bag = None
+
+        if file_path:
+            self.load(file_path)
+
+    def load(self, file_path):
+        """
+        Load an XML file as a Bag.
+
+        Args:
+            file_path: Path to the XML file to load.
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist.
+            Exception: If the file cannot be parsed as XML/Bag.
+        """
+        xml_file = Path(file_path)
+        if not xml_file.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        try:
+            self.bag = Bag(file_path)
+            self.file_path = file_path
+        except Exception as e:
+            raise Exception(f"Failed to load XML file as Bag: {e}")
+
+    def save(self, file_path=None):
+        """
+        Save the Bag to an XML file.
+
+        Args:
+            file_path: Path to save the file. If None, uses the loaded file path.
+
+        Raises:
+            ValueError: If no file path is provided and none was loaded.
+            Exception: If the file cannot be written.
+        """
+        if file_path is None:
+            file_path = self.file_path
+
+        if file_path is None:
+            raise ValueError("No file path specified for saving")
+
+        if self.bag is None:
+            raise ValueError("No Bag loaded to save")
+
+        try:
+            self.bag.toXml(file_path, autocreate=True, encoding='UTF-8')
+        except Exception as e:
+            raise Exception(f"Failed to write XML file: {e}")
+
+    def add_entity(self, entity_path, attributes=None):
+        """
+        Add an entity in the Bag.
+
+        Args:
+            entity_path: Dot-separated path to the entity (e.g., "projects.pippo.pluto").
+            attributes: Dictionary of attributes to set on the entity.
+
+        Raises:
+            ValueError: If entity_path is empty or Bag is not loaded.
+        """
+        if self.bag is None:
+            raise ValueError("No Bag loaded")
+
+        if not entity_path:
+            raise ValueError("Empty entity path")
+
+        if attributes is None:
+            attributes = {}
+
+        # Add the node with attributes
+        # If the path doesn't exist, Bag will create it
+        self.bag.addItem(entity_path, None, attributes)
+        
+    def set_entity(self, entity_path, attributes=None):
+        """
+        Set an entity in the Bag.
+
+        Args:
+            entity_path: Dot-separated path to the entity (e.g., "projects.pippo.pluto").
+            attributes: Dictionary of attributes to set on the entity.
+
+        Raises:
+            ValueError: If entity_path is empty or Bag is not loaded.
+        """
+        if self.bag is None:
+            raise ValueError("No Bag loaded")
+
+        if not entity_path:
+            raise ValueError("Empty entity path")
+
+        if attributes is None:
+            attributes = {}
+
+        # Set or update the node with attributes
+        # If the path doesn't exist, Bag will create it
+        self.bag.setItem(entity_path, None, attributes)
+
+    def update_entity(self, entity_path, attributes=None):
+        """
+        Update an existing entity (error if it doesn't exist).
+
+        Args:
+            entity_path: Dot-separated path to the entity.
+            attributes: Dictionary of attributes to update on the entity.
+
+        Raises:
+            ValueError: If entity_path is empty, Bag is not loaded, or entity not found.
+        """
+        if self.bag is None:
+            raise ValueError("No Bag loaded")
+
+        if not entity_path:
+            raise ValueError("Empty entity path")
+
+        if attributes is None:
+            attributes = {}
+
+        # Check if the node exists
+        node = self.bag.getNode(entity_path)
+        if node is None:
+            raise ValueError(f"Element not found: {entity_path}")
+
+        # Update attributes while preserving the node value
+        self.bag.setItem(entity_path, node.value, attributes)
+
+    def delete_entity(self, entity_path):
+        """
+        Delete an entity from the Bag.
+
+        Args:
+            entity_path: Dot-separated path to the entity.
+
+        Raises:
+            ValueError: If entity_path is empty, Bag is not loaded, or entity not found.
+        """
+        if self.bag is None:
+            raise ValueError("No Bag loaded")
+
+        if not entity_path:
+            raise ValueError("Empty entity path")
+
+        # Check if the node exists
+        if self.bag.getNode(entity_path) is None:
+            raise ValueError(f"Element not found: {entity_path}")
+
+        # Delete the node
+        self.bag.delItem(entity_path)
+
+    def entity_exists(self, entity_path):
+        """
+        Check if an entity exists in the Bag.
+
+        Args:
+            entity_path: Dot-separated path to the entity.
+
+        Returns:
+            bool: True if the entity exists, False otherwise.
+        """
+        if self.bag is None:
+            return False
+
+        return self.bag.getNode(entity_path) is not None
+
+    def get_entity_attributes(self, entity_path):
+        """
+        Get the attributes of an entity.
+
+        Args:
+            entity_path: Dot-separated path to the entity.
+
+        Returns:
+            dict: Dictionary of attributes, or None if entity not found.
+        """
+        if self.bag is None:
+            return None
+
+        node = self.bag.getNode(entity_path)
+        if node is None:
+            return None
+
+        return dict(node.attr) if node.attr else {}
+
+    def get_entity(self, entity_path):
+        """
+        Get the complete entity information (value and attributes).
+
+        Args:
+            entity_path: Dot-separated path to the entity.
+
+        Returns:
+            dict: Dictionary with 'value' and 'attributes' keys, or None if entity not found.
+                  Example: {'value': 'some_value', 'attributes': {'name': 'test', 'path': '/foo'}}
+        """
+        if self.bag is None:
+            return None
+
+        node = self.bag.getNode(entity_path)
+        if node is None:
+            return None
+
+        return {
+            'value': node.value,
+            'attributes': dict(node.attr) if node.attr else {}
+        }

--- a/gnrpy/gnr/core/gnrbageditor.py
+++ b/gnrpy/gnr/core/gnrbageditor.py
@@ -43,12 +43,13 @@ class BagEditor:
         except Exception as e:
             raise Exception(f"Failed to load XML file as Bag: {e}")
 
-    def save(self, file_path=None):
+    def save(self, file_path=None, indent=False):
         """
         Save the Bag to an XML file.
 
         Args:
             file_path: Path to save the file. If None, uses the loaded file path.
+            indent: If True, pretty-print the XML with indentation.
 
         Raises:
             ValueError: If no file path is provided and none was loaded.
@@ -64,7 +65,7 @@ class BagEditor:
             raise ValueError("No Bag loaded to save")
 
         try:
-            self.bag.toXml(file_path, autocreate=True, encoding='UTF-8')
+            self.bag.toXml(file_path, autocreate=True, encoding='UTF-8', pretty=indent)
         except Exception as e:
             raise Exception(f"Failed to write XML file: {e}")
 

--- a/gnrpy/gnr/core/gnrbageditor.py
+++ b/gnrpy/gnr/core/gnrbageditor.py
@@ -3,8 +3,11 @@ BagEditor class for manipulating XML files using Genropy Bag.
 Provides methods to add, set, update, and delete entities in Bag structures.
 """
 from pathlib import Path
+from datetime import datetime
+import shutil
 
 from gnr.core.gnrbag import Bag
+from gnr.core import logger
 
 class BagEditor:
     """Editor for XML files using Genropy Bag."""
@@ -63,6 +66,20 @@ class BagEditor:
 
         if self.bag is None:
             raise ValueError("No Bag loaded to save")
+
+        # Create backup if saving to the same file that was loaded
+        if file_path == self.file_path and self.file_path is not None:
+            source_path = Path(file_path)
+            if source_path.exists():
+                # Generate backup filename: <filename><extension>-YYYYMMDDHHMMSS
+                timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+                backup_path = source_path.parent / f"{source_path.name}-{timestamp}"
+
+                try:
+                    shutil.copy2(file_path, backup_path)
+                    logger.info(f"Backup created: {backup_path}")
+                except Exception as e:
+                    raise Exception(f"Failed to create backup file: {e}")
 
         try:
             self.bag.toXml(file_path, autocreate=True, encoding='UTF-8', pretty=indent)

--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -186,7 +186,6 @@ packages = [
 # COVERAGE
 [tool.coverage.run]
 omit = [
-     "*/cli/*",
 ]
 
 # LINTERS

--- a/gnrpy/tests/core/gnrbageditor_test.py
+++ b/gnrpy/tests/core/gnrbageditor_test.py
@@ -1,0 +1,1028 @@
+"""
+Unit tests for BagEditor class and CLI.
+"""
+import pytest
+from .common import BaseGnrTest
+import tempfile
+from pathlib import Path
+import subprocess
+import sys
+import io
+from unittest.mock import patch
+from gnr.core.gnrbageditor import BagEditor
+from gnr.core.cli.gnrbagedit import main as cli_main
+
+
+class TestBagEditor(BaseGnrTest):
+    """Test cases for BagEditor class."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test fixtures."""
+        # Create a temporary XML file for testing
+        cls.test_dir = tempfile.mkdtemp()
+        cls.test_file = Path(cls.test_dir) / "test.xml"
+
+        # Store the original XML content
+        cls.original_xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<GenRoBag>
+    <projects>
+        <project1 name="Test Project" path="/test"/>
+    </projects>
+</GenRoBag>
+"""
+        cls.test_file.write_text(cls.original_xml_content)
+
+        cls.editor = BagEditor()
+
+    def setup_method(self, method):
+        """Reset test file before each test for isolation."""
+        # Restore original XML content before each test
+        self.test_file.write_text(self.original_xml_content)
+        # Reset the editor to ensure clean state
+        self.editor = BagEditor()
+
+    @classmethod
+    def teardown_class(cls):
+        """Clean up test fixtures."""
+        # Remove temporary files
+        if cls.test_file.exists():
+            cls.test_file.unlink()
+        Path(cls.test_dir).rmdir()
+
+    def test_init_without_file(self):
+        """Test initializing BagEditor without a file."""
+        editor = BagEditor()
+        assert editor.bag is None
+        assert editor.file_path is None
+
+    def test_init_with_file(self):
+        """Test initializing BagEditor with a file."""
+        editor = BagEditor(str(self.test_file))
+        assert editor.bag is not None
+        assert editor.file_path == str(self.test_file)
+
+    def test_load_existing_file(self):
+        """Test loading an existing XML file."""
+        self.editor.load(str(self.test_file))
+        assert self.editor.bag is not None
+        assert self.editor.file_path == str(self.test_file)
+
+    def test_load_nonexistent_file(self):
+        """Test loading a nonexistent file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            self.editor.load("/nonexistent/file.xml")
+
+    def test_load_invalid_xml(self):
+        """Test loading an invalid XML file raises Exception."""
+        # Create a file with invalid XML content
+        invalid_file = Path(self.test_dir) / "invalid.xml"
+        invalid_file.write_text("This is not valid XML content")
+
+        with pytest.raises(Exception) as context:
+            self.editor.load(str(invalid_file))
+
+        assert "Failed to load XML file as Bag" in str(context.value)
+
+        # Clean up
+        invalid_file.unlink()
+
+    def test_add_entity(self):
+        """Test adding a new entity."""
+        self.editor.load(str(self.test_file))
+
+        # Add a new entity
+        self.editor.add_entity("projects.project2", {"name": "New Project", "path": "/new"})
+
+        # Verify it was added
+        assert self.editor.entity_exists("projects.project2") == True
+        attrs = self.editor.get_entity_attributes("projects.project2")
+        assert attrs['name'] == "New Project"
+        assert attrs['path'] == "/new"
+
+    def test_add_entity_nested(self):
+        """Test adding a nested entity."""
+        self.editor.load(str(self.test_file))
+
+        # Add a deeply nested entity
+        self.editor.add_entity("projects.goober.foobar", {"path": "/like"})
+
+        # Verify it was added
+        assert self.editor.entity_exists("projects.goober.foobar") == True
+        attrs = self.editor.get_entity_attributes("projects.goober.foobar")
+        assert attrs['path'] == '/like'
+
+    def test_add_entity_without_bag(self):
+        """Test adding entity without loading a bag raises ValueError."""
+        with pytest.raises(ValueError):
+            self.editor.add_entity("test.path", {})
+
+    def test_add_entity_empty_path(self):
+        """Test adding entity with empty path raises ValueError."""
+        self.editor.load(str(self.test_file))
+        with pytest.raises(ValueError):
+            self.editor.add_entity("", {})
+
+    def test_add_entity_none_attributes(self):
+        """Test adding entity with None attributes (defaults to empty dict)."""
+        self.editor.load(str(self.test_file))
+
+        # Add entity with None attributes
+        self.editor.add_entity("projects.project3", None)
+
+        # Verify it was added
+        assert self.editor.entity_exists("projects.project3") is True
+
+    def test_set_entity(self):
+        """Test setting an entity (creates if doesn't exist, replaces if exists)."""
+        self.editor.load(str(self.test_file))
+
+        # Set a new entity
+        self.editor.set_entity("projects.project3", {"name": "Set Project", "path": "/set"})
+
+        # Verify it was created
+        assert self.editor.entity_exists("projects.project3") is True
+        attrs = self.editor.get_entity_attributes("projects.project3")
+        assert attrs['name'] == "Set Project"
+        assert attrs['path'] == "/set"
+
+    def test_set_entity_existing(self):
+        """Test setting an existing entity replaces it."""
+        self.editor.load(str(self.test_file))
+
+        # Set an existing entity with new attributes
+        self.editor.set_entity("projects.project1", {"name": "Replaced Project", "status": "active"})
+
+        # Verify it was replaced
+        attrs = self.editor.get_entity_attributes("projects.project1")
+        assert attrs['name'] == "Replaced Project"
+        assert attrs['status'] == "active"
+
+    def test_set_entity_without_bag(self):
+        """Test setting entity without loading a bag raises ValueError."""
+        with pytest.raises(ValueError):
+            self.editor.set_entity("test.path", {})
+
+    def test_set_entity_empty_path(self):
+        """Test setting entity with empty path raises ValueError."""
+        self.editor.load(str(self.test_file))
+        with pytest.raises(ValueError):
+            self.editor.set_entity("", {})
+
+    def test_set_entity_none_attributes(self):
+        """Test setting entity with None attributes (defaults to empty dict)."""
+        self.editor.load(str(self.test_file))
+
+        # Set entity with None attributes
+        self.editor.set_entity("projects.project4", None)
+
+        # Verify it was created
+        assert self.editor.entity_exists("projects.project4") is True
+
+    def test_update_entity(self):
+        """Test updating an existing entity."""
+        self.editor.load(str(self.test_file))
+
+        # Update existing entity
+        self.editor.update_entity("projects.project1", {"name": "Updated Project"})
+
+        # Verify it was updated
+        attrs = self.editor.get_entity_attributes("projects.project1")
+        assert attrs['name'] == "Updated Project"
+
+    def test_update_nonexistent_entity(self):
+        """Test updating a nonexistent entity raises ValueError."""
+        self.editor.load(str(self.test_file))
+
+        with pytest.raises(ValueError) as context:
+            self.editor.update_entity("projects.nonexistent", {"name": "Test"})
+
+        assert "Element not found" in str(context.value)
+
+    def test_update_entity_without_bag(self):
+        """Test updating entity without loading a bag raises ValueError."""
+        with pytest.raises(ValueError):
+            self.editor.update_entity("test.path", {})
+
+    def test_update_entity_empty_path(self):
+        """Test updating entity with empty path raises ValueError."""
+        self.editor.load(str(self.test_file))
+        with pytest.raises(ValueError):
+            self.editor.update_entity("", {})
+
+    def test_update_entity_none_attributes(self):
+        """Test updating entity with None attributes (defaults to empty dict)."""
+        self.editor.load(str(self.test_file))
+
+        # Update entity with None attributes
+        self.editor.update_entity("projects.project1", None)
+
+        # Verify entity still exists
+        assert self.editor.entity_exists("projects.project1") is True
+
+    def test_delete_entity(self):
+        """Test deleting an entity."""
+        self.editor.load(str(self.test_file))
+
+        # Verify entity exists
+        assert self.editor.entity_exists("projects.project1") is True
+
+        # Delete it
+        self.editor.delete_entity("projects.project1")
+
+        # Verify it's gone
+        assert self.editor.entity_exists("projects.project1") is False
+
+    def test_delete_nonexistent_entity(self):
+        """Test deleting a nonexistent entity raises ValueError."""
+        self.editor.load(str(self.test_file))
+
+        with pytest.raises(ValueError) as context:
+            self.editor.delete_entity("projects.nonexistent")
+
+        assert "Element not found" in str(context.value)
+
+    def test_delete_entity_without_bag(self):
+        """Test deleting entity without loading a bag raises ValueError."""
+        with pytest.raises(ValueError):
+            self.editor.delete_entity("test.path")
+
+    def test_delete_entity_empty_path(self):
+        """Test deleting entity with empty path raises ValueError."""
+        self.editor.load(str(self.test_file))
+        with pytest.raises(ValueError):
+            self.editor.delete_entity("")
+
+    def test_entity_exists(self):
+        """Test checking if entity exists."""
+        self.editor.load(str(self.test_file))
+
+        assert self.editor.entity_exists("projects.project1") is True
+        assert self.editor.entity_exists("projects.nonexistent") is False
+
+    def test_entity_exists_without_bag(self):
+        """Test checking entity exists without loading a bag returns False."""
+        assert self.editor.entity_exists("test.path") is False
+
+    def test_get_entity_attributes(self):
+        """Test getting entity attributes."""
+        self.editor.load(str(self.test_file))
+
+        attrs = self.editor.get_entity_attributes("projects.project1")
+        assert attrs is not None
+        assert attrs["name"] == "Test Project"
+        assert attrs["path"] == "/test"
+
+    def test_get_nonexistent_entity_attributes(self):
+        """Test getting attributes of nonexistent entity returns None."""
+        self.editor.load(str(self.test_file))
+
+        attrs = self.editor.get_entity_attributes("projects.nonexistent")
+        assert attrs is None
+
+    def test_get_entity_attributes_without_bag(self):
+        """Test getting entity attributes without loading a bag returns None."""
+        attrs = self.editor.get_entity_attributes("test.path")
+        assert attrs is None
+
+    def test_get_entity(self):
+        """Test getting complete entity information (value and attributes)."""
+        self.editor.load(str(self.test_file))
+
+        entity = self.editor.get_entity("projects.project1")
+        assert entity is not None
+        assert "value" in entity
+        assert "attributes" in entity
+        assert entity["attributes"]["name"] == "Test Project"
+        assert entity["attributes"]["path"] == "/test"
+
+    def test_get_nonexistent_entity(self):
+        """Test getting a nonexistent entity returns None."""
+        self.editor.load(str(self.test_file))
+
+        entity = self.editor.get_entity("projects.nonexistent")
+        assert entity is None
+
+    def test_get_entity_without_bag(self):
+        """Test getting entity without loading a bag returns None."""
+        entity = self.editor.get_entity("test.path")
+        assert entity is None
+
+    def test_save(self):
+        """Test saving the Bag to file."""
+        self.editor.load(str(self.test_file))
+
+        # Make a change
+        self.editor.add_entity("projects.project2", {"name": "New Project"})
+
+        # Save
+        self.editor.save()
+
+        # Load in a new editor and verify
+        new_editor = BagEditor(str(self.test_file))
+        assert new_editor.entity_exists("projects.project2") is True
+
+    def test_save_to_different_file(self):
+        """Test saving to a different file."""
+        self.editor.load(str(self.test_file))
+
+        # Make a change
+        self.editor.add_entity("projects.project2", {"name": "New Project"})
+
+        # Save to different file
+        new_file = Path(self.test_dir) / "test2.xml"
+        self.editor.save(str(new_file))
+
+        # Verify new file exists and has the changes
+        assert new_file.exists() is True
+        new_editor = BagEditor(str(new_file))
+        assert new_editor.entity_exists("projects.project2") is True
+
+        # Clean up
+        new_file.unlink()
+
+    def test_save_without_bag(self):
+        """Test saving without loading a bag raises ValueError."""
+        # Create a fresh editor without loading a bag
+        editor = BagEditor()
+        with pytest.raises(ValueError):
+            editor.save(str(self.test_file))
+
+    def test_save_without_file_path(self):
+        """Test saving without file path raises ValueError."""
+        self.editor.load(str(self.test_file))
+        self.editor.file_path = None
+
+        with pytest.raises(ValueError):
+            self.editor.save()
+
+    def test_save_with_invalid_path(self):
+        """Test saving to an invalid path raises Exception."""
+        self.editor.load(str(self.test_file))
+
+        # Try to save to an invalid location (path with null bytes)
+        with pytest.raises(Exception) as context:
+            self.editor.save("/invalid/\x00/path.xml")
+
+        assert "Failed to write XML file" in str(context.value)
+
+    def test_get_entity_attributes_empty_attrs(self):
+        """Test getting entity attributes when entity has no attributes."""
+        self.editor.load(str(self.test_file))
+
+        # Add an entity without attributes
+        self.editor.add_entity("projects.empty_project", {})
+
+        # Get attributes - should return empty dict
+        attrs = self.editor.get_entity_attributes("projects.empty_project")
+        assert attrs == {}
+
+    def test_get_entity_empty_attrs(self):
+        """Test getting complete entity when entity has no attributes."""
+        self.editor.load(str(self.test_file))
+
+        # Add an entity without attributes
+        self.editor.add_entity("projects.empty_entity", {})
+
+        # Get entity - should have empty attributes dict
+        entity = self.editor.get_entity("projects.empty_entity")
+        assert entity is not None
+        assert "value" in entity
+        assert "attributes" in entity
+        assert entity["attributes"] == {}
+
+
+class TestBagEditorCLI(BaseGnrTest):
+    """Test cases for BagEditor CLI command."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test fixtures for CLI tests."""
+        cls.test_dir = tempfile.mkdtemp()
+        cls.test_file = Path(cls.test_dir) / "test_cli.xml"
+
+        cls.original_xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<GenRoBag>
+    <projects>
+        <project1 name="Test Project" path="/test"/>
+    </projects>
+</GenRoBag>
+"""
+        cls.test_file.write_text(cls.original_xml_content)
+
+        # Get the CLI module path
+        cls.cli_module = "gnr.core.cli.gnrbagedit"
+
+    def setup_method(self, method):
+        """Reset test file before each test."""
+        self.test_file.write_text(self.original_xml_content)
+
+    @classmethod
+    def teardown_class(cls):
+        """Clean up test fixtures."""
+        if cls.test_file.exists():
+            cls.test_file.unlink()
+        Path(cls.test_dir).rmdir()
+
+    def run_cli(self, args, stdin_input=None):
+        """Helper method to run the CLI command."""
+        # Mock sys.argv
+        with patch.object(sys, 'argv', ['gnrbagedit'] + args):
+            # Capture stdout and stderr
+            stdout_capture = io.StringIO()
+            stderr_capture = io.StringIO()
+
+            # Mock stdin if provided
+            if stdin_input is not None:
+                stdin_mock = io.StringIO(stdin_input)
+            else:
+                stdin_mock = sys.stdin
+
+            with patch('sys.stdout', stdout_capture), \
+                 patch('sys.stderr', stderr_capture), \
+                 patch('sys.stdin', stdin_mock):
+
+                try:
+                    cli_main()
+                    returncode = 0
+                except SystemExit as e:
+                    returncode = e.code if e.code is not None else 0
+                except Exception:
+                    returncode = 1
+
+            # Create a result object similar to subprocess.CompletedProcess
+            class Result:
+                def __init__(self, returncode, stdout, stderr):
+                    self.returncode = returncode
+                    self.stdout = stdout
+                    self.stderr = stderr
+
+            return Result(returncode, stdout_capture.getvalue(), stderr_capture.getvalue())
+
+    def test_cli_add_entity_to_file(self):
+        """Test adding entity to a file (overwrite default)."""
+        result = self.run_cli([
+            str(self.test_file),
+            "add",
+            "projects.project2",
+            'name="New Project"',
+            'path="/new"'
+        ])
+
+        assert result.returncode == 0
+        assert "Successfully added entity: projects.project2" in result.stderr
+
+        # Verify the file was modified
+        editor = BagEditor(str(self.test_file))
+        assert editor.entity_exists("projects.project2")
+        attrs = editor.get_entity_attributes("projects.project2")
+        assert attrs['name'] == "New Project"
+        assert attrs['path'] == "/new"
+
+    def test_cli_add_entity_with_output_file(self):
+        """Test adding entity with --output to different file."""
+        output_file = Path(self.test_dir) / "output.xml"
+
+        result = self.run_cli([
+            str(self.test_file),
+            "add",
+            "projects.project2",
+            'name="New Project"',
+            "--output",
+            str(output_file)
+        ])
+
+        assert result.returncode == 0
+        assert f"saved to {output_file}" in result.stderr
+
+        # Verify output file exists and has the change
+        assert output_file.exists()
+        editor = BagEditor(str(output_file))
+        assert editor.entity_exists("projects.project2")
+
+        # Verify original file is unchanged
+        original_editor = BagEditor(str(self.test_file))
+        assert not original_editor.entity_exists("projects.project2")
+
+        # Cleanup
+        output_file.unlink()
+
+    def test_cli_add_entity_with_output_stdout(self):
+        """Test adding entity with --output - (stdout)."""
+        result = self.run_cli([
+            str(self.test_file),
+            "add",
+            "projects.project2",
+            'name="New Project"',
+            "--output",
+            "-"
+        ])
+
+        assert result.returncode == 0
+        assert "<?xml version" in result.stdout
+        assert "project2" in result.stdout
+        assert 'name="New Project"' in result.stdout
+
+        # Verify original file is unchanged
+        original_editor = BagEditor(str(self.test_file))
+        assert not original_editor.entity_exists("projects.project2")
+
+    def test_cli_stdin_to_stdout(self):
+        """Test reading from stdin and writing to stdout."""
+        stdin_content = self.test_file.read_text()
+
+        result = self.run_cli([
+            "-",
+            "add",
+            "projects.project2",
+            'name="Stdin Project"'
+        ], stdin_input=stdin_content)
+
+        assert result.returncode == 0
+        assert "<?xml version" in result.stdout
+        assert "project2" in result.stdout
+        assert 'name="Stdin Project"' in result.stdout
+
+    def test_cli_stdin_with_output_file(self):
+        """Test reading from stdin and writing to file."""
+        stdin_content = self.test_file.read_text()
+        output_file = Path(self.test_dir) / "stdin_output.xml"
+
+        result = self.run_cli([
+            "-",
+            "add",
+            "projects.project2",
+            'name="Stdin Project"',
+            "--output",
+            str(output_file)
+        ], stdin_input=stdin_content)
+
+        assert result.returncode == 0
+        assert output_file.exists()
+
+        # Verify output file has the change
+        editor = BagEditor(str(output_file))
+        assert editor.entity_exists("projects.project2")
+
+        # Cleanup
+        output_file.unlink()
+
+    def test_cli_set_entity(self):
+        """Test set operation via CLI."""
+        result = self.run_cli([
+            str(self.test_file),
+            "set",
+            "projects.project1",
+            'name="Updated"',
+            'status="active"',
+            "--output",
+            "-"
+        ])
+
+        assert result.returncode == 0
+        assert "project1" in result.stdout
+        assert 'name="Updated"' in result.stdout
+        assert 'status="active"' in result.stdout
+
+    def test_cli_update_entity(self):
+        """Test update operation via CLI."""
+        result = self.run_cli([
+            str(self.test_file),
+            "update",
+            "projects.project1",
+            'name="Updated Project"'
+        ])
+
+        assert result.returncode == 0
+        assert "Successfully updateed entity: projects.project1" in result.stderr
+
+        # Verify the update
+        editor = BagEditor(str(self.test_file))
+        attrs = editor.get_entity_attributes("projects.project1")
+        assert attrs['name'] == "Updated Project"
+
+    def test_cli_update_nonexistent_entity(self):
+        """Test update operation on nonexistent entity fails."""
+        result = self.run_cli([
+            str(self.test_file),
+            "update",
+            "projects.nonexistent",
+            'name="Test"'
+        ])
+
+        assert result.returncode != 0
+        assert "Element not found" in result.stderr
+
+    def test_cli_delete_entity(self):
+        """Test delete operation via CLI."""
+        result = self.run_cli([
+            str(self.test_file),
+            "delete",
+            "projects.project1"
+        ])
+
+        assert result.returncode == 0
+        assert "Successfully deleteed entity: projects.project1" in result.stderr
+
+        # Verify the deletion
+        editor = BagEditor(str(self.test_file))
+        assert not editor.entity_exists("projects.project1")
+
+    def test_cli_delete_nonexistent_entity(self):
+        """Test delete operation on nonexistent entity fails."""
+        result = self.run_cli([
+            str(self.test_file),
+            "delete",
+            "projects.nonexistent"
+        ])
+
+        assert result.returncode != 0
+        assert "Element not found" in result.stderr
+
+    def test_cli_get_entity(self):
+        """Test get operation via CLI."""
+        result = self.run_cli([
+            str(self.test_file),
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode == 0
+        assert "Entity: projects.project1" in result.stdout
+        assert "name: Test Project" in result.stdout
+        assert "path: /test" in result.stdout
+
+    def test_cli_get_nonexistent_entity(self):
+        """Test get operation on nonexistent entity fails."""
+        result = self.run_cli([
+            str(self.test_file),
+            "get",
+            "projects.nonexistent"
+        ])
+
+        assert result.returncode != 0
+        assert "Entity not found" in result.stderr
+
+    def test_cli_get_with_stdin(self):
+        """Test get operation with stdin input."""
+        stdin_content = self.test_file.read_text()
+
+        result = self.run_cli([
+            "-",
+            "get",
+            "projects.project1"
+        ], stdin_input=stdin_content)
+
+        assert result.returncode == 0
+        assert "Entity: projects.project1" in result.stdout
+        assert "name: Test Project" in result.stdout
+
+    def test_cli_file_not_found(self):
+        """Test CLI with nonexistent file."""
+        result = self.run_cli([
+            "/nonexistent/file.xml",
+            "add",
+            "projects.test",
+            'name="Test"'
+        ])
+
+        assert result.returncode != 0
+        assert "File not found" in result.stderr
+
+    def test_cli_empty_stdin(self):
+        """Test CLI with empty stdin."""
+        result = self.run_cli([
+            "-",
+            "add",
+            "projects.test",
+            'name="Test"'
+        ], stdin_input="")
+
+        assert result.returncode != 0
+        assert "No input provided on stdin" in result.stderr
+
+    def test_cli_invalid_xml_stdin(self):
+        """Test CLI with invalid XML on stdin."""
+        result = self.run_cli([
+            "-",
+            "add",
+            "projects.test",
+            'name="Test"'
+        ], stdin_input="This is not valid XML")
+
+        assert result.returncode != 0
+
+    def test_cli_add_without_attributes(self):
+        """Test add operation without attributes."""
+        result = self.run_cli([
+            str(self.test_file),
+            "add",
+            "projects.project3"
+        ])
+
+        assert result.returncode == 0
+
+        # Verify the entity was added
+        editor = BagEditor(str(self.test_file))
+        assert editor.entity_exists("projects.project3")
+
+    def test_cli_multiple_operations_chain(self):
+        """Test multiple operations in sequence."""
+        # Add entity
+        result1 = self.run_cli([
+            str(self.test_file),
+            "add",
+            "projects.project2",
+            'name="Project 2"'
+        ])
+        assert result1.returncode == 0
+
+        # Update entity
+        result2 = self.run_cli([
+            str(self.test_file),
+            "update",
+            "projects.project2",
+            'name="Updated Project 2"'
+        ])
+        assert result2.returncode == 0
+
+        # Get entity
+        result3 = self.run_cli([
+            str(self.test_file),
+            "get",
+            "projects.project2"
+        ])
+        assert result3.returncode == 0
+        assert "Updated Project 2" in result3.stdout
+
+        # Delete entity
+        result4 = self.run_cli([
+            str(self.test_file),
+            "delete",
+            "projects.project2"
+        ])
+        assert result4.returncode == 0
+
+        # Verify deletion
+        editor = BagEditor(str(self.test_file))
+        assert not editor.entity_exists("projects.project2")
+
+    def test_cli_invalid_attribute_format(self):
+        """Test with invalid attribute format (missing =)."""
+        result = self.run_cli([
+            str(self.test_file),
+            "add",
+            "projects.test",
+            'invalid_format'
+        ])
+
+        assert result.returncode != 0
+        assert "Invalid attribute format" in result.stderr
+
+    def test_cli_get_with_attributes_warning(self):
+        """Test get operation with attributes (should warn)."""
+        result = self.run_cli([
+            str(self.test_file),
+            "get",
+            "projects.project1",
+            'name="ignored"'
+        ])
+
+        assert result.returncode == 0
+        assert "Attributes are ignored for get operation" in result.stderr
+
+    def test_cli_delete_with_attributes_warning(self):
+        """Test delete operation with attributes (should warn)."""
+        result = self.run_cli([
+            str(self.test_file),
+            "delete",
+            "projects.project1",
+            'name="ignored"'
+        ])
+
+        assert result.returncode == 0
+        assert "Attributes are ignored for delete operation" in result.stderr
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_environment_default_flag(self, mock_paths):
+        """Test --environment-default flag."""
+        # Mock to return our test file as environment default
+        mock_paths.return_value = (str(self.test_file), "instance.xml", "siteconfig.xml")
+
+        result = self.run_cli([
+            "--environment-default",
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode == 0
+        assert "Test Project" in result.stdout
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_instance_default_flag(self, mock_paths):
+        """Test --instance-default flag."""
+        # Mock to return our test file as instance default
+        mock_paths.return_value = ("env.xml", str(self.test_file), "siteconfig.xml")
+
+        result = self.run_cli([
+            "--instance-default",
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode == 0
+        assert "Test Project" in result.stdout
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_siteconfig_default_flag(self, mock_paths):
+        """Test --siteconfig-default flag."""
+        # Mock to return our test file as siteconfig default
+        mock_paths.return_value = ("env.xml", "instance.xml", str(self.test_file))
+
+        result = self.run_cli([
+            "--siteconfig-default",
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode == 0
+        assert "Test Project" in result.stdout
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_multiple_default_flags_error(self, mock_paths):
+        """Test error when multiple default flags are specified."""
+        mock_paths.return_value = (str(self.test_file), "instance.xml", "siteconfig.xml")
+
+        result = self.run_cli([
+            "--environment-default",
+            "--instance-default",
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode != 0
+        assert "Only one default flag can be specified" in result.stderr
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_environment_default_not_configured(self, mock_paths):
+        """Test --environment-default when environment is not configured."""
+        mock_paths.return_value = (None, None, None)
+
+        result = self.run_cli([
+            "--environment-default",
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode != 0
+        assert "No Genro environment configured" in result.stderr
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_instance_default_not_configured(self, mock_paths):
+        """Test --instance-default when environment is not configured."""
+        mock_paths.return_value = (None, None, None)
+
+        result = self.run_cli([
+            "--instance-default",
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode != 0
+        assert "No Genro environment configured" in result.stderr
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_siteconfig_default_not_configured(self, mock_paths):
+        """Test --siteconfig-default when environment is not configured."""
+        mock_paths.return_value = (None, None, None)
+
+        result = self.run_cli([
+            "--siteconfig-default",
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode != 0
+        assert "No Genro environment configured" in result.stderr
+
+    @patch('gnr.core.cli.gnrbagedit.get_default_file_paths')
+    def test_cli_file_with_default_flag_error(self, mock_paths):
+        """Test error when both file and default flag are specified."""
+        mock_paths.return_value = (str(self.test_file), "instance.xml", "siteconfig.xml")
+
+        result = self.run_cli([
+            "--environment-default",
+            str(self.test_file),
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode != 0
+        assert "Cannot specify both a file and a default flag" in result.stderr
+
+    def test_cli_no_file_no_flag_error(self):
+        """Test error when neither file nor default flag is specified."""
+        result = self.run_cli([
+            "get",
+            "projects.project1"
+        ])
+
+        assert result.returncode != 0
+        assert "Either specify a file or use one of the --*-default flags" in result.stderr
+
+    def test_cli_get_entity_no_attributes(self):
+        """Test get operation on entity with no attributes."""
+        # Add an entity without attributes
+        editor = BagEditor(str(self.test_file))
+        editor.add_entity("projects.empty", {})
+        editor.save()
+
+        result = self.run_cli([
+            str(self.test_file),
+            "get",
+            "projects.empty"
+        ])
+
+        assert result.returncode == 0
+        assert "Attributes: (none)" in result.stdout
+
+    @patch('tempfile.mkstemp')
+    def test_cli_stdin_tempfile_error(self, mock_mkstemp):
+        """Test error handling when temp file creation fails."""
+        mock_mkstemp.side_effect = Exception("Temp file creation failed")
+
+        stdin_content = self.test_file.read_text()
+        result = self.run_cli([
+            "-",
+            "get",
+            "projects.project1"
+        ], stdin_input=stdin_content)
+
+        assert result.returncode != 0
+        assert "Error reading from stdin" in result.stderr
+
+    @patch('gnr.core.gnrbageditor.BagEditor.add_entity')
+    def test_cli_generic_exception_handling(self, mock_add):
+        """Test generic exception handling in CLI."""
+        mock_add.side_effect = Exception("Unexpected error")
+
+        result = self.run_cli([
+            str(self.test_file),
+            "add",
+            "projects.test",
+            'name="Test"'
+        ])
+
+        assert result.returncode != 0
+        assert "Error:" in result.stderr
+
+    def test_cli_main_as_script(self):
+        """Test running CLI as a script."""
+        # This tests the if __name__ == '__main__' block
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "gnr/core/cli/gnrbagedit.py", str(self.test_file), "get", "projects.project1"],
+            capture_output=True,
+            text=True
+        )
+        # Just verify it runs without crashing
+        assert "projects.project1" in result.stdout or result.returncode in [0, 1, 2]
+
+    @patch('gnr.core.cli.gnrbagedit.getEnvironmentPath')
+    def test_get_default_file_paths_exception(self, mock_env):
+        """Test get_default_file_paths handles exceptions."""
+        from gnr.core.cli.gnrbagedit import get_default_file_paths
+
+        # Mock getEnvironmentPath to raise an exception
+        mock_env.side_effect = Exception("Environment error")
+
+        result = get_default_file_paths()
+        assert result == (None, None, None)
+
+    @patch('gnr.core.cli.gnrbagedit.getEnvironmentPath')
+    def test_get_default_file_paths_none(self, mock_env):
+        """Test get_default_file_paths when getEnvironmentPath returns None."""
+        from gnr.core.cli.gnrbagedit import get_default_file_paths
+
+        # Mock getEnvironmentPath to return None
+        mock_env.return_value = None
+
+        result = get_default_file_paths()
+        assert result == (None, None, None)
+
+    @patch('gnr.core.cli.gnrbagedit.getEnvironmentPath')
+    def test_get_default_file_paths_valid(self, mock_env):
+        """Test get_default_file_paths with valid path."""
+        from gnr.core.cli.gnrbagedit import get_default_file_paths
+
+        # Mock getEnvironmentPath to return a valid path
+        mock_env.return_value = "/path/to/environment.xml"
+
+        result = get_default_file_paths()
+        assert result[0] == "/path/to/environment.xml"
+        assert result[1] == "/path/to/instanceconfig/default.xml"
+        assert result[2] == "/path/to/siteconfig/default.xml"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/gnrpy/tests/core/gnrbageditor_test.py
+++ b/gnrpy/tests/core/gnrbageditor_test.py
@@ -979,7 +979,6 @@ class TestBagEditorCLI(BaseGnrTest):
     def test_cli_main_as_script(self):
         """Test running CLI as a script."""
         # This tests the if __name__ == '__main__' block
-        import subprocess
         result = subprocess.run(
             [sys.executable, "gnr/core/cli/gnrbagedit.py", str(self.test_file), "get", "projects.project1"],
             capture_output=True,

--- a/gnrpy/tests/core/gnrbageditor_test.py
+++ b/gnrpy/tests/core/gnrbageditor_test.py
@@ -594,7 +594,7 @@ class TestBagEditorCLI(BaseGnrTest):
         ])
 
         assert result.returncode == 0
-        assert "Successfully updateed entity: projects.project1" in result.stderr
+        assert "Successfully updated entity: projects.project1" in result.stderr
 
         # Verify the update
         editor = BagEditor(str(self.test_file))
@@ -622,7 +622,7 @@ class TestBagEditorCLI(BaseGnrTest):
         ])
 
         assert result.returncode == 0
-        assert "Successfully deleteed entity: projects.project1" in result.stderr
+        assert "Successfully deleted entity: projects.project1" in result.stderr
 
         # Verify the deletion
         editor = BagEditor(str(self.test_file))
@@ -961,6 +961,38 @@ class TestBagEditorCLI(BaseGnrTest):
         assert result.returncode != 0
         assert "Error reading from stdin" in result.stderr
 
+    @patch('os.fdopen')
+    def test_cli_stdin_write_error_with_cleanup(self, mock_fdopen):
+        """Test error handling when writing to temp file fails after creation."""
+        # Mock fdopen to raise an exception after temp file is created
+        mock_fdopen.side_effect = Exception("Write failed")
+
+        stdin_content = self.test_file.read_text()
+        result = self.run_cli([
+            "-",
+            "get",
+            "projects.project1"
+        ], stdin_input=stdin_content)
+
+        assert result.returncode != 0
+        assert "Error reading from stdin" in result.stderr
+
+    @patch('gnr.core.gnrbageditor.BagEditor.load')
+    def test_cli_stdin_file_not_found_with_cleanup(self, mock_load):
+        """Test FileNotFoundError during load with temp file cleanup."""
+        # Mock load to raise FileNotFoundError after temp file is created
+        mock_load.side_effect = FileNotFoundError("File not found")
+
+        stdin_content = self.test_file.read_text()
+        result = self.run_cli([
+            "-",
+            "get",
+            "projects.project1"
+        ], stdin_input=stdin_content)
+
+        assert result.returncode != 0
+        assert "File not found" in result.stderr
+
     @patch('gnr.core.gnrbageditor.BagEditor.add_entity')
     def test_cli_generic_exception_handling(self, mock_add):
         """Test generic exception handling in CLI."""
@@ -986,6 +1018,41 @@ class TestBagEditorCLI(BaseGnrTest):
         )
         # Just verify it runs without crashing
         assert "projects.project1" in result.stdout or result.returncode in [0, 1, 2]
+
+    def test_cli_main_direct_call(self):
+        """Test the __name__ == '__main__' block by executing the module."""
+        import importlib.util
+        import sys
+        from pathlib import Path
+
+        # Get the path to gnrbagedit.py
+        module_path = Path(__file__).parent.parent.parent / "gnr" / "core" / "cli" / "gnrbagedit.py"
+
+        # Load the module
+        spec = importlib.util.spec_from_file_location("__main__", str(module_path))
+        module = importlib.util.module_from_spec(spec)
+
+        # Mock sys.argv for this test
+        original_argv = sys.argv
+        sys.argv = ["gnrbagedit", str(self.test_file), "get", "projects.project1"]
+
+        # Capture stdout/stderr
+        stdout_capture = io.StringIO()
+        stderr_capture = io.StringIO()
+
+        try:
+            with patch('sys.stdout', stdout_capture), \
+                 patch('sys.stderr', stderr_capture):
+                try:
+                    spec.loader.exec_module(module)
+                except SystemExit:
+                    pass  # Expected for CLI
+        finally:
+            sys.argv = original_argv
+
+        # Verify output
+        output = stdout_capture.getvalue()
+        assert "projects.project1" in output or "Entity:" in output
 
     @patch('gnr.core.cli.gnrbagedit.getEnvironmentPath')
     def test_get_default_file_paths_exception(self, mock_env):


### PR DESCRIPTION
This PR provides the CLI tool requested in #364, which allows to manipulate a Bag using CLI, replicating the Bag API to add/get/set/update/delete entities and their attributes, providing a path in the tree. When editing, it can replace the original file, or output somewhere else, including stdout. It can also read from stdin if needed, useful in scripting.

Please refer to `gnr core bagedit --help` for all details.

