### PR TITLE
Fix counter initialization for packages without tables

### DIFF
--- a/projects/gnrcore/packages/adm/model/counter.py
+++ b/projects/gnrcore/packages/adm/model/counter.py
@@ -45,7 +45,10 @@ class Table(object):
             self.initializePackageSequences(pkg,thermo_wrapper=thermo_wrapper)
 
     def initializePackageSequences(self,pkgobj,thermo_wrapper=None):
-        tables = thermo_wrapper(list(pkgobj['tables'].values()),message=lambda t,n,m: 'Sequences for table %s' %t.name,line_code='tbl') if thermo_wrapper else list(pkgobj['tables'].values())
+        tables = pkgobj['tables']
+        if not tables:
+            return
+        tables = thermo_wrapper(tables.values(),message=lambda t,n,m: 'Sequences for table %s' %t.name,line_code='tbl') if thermo_wrapper else tables.values()
         for tblobj in tables:
             self.initializeTableSequences(tblobj.dbtable,thermo_wrapper=thermo_wrapper)
 


### PR DESCRIPTION
## Summary
- Handle the case where a package has no tables during counter sequence initialization
- Prevents error when `pkgobj['tables']` returns None

## Changes
- Added early return check in `initializePackageSequences` method when package has no tables
- Simplified the table iteration logic

## Test plan
- [x] Verify counter initialization works for packages with tables
- [ ] Verify no error occurs for packages without tables during initialization