### PR TITLE
refactor(sql): unify virtual column handling and mangle ownership

### DIFF
--- a/gnrpy/gnr/sql/gnrsql.py
+++ b/gnrpy/gnr/sql/gnrsql.py
@@ -1043,7 +1043,8 @@ class GnrSqlDb(GnrObject):
               relationDict=None, sqlparams=None, excludeLogicalDeleted=True,
               excludeDraft=True,
               addPkeyColumn=True,ignorePartition=False, locale=None,
-              mode=None,_storename=None,aliasPrefix=None,ignoreTableOrderBy=None, subtable=None,**kwargs):
+              mode=None,_storename=None,aliasPrefix=None,ignoreTableOrderBy=None, subtable=None,
+              mainquery_kw=None,**kwargs):
         q = self.table(table).query(columns=columns, where=where, order_by=order_by,
                          distinct=distinct, limit=limit, offset=offset,
                          group_by=group_by, having=having, for_update=for_update,
@@ -1051,7 +1052,8 @@ class GnrSqlDb(GnrObject):
                          excludeLogicalDeleted=excludeLogicalDeleted,excludeDraft=excludeDraft,
                          ignorePartition=ignorePartition,
                          addPkeyColumn=addPkeyColumn, locale=locale,_storename=_storename,
-                         aliasPrefix=aliasPrefix,ignoreTableOrderBy=ignoreTableOrderBy,subtable=subtable)
+                         aliasPrefix=aliasPrefix,ignoreTableOrderBy=ignoreTableOrderBy,subtable=subtable,
+                         mainquery_kw=mainquery_kw)
         result = q.sqltext
         if kwargs:
             prefix = str(id(kwargs))

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -147,9 +147,22 @@ class SqlCompiledQuery(object):
             result = self.tpl % result
         return result
 
+class SqlCompiledSubQuery(SqlCompiledQuery):
+    """A compiled subquery with correlation analysis and identity support.
+
+    Extends ``SqlCompiledQuery`` with attributes specific to subqueries
+    used inside formula columns: correlation info for JOIN conversion,
+    aggregate column tracking, and identity hashing for merge.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.correlation = None
+        self.aggregate_column = None
+
     @property
     def identity_hash(self):
-        """Mangler-independent fingerprint for CTE merge.
+        """Mangler-independent fingerprint for subquery merge.
 
         Resolves mangled parameter placeholders in ``self.where`` with their
         actual values, then hashes ``(maintable, resolved_where)``.
@@ -165,7 +178,7 @@ class SqlCompiledQuery(object):
         return hash((self.maintable, resolved_where))
 
     def __eq__(self, other):
-        if not isinstance(other, SqlCompiledQuery):
+        if not isinstance(other, SqlCompiledSubQuery):
             return NotImplemented
         return self.identity_hash is not None and self.identity_hash == other.identity_hash
 
@@ -473,7 +486,7 @@ class SqlQueryCompiler(object):
             mangler=mangler_prefix,
             **sq_pars
         )
-        compiled = q.compileQuery()
+        compiled = q.compileQuery(compiled_class=SqlCompiledSubQuery)
         compiled.tpl = tpl
 
         # 5. Merge mangled subquery params into main query params
@@ -726,7 +739,8 @@ class SqlQueryCompiler(object):
                       storename=None,subtable=None,
                       count=False, excludeLogicalDeleted=True,excludeDraft=True,
                       ignorePartition=False,ignoreTableOrderBy=False,
-                      addPkeyColumn=True):
+                      addPkeyColumn=True,
+                      compiled_class=None):
         """Prepare the SqlCompiledQuery to get the sql query for a selection.
 
         :param columns: it represents the :ref:`columns` to be returned by the "SELECT"
@@ -751,9 +765,12 @@ class SqlQueryCompiler(object):
         :param excludeLogicalDeleted: boolean. If ``True``, exclude from the query all the records that are
                                       "logical deleted"
         :param excludeDraft: TODO
-        :param addPkeyColumn: boolean. If ``True``, add a column with the pkey attribute"""
+        :param addPkeyColumn: boolean. If ``True``, add a column with the pkey attribute
+        :param compiled_class: optional factory class for the compiled query object.
+                               Defaults to ``SqlCompiledQuery``."""
         # get the SqlCompiledQuery: an object that mantains all the informations to build the sql text
-        self.cpl = SqlCompiledQuery(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0),
+        compiled_class = compiled_class or SqlCompiledQuery
+        self.cpl = compiled_class(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0),
                                     mangler=self.mangler, sqlparams=self.sqlparams)
         distinct = distinct or '' # distinct is a text to be inserted in the sql query string
 
@@ -1312,10 +1329,11 @@ class SqlQuery(object):
 
     compiled = property(_get_compiled)
 
-    def compileQuery(self, count=False):
+    def compileQuery(self, count=False, compiled_class=None):
         """Return the :meth:`compiledQuery() <SqlQueryCompiler.compiledQuery()>` method.
 
-        :param count: boolean. If ``True``, optimize the sql query to get the number of resulting rows (like count(*))"""
+        :param count: boolean. If ``True``, optimize the sql query to get the number of resulting rows (like count(*))
+        :param compiled_class: optional factory class for the compiled query object."""
         return SqlQueryCompiler(self.dbtable.model,
                                 joinConditions=self.joinConditions,
                                 sqlContextName=self.sqlContextName,
@@ -1326,6 +1344,7 @@ class SqlQuery(object):
                                 query_kw=self.query_kw,
                                 mainquery_kw=self.mainquery_kw,
                                 query=self).compiledQuery(count=count,
+                                                                  compiled_class=compiled_class,
                                                                   relationDict=self.relationDict,
                                                                   **self.querypars)
 

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -121,7 +121,7 @@ class SqlQueryCompiler(object):
                            :meth:`setJoinCondition() <gnr.web.gnrwebpage.GnrWebPage.setJoinCondition>` method)
     :param sqlparams: a dict of parameters used in "WHERE" clause
     :param locale: the current locale (e.g: en, en_us, it)"""
-    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None):
+    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None, query_kw=None, mainquery_kw=None):
         self.tblobj = tblobj
         self.db = tblobj.db
         self.dbmodel = tblobj.db.model
@@ -137,6 +137,9 @@ class SqlQueryCompiler(object):
         self.aliasPrefix = aliasPrefix or 't'
         self.locale = locale
         self.mangler = mangler
+        self.query_kw = query_kw or {}
+        self.mainquery_kw = mainquery_kw or {}
+        self.subquery_kw = {}
         self.macro_expander = self.db.adapter.macroExpander(self)
 
     def aliasCode(self,n):
@@ -159,7 +162,10 @@ class SqlQueryCompiler(object):
             return
         for k, v in list(self.sqlparams.items()):
             if not k.startswith('env_'):
