### PR TITLE
feat(security): add table and column permission checks in SqlQueryCompiler

### DIFF
--- a/gnrpy/gnr/sql/gnrsql.py
+++ b/gnrpy/gnr/sql/gnrsql.py
@@ -157,6 +157,8 @@ class GnrSqlDb(GnrObject):
         self.typeConverter = GnrClassCatalog()
         self.debugger = debugger
         self.application = application
+        # Permission enforcement levels: T=table, R=relations, C=columns (e.g. "T,R,C")
+        self.permission_enforcement = kwargs.get('permission_enforcement', '')
         self.model = self.createModel()
 
         if ':' in self.implementation:

--- a/gnrpy/gnr/sql/gnrsql_exceptions.py
+++ b/gnrpy/gnr/sql/gnrsql_exceptions.py
@@ -92,4 +92,8 @@ class GnrSqlMissingColumn(GnrException):
         
 class GnrSqlRelationError(GnrException):
     pass
-        
+
+class GnrSqlTablePermissionError(GnrException):
+    """Exception raised when user has no permission to access a table"""
+    pass
+

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -141,8 +141,21 @@ class SqlQueryCompiler(object):
     def aliasCode(self,n):
         return '%s%i' %(self.aliasPrefix,n)
 
-    def checkTablePermission(self, table):
-        """Check if the current user has permission to access the table.
+    def _initPermissionEnforcement(self):
+        """Initialize permission enforcement flags as a set.
+
+        Called once at init. The flags are: T=table, R=relations, C=columns.
+        The currentEnv can disable all checks by setting permission_enforcement=False.
+        """
+        env_value = self.db.currentEnv.get('permission_enforcement')
+        if env_value is False:
+            self._permission_enforcement = set()
+            return
+        enforcement = getattr(self.db, 'permission_enforcement', '') or ''
+        self._permission_enforcement = set(enforcement.replace(',', '').upper())
+
+    def _checkTablePermission(self, table):
+        """Check table permission via currentPage.
 
         :param table: the full table name (pkg.tablename)
         """
@@ -158,6 +171,8 @@ class SqlQueryCompiler(object):
         :param tblobj: the table object (defaults to main table)
         :returns: True if column is hidden, False otherwise
         """
+        if 'C' not in self._permission_enforcement:
+            return False
         currentPage = getattr(self.db, 'currentPage', None)
         if not currentPage:
             return False
@@ -180,7 +195,9 @@ class SqlQueryCompiler(object):
         self._explodingTables = []
         self.lazy = lazy or []
         self.eager = eager or []
-        self.checkTablePermission(self.tblobj.fullname)
+        self._initPermissionEnforcement()
+        if 'T' in self._permission_enforcement:
+            self._checkTablePermission(self.tblobj.fullname)
         self.aliases = {self.tblobj.sqlfullname: self.aliasCode(0)}
         self.fieldlist = []
 
@@ -373,7 +390,8 @@ class SqlQueryCompiler(object):
             from_tbl = self.dbmodel.table(joiner['one_relation'])
             from_column = joiner['one_relation'].split('.')[-1]
             manyrelation = not joiner.get('one_one', False)
-        self.checkTablePermission(target_tbl.fullname)
+        if 'R' in self._permission_enforcement:
+            self._checkTablePermission(target_tbl.fullname)
         #target_sqlschema = target_tbl.sqlschema
         #target_sqltable = target_tbl.sqlname
         ignore_tenant = joiner.get('ignore_tenant')
@@ -706,7 +724,7 @@ class SqlQueryCompiler(object):
             # Check column permission: extract column name from last dotted part, strip $ or @
             colname_for_check = col.split(' AS ')[0].split('.')[-1].lstrip('$@')
             if colname_for_check and self.isColumnHidden(colname_for_check):
-                col = "'***' AS %s" % as_
+                col = "NULL AS %s" % as_
             col_dict[as_] = col
         # build the clean and complete sql string for the columns, but still all fields are expressed as $fieldname
         as_col_values = col_dict.values()

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -45,7 +45,7 @@ from gnr.core.gnrbag import Bag, BagResolver, BagAsXml
 from gnr.core.gnranalyzingbag import AnalyzingBag
 from gnr.sql.gnrsql_exceptions import GnrSqlException,SelectionExecutionError, RecordDuplicateError,\
     RecordNotExistingError, RecordSelectionError,\
-    GnrSqlMissingField, GnrSqlMissingColumn
+    GnrSqlMissingField, GnrSqlMissingColumn, GnrSqlTablePermissionError
 
 COLFINDER = re.compile(r"(\W|^)\$(\w+)")
 RELFINDER = re.compile(r"([^A-Za-z0-9_]|^)(\@(\w[\w.@:]+))")
@@ -141,6 +141,34 @@ class SqlQueryCompiler(object):
     def aliasCode(self,n):
         return '%s%i' %(self.aliasPrefix,n)
 
