### PR TITLE
Fix menuLineBadge check for virtual columns

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage_proxy/menuproxy.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/menuproxy.py
@@ -57,9 +57,8 @@ class GnrMenuProxy(GnrBaseProxy):
 
             # build WHERE clause based on column dtype
             column = tblobj.column(fieldpath)
-            if not column:
-                logger.error(f"Column {fieldpath} not found in table {table}")
-                return 0
+            if column is None:
+                raise ValueError(f"Column {fieldpath} not found in table {table}")
             dtype = column.attributes.get('dtype')
             if dtype == 'B':
                 # boolean: check for TRUE/NOT TRUE


### PR DESCRIPTION
## Summary
- Fixes menulinebadge returning 0 for virtual columns after #444
- Changes column existence check from `if not column:` to `if column is None:`
- Replaces error logging with ValueError exception for missing columns

## Problem
After merging #444, the check `if not column:` incorrectly treats empty Bags (returned for virtual columns) as non-existent columns. This causes all menulinebadge using virtual columns to always return 0.

## Solution
Use explicit `if column is None:` check to distinguish between:
- Column not found: `tblobj.column()` returns `None`
- Virtual column: `tblobj.column()` returns empty Bag (falsy but not None)

Also improves error handling by raising ValueError instead of logging and returning 0.

## Test plan
- [x] Test menulinebadge with virtual columns
- [x] Test menulinebadge with regular columns
- [x] Verify proper error when column doesn't exist

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)