### PR TITLE
fix: normalize locale to 2-char language code for translations

### DIFF
--- a/gnrjs/gnr_d11/js/gnrlang.js
+++ b/gnrjs/gnr_d11/js/gnrlang.js
@@ -42,8 +42,8 @@ function _T(str,lazy){
     if(isNullOrBlank(str)){
         return str;
     }
-    var locale = genro.locale() || 'en-EN';
-    var language = locale.split('-')[0];
+    var locale = genro.locale() || 'en';
+    var language = locale.slice(0, 2);
     var localekey = 'localsdict_'+language;
     var noLocMarker = (str.search(/^!!|\[!!/)<0);
     if(lazy && noLocMarker){

--- a/gnrpy/gnr/app/gnrlocalization.py
+++ b/gnrpy/gnr/app/gnrlocalization.py
@@ -93,7 +93,7 @@ class AppLocalizer(object):
         return self.getTranslation(txt,language=language)['translation']
 
     def getTranslation(self,txt,language=None):
-        language = (language or self.application.locale).split('-')[0].lower()
+        language = (language or self.application.locale)[:2].lower()
         result = dict(status='OK',translation=None)
         if isinstance(txt,GnrLocString):
             lockey = txt.lockey


### PR DESCRIPTION
## Summary
- Fix locale extraction logic that caused menu translations to fail when user locale was stored with underscore format (e.g., `it_IT`)
- The previous `split('-')` approach only worked for hyphenated locales (`it-IT`), now using `[:2]` slice to reliably extract the 2-character language code

## Test plan
- [x] Tests pass (699 passed)
- [ ] Verify menu displays in correct language when user has explicit locale set (e.g., `it_IT`)
- [ ] Verify menu still works correctly when user has no locale set (falls back to browser Accept-Language)