### PR TITLE
refactor: centralize mobile app config access

### DIFF
--- a/gnrpy/gnr/dev/mobilechecks.py
+++ b/gnrpy/gnr/dev/mobilechecks.py
@@ -11,11 +11,11 @@ class MobileAppChecks(object):
         self.site = site
         self.mobile_app_config = self.site.get_mobile_app_config()
         self.base_url = base_url if base_url else self.site.config.getNode("wsgi").getAttr("external_host")
-
+        
     def _verify_config_item(self, mobile_os):
         status = True
         description = f"{mobile_os} config exists"
-        if not self.mobile_app_config.get(mobile_os).get('store_url'):
+        if not self.mobile_app_config.get(mobile_os, {}).get('store_url'):
             status = False
             description = f"{mobile_os} config missing"
         return (status, description)
@@ -57,7 +57,7 @@ class MobileAppChecks(object):
 
     def test_android_deeplinking(self):
         """Verify Android deeplinking deployment"""
-        sub_path = "/.well-known/apple-app-site-association"
+        sub_path = "/.well-known/assetlinks.json"
         return self._verify_url_presence(sub_path)
     
         

--- a/gnrpy/gnr/dev/mobilechecks.py
+++ b/gnrpy/gnr/dev/mobilechecks.py
@@ -9,23 +9,24 @@ class MobileAppChecks(object):
 
     def __init__(self, site, base_url=None):
         self.site = site
+        self.mobile_app_config = self.site.get_mobile_app_config()
         self.base_url = base_url if base_url else self.site.config.getNode("wsgi").getAttr("external_host")
 
-    def _verify_config_item(self, path):
+    def _verify_config_item(self, mobile_os):
         status = True
-        description = "Path presence confirmed"
-        if not self.site.gnrapp.config.getNode(path):
+        description = f"{mobile_os} config exists"
+        if not self.mobile_app_config.get(mobile_os).get('store_url'):
             status = False
-            description = "Path configuration is missing"
+            description = f"{mobile_os} config missing"
         return (status, description)
 
     def test_ios_config(self):
         """'mobile_app.ios' path presence in instance configuration """
-        return self._verify_config_item("mobile_app.ios")
+        return self._verify_config_item("ios")
 
     def test_android_config(self):
         """'mobile_app.android' path presence in instance configuration """
-        return self._verify_config_item("mobile_app.android")
+        return self._verify_config_item("android")
 
     def _verify_url_presence(self, sub_path):
         try:

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -769,7 +769,7 @@ class GnrWsgiSite(object):
         if bundles:
             bundles = Bag(bundles)['#0']
         else:
-            bundles = self.application.config['mobile_app']
+            bundles = self.gnrapp.config['mobile_app']
         if not bundles:
             return {}
         if mobile_os:

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -767,12 +767,19 @@ class GnrWsgiSite(object):
     def get_mobile_app_config(self,mobile_os=None):
         bundles = self.getResource('mobile_app/bundles.xml')
         if bundles:
-            bundles = Bag(bundles)['#0']
-        else:
+            try:
+                bundles = Bag(bundles)['#0']
+            except Exception as e:
+                bundles = None
+                logger.error("Mobile app bundles %s file exists but can't be read: %s", bundles, e)
+                
+        if not bundles:
             # Backward compatibility: prefer mobile_app/bundles.xml resource
             bundles = self.gnrapp.config['mobile_app']
+            
         if not bundles:
             return {}
+        
         if mobile_os:
             return bundles.getAttr(mobile_os) or {}
         return {k:bundles.getAttr(k) for k in bundles.keys()}

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -762,6 +762,29 @@ class GnrWsgiSite(object):
         page = self.resource_loader(['sys', 'headless'], request, response)
         page.locale = self.server_locale
         return page
