### PR TITLE
Add deferred_ts for deferred email sending

### DIFF
--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -55,12 +55,14 @@ class Table(object):
         tbl.column('priority', name_long='!![en]Priority',
                    values='9:[!![en]No send],3:[!![en]Low],2:[!![en]Standard],1:[!![en]High],-1:[!![en]Immediate]')
         tbl.column('read', dtype='B', name_long='!!Read',indexed=True)
+        tbl.column('deferred_ts', dtype='DHZ', name_long='!!Deferred send',
+                   name_short='!!Deferred', indexed=True)
 
-        #tbl.joinColumn('dest_user_id', name_long='!!Destination user').relation('adm.user.id', 
+        #tbl.joinColumn('dest_user_id', name_long='!!Destination user').relation('adm.user.id',
         #                                    cnd='@dest_user_id.email=$to_address', relation_name='received_messages')
         tbl.formulaColumn('dest_user_id', '$user_id', name_long='!!Destination user')
         tbl.formulaColumn('sent','$send_date IS NOT NULL', name_long='!!Sent')
-        tbl.formulaColumn('message_to_send', "$in_out=:out AND $send_date IS NULL AND $error_msg IS NULL", var_out='O',
+        tbl.formulaColumn('message_to_send', "$in_out=:out AND $send_date IS NULL AND $error_msg IS NULL AND ($deferred_ts IS NULL OR $deferred_ts <= NOW())", var_out='O',
                             name_long='!!Message to send', dtype='B')
         tbl.formulaColumn('plain_text', """regexp_replace($body, '<[^>]*>', '', 'g')""")
         tbl.formulaColumn('abstract', """LEFT(REPLACE($plain_text,'&nbsp;', ''),300)""", name_long='!![en]Abstract')

--- a/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
+++ b/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
@@ -19,10 +19,8 @@ class Main(BaseResourceAction):
             self.sendEmailsForAccount(account)
     
     def sendEmailsForAccount(self,account):
-        email_to_send = self.message_tbl.query(where="""$in_out=:out AND $send_date IS NULL 
-                                                        AND $account_id=:acid 
-                                                        AND $error_msg IS NULL""",
-                                        out='O',order_by='$__ins_ts',
+        email_to_send = self.message_tbl.query(where='$message_to_send IS TRUE AND $account_id=:acid',
+                                        order_by='$__ins_ts',
                                         limit=account['send_limit'],
                                         acid=account['id'],
                                         bagFields=True).fetch()


### PR DESCRIPTION
## Feature: Deferred Send Timestamp for Email Messages

This PR implements a deferred send timestamp feature for the email.message table, enabling deferred/staggered email delivery to avoid system overload during bulk operations.

### Changes

#### 1. Model (`email/model/message.py`)
- **New column**: `deferred_ts` (dtype='DHZ', indexed)
  - NULL = immediate send (default, backward compatible)
  - Set to future datetime = deferred send
  - DHZ type ensures timezone-aware timestamp handling
- **Updated formula**: `message_to_send` now includes:
  ```sql
  AND ($deferred_ts IS NULL OR $deferred_ts <= NOW())
  ```

#### 2. Task Action (`email/resources/tables/account/action/send_mail.py`)
- Simplified query to use `message_to_send` formula instead of replicating logic
- Now automatically respects deferred_ts through formula column

### Use Case

**Problem**: Sending thousands of emails simultaneously (e.g., 7,000 members) overloads SMTP servers and causes system slowdowns.

**Solution**: Create all messages at once with progressive `deferred_ts` values:
- Message 1-30: deferred_ts = NOW (immediate)
- Message 31-60: deferred_ts = NOW + 25 minutes
- Message 61-90: deferred_ts = NOW + 50 minutes
- ...

The existing task scheduler (with `send_limit`) picks up messages as their deferred time arrives, distributing the load over hours/days.

### Example Calculation

To send 7,000 emails over 4 days with blocks of 30:
- 234 blocks total
- Delay between blocks = 345,600 seconds / 233 = **1,480 seconds** (~25 minutes)
- Result: ~73 emails/hour, no system overload

### Backward Compatibility

✅ **Fully backward compatible**
- Existing messages (deferred_ts = NULL) send immediately as before
- No changes required to existing code
- New feature is opt-in via deferred_ts parameter

### Technical Notes

**Why DHZ instead of DH?**
- DHZ = DateTime with TimeZone
- Ensures accurate comparison with NOW() across different server timezones
- Critical for distributed deployments

**Why "deferred_ts" instead of "scheduled_ts"?**
- More accurate semantic: "defer" = postpone/delay action
- "scheduled" implies recurring/planned events (cron-like)
- Aligns with deferred/delayed messaging patterns in email systems

### Related

- Issue: softwellsrl/anaci#246
- Application: ANACI bulk circular sending

### Testing

- [ ] Verify deferred_ts column creation
- [ ] Test message_to_send formula with NULL deferred_ts
- [ ] Test message_to_send formula with future deferred_ts
- [ ] Test message_to_send formula with past deferred_ts
- [ ] Verify send_mail task respects deferred timestamps
- [ ] Test timezone handling with DHZ type