### PR TITLE
Export DHZ content to XLSX as string problem

### DIFF
--- a/gnrpy/gnr/core/gnrxls.py
+++ b/gnrpy/gnr/core/gnrxls.py
@@ -467,7 +467,7 @@ class XlsxWriter(BaseXls):
                 self.writeCell(sheet, current_row, c, value, style="date")
             elif coltype=='DH':
                 self.writeCell(sheet, current_row, c, value, style="datetime")
-            elif coltype=='DHZ':
+            elif coltype=='DHZ' and not isinstance(value, str):
                 # Excel format doesn't manage timezone: writing the UTC (the user timezone is missing here)
                 self.writeCell(sheet, current_row, c, value.replace(tzinfo=None) if value else None, style="datetime")
             else:


### PR DESCRIPTION
In a 1:N relationship (such as Customers:Invoices), dragging a DHZ column onto the view causes an error during Excel export: the content is a string, but it is treated as a DHZ and therefore Genropy attempts to remove the timezone.

This patch checks the content: if it is a string, it skips timezone handling.


<img width="1361" height="437" alt="err1" src="https://github.com/user-attachments/assets/f7da8f17-e142-4c01-9dff-7cc6ea8e228a" />
<img width="653" height="284" alt="err2" src="https://github.com/user-attachments/assets/8842d1d3-5fc1-4a6e-a96c-85e021d67b12" />