-                self.sqlparams['%s_%s' % (self.mangler, k)] = v
+                mangled_key = '%s_%s' % (self.mangler, k)
+                mangled_value = self.query_kw.get(k, self.mainquery_kw.get(k))
+                self.subquery_kw[mangled_key] = mangled_value
+                self.sqlparams[mangled_key] = v
 
     def init(self, lazy=None, eager=None):
         """TODO
@@ -247,51 +253,28 @@ class SqlQueryCompiler(object):
 
                 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                sql_formula = fldalias.sql_formula
+                # Virtual column dispatch based on subquery presence:
+                #   - A subquery exists only if select, exists, or select_ attributes are present
+                #   - sql_formula alone (str or True) without select/exists = pure formula
+                #   - sql_formula=True delegates to a Python method sql_formula_<fieldname>()
                 attr = dict(fldalias.attributes)
-                if sql_formula is True:
-                    sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
-                select_dict = dictExtract(attr,'select_')
-                if not sql_formula:
-                    sql_formula = '#default' if fldalias.select else 'EXISTS(#default)'
-                    select_dict['default'] = fldalias.select or fldalias.exists
-                if select_dict:
-                    for susbselect,sq_pars in list(select_dict.items()):
-                        if isinstance(sq_pars, str):
-                            sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
-                        sq_pars = dict(sq_pars)
-                        cast = sq_pars.pop('cast',None)
-                        tpl = ' CAST( ( %s ) AS ' +cast +') ' if cast else ' ( %s ) '
-                        sq_table = sq_pars.pop('table')
-                        sq_where = sq_pars.pop('where')
-                        sq_pars.setdefault('ignorePartition',True)
-                        sq_pars.setdefault('excludeDraft',False)
-                        sq_pars.setdefault('excludeLogicalDeleted',False)
-                        sq_pars.setdefault('subtable','*')
-                        aliasPrefix = '%s_t' %alias
-                        sq_where = THISFINDER.sub(expandThis,sq_where)
-                        sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
-                        sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
-                subreldict = {}
-                sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
-                sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
-                sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
-                sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
-                sql_formula = PREFFINDER.sub(expandPref, sql_formula)
-                sql_formula = THISFINDER.sub(expandThis,sql_formula)
-                sql_formula_var = dictExtract(attr,'var_')
-                if sql_formula_var:
-                    prefix = str(id(fldalias))
-                    currentEnv = self.db.currentEnv
-                    for k,v in list(sql_formula_var.items()):
-                        newk = f'{prefix}_{self._currColKey}_{k}'
-                        currentEnv[newk] = v
-                        sql_formula = re.sub("(:)(%s)(\\W|$)" %k,lambda m: '%senv_%s%s'%(m.group(1),newk,m.group(3)), sql_formula)
-                subColPars = {}
-                for key, value in list(subreldict.items()):
-                    subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
-                sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
-                return f'( {sql_formula} )' 
+                formula_kw = dictExtract(attr, 'var_')
+                multi_select = dictExtract(attr, 'select_')
+                has_subquery = fldalias.select or fldalias.exists or multi_select
+                if not has_subquery:
+                    # Pure formula: only $col and @rel.col references, resolved inline
+                    return self._handleFormulaColumn(fldalias, fld, curr_tblobj, alias, curr,
+                                                      attr, formula_kw)
+                elif not multi_select:
+                    # Single subquery (select or exists), with or without a wrapping sql_formula
+                    return self._handleSubQuery(fldalias, fld, curr_tblobj, alias, curr,
+                                                      expandThis, expandEnv, expandPref,
+                                                      attr, formula_kw)
+                else:
+                    # Multiple subqueries (select_ prefix in attributes)
+                    return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
+                                                      expandThis, expandEnv, expandPref,
+                                                      attr, formula_kw, multi_select)
             elif fldalias.py_method:
                 #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
                 self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
@@ -300,6 +283,108 @@ class SqlQueryCompiler(object):
                 raise GnrSqlMissingColumn('Invalid column %s in table %s.%s (requested field %s)' % (
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
+
+    def _handleFormulaColumn(self, fldalias, fld, curr_tblobj, alias, curr, attr, formula_kw):
+        """Handle pure formula columns with no subquery.
+
+        Translates a sql_formula string containing $col and @rel.col placeholders
+        into valid SQL by resolving each reference to its table alias (e.g. t0.col, t3.col).
+
+        The sql_formula can be either:
+            - A string (e.g. ``"UPPER($title)"`` or ``"$role || ' in ' || @movie_id.title"``).
+            - The boolean ``True``, meaning the formula is defined as a Python method
+              ``sql_formula_<fieldname>(attributes)`` on the table object.
+
+        Resolution is done in two passes via regex substitution:
+            1. RELFINDER resolves ``@relation.column`` references (e.g. ``@movie_id.title`` -> ``t3.title``).
+            2. COLFINDER resolves ``$column`` references (e.g. ``$title`` -> ``t0.title``).
+
+        Both regexes capture a leading non-word character in group(1) and the field path
+        in group(2). The callback delegates to ``getFieldAlias`` which handles join registration.
+
+        Args:
+            fldalias: The virtual column definition node from the model.
+            fld: The field name (e.g. ``'title_upper'``).
+            curr_tblobj: The current table object in the model.
+            alias: The SQL table alias for the current table (e.g. ``'t0'``).
+            curr: The current table model node.
+            attr: Pre-extracted dict of fldalias.attributes.
+            formula_kw: Pre-extracted var_ parameters (dict), for :placeholder resolution.
+
+        Returns:
+            A parenthesized SQL expression string (e.g. ``'( UPPER(t0.title) )'``).
+        """
+        sql_formula = fldalias.sql_formula
+        if sql_formula is True:
+            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
+        def resolveField(m):
+            return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
+        sql_formula = RELFINDER.sub(resolveField, sql_formula)
+        sql_formula = COLFINDER.sub(resolveField, sql_formula)
+        if formula_kw:
+            prefix = f'{id(fldalias)}_{self._currColKey}'
+            for k, v in formula_kw.items():
+                mangled_k = f'{prefix}_{k}'
+                self.sqlparams[mangled_k] = v
+                sql_formula = re.sub(r"(:)(%s)(\W|$)" % k,
+                                     lambda m, mk=mangled_k: f'{m.group(1)}{mk}{m.group(3)}',
+                                     sql_formula)
+        return f'( {sql_formula} )'
+
+    def _handleSubQuery(self, fldalias, fld, curr_tblobj, alias, curr, expandThis, expandEnv, expandPref,
+                        attr, formula_kw):
+        """Handle a single subquery column (select or exists), with or without a wrapping sql_formula.
+        When sql_formula is absent, it defaults to '#default' (or 'EXISTS(#default)').
+        Subquery parameters live inside the select dict and are resolved by queryCompile."""
+        return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
+                                          expandThis, expandEnv, expandPref,
+                                          attr, formula_kw)
+
+    def _handleFormulaColumn_legacy(self, fldalias, fld, curr_tblobj, alias, curr,
+                              expandThis, expandEnv, expandPref,
+                              attr, formula_kw, multi_select=None):
+        sql_formula = fldalias.sql_formula
+        if sql_formula is True:
+            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
+        select_dict = multi_select or {}
+        if not sql_formula:
+            sql_formula = '#default' if fldalias.select else 'EXISTS(#default)'
+            select_dict['default'] = fldalias.select or fldalias.exists
+        for susbselect,sq_pars in list(select_dict.items()):
+            if isinstance(sq_pars, str):
+                sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
+            sq_pars = dict(sq_pars)
+            cast = sq_pars.pop('cast',None)
+            tpl = ' CAST( ( %s ) AS ' +cast +') ' if cast else ' ( %s ) '
+            sq_table = sq_pars.pop('table')
+            sq_where = sq_pars.pop('where')
+            sq_pars.setdefault('ignorePartition',True)
+            sq_pars.setdefault('excludeDraft',False)
+            sq_pars.setdefault('excludeLogicalDeleted',False)
+            sq_pars.setdefault('subtable','*')
+            aliasPrefix = '%s_t' %alias
+            sq_where = THISFINDER.sub(expandThis,sq_where)
+            sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
+            sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
+        subreldict = {}
+        sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
+        sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
+        sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
+        sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
+        sql_formula = PREFFINDER.sub(expandPref, sql_formula)
+        sql_formula = THISFINDER.sub(expandThis,sql_formula)
+        if formula_kw:
+            prefix = str(id(fldalias))
+            currentEnv = self.db.currentEnv
+            for k,v in list(formula_kw.items()):
+                newk = f'{prefix}_{self._currColKey}_{k}'
+                currentEnv[newk] = v
+                sql_formula = re.sub("(:)(%s)(\\W|$)" %k,lambda m: '%senv_%s%s'%(m.group(1),newk,m.group(3)), sql_formula)
+        subColPars = {}
+        for key, value in list(subreldict.items()):
+            subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
+        sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
+        return f'( {sql_formula} )'
 
     def _findRelationAlias(self, pathlist, curr, basealias, newpath, parent=None):
         """Internal method: called by getFieldAlias to get the alias (t1, t2...) for the join table.
@@ -1060,6 +1145,7 @@ class SqlQuery(object):
                  checkPermissions=None,
                  aliasPrefix=None,
                  mangler=None,
+                 mainquery_kw=None,
                  **kwargs):
         self.dbtable = dbtable
         self.sqlparams = sqlparams or {}
@@ -1068,6 +1154,7 @@ class SqlQuery(object):
         self.joinConditions = joinConditions or {}
         self.sqlContextName = sqlContextName
         self.relationDict = relationDict or {}
+        self.query_kw = dict(kwargs)
         self.sqlparams.update(kwargs)
         self.excludeLogicalDeleted = excludeLogicalDeleted
         self.excludeDraft = excludeDraft
@@ -1079,6 +1166,7 @@ class SqlQuery(object):
         self.checkPermissions = checkPermissions
         self.aliasPrefix = aliasPrefix
         self.mangler = mangler
+        self.mainquery_kw = mainquery_kw or {}
         test = " ".join([v for v in (columns, where, order_by, group_by, having) if v])
         rels = set(re.findall(r'\$(\w*)', test))
         params = set(re.findall(r'\:(\w*)', test))
@@ -1137,7 +1225,9 @@ class SqlQuery(object):
                                 sqlparams=self.sqlparams,
                                 aliasPrefix=self.aliasPrefix,
                                 locale=self.locale,
-                                mangler=self.mangler).compiledQuery(count=count,
+                                mangler=self.mangler,
+                                query_kw=self.query_kw,
+                                mainquery_kw=self.mainquery_kw).compiledQuery(count=count,
                                                                   relationDict=self.relationDict,
                                                                   **self.querypars)
 

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -65,13 +65,18 @@ class SqlCompiledQuery(object):
     """SqlCompiledQuery is a private class used by the :class:`SqlQueryCompiler` class.
        It is used to store all parameters needed to compile a query string."""
 
-    def __init__(self, maintable, relationDict=None,maintable_as=None):
-        """Initialize the SqlCompiledQuery class
+    def __init__(self, maintable, relationDict=None, maintable_as=None,
+                 mangler=None, sqlparams=None):
+        """Initialize the SqlCompiledQuery.
 
-        :param maintable: the name of the main table to query. For more information, check the
-                          :ref:`maintable` section.
-        :param relationDict: a dict to assign a symbolic name to a :ref:`relation`. For more information
-                             check the :ref:`relationdict` documentation section"""
+        Args:
+            maintable: The fully qualified name of the main table to query.
+            relationDict: A dict mapping symbolic names to relations.
+            maintable_as: Optional SQL alias for the main table.
+            mangler: Optional prefix for parameter namespacing (e.g. ``'sq0'``).
+            sqlparams: The original query parameters dict, used by ``mangle``
+                to determine which ``:param`` placeholders to rename.
+        """
         self.maintable = maintable
         self.relationDict = relationDict or {}
         self.aliasDict = {}
@@ -93,13 +98,45 @@ class SqlCompiledQuery(object):
         self.pyColumns = []
         self.maintable_as = maintable_as
         self.tpl = None
-        self._identity_hash = None
+        self.mangler = mangler
+        self._sqlparams = sqlparams or {}
+        self.mangled_params = {}
+
+    def mangle(self, sql_text):
+        """Rename ``:param`` placeholders to ``:mangler_param`` in SQL text.
+
+        Each renamed parameter is also recorded in ``self.mangled_params``
+        with its original value. Parameters starting with ``env_`` are
+        left untouched.  If no mangler is set, returns *sql_text* unchanged.
+
+        Args:
+            sql_text: The SQL fragment to process.
+
+        Returns:
+            The SQL text with renamed placeholders.
+        """
+        if not self.mangler or not sql_text:
+            return sql_text
+        def replace_param(m):
+            param_name = m.group(2)
+            if param_name.startswith('env_'):
+                return m.group(0)
+            if param_name in self._sqlparams:
+                mangled_key = '%s_%s' % (self.mangler, param_name)
+                self.mangled_params[mangled_key] = self._sqlparams[param_name]
+                return '%s%s%s' % (m.group(1), mangled_key, m.group(3))
+            return m.group(0)
+        return re.sub(r"(:)(\w+)(\W|$)", replace_param, sql_text)
 
     def get_sqltext(self, db):
-        """Compile the sql query string based on current query parameters and the specific db
-        adapter for the current db in use.
+        """Compile the SQL query string using the db adapter.
 
