### PR TITLE
fix: normalize locale and language format across codebase

### DIFF
--- a/gnrpy/gnr/core/gnrdate.py
+++ b/gnrpy/gnr/core/gnrdate.py
@@ -62,8 +62,8 @@ def checkDateKeywords(keywords,datestr,locale):
 def monthsFromDateRange(date_start=None,date_end=None,locale=None):
     curr_date = datetime.date(date_start.year,date_start.month,1)
     result = []
-    if locale and '-' in locale:
-        locale = locale.split('-')[0]
+    if locale and len(locale) > 2:
+        locale = locale[:2]
     months = dates.get_month_names(width='wide', locale=locale)
     while curr_date<=date_end:
         m = curr_date.month

--- a/gnrpy/gnr/core/gnrrlab.py
+++ b/gnrpy/gnr/core/gnrrlab.py
@@ -46,7 +46,7 @@ class RlabResource(object):
             self.locale = locale or '{language}-{languageUPPER}'.format(language=self.language,
                                         languageUPPER=self.language.upper())
         elif self.locale:
-            self.language = self.locale.split('-')[0].lower()
+            self.language = self.locale[:2].lower()
         result = self.makePdf(record=record, **kwargs) 
 
         if downloadAs:

--- a/gnrpy/gnr/sql/gnrsqlmodel.py
+++ b/gnrpy/gnr/sql/gnrsqlmodel.py
@@ -1773,7 +1773,7 @@ class DbColumnObj(DbBaseColumnObj):
             default_language = self.db.currentEnv.get('default_language')
             current_language = self.db.currentEnv.get('current_language')
             if default_language and current_language and current_language != default_language:
-                return f"{base_sqlname}_{current_language.lower()}"
+                return f"{base_sqlname}_{current_language}"
         return base_sqlname
     sqlname = property(_get_sqlname)
 

--- a/gnrpy/gnr/web/gnrbaseclasses.py
+++ b/gnrpy/gnr/web/gnrbaseclasses.py
@@ -348,15 +348,8 @@ class TableScriptToHtml(BagToHtmlWeb):
         else:
             record = self.tblobj.recordAs(record, virtual_columns=self.virtual_columns)
         html_folder = self.getHtmlPath(autocreate=True)
-        if locale:
-            self.locale = locale #locale forced
-        self.language = language    
-        if self.language:
-            self.language = self.language.lower()
-            self.locale = locale or '{language}-{languageUPPER}'.format(language=self.language,
-                                        languageUPPER=self.language.upper())
-        elif self.locale:
-            self.language = self.locale.split('-')[0].lower()
+        self.locale = locale or self.page.locale
+        self.language = language or self.page.language
         if self.record_template:
             htmlContent = self.contentFromTemplate(record=record)
         result = super(TableScriptToHtml, self).__call__(record=record, folder=html_folder, htmlContent=htmlContent, **kwargs)

--- a/gnrpy/gnr/web/gnrhtmlpage.py
+++ b/gnrpy/gnr/web/gnrhtmlpage.py
@@ -192,7 +192,7 @@ class GnrHtmlDojoPage(GnrHtmlPage):
         theme = theme or self.theme
         version = version or self.dojo_version
         djConfig = "parseOnLoad: true, isDebug: %s, locale: '%s'" % (
-        self.isDeveloper() and 'true' or 'false', self.locale)
+        self.isDeveloper() and 'true' or 'false', self.locale.lower().replace('_', '-'))
         css_dojo = self.frontend.css_frontend(theme=theme)
         import_statements = ';\n    '.join(
                 ['@import url("%s")' % self.dojo_storage_handler.url(version, 'dojo', f) for f in css_dojo])

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -429,7 +429,7 @@ class GnrWebPage(GnrBaseWebPage):
         """
         db_languages = self._db.extra_kw.get('languages')
         db_languages = db_languages.split(',') if db_languages else []
-        return db_languages[0].upper() if db_languages else None
+        return db_languages[0].lower() if db_languages else None
 
     @property
     def locale_language(self):
@@ -437,7 +437,7 @@ class GnrWebPage(GnrBaseWebPage):
 
         :returns: the language part of the locale (e.g. 'it' from 'it_IT'), or None
         """
