### PR TITLE
fix(tests): cleanup stale postgres temp instances before test setup

### DIFF
--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import os.path
+import subprocess
 import pytest
 from testing.postgresql import Postgresql
 
@@ -72,6 +73,8 @@ class BaseGnrSqlTest:
                                password=os.environ.get("GNR_TEST_PG_PASSWORD"))
             cls.mysql_conf = None
         else:
+            # cleanup stale postgres temp instances from previous interrupted runs
+            subprocess.run(['pkill', '-f', 'postgres.*tmp'], capture_output=True)
             cls.pg_instance = Postgresql()
             cls.pg_conf = cls.pg_instance.dsn()
             cls.mysql_conf = dict(host="localhost",


### PR DESCRIPTION
## Summary
- Kill stale temporary postgres processes at test setup time
- Prevents 'No space left on device' errors caused by accumulated orphan postgres instances from interrupted test runs

## Test plan
- [x] Run `pytest gnrpy/tests/sql/e_query_test.py` multiple times, interrupting with Ctrl+C
- [x] Verify subsequent runs still work without shared memory errors