### PR TITLE
fix: use isNullOrBlank for badge content check

### DIFF
--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
@@ -76,7 +76,7 @@ class MenuIframes(BaseComponent):
             let label = node.attr.label;
             let badgeContent =  node.attr.badgeContent;
             let badgeClass = node.attr.badgeClass || 'menuline_badge';
-            if(badgeContent!==null){
+            if(!isNullOrBlank(badgeContent)){
                 label = `innerHTML:${label} <span class="${badgeClass}">${badgeContent}</span>`
             }
             return label;


### PR DESCRIPTION
## Summary
- Fix menu badge display when content is undefined or empty string
- Replace strict null check with isNullOrBlank utility function for better edge case handling

## Context
This hotfix improves the badge content check introduced in #444. The previous implementation only checked for `!==null`, which would incorrectly display badges when content is `undefined` or an empty string.

## Changes
- Changed condition from `badgeContent!==null` to `!isNullOrBlank(badgeContent)` in `_menutree_getLabel()`

## Test plan
- [x] Verified badge does not appear when content is undefined
- [x] Verified badge does not appear when content is empty string
- [x] Verified badge still appears correctly when content has a valid value