### PR TITLE
fix: extension creation on managed PostgreSQL services

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmigration.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration.py
@@ -1133,7 +1133,7 @@ class SqlMigrator():
         
         extensions_commands = self.sql_commands.pop('extensions_commands',None)
         if extensions_commands:
-            self.db.adapter.execute(extensions_commands,manager=True)
+            self.db.adapter.execute(extensions_commands,autoCommit=True)
 
     #jsonorm = OrmExtractor(GnrApp('dbsetup_tester').db).get_json_struct()
     


### PR DESCRIPTION
## Summary
- Fixed extension creation (e.g., `unaccent`) failing on managed PostgreSQL services like NeonDB
- Changed `extensions_commands` execution from `manager=True` to `autoCommit=True` in `SqlMigrator.applyChanges()`

## Problem
The `manager=True` parameter causes the adapter to connect to `template1` database to execute commands. On managed PostgreSQL services (NeonDB, and potentially others), users lack privileges to create extensions on system databases, resulting in:

```
permission denied to create extension "unaccent"
HINT: Must have CREATE privilege on current database to create this extension.
```

This works on AWS RDS because the `rds_superuser` role has sufficient privileges on `template1`.

## Solution
Using `autoCommit=True` instead connects to the target database (the one just created), where the user has the necessary permissions to create extensions.

## Test plan
- [x] All existing tests pass (699 tests)
- [x] Verify extension creation works on NeonDB with new tenant database
- [ ] Verify extension creation still works on AWS RDS