### PR TITLE
feat(bag): add Docker-style template variable syntax with defaults

### DIFF
--- a/gnrpy/gnr/core/gnrbag.py
+++ b/gnrpy/gnr/core/gnrbag.py
@@ -2034,6 +2034,11 @@ class Bag(GnrObject):
             # source = source.format_map(AllowMissingDict(_template_kwargs))
 
             if self._template_kwargs:
+                if fromFile:
+                    # Read file content before template substitution
+                    with open(source, 'r', encoding='utf-8') as f:
+                        source = f.read()
+                    fromFile = False
                 source = TemplateDict(self._template_kwargs).substitute(source)
             return self._fromXml(source, fromFile)
         elif mode == 'xsd':

--- a/gnrpy/tests/core/gnrbag_test.py
+++ b/gnrpy/tests/core/gnrbag_test.py
@@ -61,6 +61,22 @@ class TestBasicBag(object):
             assert issubclass(w[0].category, DeprecationWarning)
             assert "Dollar syntax" in str(w[0].message)
 
+    def test_template_kwargs_from_file(self):
+        import tempfile
+        import os
+        # Test that template substitution works when loading from file
+        xml_content = "<db host='{DB_HOST:-localhost}' port='{DB_PORT:-5432}'/>"
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False) as f:
+            f.write(xml_content)
+            temp_path = f.name
+        try:
+            test_kwargs = dict(DB_HOST="myserver")
+            b = Bag(temp_path, _template_kwargs=test_kwargs)
+            assert b.getAttr('db', 'host') == "myserver"  # from kwargs
+            assert b.getAttr('db', 'port') == "5432"  # default value
+        finally:
+            os.unlink(temp_path)
+
     def test_fillFromBag(self):
         c = Bag(self.mybag)
         assert c == self.mybag

--- a/gnrpy/tests/core/gnrbag_test.py
+++ b/gnrpy/tests/core/gnrbag_test.py
@@ -39,7 +39,28 @@ class TestBasicBag(object):
         test_kwargs = dict(TESTVAR="admin", TESTVAR2="admin2")
         b = Bag(source, _template_kwargs=test_kwargs)
         assert b['name'] == "admin"
-        
+
+    def test_template_kwargs_with_default(self):
+        # Test Docker-style {VAR:-default} syntax
+        source = "<db host='{DB_HOST:-localhost}' port='{DB_PORT:-5432}'/>"
+        test_kwargs = dict(DB_HOST="myserver")
+        b = Bag(source, _template_kwargs=test_kwargs)
+        assert b.getAttr('db', 'host') == "myserver"  # from kwargs
+        assert b.getAttr('db', 'port') == "5432"  # default value
+
+    def test_template_kwargs_dollar_syntax_deprecated(self):
+        import warnings
+        # Test that $VAR syntax works but raises deprecation warning
+        source = "<name>$TESTVAR</name>"
+        test_kwargs = dict(TESTVAR="admin")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b = Bag(source, _template_kwargs=test_kwargs)
+            assert b['name'] == "admin"
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "Dollar syntax" in str(w[0].message)
+
     def test_fillFromBag(self):
         c = Bag(self.mybag)
         assert c == self.mybag


### PR DESCRIPTION
## Summary

- Add `TemplateDict` class for Docker-style variable substitution in Bag XML templates
- Support for default values using `{VAR:-default}` syntax
- Deprecate `$VAR` and `${VAR}` syntax with warning (still works but emits DeprecationWarning)

## New syntax

| Syntax | Description |
|--------|-------------|
| `{VAR}` | Variable (keeps placeholder if missing) |
| `{VAR:-default}` | Variable with default value |
| `$VAR`, `${VAR}` | **Deprecated** - converted to `{VAR}` with warning |

## Example

```xml
<!-- Old syntax (deprecated) -->
<db host="$DB_HOST" port="${DB_PORT}"/>

<!-- New syntax with defaults -->
<db host="{DB_HOST:-localhost}" port="{DB_PORT:-5432}"/>
```

```python
# If DB_HOST is provided but DB_PORT is not:
b = Bag(source, _template_kwargs=dict(DB_HOST="myserver"))
# Result: host="myserver", port="5432" (default)
```

## Backward compatibility

- Existing `{VAR}` syntax continues to work unchanged
- `$VAR` and `${VAR}` syntax still works but emits a deprecation warning

## Test plan

- [x] Test existing `{VAR}` syntax still works
- [x] Test `{VAR:-default}` syntax with and without provided values
- [x] Test `$VAR` syntax works but raises DeprecationWarning