### PR TITLE
fix: adapt multidb backup/restore to storetable-based architecture

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -9,6 +9,7 @@ Enhancements
 * Introduced a new experimental aiohttp-based task scheduler/worker, not enabled by
   default. It needs a new deployment if activated, YMMV.
 * Introduce a localization attribute for table columns.
+* Support for multidb backup/restore for storetable-based architecture (#402)
  
 Fixes
 -----

--- a/gnrpy/gnr/sql/gnrsql.py
+++ b/gnrpy/gnr/sql/gnrsql.py
@@ -331,8 +331,7 @@ class GnrSqlDb(GnrObject):
         if mainfilepath:
             self._autoRestore_one(dbname=self.dbname,filepath=mainfilepath,sqltextCb=sqltextCb,onRestored=onRestored)
         for storename,filepath in list(stores.items()):
-            conf = dbstoreconfig.getItem(storename)
-            dbattr = conf.getAttr('db')
+            dbattr = dbstoreconfig.getAttr(storename)
             dbname = dbattr.pop('dbname')
             self._autoRestore_one(dbname=dbname,filepath=filepath,sqltextCb=sqltextCb,onRestored=onRestored)
         if destroyFolder:

--- a/projects/gnrcore/packages/adm/resources/tables/backup/action/dumpall.py
+++ b/projects/gnrcore/packages/adm/resources/tables/backup/action/dumpall.py
@@ -48,17 +48,17 @@ class Main(BaseResourceBatch):
         checkedDbstores = self.batch_parameters.get('checkedDbstores')
         checkedDbstores = checkedDbstores.split(',') if checkedDbstores else [s for s in self.db.stores_handler.dbstores.keys() if not s.startswith('instance_')]
         dbstoreconf = Bag()
-        dbstorefolder = os.path.join(self.db.application.instanceFolder, 'dbstores')
         options = self.batch_parameters['options']
-    
+
         for s in self.btc.thermo_wrapper(checkedDbstores,line_code='dbl',message=lambda item, k, m, **kwargs: '!!Dumping %s' %item):
             with self.db.tempEnv(storename=s):
                 folder_path = self.backupSn.internal_path
+                dbname = self.db.stores_handler.dbstores[s]['database']
                 self.filelist.append(self.db.dump(os.path.join(folder_path,s),
-                                    dbname=self.db.stores_handler.dbstores[s]['database'],
+                                    dbname=dbname,
                                     excluded_schemas=self.getExcluded(),
                                     options=options))
-                dbstoreconf[s] = Bag(os.path.join(dbstorefolder,'%s.xml' %s))
+                dbstoreconf.addItem(s, None, dbname=dbname)
         dbStoreSn = self.tempSn.child('_dbstores.xml')
         with dbStoreSn.open('wb') as confpath:
             dbstoreconf.toXml(confpath)


### PR DESCRIPTION
## Summary

Fixes the dump-all and restore functionality to work with the storetable-based dbstores architecture introduced in PR #312. Previously, these components still referenced the old XML file approach which no longer exists.

## Changes

- **dumpall.py**: Remove XML file reading logic and get dbstore configuration directly from `stores_handler.dbstores`
- **dumpall.py**: Generate flat `_dbstores.xml` structure with dbname as direct attributes
- **gnrsql.py**: Update `autoRestore()` method to read the new flat XML structure

## Technical Details

The storetable configuration is part of the main database dump, so the `_dbstores.xml` manifest only needs to store a simple store-to-database name mapping. Full connection parameters (host, port, user, etc.) are automatically restored when the main database is restored.

### New _dbstores.xml format:
```xml
<GenRoBag>
  <store1 dbname="myapp_store1"/>
  <store2 dbname="myapp_store2"/>
</GenRoBag>
```

### Previous format (nested structure):
```xml
<GenRoBag>
  <store1>
    <db dbname="myapp_store1" host="..." user="..." />
  </store1>
</GenRoBag>
```

## Test Plan

- [x] All existing tests pass (699 passed)
- [x] Code passes flake8 validation
- Manual testing recommended:
  - Test dump-all on a multidb instance
  - Verify `_dbstores.xml` has correct flat structure
  - Test restore functionality

Fixes #401