### PR TITLE
environment vars have precedence over local configuration.

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -25,6 +25,7 @@ import atexit
 import shutil
 import locale
 import sys
+import re
 import types
 import importlib
 import importlib.metadata
@@ -929,7 +930,7 @@ class GnrApp(object):
                     'gnr.environment_xml.instances:#a.path,#a.instance_template') or []:
                 if path == os.path.dirname(self.instanceFolder):
                     instance_config.update(normalizePackages(self.gnr_config['gnr.instanceconfig.%s_xml' % instance_template]) or Bag())
-        instance_config.update(base_instance_config)
+        instance_config.update(base_instance_config, preservePattern=re.compile(r'^[\$\{]'))
         return instance_config
         
     def init(self, forTesting=False,restorepath=None):


### PR DESCRIPTION
use new Bag's update(preservePattern) in order to force the usage of env vars in configuration
when loading it from multiple sources. If the default instance config defined values are env vars, they're not overriden by the instance configuration, giving precedence to the enviroment over the local configuration.

refs #372