### PR TITLE
disable database dump if the adapter is not capable.

### DIFF
--- a/gnrpy/gnr/sql/adapters/_gnrbaseadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbaseadapter.py
@@ -118,6 +118,15 @@ class SqlDbAdapter(object):
             missing_desc = ", ".join(missing)
             logger.warning(f"DB adapter required executables not found: {missing_desc}, please install to avoid runtime errors."),
             
+        return missing
+
+    def has_admin_tools(self):
+        """
+        return a bool whether the adapter has all
+        the admin tools available.
+        """
+        return not self._check_required_executables()
+    
     def adaptSqlName(self,name):
         """
         Adapt/fix a name if needed in a specific adapter/driver

--- a/resources/common/gnrcomponents/maintenance.py
+++ b/resources/common/gnrcomponents/maintenance.py
@@ -29,7 +29,10 @@ class MaintenancePlugin(BaseComponent):
         """!!Maintenance"""
         frame = pane.framePane(datapath='gnr.maintenance')
         tc = frame.center.tabContainer(margin='2px')
-        self.maintenance_admin(tc.framePane(title='Administration',margin='2px',rounded=4,border='1px solid #efefef',datapath='.administration'))
+        # disable db administration if the adapter doesn't have the tools to
+        # execute operations
+        if self.site.gnrapp.db.adapter.has_admin_tools():
+            self.maintenance_admin(tc.framePane(title='Administration',margin='2px',rounded=4,border='1px solid #efefef',datapath='.administration'))
         self.maintenance_register(tc.framePane(title='!!Users & Connections',margin='2px',rounded=4,border='1px solid #efefef'))
 
     def maintenance_admin(self,frame):


### PR DESCRIPTION
added new 'has_admin_tools' method to base adapter, which return a bool based on required executables checks.

Disabled the maintenance component for db dump if the adapter doesn't have the admin tools

refs #371