-        return self.locale[0:2].upper() if self.locale else None
+        return self.locale[0:2].lower() if self.locale else None
 
     @property
     def db(self):
@@ -504,15 +504,14 @@ class GnrWebPage(GnrBaseWebPage):
         self.db.workdate = workdate
     workdate = property(_get_workdate, _set_workdate)
 
-    def _get_language(self):
+    @property
+    def language(self):
         if not getattr(self,'_language',None):
-            self._language = self.pageStore().getItem('rootenv.language') or self.locale_language
+            avatar_language = getattr(self.avatar,'language',None) if self.avatar else None
+            language = avatar_language or self.locale_language
+            self._language = language.lower() if language else None
+            self.pageStore().setItem('rootenv.language', self._language)
         return self._language
-
-    def _set_language(self, language):
-        self.pageStore().setItem('rootenv.language', language)
-        self._language = language
-    language = property(_get_language, _set_language)
 
     def _set_locale(self, val):
         self._locale = val
@@ -520,8 +519,20 @@ class GnrWebPage(GnrBaseWebPage):
     def _get_locale(self):
         if not getattr(self,'_locale',None):
             headers_locale = self.request.headers.get('Accept-Language', 'en').split(',')[0]
-            self._locale = (self.avatar.locale if self.avatar and getattr(self.avatar,'locale',None) else headers_locale) or 'en' #to check
-            #self._locale = headers_locale or 'en'
+            headers_locale = headers_locale.split(';')[0].replace('-', '_')
+            avatar_locale = None
+            if self.avatar:
+                avatar_locale = getattr(self.avatar,'locale',None)
+                if not avatar_locale:
+                    avatar_language = getattr(self.avatar,'language',None)
+                    avatar_locale = avatar_language
+            locale = avatar_locale or headers_locale or 'en'
+            if '_' in locale:
+                lang, territory = locale.split('_', 1)
+                locale = f'{lang.lower()}_{territory.upper()}'
+            else:
+                locale = locale.lower()
+            self._locale = locale
         return self._locale
     locale = property(_get_locale, _set_locale)
     

--- a/gnrpy/gnr/web/gnrwebpage_proxy/frontend/dojo_base.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/frontend/dojo_base.py
@@ -34,7 +34,7 @@ class GnrBaseDojoFrontend(GnrBaseFrontend):
         self.dojofolder = dojofolder
         self.dojolib = dojolib
         self.djConfig = "parseOnLoad: false, isDebug: %s, locale: '%s' ,noFirebugLite:true" % (
-                   self.page.isDeveloper() and 'true' or 'false', self.page.locale.lower())
+                   self.page.isDeveloper() and 'true' or 'false', self.page.locale.lower().replace('_', '-'))
         
     def _get_theme(self):
         return self._theme

--- a/projects/gnrcore/packages/docu/webpages/index.py
+++ b/projects/gnrcore/packages/docu/webpages/index.py
@@ -13,8 +13,7 @@ class GnrCustomWebPage(object):
 
     @public_method
     def rst(self,*args,**kwargs):
