### PR TITLE
feat: add get_json method to GnrWebRequest

### DIFF
--- a/gnrpy/gnr/web/gnrwebreqresp.py
+++ b/gnrpy/gnr/web/gnrwebreqresp.py
@@ -43,6 +43,9 @@ class GnrWebRequest(object):
     def get_header(self, header, default=None):
         return self._request.headers.get(header, default)
 
+    def get_json(self):
+        return self._request.get_json()
+    
     def _get_filename(self):
         return self._request.filename
 


### PR DESCRIPTION
## Summary
- Add a `get_json()` method to `GnrWebRequest` class
- Wraps the underlying request's `get_json()` functionality for easier JSON body parsing in web requests

## Test plan
- [ ] Verify the method correctly returns parsed JSON from request body
- [ ] Test with various JSON payloads