### PR TITLE
added the --platform options to dockerize

### DIFF
--- a/gnrpy/gnr/app/cli/gnrdockerize.py
+++ b/gnrpy/gnr/app/cli/gnrdockerize.py
@@ -215,8 +215,8 @@ stderr_logfile_maxbytes=0
             dockerfile.close()
             logger.info(f"Dockerfile generated at: {self.dockerfile_path}")
             # Ensure to have Docker installed and running
-            build_command = ['docker', 'build', '-t',
-                             f'{self.image_name}:{version_tag}',
+            build_command = ['docker', 'build', '--platform', self.options.architecture,
+                             '-t', f'{self.image_name}:{version_tag}',
                              self.build_context_dir]
             subprocess.run(build_command, check=True)
             logger.info("Docker image built successfully.")
@@ -328,6 +328,11 @@ def main():
                         type=str,
                         default="ghcr.io",
                         help="The registry where to push the image")
+    parser.add_argument('-a', '--arch',
+                        dest="architecture",
+                        type=str,
+                        default="linux/amd64",
+                        help="The image architecture/platform to be built for")
     parser.add_argument('-t', '--tag',
                         dest="version_tag",
                         help="The image version tag",
@@ -338,7 +343,6 @@ def main():
                         type=str,
                         default="softwellsrl",
                         help="The registry username where to push the image")
-
     parser.add_argument('--bleeding',
                         action="store_true",
                         dest="bleeding",

--- a/gnrpy/gnr/core/cli/__init__.py
+++ b/gnrpy/gnr/core/cli/__init__.py
@@ -9,6 +9,8 @@ from gnr.core import gnrlog
 class GnrCliArgParse(argparse.ArgumentParser):
     
     def __init__(self, *args, **kwargs):
+        kwargs['formatter_class'] = argparse.ArgumentDefaultsHelpFormatter
+        print("KWARGS", kwargs)
         super().__init__(*args, **kwargs)
         self.add_argument("--version", action="version",
                           version="%(prog)s "+VERSION)


### PR DESCRIPTION
added the --platform options to dockerize, defaulting to 'linux/amd64' if not provided

which is the most common deployment platform. By providing an option value, the image build is created using the requested platform.

added default formatter class to gnr cli commands to show the default values.

refs #369