-        language = kwargs['selected_language'] if 'selected_language' in kwargs else self.locale.split('-')[0]
-        language = language.lower()
+        language = kwargs.get('selected_language') or self.language
         doctable = self.db.table('docu.documentation')
         pkey,docbag = doctable.readColumns(columns='$id,$docbag',
                                                     where='$hierarchical_name=:hname',
@@ -33,8 +32,7 @@ class GnrCustomWebPage(object):
 
     @public_method
     def search(self,text=None,**kwargs):
-        language = kwargs['selected_language'] if 'selected_language' in kwargs else self.locale.split('-')[0]
-        language = language.lower()
+        language = kwargs.get('selected_language') or self.language
         doctable = self.db.table('docu.documentation')
         f = doctable.query(where="$is_published IS TRUE AND ( $title_%s ILIKE :val OR $rst_%s ILIKE :val ) AND $title_%s IS NOT NULL" %(language,language,language),val='%%%s%%' %text,
                         columns='$hierarchical_name,$rst_%s AS rst,$title_%s AS title' %(language,language)).fetch()

--- a/projects/gnrcore/packages/docu/webpages/viewer.py
+++ b/projects/gnrcore/packages/docu/webpages/viewer.py
@@ -19,7 +19,7 @@ class GnrCustomWebPage(object):
             
 
     def baseViewer(self,root,hierarchical_name):
-        language = self.locale.split('-')[0]
+        language = self.language
         doctable = self.db.table('docu.documentation')
         record = doctable.record(hierarchical_name=hierarchical_name).output('record')
         self.db.table('docu.documentation').checkSourceBagModules(record)

--- a/projects/gnrcore/packages/sys/webpages/docserver.py
+++ b/projects/gnrcore/packages/sys/webpages/docserver.py
@@ -13,7 +13,7 @@ class GnrCustomWebPage(object):
 
     @public_method
     def rst(self,*args,**kwargs):
-        language = self.locale.split('-')[0]
+        language = self.language
         doctable = self.db.table('.'.join(args[0:2]))
         urlist = args[2:]
         columns = '$id,$content_rst_it,$content_rst_en' if language == 'it' else '$id,$content_rst_en,$content_rst_it'

--- a/resources/common/tables/_default/action/_common/translate_fields.py
+++ b/resources/common/tables/_default/action/_common/translate_fields.py
@@ -31,7 +31,7 @@ class Main(BaseResourceAction):
         if not self.localizer.translator:
             raise self.tblobj.exception('business_logic', msg='No translator service configured')
 
-        self.default_language = self.page.default_language.lower()
+        self.default_language = self.page.default_language
 
         fields = self.batch_parameters.get('fields')
         if not fields:

--- a/resources/common/th/th_tree.py
+++ b/resources/common/th/th_tree.py
@@ -366,7 +366,7 @@ class TableHandlerHierarchicalView(BaseComponent):
         hfield = hierarchical.split(',')[0]
         if tblobj.column(hfield).attributes.get('localized') \
             and self.default_language and self.language!=self.default_language:
-            hfield = f'{hfield}_{self.language.lower()}'
+            hfield = f'{hfield}_{self.language}'
         breadroot = pane.div()
         pane.dataController("genro.dom.setClass(breadroot.getParentNode(),'lockedToolbar',locked)",
                             locked='^#FORM.controller.locked',breadroot=breadroot)

--- a/resources/common/utils.py
+++ b/resources/common/utils.py
@@ -26,7 +26,7 @@ from gnr.core.gnrstring import templateReplace
 class SendMail(object):
     def sendMailTemplate(self, tpl, mailto, params, locale=None, **kwargs):
         locale = locale or self.locale
-        localelang = locale.split('-')[0]
+        localelang = locale[:2]
         mailtpl = self.getMailTemplate(tpl, locale=localelang)
 
         if mailtpl:
@@ -36,7 +36,7 @@ class SendMail(object):
             return 'mail sent'
 
     def getMailTemplate(self, tpl, locale):
-        localelang = locale.split('-')[0]
+        localelang = locale[:2]
         tplfile = self.getResource(os.path.join('mail_templates', localelang, tpl))
         if not tplfile:
             tplfile = self.getResource(os.path.join('mail_templates', tpl))


### PR DESCRIPTION
## Summary

- `language` property is now **read-only**, derived from `avatar.language` or `locale_language`
- `language` is always normalized to **lowercase** (e.g., `it`, `en`)
- `locale` is normalized to `xx_XX` format when complete (e.g., `it_IT`), or lowercase when 2-char only
- Replaced all `locale.split('-')[0]` patterns with `locale[:2]` or `self.language`
- Removed redundant `.lower()` calls where values are already normalized
- Simplified `TableScriptToHtml` to delegate `locale`/`language` to page

## Files Changed

| File | Change |
|------|--------|
| `gnrwebpage.py` | `language` read-only property, `locale` normalization |
| `gnrbaseclasses.py` | Simplified `TableScriptToHtml` |
| `gnrsqlmodel.py` | Removed redundant `.lower()` |
| `gnrdate.py`, `gnrrlab.py` | `locale[:2]` instead of `split('-')` |
| `th_tree.py`, `translate_fields.py` | Removed redundant `.lower()` |
| `utils.py` | `locale[:2]` instead of `split('-')` |
| `docserver.py`, `index.py`, `viewer.py` | Use `self.language` |

## Test plan

- [x] All 699 tests pass
- [ ] Manual testing of locale/language in web pages
- [ ] Verify localized columns work correctly