-        :param db: am instance of the :class:`GnrSqlDb <gnr.sql.gnrsql.GnrSqlDb>` class"""
+        Args:
+            db: A :class:`GnrSqlDb` instance.
+
+        Returns:
+            The compiled SQL string, optionally wrapped by ``self.tpl``.
+        """
         kwargs = {}
         for k in (
         'maintable', 'distinct', 'columns', 'joins', 'where', 'group_by', 'having', 'order_by', 'limit', 'offset',
@@ -110,14 +147,31 @@ class SqlCompiledQuery(object):
             result = self.tpl % result
         return result
 
+    @property
+    def identity_hash(self):
+        """Mangler-independent fingerprint for CTE merge.
+
+        Resolves mangled parameter placeholders in ``self.where`` with their
+        actual values, then hashes ``(maintable, resolved_where)``.
+
+        Returns:
+            An int hash if ``mangled_params`` is non-empty, ``None`` otherwise.
+        """
+        if not self.mangled_params:
+            return None
+        resolved_where = self.where or ''
+        for k, v in self.mangled_params.items():
+            resolved_where = resolved_where.replace(':%s' % k, str(v))
+        return hash((self.maintable, resolved_where))
+
     def __eq__(self, other):
         if not isinstance(other, SqlCompiledQuery):
             return NotImplemented
-        return self._identity_hash is not None and self._identity_hash == other._identity_hash
+        return self.identity_hash is not None and self.identity_hash == other.identity_hash
 
     def __hash__(self):
-        if self._identity_hash is not None:
-            return self._identity_hash
+        if self.identity_hash is not None:
+            return self.identity_hash
         return id(self)
 
 
@@ -154,33 +208,11 @@ class SqlQueryCompiler(object):
         self.mangler = mangler
         self.query_kw = query_kw or {}
         self.mainquery_kw = mainquery_kw or {}
-        self.subquery_kw = {}
         self.macro_expander = self.db.adapter.macroExpander(self)
 
     def aliasCode(self,n):
         return '%s%i' %(self.aliasPrefix,n)
 
-    def mangle(self, sql_text):
-        if not self.mangler:
-            return sql_text
-        def replace_param(m):
-            param_name = m.group(2)
-            if param_name.startswith('env_'):
-                return m.group(0)
-            if param_name in self.sqlparams:
-                return '%s%s_%s%s' % (m.group(1), self.mangler, param_name, m.group(3))
-            return m.group(0)
-        return re.sub(r"(:)(\w+)(\W|$)", replace_param, sql_text)
-
-    def mangleParams(self):
-        if not self.mangler:
-            return
-        for k, v in list(self.sqlparams.items()):
-            if not k.startswith('env_'):
-                mangled_key = '%s_%s' % (self.mangler, k)
-                mangled_value = self.query_kw.get(k, self.mainquery_kw.get(k))
-                self.subquery_kw[mangled_key] = mangled_value
-                self.sqlparams[mangled_key] = v
 
     def init(self, lazy=None, eager=None):
         """TODO
@@ -210,6 +242,50 @@ class SqlQueryCompiler(object):
         :param curr: TODO.
         :param basealias: TODO. """
 
+        pathlist = fieldpath.split('.')
+        fld = pathlist.pop()
+        curr = curr or self.relations
+        newpath = []
+        basealias = basealias or self.aliasCode(0)
+        if pathlist:
+            alias, curr = self._findRelationAlias(list(pathlist), curr, basealias, newpath, parent=parent)
+        else:
+            alias = basealias
+        curr_tblobj = self.db.table(curr.tbl_name, pkg=curr.pkg_name)
+        self._setupExpanders(curr, curr_tblobj, alias)
+        if not fld in curr.keys():
+            fldalias = curr_tblobj.model.getVirtualColumn(fld,sqlparams=self.sqlparams)
+            if fldalias == None:
+                raise GnrSqlMissingField('Missing field %s in table %s.%s (requested field %s)' % (
+                fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
+            if fldalias.relation_path and not fldalias.composed_of:
+                return self.getFieldAlias(fldalias.relation_path, curr=curr,
+                                          basealias=alias, parent='.'.join(pathlist))
+            if fldalias.sql_formula or fldalias.select or fldalias.exists:
+                return self._handleFormulaColumns(fldalias, fld, curr, curr_tblobj, alias)
+            elif fldalias.py_method:
+                self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
+                return 'NULL'
+            else:
+                raise GnrSqlMissingColumn('Invalid column %s in table %s.%s (requested field %s)' % (
+                fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
+        return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
+
+    def _setupExpanders(self, curr, curr_tblobj, alias):
+        """Build and store regex callbacks for expanding macros in SQL formulas.
+
+        Creates three closures that capture the current resolution context
+        (``curr``, ``curr_tblobj``, ``alias``) and stores them as
+        ``self._expandThis``, ``self._expandEnv``, ``self._expandPref``.
+
+        Must be called at the beginning of each ``getFieldAlias`` invocation,
+        after ``alias`` and ``curr_tblobj`` are resolved.
+
+        Args:
+            curr: The current relation node in the model tree.
+            curr_tblobj: The resolved table object for ``curr``.
+            alias: The SQL alias (e.g. ``'t0'``) for the current table.
+        """
         def expandThis(m):
             fld = m.group(1)
             return self.getFieldAlias(fld,curr=curr,basealias=alias)
@@ -238,86 +314,93 @@ class SqlQueryCompiler(object):
                 return handler()
             else:
                 return 'Not found %s' % what
-        pathlist = fieldpath.split('.')
-        fld = pathlist.pop()
-        curr = curr or self.relations
-        newpath = []
-        basealias = basealias or self.aliasCode(0)
-        if pathlist:
-            alias, curr = self._findRelationAlias(list(pathlist), curr, basealias, newpath, parent=parent)
-        else:
-            alias = basealias
-        curr_tblobj = self.db.table(curr.tbl_name, pkg=curr.pkg_name)
-        if not fld in curr.keys():
-            fldalias = curr_tblobj.model.getVirtualColumn(fld,sqlparams=self.sqlparams)
-            if fldalias == None:
-                raise GnrSqlMissingField('Missing field %s in table %s.%s (requested field %s)' % (
-                fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
-            elif fldalias.relation_path and not fldalias.composed_of:
 
-                # call getFieldAlias recursively
-                return self.getFieldAlias(fldalias.relation_path, curr=curr,
-                                          basealias=alias, parent='.'.join(pathlist)) 
+        self._expandThis = expandThis
+        self._expandEnv = expandEnv
+        self._expandPref = expandPref
 
-                ### FIXME: refs #120 - left to support investigation
-                #pathlist.append(fldalias.relation_path)
-                #newfieldpath = '.'.join(pathlist)        # replace the field alias with the column relation_path
-                # then call getFieldAlias again with the real path
-                #return self.getFieldAlias(f"{'.'.join(pathlist)}.{fldalias.relation_path}", #curr=curr,
-                #                                          basealias=basealias), #parent='.'.join(pathlist))  # call getFieldAlias recursively
+    def _handleFormulaColumns(self, fldalias, fld, curr, curr_tblobj, alias):
+        """Handle formula-based virtual columns (unified path).
 
-                
-            elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                attr = dict(fldalias.attributes)
-                formula_kw = dictExtract(attr, 'var_')
-                multi_select = dictExtract(attr, 'select_')
-                sql_formula = fldalias.sql_formula
-                if sql_formula is True:
-                    sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
-                select_dict = dict(multi_select) if multi_select else {}
-                if not sql_formula:
-                    select_dict['default'] = fldalias.select or fldalias.exists
-                if not select_dict:
-                    return self._handleFormulaColumn(fldalias, alias, curr,
-                                                      sql_formula, formula_kw)
-                elif len(select_dict) == 1:
-                    sq_select = select_dict['default']
-                    if isinstance(sq_select, str):
-                        sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
-                    sq_pars = dict(sq_select)
-                    cast = sq_pars.pop('cast', None)
-                    if fldalias.exists:
-                        tpl = ' EXISTS( %s ) '
-                    elif cast:
-                        tpl = ' CAST( ( %s ) AS ' + cast + ') '
-                    else:
-                        tpl = ' ( %s ) '
-                    compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
-                    return tpl % compiled.get_sqltext(self.db)
-                else:
-                    return self._handleFormulaColumn_legacy(fldalias, alias, curr,
-                                                      expandThis, expandEnv, expandPref,
-                                                      sql_formula, formula_kw, select_dict)
-            elif fldalias.py_method:
-                #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
-                self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
-                return 'NULL'
-            else:
-                raise GnrSqlMissingColumn('Invalid column %s in table %s.%s (requested field %s)' % (
-                fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
-        return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
+        The ``sql_formula`` acts as a template in which compiled subqueries
+        are injected.  If no formula is provided, a default template is used:
+        ``EXISTS( %s )`` for exists columns, ``( %s )`` otherwise.
 
-    def _handleFormulaColumn(self, fldalias, alias, curr, sql_formula, formula_kw):
-        """Handle pure formula columns with no subquery.
+        Handles all cases uniformly:
+
+        - Pure formula (no subquery).
+        - Single subquery with or without a wrapping formula.
+        - Multiple subqueries with ``#name`` placeholders in the formula.
 
         Args:
-            sql_formula: The resolved SQL formula string.
-            formula_kw: Pre-extracted var_ parameters (dict), for :placeholder resolution.
+            fldalias: The virtual column descriptor.
+            fld: The field name to resolve.
+            curr: The current relation node in the model tree.
+            curr_tblobj: The resolved table object for ``curr``.
+            alias: The SQL alias (e.g. ``'t0'``) for the current table.
+
+        Returns:
+            A SQL expression string for the virtual column.
+        """
+        attr = dict(fldalias.attributes)
+        formula_kw = dictExtract(attr, 'var_')
+        multi_select = dictExtract(attr, 'select_')
+        sql_formula = fldalias.sql_formula
+        if sql_formula is True:
+            sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
+        select_dict = dict(multi_select) if multi_select else {}
+        if not sql_formula:
+            select_dict['default'] = fldalias.select or fldalias.exists
+        if not select_dict:
+            # Pure formula, no subquery
+            return self._resolveFormula(fldalias, alias, curr,
+                                              sql_formula, formula_kw)
+        # Build default template if no formula provided
+        if not sql_formula:
+            if fldalias.exists:
+                sql_formula = 'EXISTS( %s )'
+            else:
+                sql_formula = '( %s )'
+        # Compile each subquery and inject into the formula
+        for name, sq_select in list(select_dict.items()):
+            if isinstance(sq_select, str):
+                sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
+            sq_pars = dict(sq_select)
+            sq_pars.pop('cast', None)
+            compiled = self._compiledSubQuery(alias, sq_pars)
+            sq_text = compiled.get_sqltext(self.db)
+            if name == 'default':
+                sql_formula = sql_formula % sq_text
+            else:
+                sql_formula = re.sub('#%s\\b' % name, sq_text, sql_formula)
+        # Resolve field references, macros, expanders, formula_kw
+        return self._resolveFormula(fldalias, alias, curr, sql_formula, formula_kw)
+
+    def _resolveFormula(self, fldalias, alias, curr, sql_formula, formula_kw):
+        """Resolve field references, macros and parameters in a SQL formula.
+
+        Args:
+            fldalias: The virtual column descriptor.
+            alias: The SQL alias for the current table.
+            curr: The current relation node.
+            sql_formula: The SQL formula to resolve.
+            formula_kw: Pre-extracted ``var_`` parameters for ``:placeholder``
+                resolution.
+
+        Returns:
+            A parenthesized SQL formula string with all references resolved.
         """
         def resolveField(m):
             return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
         sql_formula = RELFINDER.sub(resolveField, sql_formula)
         sql_formula = COLFINDER.sub(resolveField, sql_formula)
+        sql_formula = self.macro_expander.replace(sql_formula, 'TSRANK,TSHEADLINE')
+        subreldict = {}
+        sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
+        sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
+        sql_formula = ENVFINDER.sub(self._expandEnv, sql_formula)
+        sql_formula = PREFFINDER.sub(self._expandPref, sql_formula)
+        sql_formula = THISFINDER.sub(self._expandThis, sql_formula)
         if formula_kw:
             prefix = f'{id(fldalias)}_{self._currColKey}'
             for k, v in formula_kw.items():
@@ -326,26 +409,30 @@ class SqlQueryCompiler(object):
                 sql_formula = re.sub(r"(:)(%s)(\W|$)" % k,
                                      lambda m, mk=mangled_k: f'{m.group(1)}{mk}{m.group(3)}',
                                      sql_formula)
+        if subreldict:
+            subColPars = {}
+            for key, value in list(subreldict.items()):
+                subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
+            sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
         return f'( {sql_formula} )'
 
-    def _compiledSubQuery(self, alias, expandThis, sq_pars, tpl=None):
-        """Compile a subquery column (select or exists) into SQL text.
+    def _compiledSubQuery(self, alias, sq_pars, tpl=None):
+        """Compile a subquery column into a ``SqlCompiledQuery``.
 
-        Builds and compiles an independent SqlQuery with a mangler prefix,
-        so that subquery parameters (e.g. ``avail='yes'``) are namespaced
-        into the main query's sqlparams without collisions.
-        The compiled SQL is wrapped with the given template (e.g. for CAST).
+        Builds an independent ``SqlQuery`` with a mangler prefix so that
+        subquery parameters are namespaced without collisions.  The mangled
+        parameters are then merged into the main query's ``sqlparams``.
 
         Args:
             alias: The SQL table alias for the current table (e.g. ``'t0'``).
-            expandThis: Callback to replace ``#THIS.col`` with ``alias.col``.
-            sq_pars: The subquery parameters dict (table, where, columns, plus
-                     any extra params like avail='yes'). Already without 'cast'.
-            tpl: SQL template to wrap the subquery (e.g. ``' ( %s ) '`` or
-                 ``' CAST( ( %s ) AS integer) '``).
+            sq_pars: The subquery parameters dict (``table``, ``where``,
+                ``columns``, plus extra params like ``avail='yes'``).
+                Must not contain ``'cast'`` (already popped by caller).
+            tpl: Optional SQL template to store on the compiled query
+                (e.g. ``' ( %s ) '``).
 
         Returns:
-            str: the compiled subquery SQL text, wrapped with the template.
+            The compiled ``SqlCompiledQuery`` for the subquery.
         """
         # 1. Extract table and where; remaining items are subquery parameters
         sq_table = sq_pars.pop('table')
@@ -357,7 +444,7 @@ class SqlQueryCompiler(object):
         aliasPrefix = '%s_t' % alias
 
         # 3. Expand #THIS in the subquery WHERE
-        sq_where = THISFINDER.sub(expandThis, sq_where)
+        sq_where = THISFINDER.sub(self._expandThis, sq_where)
 
         # 4. Compile the subquery with a mangler for parameter namespacing
         mangler_prefix = self.query._next_mangler_key('sq')
@@ -372,56 +459,11 @@ class SqlQueryCompiler(object):
         compiled = q.compileQuery()
         compiled.tpl = tpl
 
-        # 5. Build identity hash for CTE merge: resolve params in WHERE to get
-        #    a mangler-independent fingerprint
-        resolved_where = compiled.where or ''
-        for k, v in q.sqlparams.items():
-            resolved_where = resolved_where.replace(':%s' % k, str(v))
-        compiled._identity_hash = hash((compiled.maintable, resolved_where))
-
-        # 6. Merge mangled subquery params into main query params
-        self.sqlparams.update(q.sqlparams)
+        # 5. Merge mangled subquery params into main query params
+        self.sqlparams.update(compiled.mangled_params)
 
         return compiled
 
-    def _handleFormulaColumn_legacy(self, fldalias, alias, curr,
-                              expandThis, expandEnv, expandPref,
-                              sql_formula, formula_kw, select_dict):
-        for susbselect,sq_pars in list(select_dict.items()):
-            if isinstance(sq_pars, str):
-                sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
-            sq_pars = dict(sq_pars)
-            cast = sq_pars.pop('cast',None)
-            tpl = ' CAST( ( %s ) AS ' +cast +') ' if cast else ' ( %s ) '
-            sq_table = sq_pars.pop('table')
-            sq_where = sq_pars.pop('where')
-            sq_pars.setdefault('ignorePartition',True)
-            sq_pars.setdefault('excludeDraft',False)
-            sq_pars.setdefault('excludeLogicalDeleted',False)
-            sq_pars.setdefault('subtable','*')
-            aliasPrefix = '%s_t' %alias
-            sq_where = THISFINDER.sub(expandThis,sq_where)
-            sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
-            sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
-        subreldict = {}
-        sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
-        sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
-        sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
-        sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
-        sql_formula = PREFFINDER.sub(expandPref, sql_formula)
-        sql_formula = THISFINDER.sub(expandThis,sql_formula)
-        if formula_kw:
-            prefix = str(id(fldalias))
-            currentEnv = self.db.currentEnv
-            for k,v in list(formula_kw.items()):
-                newk = f'{prefix}_{self._currColKey}_{k}'
-                currentEnv[newk] = v
-                sql_formula = re.sub("(:)(%s)(\\W|$)" %k,lambda m: '%senv_%s%s'%(m.group(1),newk,m.group(3)), sql_formula)
-        subColPars = {}
-        for key, value in list(subreldict.items()):
-            subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
-        sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
-        return f'( {sql_formula} )'
 
     def _findRelationAlias(self, pathlist, curr, basealias, newpath, parent=None):
         """Internal method: called by getFieldAlias to get the alias (t1, t2...) for the join table.
@@ -694,7 +736,8 @@ class SqlQueryCompiler(object):
         :param excludeDraft: TODO
         :param addPkeyColumn: boolean. If ``True``, add a column with the pkey attribute"""
         # get the SqlCompiledQuery: an object that mantains all the informations to build the sql text
-        self.cpl = SqlCompiledQuery(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0))
+        self.cpl = SqlCompiledQuery(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0),
+                                    mangler=self.mangler, sqlparams=self.sqlparams)
         distinct = distinct or '' # distinct is a text to be inserted in the sql query string
 
         # aggregate: test if the result will aggregate db rows
@@ -869,16 +912,16 @@ class SqlQueryCompiler(object):
                         # of rows returned by the query, but it is correct in terms of main table records.
                         # It is the right behaviour ???? Yes in some cases: see SqlSelection._aggregateRows
         self.cpl.distinct = distinct
-        self.cpl.columns = self.mangle(self.macro_expander.replace(columns,'TSRANK,TSHEADLINE'))
-        self.cpl.where = self.mangle(where)
-        self.cpl.group_by = self.mangle(group_by)
-        self.cpl.having = self.mangle(having)
-        self.cpl.order_by = self.mangle(self.macro_expander.replace(order_by,'TSRANK'))
-        self.cpl.joins = [self.mangle(j) for j in self.cpl.joins]
+        self.cpl.columns = self.cpl.mangle(self.macro_expander.replace(columns,'TSRANK,TSHEADLINE'))
+        self.cpl.where = self.cpl.mangle(where)
+        self.cpl.group_by = self.cpl.mangle(group_by)
+        self.cpl.having = self.cpl.mangle(having)
+        self.cpl.order_by = self.cpl.mangle(self.macro_expander.replace(order_by,'TSRANK'))
+        self.cpl.joins = [self.cpl.mangle(j) for j in self.cpl.joins]
         self.cpl.limit = limit
         self.cpl.offset = offset
         self.cpl.for_update = for_update
-        self.mangleParams()
+        self.sqlparams.update(self.cpl.mangled_params)
         #raise str(self.cpl.get_sqltext(self.db))  # uncomment it for hard debug
         return self.cpl
 

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -319,6 +319,23 @@ class SqlQueryCompiler(object):
         self._expandEnv = expandEnv
         self._expandPref = expandPref
 
+    def _should_convert_to_join(self, fldalias):
+        """Check if the subquery_as_join optimization is requested.
+
+        Priority: per-column attribute ``sq_as_join`` overrides the global
+        ``subquery_as_join`` flag on the db instance.
+
+        Args:
+            fldalias: The virtual column descriptor.
+
+        Returns:
+            True if the optimization is requested, False otherwise.
+        """
+        col_flag = fldalias.attributes.get('sq_as_join')
+        if col_flag is not None:
+            return bool(col_flag)
+        return gnrstring.boolean(self.db.extra_kw.get('subquery_as_join', False))
+
     def _handleFormulaColumns(self, fldalias, fld, curr, curr_tblobj, alias):
         """Handle formula-based virtual columns (unified path).
 

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -92,6 +92,8 @@ class SqlCompiledQuery(object):
         self.aggregateDict = {}
         self.pyColumns = []
         self.maintable_as = maintable_as
+        self.tpl = None
+        self._identity_hash = None
 
     def get_sqltext(self, db):
         """Compile the sql query string based on current query parameters and the specific db
@@ -103,8 +105,20 @@ class SqlCompiledQuery(object):
         'maintable', 'distinct', 'columns', 'joins', 'where', 'group_by', 'having', 'order_by', 'limit', 'offset',
         'for_update'):
             kwargs[k] = getattr(self, k)
-        return db.adapter.compileSql(maintable_as=self.maintable_as,**kwargs)
+        result = db.adapter.compileSql(maintable_as=self.maintable_as,**kwargs)
+        if self.tpl:
+            result = self.tpl % result
+        return result
 
+    def __eq__(self, other):
+        if not isinstance(other, SqlCompiledQuery):
+            return NotImplemented
+        return self._identity_hash is not None and self._identity_hash == other._identity_hash
+
+    def __hash__(self):
+        if self._identity_hash is not None:
+            return self._identity_hash
+        return id(self)
 
 
 class SqlQueryCompiler(object):
@@ -121,9 +135,10 @@ class SqlQueryCompiler(object):
                            :meth:`setJoinCondition() <gnr.web.gnrwebpage.GnrWebPage.setJoinCondition>` method)
     :param sqlparams: a dict of parameters used in "WHERE" clause
     :param locale: the current locale (e.g: en, en_us, it)"""
-    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None, query_kw=None, mainquery_kw=None):
+    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None, query_kw=None, mainquery_kw=None, query=None):
         self.tblobj = tblobj
         self.db = tblobj.db
+        self.query = query
         self.dbmodel = tblobj.db.model
         if tblobj.db.reuse_relation_tree:
             self.relations = tblobj.relations
@@ -253,28 +268,36 @@ class SqlQueryCompiler(object):
 
                 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                # Virtual column dispatch based on subquery presence:
-                #   - A subquery exists only if select, exists, or select_ attributes are present
-                #   - sql_formula alone (str or True) without select/exists = pure formula
-                #   - sql_formula=True delegates to a Python method sql_formula_<fieldname>()
                 attr = dict(fldalias.attributes)
                 formula_kw = dictExtract(attr, 'var_')
                 multi_select = dictExtract(attr, 'select_')
-                has_subquery = fldalias.select or fldalias.exists or multi_select
-                if not has_subquery:
-                    # Pure formula: only $col and @rel.col references, resolved inline
-                    return self._handleFormulaColumn(fldalias, fld, curr_tblobj, alias, curr,
-                                                      attr, formula_kw)
-                elif not multi_select:
-                    # Single subquery (select or exists), with or without a wrapping sql_formula
-                    return self._handleSubQuery(fldalias, fld, curr_tblobj, alias, curr,
-                                                      expandThis, expandEnv, expandPref,
-                                                      attr, formula_kw)
+                sql_formula = fldalias.sql_formula
+                if sql_formula is True:
+                    sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
+                select_dict = dict(multi_select) if multi_select else {}
+                if not sql_formula:
+                    select_dict['default'] = fldalias.select or fldalias.exists
+                if not select_dict:
+                    return self._handleFormulaColumn(fldalias, alias, curr,
+                                                      sql_formula, formula_kw)
+                elif len(select_dict) == 1:
+                    sq_select = select_dict['default']
+                    if isinstance(sq_select, str):
+                        sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
+                    sq_pars = dict(sq_select)
+                    cast = sq_pars.pop('cast', None)
+                    if fldalias.exists:
+                        tpl = ' EXISTS( %s ) '
+                    elif cast:
+                        tpl = ' CAST( ( %s ) AS ' + cast + ') '
+                    else:
+                        tpl = ' ( %s ) '
+                    compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
+                    return tpl % compiled.get_sqltext(self.db)
                 else:
-                    # Multiple subqueries (select_ prefix in attributes)
-                    return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
+                    return self._handleFormulaColumn_legacy(fldalias, alias, curr,
                                                       expandThis, expandEnv, expandPref,
-                                                      attr, formula_kw, multi_select)
+                                                      sql_formula, formula_kw, select_dict)
             elif fldalias.py_method:
                 #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
                 self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
@@ -284,39 +307,13 @@ class SqlQueryCompiler(object):
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
 
-    def _handleFormulaColumn(self, fldalias, fld, curr_tblobj, alias, curr, attr, formula_kw):
+    def _handleFormulaColumn(self, fldalias, alias, curr, sql_formula, formula_kw):
         """Handle pure formula columns with no subquery.
 
-        Translates a sql_formula string containing $col and @rel.col placeholders
-        into valid SQL by resolving each reference to its table alias (e.g. t0.col, t3.col).
-
-        The sql_formula can be either:
-            - A string (e.g. ``"UPPER($title)"`` or ``"$role || ' in ' || @movie_id.title"``).
-            - The boolean ``True``, meaning the formula is defined as a Python method
-              ``sql_formula_<fieldname>(attributes)`` on the table object.
-
-        Resolution is done in two passes via regex substitution:
-            1. RELFINDER resolves ``@relation.column`` references (e.g. ``@movie_id.title`` -> ``t3.title``).
-            2. COLFINDER resolves ``$column`` references (e.g. ``$title`` -> ``t0.title``).
-
-        Both regexes capture a leading non-word character in group(1) and the field path
-        in group(2). The callback delegates to ``getFieldAlias`` which handles join registration.
-
         Args:
-            fldalias: The virtual column definition node from the model.
-            fld: The field name (e.g. ``'title_upper'``).
-            curr_tblobj: The current table object in the model.
-            alias: The SQL table alias for the current table (e.g. ``'t0'``).
-            curr: The current table model node.
-            attr: Pre-extracted dict of fldalias.attributes.
+            sql_formula: The resolved SQL formula string.
             formula_kw: Pre-extracted var_ parameters (dict), for :placeholder resolution.
-
-        Returns:
-            A parenthesized SQL expression string (e.g. ``'( UPPER(t0.title) )'``).
         """
-        sql_formula = fldalias.sql_formula
-        if sql_formula is True:
-            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
         def resolveField(m):
             return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
         sql_formula = RELFINDER.sub(resolveField, sql_formula)
@@ -331,25 +328,65 @@ class SqlQueryCompiler(object):
                                      sql_formula)
         return f'( {sql_formula} )'
 
-    def _handleSubQuery(self, fldalias, fld, curr_tblobj, alias, curr, expandThis, expandEnv, expandPref,
-                        attr, formula_kw):
-        """Handle a single subquery column (select or exists), with or without a wrapping sql_formula.
-        When sql_formula is absent, it defaults to '#default' (or 'EXISTS(#default)').
-        Subquery parameters live inside the select dict and are resolved by queryCompile."""
-        return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
-                                          expandThis, expandEnv, expandPref,
-                                          attr, formula_kw)
+    def _compiledSubQuery(self, alias, expandThis, sq_pars, tpl=None):
+        """Compile a subquery column (select or exists) into SQL text.
 
-    def _handleFormulaColumn_legacy(self, fldalias, fld, curr_tblobj, alias, curr,
+        Builds and compiles an independent SqlQuery with a mangler prefix,
+        so that subquery parameters (e.g. ``avail='yes'``) are namespaced
+        into the main query's sqlparams without collisions.
+        The compiled SQL is wrapped with the given template (e.g. for CAST).
+
+        Args:
+            alias: The SQL table alias for the current table (e.g. ``'t0'``).
+            expandThis: Callback to replace ``#THIS.col`` with ``alias.col``.
+            sq_pars: The subquery parameters dict (table, where, columns, plus
+                     any extra params like avail='yes'). Already without 'cast'.
+            tpl: SQL template to wrap the subquery (e.g. ``' ( %s ) '`` or
+                 ``' CAST( ( %s ) AS integer) '``).
+
+        Returns:
+            str: the compiled subquery SQL text, wrapped with the template.
+        """
+        # 1. Extract table and where; remaining items are subquery parameters
+        sq_table = sq_pars.pop('table')
+        sq_where = sq_pars.pop('where')
+        sq_pars.setdefault('ignorePartition', True)
+        sq_pars.setdefault('excludeDraft', False)
+        sq_pars.setdefault('excludeLogicalDeleted', False)
+        sq_pars.setdefault('subtable', '*')
+        aliasPrefix = '%s_t' % alias
+
+        # 3. Expand #THIS in the subquery WHERE
+        sq_where = THISFINDER.sub(expandThis, sq_where)
+
+        # 4. Compile the subquery with a mangler for parameter namespacing
+        mangler_prefix = self.query._next_mangler_key('sq')
+        q = self.db.table(sq_table).query(
+            where=sq_where,
+            aliasPrefix=aliasPrefix,
+            addPkeyColumn=False,
+            ignoreTableOrderBy=True,
+            mangler=mangler_prefix,
+            **sq_pars
+        )
+        compiled = q.compileQuery()
+        compiled.tpl = tpl
+
+        # 5. Build identity hash for CTE merge: resolve params in WHERE to get
+        #    a mangler-independent fingerprint
+        resolved_where = compiled.where or ''
+        for k, v in q.sqlparams.items():
+            resolved_where = resolved_where.replace(':%s' % k, str(v))
+        compiled._identity_hash = hash((compiled.maintable, resolved_where))
+
+        # 6. Merge mangled subquery params into main query params
+        self.sqlparams.update(q.sqlparams)
+
+        return compiled
+
+    def _handleFormulaColumn_legacy(self, fldalias, alias, curr,
                               expandThis, expandEnv, expandPref,
-                              attr, formula_kw, multi_select=None):
-        sql_formula = fldalias.sql_formula
-        if sql_formula is True:
-            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
-        select_dict = multi_select or {}
-        if not sql_formula:
-            sql_formula = '#default' if fldalias.select else 'EXISTS(#default)'
-            select_dict['default'] = fldalias.select or fldalias.exists
+                              sql_formula, formula_kw, select_dict):
         for susbselect,sq_pars in list(select_dict.items()):
             if isinstance(sq_pars, str):
                 sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
@@ -1227,7 +1264,8 @@ class SqlQuery(object):
                                 locale=self.locale,
                                 mangler=self.mangler,
                                 query_kw=self.query_kw,
-                                mainquery_kw=self.mainquery_kw).compiledQuery(count=count,
+                                mainquery_kw=self.mainquery_kw,
+                                query=self).compiledQuery(count=count,
                                                                   relationDict=self.relationDict,
                                                                   **self.querypars)
 
@@ -1469,22 +1507,23 @@ class SqlQuery(object):
             cursor.close()
         return n
 
-    def _next_compound_key(self):
+    def _next_mangler_key(self, prefix):
         env = self.db.currentEnv
-        idx = env.get('_compound_counter', 0)
-        env['_compound_counter'] = idx + 1
-        return 'q%d' % idx
+        counters = env.setdefault('_mangler_counters', {})
+        idx = counters.get(prefix, 0)
+        counters[prefix] = idx + 1
+        return '%s%d' % (prefix, idx)
 
     def _compound(self, other, operator):
         if isinstance(other, SqlCompoundQuery):
-            self_key = self._next_compound_key()
+            self_key = self._next_mangler_key('cq')
             self.mangler = self_key
             queries = dict(other.queries)
             queries[self_key] = self
             template = '{%s} %s SELECT * FROM (%s) AS _cr' % (self_key, operator, other._template)
         else:
-            self_key = self._next_compound_key()
-            other_key = other._next_compound_key()
+            self_key = self._next_mangler_key('cq')
+            other_key = other._next_mangler_key('cq')
             self.mangler = self_key
             other.mangler = other_key
             queries = {self_key: self, other_key: other}
@@ -1537,7 +1576,7 @@ class SqlCompoundQuery(SqlQuery):
             queries.update(other.queries)
             template = 'SELECT * FROM (%s) AS _cl %s SELECT * FROM (%s) AS _cr' % (self._template, operator, other._template)
         else:
-            key = other._next_compound_key()
+            key = other._next_mangler_key('cq')
             other.mangler = key
             queries[key] = other
             template = '%s %s {%s}' % (self._template, operator, key)

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -134,6 +134,10 @@ def configurePackage(pkg):
     movie.formulaColumn('dvd_count', select=dict(
         columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
     ), dtype='L')
+    movie.formulaColumn('dvd_count_available', select=dict(
+        columns='COUNT(*)', table='video.dvd',
+        where='$movie_id=#THIS.id AND $available=:avail', avail='yes'
+    ), dtype='L')
 
     dvd = pkg.table('dvd', name_short='Dvd', name_long='Dvd', pkey='code')
     dvd.column('code', 'L')

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -113,6 +113,9 @@ def configurePackage(pkg):
                 name_long='Person id').relation('people.id')
     cast.column('role', name_short='Rl.', name_long='Role')
     cast.column('prizes', name_short='Priz.', name_long='Prizes', size='40')
+    cast.formulaColumn('movie_year', sql_formula='@movie_id.year')
+    cast.formulaColumn('role_in_movie', sql_formula="$role || ' in ' || @movie_id.title")
+    cast.aliasColumn('movie_title', relation_path='@movie_id.title')
 
     movie = pkg.table('movie', name_short='Mv', name_long='Movie',
                       rowcaption='title', pkey='id')
@@ -124,6 +127,13 @@ def configurePackage(pkg):
     movie.column('year', 'L', name_short='Yr', name_long='Year', indexed='y')
     movie.column('nationality', name_short='Ntl', name_long='Nationality')
     movie.column('description', name_short='Dsc', name_long='Movie description')
+
+    movie.formulaColumn('title_upper', sql_formula='UPPER($title)')
+    movie.formulaColumn('title_year', sql_formula="$title || ' (' || $year || ')'")
+    movie.formulaColumn('title_with_label', sql_formula="$title || :label", var_label=' [DVD]')
+    movie.formulaColumn('dvd_count', select=dict(
+        columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
+    ), dtype='L')
 
     dvd = pkg.table('dvd', name_short='Dvd', name_long='Dvd', pkey='code')
     dvd.column('code', 'L')

--- a/gnrpy/tests/sql/data/dbstructure_final.xml
+++ b/gnrpy/tests/sql/data/dbstructure_final.xml
@@ -12,13 +12,19 @@
 <subtables tag="subtable_list"><first_movie _T="BAG" condition="$movie_id=1" tag="subtable"></first_movie>
 <second_movie _T="BAG" condition="$movie_id=2" tag="subtable"></second_movie></subtables>
 <virtual_columns tag="virtual_columns_list"><subtable_first_movie _T="BAG" sql_formula="$movie_id=1" virtual_column="y" dtype="B" name_long="first_movie" group="subtables" _addClass="subtable_first_movie" tag="virtual_column"></subtable_first_movie>
-<subtable_second_movie _T="BAG" sql_formula="$movie_id=2" virtual_column="y" dtype="B" name_long="second_movie" group="subtables" _addClass="subtable_second_movie" tag="virtual_column"></subtable_second_movie></virtual_columns></cast>
+<subtable_second_movie _T="BAG" sql_formula="$movie_id=2" virtual_column="y" dtype="B" name_long="second_movie" group="subtables" _addClass="subtable_second_movie" tag="virtual_column"></subtable_second_movie>
+<movie_year _T="BAG" sql_formula="@movie_id.year" virtual_column="y" dtype="A" tag="virtual_column"></movie_year>
+<role_in_movie _T="BAG" sql_formula="$role || ' in ' || @movie_id.title" virtual_column="y" dtype="A" tag="virtual_column"></role_in_movie>
+<movie_title _T="BAG" relation_path="@movie_id.title" virtual_column="y" tag="virtual_column"></movie_title></virtual_columns></cast>
 <movie name_short="Mv" name_long="Movie" pkey="id" rowcaption="title" pkg="video" fullname="video.movie" tag="table"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
 <title _T="BAG" name_short="Ttl." name_long="Title" validate_case="capitalize" validate_len="3:40" tag="column"></title>
 <genre _T="BAG" name_short="Gnr" name_long="Genre" indexed="y" validate_case="upper" validate_len="3:10" tag="column"></genre>
 <year _T="BAG" dtype="L" name_short="Yr" name_long="Year" indexed="y" tag="column"></year>
 <nationality _T="BAG" name_short="Ntl" name_long="Nationality" tag="column"></nationality>
-<description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description></columns></movie>
+<description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description></columns>
+<virtual_columns tag="virtual_columns_list"><title_upper _T="BAG" sql_formula="UPPER($title)" virtual_column="y" dtype="A" tag="virtual_column"></title_upper>
+<title_year _T="BAG" sql_formula="$title || ' (' || $year || ')'" virtual_column="y" dtype="A" tag="virtual_column"></title_year>
+<dvd_count _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count></virtual_columns></movie>
 <dvd name_short="Dvd" name_long="Dvd" pkey="code" pkg="video" fullname="video.dvd" tag="table"><columns tag="column_list"><code _T="BAG" dtype="L" tag="column"></code>
 <movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column"><relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation></movie_id>
 <purchasedate _T="BAG" dtype="D" name_short="Pdt" name_long="Purchase date" tag="column"></purchasedate>

--- a/gnrpy/tests/sql/data/dbstructure_final.xml
+++ b/gnrpy/tests/sql/data/dbstructure_final.xml
@@ -24,7 +24,9 @@
 <description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description></columns>
 <virtual_columns tag="virtual_columns_list"><title_upper _T="BAG" sql_formula="UPPER($title)" virtual_column="y" dtype="A" tag="virtual_column"></title_upper>
 <title_year _T="BAG" sql_formula="$title || ' (' || $year || ')'" virtual_column="y" dtype="A" tag="virtual_column"></title_year>
-<dvd_count _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count></virtual_columns></movie>
+<title_with_label _T="BAG" sql_formula="$title || :label" virtual_column="y" dtype="A" var_label=" [DVD]" tag="virtual_column"></title_with_label>
+<dvd_count _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count>
+<dvd_count_available _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id AND $available=:avail", "avail": "yes"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count_available></virtual_columns></movie>
 <dvd name_short="Dvd" name_long="Dvd" pkey="code" pkg="video" fullname="video.dvd" tag="table"><columns tag="column_list"><code _T="BAG" dtype="L" tag="column"></code>
 <movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column"><relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation></movie_id>
 <purchasedate _T="BAG" dtype="D" name_short="Pdt" name_long="Purchase date" tag="column"></purchasedate>

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -520,52 +520,60 @@ class BaseSql(BaseGnrSqlTest):
         assert counts == sorted(counts, reverse=True)
         assert counts[0] == 3
 
-    # --- SqlCompiledQuery __eq__ / __hash__ / _identity_hash tests ---
+    # --- SqlCompiledQuery __eq__ / __hash__ / identity_hash tests ---
 
     def test_compiled_eq_same_identity_hash(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_movie')
-        a._identity_hash = hash(('video_movie', 'some_where'))
-        b._identity_hash = hash(('video_movie', 'some_where'))
+        a.where = 'x = :p'
+        b.where = 'x = :p'
+        a.mangled_params = {'p': 'val'}
+        b.mangled_params = {'p': 'val'}
         assert a == b
 
     def test_compiled_eq_different_identity_hash(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_movie')
-        a._identity_hash = hash(('video_movie', 'where_1'))
-        b._identity_hash = hash(('video_movie', 'where_2'))
+        a.where = 'x = :p'
+        b.where = 'x = :p'
+        a.mangled_params = {'p': 'val1'}
+        b.mangled_params = {'p': 'val2'}
         assert a != b
 
     def test_compiled_eq_different_table(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_dvd')
-        a._identity_hash = hash(('video_movie', 'w'))
-        b._identity_hash = hash(('video_dvd', 'w'))
+        a.where = 'x = :p'
+        b.where = 'x = :p'
+        a.mangled_params = {'p': 'val'}
+        b.mangled_params = {'p': 'val'}
         assert a != b
 
-    def test_compiled_eq_none_identity_hash(self):
+    def test_compiled_eq_no_mangled_params(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_movie')
-        # entrambi hanno _identity_hash=None (default)
+        # entrambi senza mangled_params → identity_hash è None
         assert a != b
 
-    def test_compiled_eq_one_none(self):
+    def test_compiled_eq_one_without_mangled(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_movie')
-        a._identity_hash = hash(('video_movie', 'w'))
-        # b._identity_hash resta None
+        a.where = 'x = :p'
+        a.mangled_params = {'p': 'val'}
+        # b senza mangled_params
         assert a != b
 
     def test_compiled_eq_not_implemented(self):
         a = SqlCompiledQuery('video_movie')
-        a._identity_hash = 42
+        a.where = 'x = :p'
+        a.mangled_params = {'p': 'val'}
         assert a.__eq__("not a compiled") is NotImplemented
 
     def test_compiled_hash_with_identity(self):
         a = SqlCompiledQuery('video_movie')
-        h = hash(('video_movie', 'w'))
-        a._identity_hash = h
-        assert hash(a) == h
+        a.where = 'x = :p'
+        a.mangled_params = {'p': 'val'}
+        assert hash(a) == hash(('video_movie', 'x = val'))
 
     def test_compiled_hash_without_identity(self):
         a = SqlCompiledQuery('video_movie')
@@ -574,26 +582,30 @@ class BaseSql(BaseGnrSqlTest):
     def test_compiled_in_set(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_movie')
-        h = hash(('video_movie', 'same_where'))
-        a._identity_hash = h
-        b._identity_hash = h
+        a.where = 'x = :p'
+        b.where = 'x = :p'
+        a.mangled_params = {'p': 'val'}
+        b.mangled_params = {'p': 'val'}
         s = {a, b}
         assert len(s) == 1
 
     def test_compiled_as_dict_key(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_movie')
-        h = hash(('video_movie', 'same_where'))
-        a._identity_hash = h
-        b._identity_hash = h
+        a.where = 'x = :p'
+        b.where = 'x = :p'
+        a.mangled_params = {'p': 'val'}
+        b.mangled_params = {'p': 'val'}
         d = {a: 'value_a'}
         assert d[b] == 'value_a'
 
     def test_compiled_different_in_set(self):
         a = SqlCompiledQuery('video_movie')
         b = SqlCompiledQuery('video_movie')
-        a._identity_hash = hash(('video_movie', 'w1'))
-        b._identity_hash = hash(('video_movie', 'w2'))
+        a.where = 'x = :p1'
+        b.where = 'x = :p2'
+        a.mangled_params = {'p1': 'val1'}
+        b.mangled_params = {'p2': 'val2'}
         s = {a, b}
         assert len(s) == 2
 
@@ -615,10 +627,10 @@ class BaseSql(BaseGnrSqlTest):
         assert compiled.tpl is None
 
     def test_compiled_identity_hash_none_for_main_query(self):
-        """Le query principali non hanno _identity_hash (è per le subquery)"""
+        """Le query principali non hanno identity_hash (è per le subquery)"""
         q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
         compiled = q.compileQuery()
-        assert compiled._identity_hash is None
+        assert compiled.identity_hash is None
 
     # --- get_sqltext template handling ---
 

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -823,6 +823,80 @@ class TestGnrSqlDb_postgres3(BaseSql):
                           user=cls.pg_conf.get("user"),
                           password=cls.pg_conf.get("password")
                           )
-        
+
     init = classmethod(init)
+
+
+# --- Step 1: _should_convert_to_join flag tests ---
+
+class TestShouldConvertToJoinFlag(BaseGnrSqlTest):
+    """Test che _should_convert_to_join legga correttamente il flag
+    a livello globale (db.extra_kw) e per-colonna (sq_as_join)."""
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.dbname = cls.CONFIG['db.sqlite?filename'] + '_flag'
+        cls.db = GnrSqlDb(dbname=cls.dbname)
+        configurePackage(cls.db.packageSrc('video'))
+        cls.db.startup()
+        cls.db.checkDb(applyChanges=True)
+        cls.db.importXmlData(cls.SAMPLE_XMLDATA)
+        cls.db.commit()
+
+    def _make_compiler(self):
+        tblobj = self.db.table('video.movie').model
+        q = self.db.query('video.movie', columns='$title')
+        return gsd.SqlQueryCompiler(tblobj, sqlparams={}, query=q)
+
+    def test_flag_default_false(self):
+        """Senza flag globale ne per-colonna, _should_convert_to_join ritorna False"""
+        compiler = self._make_compiler()
+        fldalias = self.db.table('video.movie').model.getVirtualColumn('dvd_count')
+        assert compiler._should_convert_to_join(fldalias) is False
+
+    def test_flag_global_true(self):
+        """Con flag globale subquery_as_join=True, ritorna True"""
+        old = self.db.extra_kw.get('subquery_as_join')
+        self.db.extra_kw['subquery_as_join'] = True
+        try:
+            compiler = self._make_compiler()
+            fldalias = self.db.table('video.movie').model.getVirtualColumn('dvd_count')
+            assert compiler._should_convert_to_join(fldalias) is True
+        finally:
+            if old is None:
+                self.db.extra_kw.pop('subquery_as_join', None)
+            else:
+                self.db.extra_kw['subquery_as_join'] = old
+
+    def test_flag_column_overrides_global(self):
+        """Il flag per-colonna sq_as_join sovrascrive il globale"""
+        old = self.db.extra_kw.get('subquery_as_join')
+        self.db.extra_kw['subquery_as_join'] = True
+        try:
+            compiler = self._make_compiler()
+            fldalias = self.db.table('video.movie').model.getVirtualColumn('dvd_count')
+            # Simula sq_as_join=False sulla colonna
+            fldalias.attributes['sq_as_join'] = False
+            assert compiler._should_convert_to_join(fldalias) is False
+            # Rimuovi il flag per non inquinare altri test
+            del fldalias.attributes['sq_as_join']
+        finally:
+            if old is None:
+                self.db.extra_kw.pop('subquery_as_join', None)
+            else:
+                self.db.extra_kw['subquery_as_join'] = old
+
+    def test_no_flag_subquery_still_inline(self):
+        """Senza flag, la subquery resta inline (SELECT annidato)"""
+        q = self.db.query('video.movie', columns='$title,$dvd_count',
+                          where='$id = :id', id=0)
+        sqltext, _ = q.test()
+        upper = sqltext.upper()
+        assert upper.count('SELECT') >= 2  # subquery inline
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.closeConnection()
+        cls.db.dropDb(cls.dbname)
 

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -414,6 +414,99 @@ class BaseSql(BaseGnrSqlTest):
         titles = sorted([r['title'] for r in result])
         assert titles == ['Match point', 'Munich']
 
+    def test_formulaColumn_pure(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$title_upper',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_upper'] == 'MATCH POINT'
+
+    def test_formulaColumn_pure_relation(self):
+        result = self.db.query('video.cast',
+                              columns='$movie_year,$role',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['movie_year'] == 2005
+
+    def test_aliasColumn(self):
+        result = self.db.query('video.cast',
+                              columns='$movie_title,$role',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['movie_title'] == 'Match point'
+
+    def test_formulaColumn_with_subquery(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count'] == 3
+
+    def test_formulaColumn_subquery_no_match(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['dvd_count'] == 0
+
+    def test_formulaColumn_mixed(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$title_upper,$dvd_count',
+                              where='$id = :id', id=1).fetch()
+        assert result[0]['title_upper'] == 'SCOOP'
+        assert result[0]['dvd_count'] == 2
+
+    def test_formulaColumn_multi_col(self):
+        result = self.db.query('video.movie',
+                              columns='$title_year',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_year'] == 'Match point (2005)'
+
+    def test_formulaColumn_col_and_rel(self):
+        result = self.db.query('video.cast',
+                              columns='$role_in_movie',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['role_in_movie'] == 'director in Match point'
+
+    def test_aliasColumn_in_where(self):
+        result = self.db.query('video.cast',
+                              columns='$movie_title,$role',
+                              where='$movie_title = :title',
+                              title='Match point').fetch()
+        assert len(result) == 3
+        assert all(r['movie_title'] == 'Match point' for r in result)
+
+    def test_formulaColumn_with_var(self):
+        result = self.db.query('video.movie',
+                              columns='$title_with_label',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_with_label'] == 'Match point [DVD]'
+
+    def test_formulaColumn_with_var_via_relation(self):
+        result = self.db.query('video.cast',
+                              columns='@movie_id.title_with_label,$role',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['_movie_id_title_with_label'] == 'Match point [DVD]'
+
+    def test_formulaColumn_with_var_multiple_rows(self):
+        result = self.db.query('video.cast',
+                              columns='@movie_id.title_with_label,$role',
+                              where='$movie_id = :mid', mid=0).fetch()
+        assert len(result) == 3
+        assert all(r['_movie_id_title_with_label'] == 'Match point [DVD]' for r in result)
+
+    def test_formulaColumn_with_var_and_other_formulas(self):
+        result = self.db.query('video.movie',
+                              columns='$title_with_label,$title_upper,$dvd_count',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_with_label'] == 'Match point [DVD]'
+        assert result[0]['title_upper'] == 'MATCH POINT'
+        assert result[0]['dvd_count'] == 3
+
+    def test_formulaColumn_subquery_order_by(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              order_by='$dvd_count DESC',
+                              limit=3).fetch()
+        counts = [r['dvd_count'] for r in result]
+        assert counts == sorted(counts, reverse=True)
+        assert counts[0] == 3
+
     def teardown_class(cls):
         cls.db.closeConnection()
         cls.db.dropDb(cls.dbname)

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -34,7 +34,7 @@ hdlr = logging.FileHandler('logs.log')
 gnrlogger.addHandler(hdlr)
 
 from gnr.sql.gnrsql import GnrSqlDb
-from gnr.sql.gnrsqldata import SqlQuery, SqlSelection
+from gnr.sql.gnrsqldata import SqlQuery, SqlSelection, SqlCompiledQuery
 from gnr.sql import gnrsqldata as gsd
 
 from .common import BaseGnrSqlTest, configurePackage
@@ -349,16 +349,16 @@ class BaseSql(BaseGnrSqlTest):
         assert query.count() == 2
 
     def test_compound_union_sqltext(self):
-        self.db.currentEnv['_compound_counter'] = 0
+        self.db.currentEnv['_mangler_counters'] = {}
         q1 = self.db.query('video.movie', columns='$title', where='$year = :year', year=2005)
         q2 = self.db.query('video.movie', columns='$title', where='$year = :year', year=2006)
         compound = q1 + q2
         sqltext, sqlparams = compound.test()
         assert 'UNION' in sqltext
-        assert ':q0_year' in sqltext
-        assert ':q1_year' in sqltext
-        assert sqlparams['q0_year'] == 2005
-        assert sqlparams['q1_year'] == 2006
+        assert ':cq0_year' in sqltext
+        assert ':cq1_year' in sqltext
+        assert sqlparams['cq0_year'] == 2005
+        assert sqlparams['cq1_year'] == 2006
 
     def test_compound_union_fetch(self):
         q1 = self.db.query('video.movie', columns='$title', where='$year = :year', year=2005)
@@ -498,6 +498,19 @@ class BaseSql(BaseGnrSqlTest):
         assert result[0]['title_upper'] == 'MATCH POINT'
         assert result[0]['dvd_count'] == 3
 
+    def test_formulaColumn_subquery_with_params(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_available',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count_available'] == 3  # movie 0 has 3 dvds with available='yes'
+
+    def test_formulaColumn_subquery_params_and_count(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count,$dvd_count_available',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count'] == 3
+        assert result[0]['dvd_count_available'] == 3
+
     def test_formulaColumn_subquery_order_by(self):
         result = self.db.query('video.movie',
                               columns='$title,$dvd_count',
@@ -506,6 +519,244 @@ class BaseSql(BaseGnrSqlTest):
         counts = [r['dvd_count'] for r in result]
         assert counts == sorted(counts, reverse=True)
         assert counts[0] == 3
+
+    # --- SqlCompiledQuery __eq__ / __hash__ / _identity_hash tests ---
+
+    def test_compiled_eq_same_identity_hash(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'some_where'))
+        b._identity_hash = hash(('video_movie', 'some_where'))
+        assert a == b
+
+    def test_compiled_eq_different_identity_hash(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'where_1'))
+        b._identity_hash = hash(('video_movie', 'where_2'))
+        assert a != b
+
+    def test_compiled_eq_different_table(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_dvd')
+        a._identity_hash = hash(('video_movie', 'w'))
+        b._identity_hash = hash(('video_dvd', 'w'))
+        assert a != b
+
+    def test_compiled_eq_none_identity_hash(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        # entrambi hanno _identity_hash=None (default)
+        assert a != b
+
+    def test_compiled_eq_one_none(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'w'))
+        # b._identity_hash resta None
+        assert a != b
+
+    def test_compiled_eq_not_implemented(self):
+        a = SqlCompiledQuery('video_movie')
+        a._identity_hash = 42
+        assert a.__eq__("not a compiled") is NotImplemented
+
+    def test_compiled_hash_with_identity(self):
+        a = SqlCompiledQuery('video_movie')
+        h = hash(('video_movie', 'w'))
+        a._identity_hash = h
+        assert hash(a) == h
+
+    def test_compiled_hash_without_identity(self):
+        a = SqlCompiledQuery('video_movie')
+        assert hash(a) == id(a)
+
+    def test_compiled_in_set(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        h = hash(('video_movie', 'same_where'))
+        a._identity_hash = h
+        b._identity_hash = h
+        s = {a, b}
+        assert len(s) == 1
+
+    def test_compiled_as_dict_key(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        h = hash(('video_movie', 'same_where'))
+        a._identity_hash = h
+        b._identity_hash = h
+        d = {a: 'value_a'}
+        assert d[b] == 'value_a'
+
+    def test_compiled_different_in_set(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'w1'))
+        b._identity_hash = hash(('video_movie', 'w2'))
+        s = {a, b}
+        assert len(s) == 2
+
+    # --- compileQuery produce SqlCompiledQuery ---
+
+    def test_compileQuery_returns_compiled_object(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert isinstance(compiled, SqlCompiledQuery)
+
+    def test_compiled_has_maintable(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert 'movie' in compiled.maintable
+
+    def test_compiled_tpl_none_by_default(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert compiled.tpl is None
+
+    def test_compiled_identity_hash_none_for_main_query(self):
+        """Le query principali non hanno _identity_hash (è per le subquery)"""
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert compiled._identity_hash is None
+
+    # --- get_sqltext template handling ---
+
+    def test_get_sqltext_without_tpl(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        sql = compiled.get_sqltext(self.db)
+        assert '%s' not in sql
+        assert 'SELECT' in sql.upper()
+
+    def test_get_sqltext_with_tpl(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        compiled.tpl = ' ( %s ) '
+        sql = compiled.get_sqltext(self.db)
+        assert sql.strip().startswith('(')
+        assert sql.strip().endswith(')')
+
+    def test_get_sqltext_cast_tpl(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        compiled.tpl = ' CAST( ( %s ) AS integer) '
+        sql = compiled.get_sqltext(self.db)
+        assert 'CAST' in sql
+        assert 'integer' in sql
+
+    def test_get_sqltext_exists_tpl(self):
+        q = self.db.query('video.dvd', columns='$code', where='$movie_id = :mid', mid=0)
+        compiled = q.compileQuery()
+        compiled.tpl = ' EXISTS( %s ) '
+        sql = compiled.get_sqltext(self.db)
+        assert 'EXISTS' in sql
+
+    # --- Subquery tramite formulaColumn: risultati corretti ---
+
+    def test_subquery_dvd_count_all_movies(self):
+        """Verifica dvd_count sui film noti — la subquery funziona per ogni riga"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id <= :maxid', maxid=10,
+                              order_by='$id').fetch()
+        expected = {
+            'Match point': 3, 'Scoop': 2, 'Munich': 2,
+            'Saving private Ryan': 0, 'Eyes wide shut': 2,
+            'Barry Lindon': 2, 'Scarface': 1, 'The untouchables': 1,
+            'Psycho': 2, 'The Aviator': 1, 'The Departed': 1
+        }
+        for r in result:
+            assert r['dvd_count'] == expected[r['title']]
+
+    def test_subquery_with_params_all_movies(self):
+        """Verifica dvd_count_available — subquery con parametri extra (:avail)"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_available',
+                              order_by='$id').fetch()
+        for r in result:
+            assert isinstance(r['dvd_count_available'], int)
+
+    def test_subquery_params_preserved_in_sqlparams(self):
+        """I parametri della subquery devono essere nei sqlparams della query principale"""
+        q = self.db.query('video.movie',
+                         columns='$title,$dvd_count_available',
+                         where='$id = :id', id=0)
+        sqltext, sqlparams = q.test()
+        has_avail = any('avail' in k for k in sqlparams)
+        assert has_avail
+
+    def test_subquery_sqltext_contains_subselect(self):
+        """L'SQL generato deve contenere la subquery wrappata tra parentesi"""
+        q = self.db.query('video.movie',
+                         columns='$title,$dvd_count',
+                         where='$id = :id', id=0)
+        sqltext, sqlparams = q.test()
+        upper = sqltext.upper()
+        assert upper.count('SELECT') >= 2  # main query + subquery
+
+    def test_two_subqueries_in_same_query(self):
+        """Due formulaColumn con subquery nella stessa query"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count,$dvd_count_available',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count'] == 3
+        assert result[0]['dvd_count_available'] == 3
+
+    def test_subquery_zero_when_no_match(self):
+        """COUNT deve dare 0 quando non ci sono righe corrispondenti"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['dvd_count'] == 0
+        assert result[0]['title'] == 'Saving private Ryan'
+
+    def test_subquery_available_zero_when_no_match(self):
+        """dvd_count_available deve dare 0 quando nessun dvd è available"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_available',
+                              where='$id = :id', id=1).fetch()
+        # movie_id=1 (Scoop) ha 2 dvd ma entrambi available='no'
+        assert result[0]['dvd_count_available'] == 0
+
+    def test_subquery_mixed_with_formula_and_alias(self):
+        """Combinazione di formulaColumn pura, aliasColumn e subquery nella stessa query"""
+        result = self.db.query('video.movie',
+                              columns='$title,$title_upper,$dvd_count,$title_year',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_upper'] == 'MATCH POINT'
+        assert result[0]['dvd_count'] == 3
+        assert result[0]['title_year'] == 'Match point (2005)'
+
+    def test_subquery_with_order_by_subquery_column(self):
+        """ORDER BY su colonna subquery"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              order_by='$dvd_count DESC',
+                              limit=3).fetch()
+        counts = [r['dvd_count'] for r in result]
+        assert counts == sorted(counts, reverse=True)
+
+    def test_subquery_with_where_on_main(self):
+        """Subquery combinata con WHERE sulla tabella principale"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$genre = :genre',
+                              genre='DRAMA').fetch()
+        assert len(result) == 4
+        for r in result:
+            assert isinstance(r['dvd_count'], int)
+
+    def test_compiled_sqltext_stable(self):
+        """Due compilazioni identiche producono lo stesso SQL"""
+        q1 = self.db.query('video.movie', columns='$title,$dvd_count',
+                          where='$id = :id', id=0)
+        q2 = self.db.query('video.movie', columns='$title,$dvd_count',
+                          where='$id = :id', id=0)
+        sql1, _ = q1.test()
+        sql2, _ = q2.test()
+        # La struttura dell'SQL deve essere uguale (i mangler possono variare)
+        assert sql1.upper().count('SELECT') == sql2.upper().count('SELECT')
 
     def teardown_class(cls):
         cls.db.closeConnection()

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -34,7 +34,7 @@ hdlr = logging.FileHandler('logs.log')
 gnrlogger.addHandler(hdlr)
 
 from gnr.sql.gnrsql import GnrSqlDb
-from gnr.sql.gnrsqldata import SqlQuery, SqlSelection, SqlCompiledQuery
+from gnr.sql.gnrsqldata import SqlQuery, SqlSelection, SqlCompiledQuery, SqlCompiledSubQuery
 from gnr.sql import gnrsqldata as gsd
 
 from .common import BaseGnrSqlTest, configurePackage
@@ -523,8 +523,8 @@ class BaseSql(BaseGnrSqlTest):
     # --- SqlCompiledQuery __eq__ / __hash__ / identity_hash tests ---
 
     def test_compiled_eq_same_identity_hash(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p'
         b.where = 'x = :p'
         a.mangled_params = {'p': 'val'}
@@ -532,8 +532,8 @@ class BaseSql(BaseGnrSqlTest):
         assert a == b
 
     def test_compiled_eq_different_identity_hash(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p'
         b.where = 'x = :p'
         a.mangled_params = {'p': 'val1'}
@@ -541,8 +541,8 @@ class BaseSql(BaseGnrSqlTest):
         assert a != b
 
     def test_compiled_eq_different_table(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_dvd')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_dvd')
         a.where = 'x = :p'
         b.where = 'x = :p'
         a.mangled_params = {'p': 'val'}
@@ -550,38 +550,38 @@ class BaseSql(BaseGnrSqlTest):
         assert a != b
 
     def test_compiled_eq_no_mangled_params(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
-        # entrambi senza mangled_params → identity_hash è None
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
+        # both without mangled_params → identity_hash is None
         assert a != b
 
     def test_compiled_eq_one_without_mangled(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p'
         a.mangled_params = {'p': 'val'}
-        # b senza mangled_params
+        # b without mangled_params
         assert a != b
 
     def test_compiled_eq_not_implemented(self):
-        a = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p'
         a.mangled_params = {'p': 'val'}
         assert a.__eq__("not a compiled") is NotImplemented
 
     def test_compiled_hash_with_identity(self):
-        a = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p'
         a.mangled_params = {'p': 'val'}
         assert hash(a) == hash(('video_movie', 'x = val'))
 
     def test_compiled_hash_without_identity(self):
-        a = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
         assert hash(a) == id(a)
 
     def test_compiled_in_set(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p'
         b.where = 'x = :p'
         a.mangled_params = {'p': 'val'}
@@ -590,8 +590,8 @@ class BaseSql(BaseGnrSqlTest):
         assert len(s) == 1
 
     def test_compiled_as_dict_key(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p'
         b.where = 'x = :p'
         a.mangled_params = {'p': 'val'}
@@ -600,8 +600,8 @@ class BaseSql(BaseGnrSqlTest):
         assert d[b] == 'value_a'
 
     def test_compiled_different_in_set(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a.where = 'x = :p1'
         b.where = 'x = :p2'
         a.mangled_params = {'p1': 'val1'}
@@ -627,10 +627,11 @@ class BaseSql(BaseGnrSqlTest):
         assert compiled.tpl is None
 
     def test_compiled_identity_hash_none_for_main_query(self):
-        """Le query principali non hanno identity_hash (è per le subquery)"""
+        """Main queries produce SqlCompiledQuery, not SqlCompiledSubQuery"""
         q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
         compiled = q.compileQuery()
-        assert compiled.identity_hash is None
+        assert not isinstance(compiled, SqlCompiledSubQuery)
+        assert not hasattr(compiled, 'identity_hash')
 
     # --- get_sqltext template handling ---
 
@@ -724,11 +725,11 @@ class BaseSql(BaseGnrSqlTest):
         assert result[0]['title'] == 'Saving private Ryan'
 
     def test_subquery_available_zero_when_no_match(self):
-        """dvd_count_available deve dare 0 quando nessun dvd è available"""
+        """dvd_count_available should return 0 when no dvd is available"""
         result = self.db.query('video.movie',
                               columns='$title,$dvd_count_available',
                               where='$id = :id', id=1).fetch()
-        # movie_id=1 (Scoop) ha 2 dvd ma entrambi available='no'
+        # movie_id=1 (Scoop) has 2 dvds but both have available='no'
         assert result[0]['dvd_count_available'] == 0
 
     def test_subquery_mixed_with_formula_and_alias(self):


### PR DESCRIPTION
## Context

This PR continues the work from #457 (SqlCompoundQuery / mangler / subquery).
The refactoring focuses on two areas: **virtual column resolution** in `SqlQueryCompiler.getFieldAlias` and **moving mangle ownership** from the compiler to the compiled query.

## Previous architecture

### Virtual columns
`getFieldAlias` was a monolithic method handling all virtual column types inline (relation_path, formula, single subquery, multiple subqueries, py_method, error). The formula/subquery dispatch had been partially separated in #457 into three handlers:
- `_handleFormulaColumn` — pure formula with no subquery
- inline in the dispatcher — single subquery with cast/exists template
- `_handleFormulaColumn_legacy` — formula with multiple subquery `#subselect` placeholders

**Bug**: the case "formula + single subquery" (e.g. `COALESCE(#default, 0)`) was not handled — the sql_formula was silently ignored in the single-subquery path.

### Mangling
`mangle()` and `mangleParams()` lived on `SqlQueryCompiler`. Mangling operated by side-effect on the shared `sqlparams` dict (passed by reference from SqlQuery). `_identity_hash` was computed externally and set on the compiled query.

## New architecture

### Virtual columns — clean dispatcher
`getFieldAlias` now has a linear dispatch:
1. `relation_path` → recursion
2. `sql_formula / select / exists` → `_handleFormulaColumns`
3. `py_method` → inline (registers Python post-processing column)
4. fallback → raise error

### `_handleFormulaColumns` — unified path
A single method handles all formula/subquery cases:
- **Pure formula** (no subquery) → delegates to `_resolveFormula`
- **Subquery with or without formula**: `sql_formula` acts as the template into which compiled subqueries are injected. If no formula is provided, the default is `EXISTS( %s )` or `( %s )`
- Works uniformly with 1 or N subqueries

`_resolveFormula` is an extracted method that resolves `$col`, `@rel`, `#THIS`, `#ENV`, `#PREF`, macros, `var_` parameters and `$field_dict` — used as the final step for both pure formulas and formulas with injected subqueries.

### Mangle on SqlCompiledQuery
`SqlCompiledQuery` receives `mangler` and `sqlparams` in the constructor and exposes:
- `mangle(sql_text)` — renames `:param` → `:mangler_param` and accumulates renamed parameters in `self.mangled_params`
- `identity_hash` (property) — mangler-independent fingerprint computed from `mangled_params` and `where`, for future CTE merge

The compiler calls `self.cpl.mangle(...)` when setting columns, where, group_by etc. After compilation, `self.sqlparams.update(self.cpl.mangled_params)` propagates the mangled parameters to the main query.

**Benefits**:
- No side-effects on the shared dict during mangling
- Each compiled query is self-contained (carries its own mangled params)
- `identity_hash` as a property eliminates external computation

## Removed code
- `SqlQueryCompiler.mangle()` — replaced by `SqlCompiledQuery.mangle()`
- `SqlQueryCompiler.mangleParams()` — eliminated (mangle accumulates directly)
- `SqlQueryCompiler.subquery_kw` — no longer needed
- `SqlQueryCompiler._handlePlainFormulaColumn()` — replaced by `_resolveFormula`
- `SqlQueryCompiler._handleFormulaColumn_legacy()` — unified into `_handleFormulaColumns`
- `SqlCompiledQuery._identity_hash` — replaced by `identity_hash` property

## Files changed
- `gnrpy/gnr/sql/gnrsqldata.py` — main refactoring
- `gnrpy/tests/sql/e_query_test.py` — tests updated for new API

## Test plan
- [x] 234 tests pass (sqlite, postgres, postgres3)

Ref #451