### PR TITLE
Fix tree search highlight with innerHTML labels

### DIFF
--- a/gnrjs/gnr_d11/js/genro_tree.js
+++ b/gnrjs/gnr_d11/js/genro_tree.js
@@ -467,6 +467,9 @@ dojo.declare("gnr.widgets.Tree", gnr.widgets.baseDojo, {
                     if(!searchColumn){
                         var label = that.getLabel(item);
                         if(label){
+                            if(label.startsWith('innerHTML:')){
+                                label = label.replace('innerHTML:','');
+                            }
                             tn.labelNode.innerHTML = label.replace(filterRegExp,"<span class='search_highlight'>$1</span>");
                         }
                     }


### PR DESCRIPTION
## Summary
- Strip `innerHTML:` prefix from tree node labels before applying search highlight markup
- Prevents the raw prefix from appearing as visible text in filtered tree results
- Consistent with existing `innerHTML:` handling in `setLabelNode` (genro_patch.js)

## Test plan
- [x] Open a tree with HTML-formatted labels (using `innerHTML:` prefix)
- [x] Use the tree search/filter feature
- [x] Verify the `innerHTML:` prefix does not appear in search results
- [ ] Verify search highlighting works correctly on HTML labels