### PR TITLE
Fixed task issue while finding new tasks to be scheduled

### DIFF
--- a/gnrpy/gnr/web/gnrdaemonhandler.py
+++ b/gnrpy/gnr/web/gnrdaemonhandler.py
@@ -296,6 +296,7 @@ class GnrDaemon(object):
             siteregister_processes_dict['register'] = childprocess
 
             if not gnrtask.USE_ASYNC_TASKS and self.hasSysPackageAndIsPrimary(sitename):
+                logger.info("Starting task scheduler")
                 taskScheduler = Process(name='ts_%s' %sitename, target=createTaskScheduler,kwargs=dict(sitename=sitename))
                 taskScheduler.daemon = True
                 taskScheduler.start()

--- a/projects/gnrcore/packages/sys/model/task.py
+++ b/projects/gnrcore/packages/sys/model/task.py
@@ -1,8 +1,7 @@
 # encoding: utf-8
 
-from datetime import datetime
-
 from gnr.core.gnrbag import Bag
+from gnr.core.gnrdatetime import datetime
 from gnr.web.gnrtask import USE_ASYNC_TASKS
 from gnr.app import pkglog as logger
 
@@ -155,6 +154,7 @@ class Table(object):
                 if reason:
                     tasks_to_run.append((task['id'],reason))
             except Exception as e:
+                logger.exception("Error checking for tasks: %s", e)
                 self.db.table('sys.error').writeException(description='Scheduling Error task %s %s :%s' %(task['table_name'],task['command'],str(e)))
         return tasks_to_run
 


### PR DESCRIPTION
Fixed task issue while finding new tasks to be scheduled: the check between the current timestamp and the last execution timestamp was failing due to comparison between a tz-aware one and a non-aware one. Issue apparently was introduced with timezone changes, since this is still the old code from 2017.

Added debug logging in the scheduling stack to simplify handling of possible future issues.

refs #433