### PR TITLE
Fix updateStorageParameters - wrap parameters in Bag

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
@@ -277,8 +277,7 @@ class BaseStorageHandler:
 
         # Extract parameters
         implementation = service_record.get('implementation')
-        parameters_bag = service_record.get('parameters')
-
+        parameters_bag = Bag(service_record.get('parameters'))
         # Use centralized method to set parameters
         self._setStorageParams(service_name,
             parameters=parameters_bag,


### PR DESCRIPTION
## Summary
- Fix `updateStorageParameters` method in `gnrstoragehandler.py`
When you read a record with a bag field using dict output, the bag field is an XML. This pr fix thits case 