+    
+    
+    def get_mobile_app_config(self,mobile_os=None):
+        bundles = self.getResource('mobile_app/bundles.xml')
+        if bundles:
+            bundles = Bag(bundles)['#0']
+        else:
+            bundles = self.application.config['mobile_app']
+        if not bundles:
+            return {}
+        if mobile_os:
+            return bundles.getAttr(mobile_os) or {}
+        return {k:bundles.getAttr(k) for k in bundles.keys()}
+
+    def is_mobile_app_enabled(self):
+        mobile_config = self.get_mobile_app_config()
+        return (mobile_config.get('ios',{}).get('store_url') \
+                or mobile_config.get('android',{}).get('store_url')) is not None
+
+
+    
+    def getResource(self, path, ext=None, pkg=None):
+        return self.resource_loader.getResource(path, ext=ext, pkg=pkg)
 
     def virtualPage(self, table=None,table_resources=None,py_requires=None):
         page = self.dummyPage

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -769,6 +769,7 @@ class GnrWsgiSite(object):
         if bundles:
             bundles = Bag(bundles)['#0']
         else:
+            # Backward compatibility: prefer mobile_app/bundles.xml resource
             bundles = self.gnrapp.config['mobile_app']
         if not bundles:
             return {}

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
@@ -232,6 +232,17 @@ class ResourceLoader(object):
         if os.path.exists(path):
             result.append(path)
                     
+
+    def getResource(self, path, ext=None, pkg=None):
+        if pkg:
+            resourceDirs = self.package_resourceDirs(pkg)
+        else:
+            resourceDirs = self.page_class_resourceDirs(None, path, pkg)
+        result = self.getResourceList(resourceDirs, path, ext=ext)
+        if result:
+            return result[0]        
+
+
     def page_class_resourceDirs(self, page_class, path, pkg=None):
         """Build page resources directories
         

--- a/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/app/__info__.py
+++ b/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/app/__info__.py
@@ -2,6 +2,4 @@
 info = dict(caption = "Mobile App",iconClass= "appstore",priority=2)
 
 def is_enabled(page):
-    if not (page.application.config['mobile_app.android?store_url'] or page.application.config['mobile_app.ios?store_url']):
-        return False
-    return True
+    return page.site.is_mobile_app_enabled()

--- a/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/app/android_qrcode.py
+++ b/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/app/android_qrcode.py
@@ -10,12 +10,12 @@ info = {
 
 
 def is_enabled(page):
-    return page.application.config['mobile_app.android?store_url']
+    return page.site.get_mobile_app_config('android').get('store_url')
 
        
 class Formlet(BaseComponent):
     def flt_main(self,pane):
-        plain_url = self.application.config['mobile_app.android?store_url']
+        plain_url = self.site.get_mobile_app_config('android').get('store_url')
         url = urllib.parse.quote_plus(plain_url)
         pane.dataController(""";
             SET #WORKSPACE.qrcode_url = `/_tools/qrcode?url=${url}`;""",

--- a/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/app/ios_qrcode.py
+++ b/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/app/ios_qrcode.py
@@ -7,11 +7,11 @@ info = {
 }       
 
 def is_enabled(page):
-    return page.application.config['mobile_app.ios?store_url']
+    return page.site.get_mobile_app_config('ios').get('store_url')
 
 class Formlet(BaseComponent):
     def flt_main(self,pane):
-        url = self.application.config['mobile_app.ios?store_url']
+        url = self.site.get_mobile_app_config('ios').get('store_url')
         pane.dataController(""";
             SET #WORKSPACE.qrcode_url = `/_tools/qrcode?text=${url}`;""",
             url=url,_onBuilt=True)

--- a/webtools/wku.py
+++ b/webtools/wku.py
@@ -6,7 +6,6 @@
 #
 #  Copyright (c) 2024 Softwell. All rights reserved.
 #
-import copy
 import json
 
 from gnr.web.gnrbaseclasses import BaseWebtool
@@ -59,79 +58,55 @@ class RobotsTxt(WKUFile):
         return super().__call__(*args, **kwargs)
 
     
-class DeepLinkIOS(WKUFile):
-    config_item = "mobile_app.ios"
+class DeepLinkMobileApp(BaseWebtool):
+    mobile_os = None
     content_type = "application/json"
-    def get_content(self, apps_config):
-        app_template = {
-            "appIDs": [],
-            "components": [
-                {
-                    "/": "/*",
-                    "comment": "match all URLs"
-                }
-            ]
-        }
 
