### PR TITLE
feat(domsource): add Proxy-based tag method builder

### DIFF
--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -1985,6 +1985,25 @@ dojo.declare("gnr.GnrDomSource", gnr.GnrStructData, {
     _validationPrefix: 'structvalidate_',
     _nodeFactory:gnr.GnrDomSourceNode,
 
+    constructor: function(source, kw) {
+        var bag = this;
+        return new Proxy(this, {
+            get: function(target, prop) {
+                if (prop in target) {
+                    var value = target[prop];
+                    if (typeof value === 'function') {
+                        return value.bind(target);
+                    }
+                    return value;
+                }
+                // Proprietà inesistente: restituisce una funzione che chiama _() con prop come tag
+                return function(name, attributes, extrakw) {
+                    return bag._(prop, name, attributes, extrakw);
+                };
+            }
+        });
+    },
+
     _ : function(tag, name/*optional*/, attributes/*Object*/, extrakw) {
         var tag_UpperLower = null;
         var content;

--- a/gnrpy/tests/core/gnrbag_test.py
+++ b/gnrpy/tests/core/gnrbag_test.py
@@ -39,7 +39,28 @@ class TestBasicBag(object):
         test_kwargs = dict(TESTVAR="admin", TESTVAR2="admin2")
         b = Bag(source, _template_kwargs=test_kwargs)
         assert b['name'] == "admin"
-        
+
+    def test_template_kwargs_with_default(self):
+        # Test Docker-style {VAR:-default} syntax
+        source = "<db host='{DB_HOST:-localhost}' port='{DB_PORT:-5432}'/>"
+        test_kwargs = dict(DB_HOST="myserver")
+        b = Bag(source, _template_kwargs=test_kwargs)
+        assert b.getAttr('db', 'host') == "myserver"  # from kwargs
+        assert b.getAttr('db', 'port') == "5432"  # default value
+
+    def test_template_kwargs_dollar_syntax_deprecated(self):
+        import warnings
+        # Test that $VAR syntax works but raises deprecation warning
+        source = "<name>$TESTVAR</name>"
+        test_kwargs = dict(TESTVAR="admin")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            b = Bag(source, _template_kwargs=test_kwargs)
+            assert b['name'] == "admin"
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "Dollar syntax" in str(w[0].message)
+
     def test_fillFromBag(self):
         c = Bag(self.mybag)
         assert c == self.mybag


### PR DESCRIPTION
## Summary

- GnrDomSource ora restituisce un Proxy che permette di chiamare i tag direttamente come metodi invece di usare il metodo `_()`

**Prima:**
```javascript
source._('div', 'myDiv', {id: 'test'});
```

**Dopo:**
```javascript
source.div('myDiv', {id: 'test'});
```

## Implementazione

Il proxy intercetta l'accesso alle proprietà e converte le proprietà sconosciute in chiamate a `_()` con il nome della proprietà come tag.

## Test plan

- [ ] Verificare che la sintassi esistente `source._('tag', ...)` continui a funzionare
- [ ] Verificare che la nuova sintassi `source.tag(...)` funzioni correttamente
- [ ] Verificare il chaining: `source.div('a').span('b')`