### PR TITLE
feat: add insertToolbarItems parameter to TinyMCE widget

### DIFF
--- a/projects/gnrcore/packages/test/webpages/tools/tinymce.py
+++ b/projects/gnrcore/packages/test/webpages/tools/tinymce.py
@@ -22,3 +22,32 @@ class GnrCustomWebPage(object):
         """TinyMCE with maxLength: character limit and counter"""
         pane.tinymce(value='^.mycontent', maxLength=1024, height='400px',
                      removeToolbarItems=['image', 'code'])
+
+    def test_5_insertToolbarItems_simple(self, pane):
+        """TinyMCE with insertToolbarItems: add codesample button"""
+        pane.data('.mycontent', 'This is a test with codesample plugin.')
+        pane.tinymce(value='^.mycontent',
+                     insertToolbarItems=['codesample'],
+                     height='400px')
+
+    def test_6_insertToolbarItems_custom(self, pane):
+        """TinyMCE with insertToolbarItems: custom button with insertText"""
+        pane.data('.mycontent', 'Test custom button insertion.')
+        pane.tinymce(value='^.mycontent',
+                     insertToolbarItems=[
+                         {'name': 'myCustomBtn', 'text': 'Insert Hello',
+                          'tooltip': 'Insert Hello World', 'insertText': '<p>Hello World!</p>'}
+                     ],
+                     height='400px')
+
+    def test_7_insertToolbarItems_mixed(self, pane):
+        """TinyMCE with insertToolbarItems: mix of plugin and custom button"""
+        pane.data('.mycontent', 'Test mixed toolbar items.')
+        pane.tinymce(value='^.mycontent',
+                     insertToolbarItems=[
+                         'codesample',
+                         {'name': 'insertSignature', 'text': 'Signature',
+                          'tooltip': 'Insert signature', 'insertText': '<p><em>Best regards</em></p>'}
+                     ],
+                     removeToolbarItems=['image'],
+                     height='400px')


### PR DESCRIPTION
## Summary

Adds support for the `insertToolbarItems` parameter to the TinyMCE widget, providing feature parity with MDEditor.

This complements the existing `removeToolbarItems` parameter (which was already implemented) by allowing users to add new toolbar items and custom buttons.

## Changes

- **Parse `insertToolbarItems` parameter**: Accepts arrays of strings or objects
- **Auto-detect plugins**: Automatically adds required TinyMCE plugins (e.g., `codesample`, `emoticons`) to the plugin list
- **Support simple plugin names**: Add toolbar items using simple strings like `'codesample'`
- **Support custom buttons**: Create custom buttons with `insertText` for HTML content insertion
- **Auto-generate button names**: Generates unique names for custom buttons without explicit names
- **Toolbar construction**: Appends items to toolbar with proper separators

## Implementation Details

The implementation maintains consistency with MDEditor's `insertToolbarItems` behavior while adapting to TinyMCE's API using `editor.ui.registry.addButton()`.

### Usage Examples

**Simple plugin insertion:**
```python
pane.tinymce(value='^.content', 
             insertToolbarItems=['codesample'])
```

**Custom button with HTML insertion:**
```python
pane.tinymce(value='^.content',
             insertToolbarItems=[
                 {'name': 'signature', 'text': 'Sign', 
                  'tooltip': 'Insert signature', 
                  'insertText': '<p><em>Best regards</em></p>'}
             ])
```

**Mixed usage:**
```python
pane.tinymce(value='^.content',
             insertToolbarItems=[
                 'codesample',
                 {'name': 'greeting', 'text': 'Hi', 
                  'insertText': '<p>Hello World!</p>'}
             ])
```

## Testing

Added comprehensive test cases in `projects/gnrcore/packages/test/webpages/tools/tinymce.py`:
- `test_5_insertToolbarItems_simple`: Simple plugin insertion
- `test_6_insertToolbarItems_custom`: Custom button with insertText
- `test_7_insertToolbarItems_mixed`: Mix of plugin and custom button

## Fixes

Closes #219