+    def checkTablePermission(self, table):
+        """Check if the current user has permission to access the table.
+
+        :param table: the full table name (pkg.tablename)
+        """
+        currentPage = getattr(self.db, 'currentPage', None)
+        if currentPage and hasattr(currentPage, 'checkTablePermission'):
+            if not currentPage.checkTablePermission(table=table, permissions='hidden'):
+                raise GnrSqlTablePermissionError(f'Access denied to table {table}')
+
+    def isColumnHidden(self, colname, tblobj=None):
+        """Check if a column is hidden for the current user.
+
+        :param colname: the column name (without $ prefix)
+        :param tblobj: the table object (defaults to main table)
+        :returns: True if column is hidden, False otherwise
+        """
+        currentPage = getattr(self.db, 'currentPage', None)
+        if not currentPage:
+            return False
+        tblobj = tblobj or self.tblobj
+        avatar = getattr(currentPage, 'avatar', None)
+        if not avatar:
+            return False
+        colperm = tblobj.getColPermissions(colname,
+                                           user=currentPage.user,
+                                           user_group=avatar.group_code)
+        return colperm.get('user_hidden') == True
 
     def init(self, lazy=None, eager=None):
         """TODO
@@ -152,6 +180,7 @@ class SqlQueryCompiler(object):
         self._explodingTables = []
         self.lazy = lazy or []
         self.eager = eager or []
+        self.checkTablePermission(self.tblobj.fullname)
         self.aliases = {self.tblobj.sqlfullname: self.aliasCode(0)}
         self.fieldlist = []
 
@@ -344,6 +373,7 @@ class SqlQueryCompiler(object):
             from_tbl = self.dbmodel.table(joiner['one_relation'])
             from_column = joiner['one_relation'].split('.')[-1]
             manyrelation = not joiner.get('one_one', False)
+        self.checkTablePermission(target_tbl.fullname)
         #target_sqlschema = target_tbl.sqlschema
         #target_sqltable = target_tbl.sqlname
         ignore_tenant = joiner.get('ignore_tenant')
@@ -673,6 +703,10 @@ class SqlQueryCompiler(object):
                 # leave the col as is, but save the AS name to recover the db column original name from selection result
                 as_ = self.db.adapter.asTranslator(as_.strip())
                 self.cpl.aliasDict[as_] = colbody.strip()
+            # Check column permission: extract column name from last dotted part, strip $ or @
+            colname_for_check = col.split(' AS ')[0].split('.')[-1].lstrip('$@')
+            if colname_for_check and self.isColumnHidden(colname_for_check):
+                col = "'***' AS %s" % as_
             col_dict[as_] = col
         # build the clean and complete sql string for the columns, but still all fields are expressed as $fieldname
         as_col_values = col_dict.values()


### PR DESCRIPTION
## Summary

Add SQL-level permission enforcement to prevent unauthorized table/column access via parameter tampering in AJAX calls.

## Security Problem Addressed

An authenticated user could manipulate AJAX call parameters (e.g., `appHandler.getSelection`) to:
- Query tables they shouldn't have access to
- Access columns marked as hidden for their user/group

## Solution

Permission checks are enforced at SQL query compilation time in `SqlQueryCompiler`, controlled by the `permission_enforcement` configuration flag.

## Configuration

In `instanceconfig.xml`, add the `permission_enforcement` attribute to the `<db>` node:

```xml
<db implementation="postgres"
    dbname="mydb"
    host="localhost"
    permission_enforcement="T,R,C" />
```

### Flag Values

| Flag | Description |
|------|-------------|
| `T`  | **Table** - Check permission on main table (t0). Raises `GnrSqlTablePermissionError` if table is hidden for user. |
| `R`  | **Relations** - Check permission on joined tables (t1, t2, ...). Raises exception if any related table is hidden. |
| `C`  | **Columns** - Mask hidden columns. Returns `NULL` instead of actual value for columns marked as `user_hidden`. |

### Examples

```xml
<!-- Full protection: tables, relations, and columns -->
<db permission_enforcement="T,R,C" />

<!-- Only main table protection -->
<db permission_enforcement="T" />

<!-- Tables and columns, but allow all relations -->
<db permission_enforcement="T,C" />

<!-- Disabled (default behavior) -->
<db permission_enforcement="" />
```

## Runtime Override

Permission enforcement can be temporarily disabled in code via `currentEnv`:

```python
# Disable all permission checks for this request/operation
db.currentEnv['permission_enforcement'] = False

# Execute query without permission checks
result = db.table('sensitive.table').query(...).fetch()
```

This is useful for:
- Batch jobs running without a user context
- Admin operations that need full access
- Background tasks

**Note**: Setting to `False` completely disables checks. You cannot add flags at runtime, only disable.

## Behavior

| Scenario | With flag | Without flag |
|----------|-----------|--------------|
| Query hidden table (T) | `GnrSqlTablePermissionError` | Query executes |
| Join hidden table (R) | `GnrSqlTablePermissionError` | Join executes |
| Select hidden column (C) | Returns `NULL` | Returns actual value |
| No `currentPage` (batch) | No check (passes) | No check |

## Files Changed

- [gnrsql.py](gnrpy/gnr/sql/gnrsql.py) - Added `permission_enforcement` config parameter
- [gnrsqldata.py](gnrpy/gnr/sql/gnrsqldata.py) - Added enforcement logic in `SqlQueryCompiler`
- [gnrsql_exceptions.py](gnrpy/gnr/sql/gnrsql_exceptions.py) - Added `GnrSqlTablePermissionError`

## Test Plan

- [ ] Configure `permission_enforcement="T,R,C"` on test instance
- [ ] Verify query on permitted table works
- [ ] Verify query on hidden table raises `GnrSqlTablePermissionError`
- [ ] Verify join to hidden table raises exception (with R flag)
- [ ] Verify hidden columns return `NULL` (with C flag)
- [ ] Verify batch jobs without `currentPage` still work
- [ ] Verify `currentEnv['permission_enforcement'] = False` disables checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)