### PR TITLE
fix: handle localized column when languages is None or single

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmodel.py
+++ b/gnrpy/gnr/sql/gnrsqlmodel.py
@@ -604,7 +604,11 @@ class DbModelSrc(GnrStructData):
             self.child('column_list', 'columns')
         vc = self.getNode(f'virtual_columns.{name}')
         if localized is True:
-            localized = self.root._dbmodel.db.extra_kw.get('languages').lower()
+            dblanguages = self.root._dbmodel.db.extra_kw.get('languages')
+            if dblanguages and len(dblanguages.split(',')) > 1:
+                localized = dblanguages.lower()
+            else:
+                localized = None
         if vc:
             colattr = dict(dtype=dtype, name_short=name_short, 
                            name_long=name_long, name_full=name_full,

--- a/gnrpy/gnr/sql/gnrsqlmodel.py
+++ b/gnrpy/gnr/sql/gnrsqlmodel.py
@@ -605,7 +605,9 @@ class DbModelSrc(GnrStructData):
         vc = self.getNode(f'virtual_columns.{name}')
         if localized is True:
             dblanguages = self.root._dbmodel.db.extra_kw.get('languages')
-            if dblanguages and len(dblanguages.split(',')) > 1:
+            # if we don't have multiple languages (comma search), there is
+            # no localization
+            if dblanguages and "," in dblanguages:
                 localized = dblanguages.lower()
             else:
                 localized = None


### PR DESCRIPTION
## Summary
- Fixes potential error when `localized=True` is passed to `column()` but `languages` config is `None`
- Disables localization when only a single language is configured (no need to duplicate columns)
- Adds proper null-safety check before calling `.lower()` on languages string

## Test plan
- [x] All existing tests pass (699 passed)
- [x] Flake8 linting passes