### PR TITLE
fix: use filepath instead of fileurl in AttachmentTable.pyColumn_fileurl

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git branch:*)"
+    ]
+  }
+}

--- a/gnrpy/gnr/app/gnrdbo.py
+++ b/gnrpy/gnr/app/gnrdbo.py
@@ -1752,7 +1752,7 @@ class AttachmentTable(GnrDboTable):
             return self.filepath_endpoint_url(record)
         if not record.get('fileurl'):
             return
-        return self.db.application.site.externalUrl(record['fileurl'])
+        return self.db.application.site.externalUrl(record['filepath'])
     
     def pyColumn_missing_file(self,record,**kwargs):
         sn = self.db.application.site.storageNode(record['filepath'])


### PR DESCRIPTION
Fix: Correct full_external_url resolution by using filepath instead of fileurl
Summary
This PR fixes a bug in the pyColumn_full_external_url method in [AttachmentTable](vscode-webview://1it6q1qb0kuvav05hkaempo0jccm8i1j8h85f71fmiuguetmmaaq/gnrpy/gnr/app/gnrdbo.py#L1748) where the wrong field was being used to resolve external URLs.

Problem
When atc_exposeEndpointUrl() returns False, the pyColumn_full_external_url method was incorrectly using record['fileurl'] instead of record['filepath'] to build the external URL. This was inconsistent with the filepath_endpoint_url method, which correctly uses record['filepath'].

Solution
Changed line [1755](vscode-webview://1it6q1qb0kuvav05hkaempo0jccm8i1j8h85f71fmiuguetmmaaq/gnrpy/gnr/app/gnrdbo.py#L1755) to use record['filepath'] instead of record['fileurl'], ensuring consistency with the filepath_endpoint_url method and proper URL resolution.

Changes
File: [gnrpy/gnr/app/gnrdbo.py](vscode-webview://1it6q1qb0kuvav05hkaempo0jccm8i1j8h85f71fmiuguetmmaaq/gnrpy/gnr/app/gnrdbo.py)
Line 1755: Changed from self.db.application.site.externalUrl(record['fileurl']) to self.db.application.site.externalUrl(record['filepath'])
This ensures that the full_external_url column properly resolves URLs in all scenarios, maintaining consistency across the attachment table's URL resolution logic.