-        file_template = {
-            "applinks": {
-                "apps": [],
-                "details": [
-                ]
-            },
-            "webcredentials": {
-                "apps": [] 
-            }
-        }
-        for a in apps_config:
-            t = copy.deepcopy(app_template)
-            t['appIDs'].append("{apple_app_id}.{apple_bundle_id}".format(**a.attr))
-            t['appIDs'].append("{apple_team_id}.{apple_bundle_id}".format(**a.attr))
-            file_template['webcredentials']['apps'].append("{apple_app_id}.{apple_bundle_id}".format(**a.attr))
-            file_template['webcredentials']['apps'].append("{apple_team_id}.{apple_bundle_id}".format(**a.attr))
-            
-            exclusions = a.getValue("excluded_path")
-            if exclusions:
-                for e in exclusions:
-                    new_exclusion = {
-                        "/": e.attr["path"],
-                        "exclude": True,
-                        "comment": e.attr["comment"]
-                        }
-                    t['components'].insert(0, new_exclusion)
+    def __call__(self, *args, **kwargs):
+        app_config = self.site.get_mobile_app_config(self.mobile_os)
+        if not app_config:
+            raise Exception(f"mobile_app.{self.mobile_os} is not configured")
+        return self.get_content(app_config)
 
-            file_template['applinks']['details'].append(t)
-            
-        return json.dumps(file_template)
-    
+class DeepLinkIOS(DeepLinkMobileApp):
+    mobile_os = 'ios'
+
+    def get_content(self, app_config):
+        t = {
+            "appIDs": [
+                "{apple_app_id}.{apple_bundle_id}".format(**app_config),
+                "{apple_team_id}.{apple_bundle_id}".format(**app_config)
+            ],
+            "components": [{"/" : "/*", "comment": "match all URLs"}]
+        }
+        for e in app_config.get('excluded_path', []):
+            t['components'].insert(0, {"/": e["path"], "exclude": True, "comment": e["comment"]})
+
+        return json.dumps({
+            "applinks": {"apps": [], "details": [t]},
+            "webcredentials": {"apps": t['appIDs'][:]}
+        })
+
     @metadata(alias_url="/.well-known/apple-app-site-association")
     def __call__(self, *args, **kwargs):
         return super().__call__(*args, **kwargs)
 
-class DeepLinkAndroid(WKUFile):
-    content_type = "application/json"
-    config_item = "mobile_app.android"
+class DeepLinkAndroid(DeepLinkMobileApp):
+    mobile_os = 'android'
 
-    def get_content(self, apps_config):
-        file_template = []
-        for a in apps_config:
-            app_template = {
-                "relation": [
-                    "delegate_permission/common.handle_all_urls",
-                    "delegate_permission/common.get_login_creds"
-                ],
-                "target": {
-                    "namespace": "android_app",
-                    "package_name": "",
-                    "sha256_cert_fingerprints": []
-                }
+    def get_content(self, app_config):
+        fingerprints = app_config['key_fingerprint'].split(',')
+        return json.dumps([{
+            "relation": [
+                "delegate_permission/common.handle_all_urls",
+                "delegate_permission/common.get_login_creds"
+            ],
+            "target": {
+                "namespace": "android_app",
+                "package_name": app_config['bundle_id'],
+                "sha256_cert_fingerprints": fingerprints
             }
-
-            app_template['target']['package_name'] = f"{a.attr['bundle_id']}"
-            fingerprints = a.attr['key_fingerprint'].split(',')
-            app_template['target']['sha256_cert_fingerprints'].extend(fingerprints)
-            file_template.append(app_template)
-        return json.dumps(file_template)
+        }])
 
     @metadata(alias_url="/.well-known/assetlinks.json")
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- Add `get_mobile_app_config()` and `is_mobile_app_enabled()` methods to `GnrWsgiSite` for centralized mobile app configuration access
- Add `getResource()` helper to `ResourceLoader` for loading resource files
- Refactor `wku.py` with `DeepLinkMobileApp` base class for iOS/Android deep links, improving extensibility
- Update all files to use the new API instead of direct `config['mobile_app']` access

## Linked Issue
N/A

## Test plan
- [x] Verify `/.well-known/apple-app-site-association` endpoint works
- [x] Verify `/.well-known/assetlinks.json` endpoint works
- [x] Verify mobile app QR codes in user settings work
- [x] Verify `is_mobile_app_enabled()` correctly detects mobile app configuration