### PR TITLE
use PathResolver rather than instancing a GnrApp to gather information

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -17,9 +17,11 @@ Fixes
 * Localization scanner regex and dialog strings locations fixed (#391,#393)
 * Password recovery is now providing more insights when message
   deliveries occurs (#121)
-* current page/request/aux instance thread-based tracker memory leak
+* Current page/request/aux instance thread-based tracker memory leak
   fixed (#379)
-
+* Project builder/dockerize now is capable of building a project
+  without the dependencies installed, provided a valid build.json is
+  avilable for the instance (#404)
   
 
 Release 26.01.09

--- a/gnrpy/gnr/app/cli/gnrdockerize.py
+++ b/gnrpy/gnr/app/cli/gnrdockerize.py
@@ -17,7 +17,6 @@ from mako.template import Template
 
 from gnr.core.cli import GnrCliArgParse
 from gnr.app.gnrdeploy import PathResolver
-from gnr.app.gnrapp import GnrApp
 from gnr.dev.builder import GnrProjectBuilder
 from gnr.app import logger
 

--- a/gnrpy/gnr/app/cli/gnrdockerize.py
+++ b/gnrpy/gnr/app/cli/gnrdockerize.py
@@ -16,6 +16,7 @@ import subprocess
 from mako.template import Template
 
 from gnr.core.cli import GnrCliArgParse
+from gnr.app.gnrdeploy import PathResolver
 from gnr.app.gnrapp import GnrApp
 from gnr.dev.builder import GnrProjectBuilder
 from gnr.app import logger
@@ -23,12 +24,12 @@ from gnr.app import logger
 description = "Create a Docker image for the instance"
 
 class MultiStageDockerImageBuilder:
-    def __init__(self, instance, options):
-        self.instance = instance
-        self.instance_name = self.instance.instanceName
-        self.image_name = options.image_name or self.instance.instanceName
+    def __init__(self, instance_name, options):
+        self.instance_name = instance_name
+        self.instance_folder = PathResolver().instance_name_to_path(self.instance_name)
+        self.image_name = options.image_name or self.instance_name
         self.options = options
-        self.builder = GnrProjectBuilder(self.instance)
+        self.builder = GnrProjectBuilder(self.instance_name)
 
         # check for required executables
         require_executables = ['docker']
@@ -76,7 +77,7 @@ class MultiStageDockerImageBuilder:
         image_labels = {"gnr_app_dockerize_on": str(now)}
         entry_dir = os.getcwd()
 
-        main_repo_url = self.builder.git_url_from_path(self.instance.instanceFolder)
+        main_repo_url = self.builder.git_url_from_path(self.instance_folder)
         self.main_repo_name = self.builder.git_repo_name_from_url(main_repo_url)
         
         os.chdir(self.build_context_dir)
@@ -367,8 +368,8 @@ def main():
     options = parser.parse_args()
 
     try:
-        instance = GnrApp(options.instance_name)
-        builder = MultiStageDockerImageBuilder(instance, options=options)
+        builder = MultiStageDockerImageBuilder(options.instance_name,
+                                               options=options)
         builder.build_docker_image(version_tag=options.version_tag)
     except Exception as e:
         logger.exception("%s", e)

--- a/gnrpy/gnr/dev/cli/gnrbuilder.py
+++ b/gnrpy/gnr/dev/cli/gnrbuilder.py
@@ -53,9 +53,7 @@ def main():
     
     options = p.parse_args()
 
-    instance = GnrApp(options.instance_name)
-
-    builder = GnrProjectBuilder(instance)
+    builder = GnrProjectBuilder(options.instance_name)
 
     if options.command == 'check':
         has_config = os.path.exists(builder.config_file)

--- a/gnrpy/gnr/dev/cli/gnrbuilder.py
+++ b/gnrpy/gnr/dev/cli/gnrbuilder.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 from gnr.core.cli import GnrCliArgParse
-from gnr.app.gnrapp import GnrApp
 from gnr.dev.builder import GnrProjectBuilder
 from gnr.dev import logger
 


### PR DESCRIPTION
about it. Since we just need the instance folder location, it's enough.

The GnrApp gets instanced only when generating a new build.json from scratch, so in this case the dependency package must be there to retrieve their git repository and branch/commit.

refs #404