### PR TITLE
feat(bag): add preservePattern parameter to Bag.update method

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -33,7 +33,10 @@ Enhancements
 * New 'gnr core bagedit' CLI tool which allows to manipulate
   (get/add/set/update/delete) entities inside bag files using the
   command line
-  
+* Bag's update() method now include a 'preservePattern' parameters
+  (a compiled regex) which will prevent to update matching values
+  or attributes, preserving the original value.
+
 Deprecations
 ------------
 

--- a/gnrpy/tests/core/gnrbag_test.py
+++ b/gnrpy/tests/core/gnrbag_test.py
@@ -115,13 +115,13 @@ class TestBasicBag(object):
 
         b.update(c, preservePattern=re.compile(r'^[\$\{]'))
 
-        # valori che iniziano con $ o { sono preservati
+        # values starting with $ or { are preserved
         assert b['name'] == '$placeholder'
         assert b['code'] == '{template}'
-        # attributi che iniziano con $ o { sono preservati
+        # attributes starting with $ or { are preserved
         assert b.getAttr('name', 'caption') == '${title}'
         assert b.getAttr('code', 'label') == '{dynamic}'
-        # valori e attributi normali sono aggiornati
+        # values and attributes not matching are updated
         assert b['value'] == 'updated'
         assert b.getAttr('value', 'desc') == 'new desc'
 

--- a/gnrpy/tests/core/gnrbag_test.py
+++ b/gnrpy/tests/core/gnrbag_test.py
@@ -101,6 +101,30 @@ class TestBasicBag(object):
         assert b['name'] == 'John K.'
         assert b.getAttr('hobbie.sport', 'role') == 'forward'
 
+    def test_update_preservePattern(self):
+        import re
+        b = Bag()
+        b.setItem('name', '$placeholder', caption='${title}')
+        b.setItem('code', '{template}', label='{dynamic}')
+        b.setItem('value', 'normal', desc='static')
+
+        c = Bag()
+        c.setItem('name', 'NewName', caption='New Caption')
+        c.setItem('code', 'NewCode', label='New Label')
+        c.setItem('value', 'updated', desc='new desc')
+
+        b.update(c, preservePattern=re.compile(r'^[\$\{]'))
+
+        # valori che iniziano con $ o { sono preservati
+        assert b['name'] == '$placeholder'
+        assert b['code'] == '{template}'
+        # attributi che iniziano con $ o { sono preservati
+        assert b.getAttr('name', 'caption') == '${title}'
+        assert b.getAttr('code', 'label') == '{dynamic}'
+        # valori e attributi normali sono aggiornati
+        assert b['value'] == 'updated'
+        assert b.getAttr('value', 'desc') == 'new desc'
+
     def test_sort(self):
         b = Bag({'d': 1, 'z': 2, 'r': 3, 'a': 4})
         b.sort()


### PR DESCRIPTION
## Summary

- Aggiunto parametro `preservePattern` al metodo `Bag.update()` che consente di preservare valori e attributi stringa che corrispondono a un pattern regex
- Lo scopo principale è consentire che valori e attributi che corrispondono a variabili locali (es. quelli che iniziano con `$` o `{`) possano essere preservati durante un update

## Esempio d'uso

```python
import re

bag1 = Bag()
bag1.setItem('name', '$placeholder', caption='${title}')

bag2 = Bag()
bag2.setItem('name', 'NewName', caption='New Caption')

# Preserva valori/attributi che iniziano con $ o {
bag1.update(bag2, preservePattern=re.compile(r'^[\$\{]'))

# bag1['name'] = '$placeholder'  (preservato)
# bag1.getAttr('name', 'caption') = '${title}'  (preservato)
```

## Test plan

- [x] Aggiunto test `test_update_preservePattern` che verifica il comportamento con valori e attributi che iniziano con `$` e `{`
- [x] Verificato che il test `test_update` originale continua a passare (nessuna regressione)