### PR TITLE
fix: normalize language handling for localized columns

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmodel.py
+++ b/gnrpy/gnr/sql/gnrsqlmodel.py
@@ -604,7 +604,7 @@ class DbModelSrc(GnrStructData):
             self.child('column_list', 'columns')
         vc = self.getNode(f'virtual_columns.{name}')
         if localized is True:
-            localized = self.root._dbmodel.db.extra_kw.get('languages')
+            localized = self.root._dbmodel.db.extra_kw.get('languages').lower()
         if vc:
             colattr = dict(dtype=dtype, name_short=name_short, 
                            name_long=name_long, name_full=name_full,
@@ -1770,10 +1770,10 @@ class DbColumnObj(DbBaseColumnObj):
         """
         base_sqlname = self.attributes.get('sqlname', self.name)
         if self.attributes.get('localized'):
-            default_lang = self.db.currentEnv.get('default_language')
-            current_lang = self.db.currentEnv.get('locale_language')
-            if default_lang and current_lang and current_lang != default_lang:
-                return f"{base_sqlname}_{current_lang}"
+            default_language = self.db.currentEnv.get('default_language')
+            current_language = self.db.currentEnv.get('current_language')
+            if default_language and current_language and current_language != default_language:
+                return f"{base_sqlname}_{current_language.lower()}"
         return base_sqlname
     sqlname = property(_get_sqlname)
 

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -429,7 +429,7 @@ class GnrWebPage(GnrBaseWebPage):
         """
         db_languages = self._db.extra_kw.get('languages')
         db_languages = db_languages.split(',') if db_languages else []
-        return db_languages[0] if db_languages else None
+        return db_languages[0].upper() if db_languages else None
 
     @property
     def locale_language(self):
@@ -437,7 +437,7 @@ class GnrWebPage(GnrBaseWebPage):
 
         :returns: the language part of the locale (e.g. 'it' from 'it_IT'), or None
         """
-        return self.locale.split('_')[0].lower() if self.locale else None
+        return self.locale[0:2].upper() if self.locale else None
 
     @property
     def db(self):
@@ -449,7 +449,7 @@ class GnrWebPage(GnrBaseWebPage):
                                dbbranch=self._call_kwargs.get("dbbranch", None),
                                workdate=self.workdate, locale=self.locale,
                                default_language=self.default_language,
-                               locale_language=self.locale_language,
+                               current_language=self.language,
                                maxdate=datetime.date.max, mindate=datetime.date.min,
                                user=self.user, userTags=self.userTags, pagename=self.pagename,
                                mainpackage=self.mainpackage, _user_conf_expirebag=expirebag,
@@ -506,7 +506,7 @@ class GnrWebPage(GnrBaseWebPage):
 
     def _get_language(self):
         if not getattr(self,'_language',None):
-            self._language = self.pageStore().getItem('rootenv.language') or self.locale.split('-')[0].upper()
+            self._language = self.pageStore().getItem('rootenv.language') or self.locale_language
         return self._language
 
     def _set_language(self, language):

--- a/resources/common/tables/_default/action/_common/translate_fields.py
+++ b/resources/common/tables/_default/action/_common/translate_fields.py
@@ -31,7 +31,7 @@ class Main(BaseResourceAction):
         if not self.localizer.translator:
             raise self.tblobj.exception('business_logic', msg='No translator service configured')
 
-        self.default_language = self.page.default_language
+        self.default_language = self.page.default_language.lower()
 
         fields = self.batch_parameters.get('fields')
         if not fields:

--- a/resources/common/th/th_tree.py
+++ b/resources/common/th/th_tree.py
@@ -365,8 +365,8 @@ class TableHandlerHierarchicalView(BaseComponent):
         hierarchical = tblobj.attributes['hierarchical']
         hfield = hierarchical.split(',')[0]
         if tblobj.column(hfield).attributes.get('localized') \
-            and self.default_language and self.locale_language!=self.default_language:
-            hfield = f'{hfield}_{self.locale_language}'
+            and self.default_language and self.language!=self.default_language:
+            hfield = f'{hfield}_{self.language.lower()}'
         breadroot = pane.div()
         pane.dataController("genro.dom.setClass(breadroot.getParentNode(),'lockedToolbar',locked)",
                             locked='^#FORM.controller.locked',breadroot=breadroot)


### PR DESCRIPTION
## Summary

This PR fixes inconsistencies in how language codes are handled throughout the localized columns system.

### Problem
The localized columns system had case-sensitivity issues:
- Language codes were handled inconsistently (sometimes uppercase, sometimes lowercase)
- The `locale_language` variable did not reflect the user actual selected language
- Language comparisons could fail due to case differences

### Solution
- **Standardize to uppercase**: language codes (`default_language`, `current_language`) are now in uppercase format (e.g., IT, EN)
- **Renamed `locale_language` to `current_language`**: for semantic clarity, the DB environment variable is now called `current_language` and reflects the user active language choice
- **Lowercase for SQL suffixes**: when building DB column names (e.g., `description_it`, `name_en`), `.lower()` is applied to follow SQL naming conventions
- **Consistent use of `page.language`**: instead of `locale_language`, we now use `page.language` which represents the user actual selection

### Files modified
- `gnrpy/gnr/sql/gnrsqlmodel.py` - normalize languages to lowercase, use `current_language`
- `gnrpy/gnr/web/gnrwebpage.py` - uppercase language codes, rename to `current_language`
- `resources/common/tables/_default/action/_common/translate_fields.py` - lowercase for DB operations
- `resources/common/th/th_tree.py` - use `page.language` instead of `locale_language`

## Test plan
- [x] Full test suite passed (699 tests)
- [ ] Manually verify localized field display with non-default language
- [ ] Verify automatic field translation functionality