### PR TITLE
refactor(sql): unified subquery dispatch and SqlCompiledSubQuery

### DIFF
--- a/gnrpy/gnr/sql/gnrsql.py
+++ b/gnrpy/gnr/sql/gnrsql.py
@@ -1043,7 +1043,8 @@ class GnrSqlDb(GnrObject):
               relationDict=None, sqlparams=None, excludeLogicalDeleted=True,
               excludeDraft=True,
               addPkeyColumn=True,ignorePartition=False, locale=None,
-              mode=None,_storename=None,aliasPrefix=None,ignoreTableOrderBy=None, subtable=None,**kwargs):
+              mode=None,_storename=None,aliasPrefix=None,ignoreTableOrderBy=None, subtable=None,
+              mainquery_kw=None,**kwargs):
         q = self.table(table).query(columns=columns, where=where, order_by=order_by,
                          distinct=distinct, limit=limit, offset=offset,
                          group_by=group_by, having=having, for_update=for_update,
@@ -1051,7 +1052,8 @@ class GnrSqlDb(GnrObject):
                          excludeLogicalDeleted=excludeLogicalDeleted,excludeDraft=excludeDraft,
                          ignorePartition=ignorePartition,
                          addPkeyColumn=addPkeyColumn, locale=locale,_storename=_storename,
-                         aliasPrefix=aliasPrefix,ignoreTableOrderBy=ignoreTableOrderBy,subtable=subtable)
+                         aliasPrefix=aliasPrefix,ignoreTableOrderBy=ignoreTableOrderBy,subtable=subtable,
+                         mainquery_kw=mainquery_kw)
         result = q.sqltext
         if kwargs:
             prefix = str(id(kwargs))

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -278,22 +278,11 @@ class SqlQueryCompiler(object):
                 if not sql_formula:
                     select_dict['default'] = fldalias.select or fldalias.exists
                 if not select_dict:
-                    return self._handleFormulaColumn(fldalias, alias, curr,
+                    return self._handleFormulaColumn_plain(fldalias, alias, curr,
                                                       sql_formula, formula_kw)
                 elif len(select_dict) == 1:
-                    sq_select = select_dict['default']
-                    if isinstance(sq_select, str):
-                        sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
-                    sq_pars = dict(sq_select)
-                    cast = sq_pars.pop('cast', None)
-                    if fldalias.exists:
-                        tpl = ' EXISTS( %s ) '
-                    elif cast:
-                        tpl = ' CAST( ( %s ) AS ' + cast + ') '
-                    else:
-                        tpl = ' ( %s ) '
-                    compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
-                    return tpl % compiled.get_sqltext(self.db)
+                    return self._handleFormulaColumn_oneQuery(fldalias, alias, expandThis,
+                                                      select_dict)
                 else:
                     return self._handleFormulaColumn_legacy(fldalias, alias, curr,
                                                       expandThis, expandEnv, expandPref,
@@ -307,7 +296,22 @@ class SqlQueryCompiler(object):
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
 
-    def _handleFormulaColumn(self, fldalias, alias, curr, sql_formula, formula_kw):
+    def _handleFormulaColumn_oneQuery(self, fldalias, alias, expandThis, select_dict):
+        sq_select = select_dict['default']
+        if isinstance(sq_select, str):
+            sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
+        sq_pars = dict(sq_select)
+        cast = sq_pars.pop('cast', None)
+        if fldalias.exists:
+            tpl = ' EXISTS( %s ) '
+        elif cast:
+            tpl = ' CAST( ( %s ) AS ' + cast + ') '
+        else:
+            tpl = ' ( %s ) '
+        compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
+        return tpl % compiled.get_sqltext(self.db)
+
+    def _handleFormulaColumn_plain(self, fldalias, alias, curr, sql_formula, formula_kw):
         """Handle pure formula columns with no subquery.
 
         Args:

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -268,25 +268,7 @@ class SqlQueryCompiler(object):
 
                 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                attr = dict(fldalias.attributes)
-                multi_select = self._preprocess_subqueryes(attr)
-                formula_kw = dictExtract(attr, 'var_')
-                sql_formula = fldalias.sql_formula
-                if sql_formula is True:
-                    sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
-                if not sql_formula:
-                    sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select) if multi_select else None
-                else:
-                    sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
-                select_dict = dict(multi_select) if multi_select else {}
-                if select_dict:
-                    for sq_name, sq_select in list(select_dict.items()):
-                        if isinstance(sq_select, str):
-                            sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
-                        sq_pars = dict(sq_select)
-                        compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
-                        sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
-                return f'( {sql_formula} )'
+                return self._handleFormulaColumn(fldalias, fld, alias, curr, curr_tblobj, expandThis)
             elif fldalias.py_method:
                 #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
                 self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
@@ -295,6 +277,27 @@ class SqlQueryCompiler(object):
                 raise GnrSqlMissingColumn('Invalid column %s in table %s.%s (requested field %s)' % (
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
+
+    def _handleFormulaColumn(self, fldalias, fld, alias, curr, curr_tblobj, expandThis):
+        attr = dict(fldalias.attributes)
+        multi_select = self._preprocess_subqueryes(attr)
+        formula_kw = dictExtract(attr, 'var_')
+        sql_formula = fldalias.sql_formula
+        if sql_formula is True:
+            sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
+        if not sql_formula:
+            sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select) if multi_select else None
+        else:
+            sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
+        select_dict = dict(multi_select) if multi_select else {}
+        if select_dict:
+            for sq_name, sq_select in list(select_dict.items()):
+                if isinstance(sq_select, str):
+                    sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
+                sq_pars = dict(sq_select)
+                compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
+                sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
+        return f'( {sql_formula} )'
 
     def _preprocess_subqueryes(self, attr):
         if 'exists' in attr:

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -121,7 +121,7 @@ class SqlQueryCompiler(object):
                            :meth:`setJoinCondition() <gnr.web.gnrwebpage.GnrWebPage.setJoinCondition>` method)
     :param sqlparams: a dict of parameters used in "WHERE" clause
     :param locale: the current locale (e.g: en, en_us, it)"""
-    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None):
+    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None, query_kw=None, mainquery_kw=None):
         self.tblobj = tblobj
         self.db = tblobj.db
         self.dbmodel = tblobj.db.model
@@ -137,6 +137,9 @@ class SqlQueryCompiler(object):
         self.aliasPrefix = aliasPrefix or 't'
         self.locale = locale
         self.mangler = mangler
+        self.query_kw = query_kw or {}
+        self.mainquery_kw = mainquery_kw or {}
+        self.subquery_kw = {}
         self.macro_expander = self.db.adapter.macroExpander(self)
 
     def aliasCode(self,n):
@@ -159,7 +162,10 @@ class SqlQueryCompiler(object):
             return
         for k, v in list(self.sqlparams.items()):
             if not k.startswith('env_'):
-                self.sqlparams['%s_%s' % (self.mangler, k)] = v
+                mangled_key = '%s_%s' % (self.mangler, k)
+                mangled_value = self.query_kw.get(k, self.mainquery_kw.get(k))
+                self.subquery_kw[mangled_key] = mangled_value
+                self.sqlparams[mangled_key] = v
 
     def init(self, lazy=None, eager=None):
         """TODO
@@ -247,51 +253,28 @@ class SqlQueryCompiler(object):
 
                 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                sql_formula = fldalias.sql_formula
+                # Virtual column dispatch based on subquery presence:
+                #   - A subquery exists only if select, exists, or select_ attributes are present
+                #   - sql_formula alone (str or True) without select/exists = pure formula
+                #   - sql_formula=True delegates to a Python method sql_formula_<fieldname>()
                 attr = dict(fldalias.attributes)
-                if sql_formula is True:
-                    sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
-                select_dict = dictExtract(attr,'select_')
-                if not sql_formula:
-                    sql_formula = '#default' if fldalias.select else 'EXISTS(#default)'
-                    select_dict['default'] = fldalias.select or fldalias.exists
-                if select_dict:
-                    for susbselect,sq_pars in list(select_dict.items()):
-                        if isinstance(sq_pars, str):
-                            sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
-                        sq_pars = dict(sq_pars)
-                        cast = sq_pars.pop('cast',None)
-                        tpl = ' CAST( ( %s ) AS ' +cast +') ' if cast else ' ( %s ) '
-                        sq_table = sq_pars.pop('table')
-                        sq_where = sq_pars.pop('where')
-                        sq_pars.setdefault('ignorePartition',True)
-                        sq_pars.setdefault('excludeDraft',False)
-                        sq_pars.setdefault('excludeLogicalDeleted',False)
-                        sq_pars.setdefault('subtable','*')
-                        aliasPrefix = '%s_t' %alias
-                        sq_where = THISFINDER.sub(expandThis,sq_where)
-                        sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
-                        sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
-                subreldict = {}
-                sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
-                sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
-                sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
-                sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
-                sql_formula = PREFFINDER.sub(expandPref, sql_formula)
-                sql_formula = THISFINDER.sub(expandThis,sql_formula)
-                sql_formula_var = dictExtract(attr,'var_')
-                if sql_formula_var:
-                    prefix = str(id(fldalias))
-                    currentEnv = self.db.currentEnv
-                    for k,v in list(sql_formula_var.items()):
-                        newk = f'{prefix}_{self._currColKey}_{k}'
-                        currentEnv[newk] = v
-                        sql_formula = re.sub("(:)(%s)(\\W|$)" %k,lambda m: '%senv_%s%s'%(m.group(1),newk,m.group(3)), sql_formula)
-                subColPars = {}
-                for key, value in list(subreldict.items()):
-                    subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
-                sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
-                return f'( {sql_formula} )' 
+                formula_kw = dictExtract(attr, 'var_')
+                multi_select = dictExtract(attr, 'select_')
+                has_subquery = fldalias.select or fldalias.exists or multi_select
+                if not has_subquery:
+                    # Pure formula: only $col and @rel.col references, resolved inline
+                    return self._handleFormulaColumn(fldalias, fld, curr_tblobj, alias, curr,
+                                                      attr, formula_kw)
+                elif not multi_select:
+                    # Single subquery (select or exists), with or without a wrapping sql_formula
+                    return self._handleSubQuery(fldalias, fld, curr_tblobj, alias, curr,
+                                                      expandThis, expandEnv, expandPref,
+                                                      attr, formula_kw)
+                else:
+                    # Multiple subqueries (select_ prefix in attributes)
+                    return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
+                                                      expandThis, expandEnv, expandPref,
+                                                      attr, formula_kw, multi_select)
             elif fldalias.py_method:
                 #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
                 self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
@@ -300,6 +283,108 @@ class SqlQueryCompiler(object):
                 raise GnrSqlMissingColumn('Invalid column %s in table %s.%s (requested field %s)' % (
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
+
+    def _handleFormulaColumn(self, fldalias, fld, curr_tblobj, alias, curr, attr, formula_kw):
+        """Handle pure formula columns with no subquery.
+
+        Translates a sql_formula string containing $col and @rel.col placeholders
+        into valid SQL by resolving each reference to its table alias (e.g. t0.col, t3.col).
+
+        The sql_formula can be either:
+            - A string (e.g. ``"UPPER($title)"`` or ``"$role || ' in ' || @movie_id.title"``).
+            - The boolean ``True``, meaning the formula is defined as a Python method
+              ``sql_formula_<fieldname>(attributes)`` on the table object.
+
+        Resolution is done in two passes via regex substitution:
+            1. RELFINDER resolves ``@relation.column`` references (e.g. ``@movie_id.title`` -> ``t3.title``).
+            2. COLFINDER resolves ``$column`` references (e.g. ``$title`` -> ``t0.title``).
+
+        Both regexes capture a leading non-word character in group(1) and the field path
+        in group(2). The callback delegates to ``getFieldAlias`` which handles join registration.
+
+        Args:
+            fldalias: The virtual column definition node from the model.
+            fld: The field name (e.g. ``'title_upper'``).
+            curr_tblobj: The current table object in the model.
+            alias: The SQL table alias for the current table (e.g. ``'t0'``).
+            curr: The current table model node.
+            attr: Pre-extracted dict of fldalias.attributes.
+            formula_kw: Pre-extracted var_ parameters (dict), for :placeholder resolution.
+
+        Returns:
+            A parenthesized SQL expression string (e.g. ``'( UPPER(t0.title) )'``).
+        """
+        sql_formula = fldalias.sql_formula
+        if sql_formula is True:
+            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
+        def resolveField(m):
+            return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
+        sql_formula = RELFINDER.sub(resolveField, sql_formula)
+        sql_formula = COLFINDER.sub(resolveField, sql_formula)
+        if formula_kw:
+            prefix = f'{id(fldalias)}_{self._currColKey}'
+            for k, v in formula_kw.items():
+                mangled_k = f'{prefix}_{k}'
+                self.sqlparams[mangled_k] = v
+                sql_formula = re.sub(r"(:)(%s)(\W|$)" % k,
+                                     lambda m, mk=mangled_k: f'{m.group(1)}{mk}{m.group(3)}',
+                                     sql_formula)
+        return f'( {sql_formula} )'
+
+    def _handleSubQuery(self, fldalias, fld, curr_tblobj, alias, curr, expandThis, expandEnv, expandPref,
+                        attr, formula_kw):
+        """Handle a single subquery column (select or exists), with or without a wrapping sql_formula.
+        When sql_formula is absent, it defaults to '#default' (or 'EXISTS(#default)').
+        Subquery parameters live inside the select dict and are resolved by queryCompile."""
+        return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
+                                          expandThis, expandEnv, expandPref,
+                                          attr, formula_kw)
+
+    def _handleFormulaColumn_legacy(self, fldalias, fld, curr_tblobj, alias, curr,
+                              expandThis, expandEnv, expandPref,
+                              attr, formula_kw, multi_select=None):
+        sql_formula = fldalias.sql_formula
+        if sql_formula is True:
+            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
+        select_dict = multi_select or {}
+        if not sql_formula:
+            sql_formula = '#default' if fldalias.select else 'EXISTS(#default)'
+            select_dict['default'] = fldalias.select or fldalias.exists
+        for susbselect,sq_pars in list(select_dict.items()):
+            if isinstance(sq_pars, str):
+                sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
+            sq_pars = dict(sq_pars)
+            cast = sq_pars.pop('cast',None)
+            tpl = ' CAST( ( %s ) AS ' +cast +') ' if cast else ' ( %s ) '
+            sq_table = sq_pars.pop('table')
+            sq_where = sq_pars.pop('where')
+            sq_pars.setdefault('ignorePartition',True)
+            sq_pars.setdefault('excludeDraft',False)
+            sq_pars.setdefault('excludeLogicalDeleted',False)
+            sq_pars.setdefault('subtable','*')
+            aliasPrefix = '%s_t' %alias
+            sq_where = THISFINDER.sub(expandThis,sq_where)
+            sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
+            sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
+        subreldict = {}
+        sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
+        sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
+        sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
+        sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
+        sql_formula = PREFFINDER.sub(expandPref, sql_formula)
+        sql_formula = THISFINDER.sub(expandThis,sql_formula)
+        if formula_kw:
+            prefix = str(id(fldalias))
+            currentEnv = self.db.currentEnv
+            for k,v in list(formula_kw.items()):
+                newk = f'{prefix}_{self._currColKey}_{k}'
+                currentEnv[newk] = v
+                sql_formula = re.sub("(:)(%s)(\\W|$)" %k,lambda m: '%senv_%s%s'%(m.group(1),newk,m.group(3)), sql_formula)
+        subColPars = {}
+        for key, value in list(subreldict.items()):
+            subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
+        sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
+        return f'( {sql_formula} )'
 
     def _findRelationAlias(self, pathlist, curr, basealias, newpath, parent=None):
         """Internal method: called by getFieldAlias to get the alias (t1, t2...) for the join table.
@@ -1060,6 +1145,7 @@ class SqlQuery(object):
                  checkPermissions=None,
                  aliasPrefix=None,
                  mangler=None,
+                 mainquery_kw=None,
                  **kwargs):
         self.dbtable = dbtable
         self.sqlparams = sqlparams or {}
@@ -1068,6 +1154,7 @@ class SqlQuery(object):
         self.joinConditions = joinConditions or {}
         self.sqlContextName = sqlContextName
         self.relationDict = relationDict or {}
+        self.query_kw = dict(kwargs)
         self.sqlparams.update(kwargs)
         self.excludeLogicalDeleted = excludeLogicalDeleted
         self.excludeDraft = excludeDraft
@@ -1079,6 +1166,7 @@ class SqlQuery(object):
         self.checkPermissions = checkPermissions
         self.aliasPrefix = aliasPrefix
         self.mangler = mangler
+        self.mainquery_kw = mainquery_kw or {}
         test = " ".join([v for v in (columns, where, order_by, group_by, having) if v])
         rels = set(re.findall(r'\$(\w*)', test))
         params = set(re.findall(r'\:(\w*)', test))
@@ -1137,7 +1225,9 @@ class SqlQuery(object):
                                 sqlparams=self.sqlparams,
                                 aliasPrefix=self.aliasPrefix,
                                 locale=self.locale,
-                                mangler=self.mangler).compiledQuery(count=count,
+                                mangler=self.mangler,
+                                query_kw=self.query_kw,
+                                mainquery_kw=self.mainquery_kw).compiledQuery(count=count,
                                                                   relationDict=self.relationDict,
                                                                   **self.querypars)
 

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -93,7 +93,6 @@ class SqlCompiledQuery(object):
         self.pyColumns = []
         self.maintable_as = maintable_as
         self.tpl = None
-        self._identity_hash = None
 
     def get_sqltext(self, db):
         """Compile the sql query string based on current query parameters and the specific db
@@ -110,8 +109,15 @@ class SqlCompiledQuery(object):
             result = self.tpl % result
         return result
 
+class SqlCompiledSubQuery(SqlCompiledQuery):
+    """A compiled subquery with identity support for merge."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._identity_hash = None
+
     def __eq__(self, other):
-        if not isinstance(other, SqlCompiledQuery):
+        if not isinstance(other, SqlCompiledSubQuery):
             return NotImplemented
         return self._identity_hash is not None and self._identity_hash == other._identity_hash
 
@@ -374,7 +380,7 @@ class SqlQueryCompiler(object):
             mangler=mangler_prefix,
             **sq_pars
         )
-        compiled = q.compileQuery()
+        compiled = q.compileQuery(compiled_class=SqlCompiledSubQuery)
         compiled.tpl = tpl
 
         # 5. Build identity hash for CTE merge: resolve params in WHERE to get
@@ -633,7 +639,8 @@ class SqlQueryCompiler(object):
                       storename=None,subtable=None,
                       count=False, excludeLogicalDeleted=True,excludeDraft=True,
                       ignorePartition=False,ignoreTableOrderBy=False,
-                      addPkeyColumn=True):
+                      addPkeyColumn=True,
+                      compiled_class=None):
         """Prepare the SqlCompiledQuery to get the sql query for a selection.
 
         :param columns: it represents the :ref:`columns` to be returned by the "SELECT"
@@ -658,9 +665,12 @@ class SqlQueryCompiler(object):
         :param excludeLogicalDeleted: boolean. If ``True``, exclude from the query all the records that are
                                       "logical deleted"
         :param excludeDraft: TODO
-        :param addPkeyColumn: boolean. If ``True``, add a column with the pkey attribute"""
+        :param addPkeyColumn: boolean. If ``True``, add a column with the pkey attribute
+        :param compiled_class: optional factory class for the compiled query object.
+                               Defaults to ``SqlCompiledQuery``."""
         # get the SqlCompiledQuery: an object that mantains all the informations to build the sql text
-        self.cpl = SqlCompiledQuery(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0))
+        compiled_class = compiled_class or SqlCompiledQuery
+        self.cpl = compiled_class(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0))
         distinct = distinct or '' # distinct is a text to be inserted in the sql query string
 
         # aggregate: test if the result will aggregate db rows
@@ -1218,10 +1228,12 @@ class SqlQuery(object):
 
     compiled = property(_get_compiled)
 
-    def compileQuery(self, count=False):
+    def compileQuery(self, count=False, compiled_class=None):
         """Return the :meth:`compiledQuery() <SqlQueryCompiler.compiledQuery()>` method.
 
-        :param count: boolean. If ``True``, optimize the sql query to get the number of resulting rows (like count(*))"""
+        :param count: boolean. If ``True``, optimize the sql query to get the number of resulting rows (like count(*))
+        :param compiled_class: optional factory class for the compiled query object.
+                               Defaults to ``SqlCompiledQuery``."""
         return SqlQueryCompiler(self.dbtable.model,
                                 joinConditions=self.joinConditions,
                                 sqlContextName=self.sqlContextName,
@@ -1232,6 +1244,7 @@ class SqlQuery(object):
                                 query_kw=self.query_kw,
                                 mainquery_kw=self.mainquery_kw,
                                 query=self).compiledQuery(count=count,
+                                                                  compiled_class=compiled_class,
                                                                   relationDict=self.relationDict,
                                                                   **self.querypars)
 

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -92,6 +92,8 @@ class SqlCompiledQuery(object):
         self.aggregateDict = {}
         self.pyColumns = []
         self.maintable_as = maintable_as
+        self.tpl = None
+        self._identity_hash = None
 
     def get_sqltext(self, db):
         """Compile the sql query string based on current query parameters and the specific db
@@ -103,8 +105,20 @@ class SqlCompiledQuery(object):
         'maintable', 'distinct', 'columns', 'joins', 'where', 'group_by', 'having', 'order_by', 'limit', 'offset',
         'for_update'):
             kwargs[k] = getattr(self, k)
-        return db.adapter.compileSql(maintable_as=self.maintable_as,**kwargs)
+        result = db.adapter.compileSql(maintable_as=self.maintable_as,**kwargs)
+        if self.tpl:
+            result = self.tpl % result
+        return result
 
+    def __eq__(self, other):
+        if not isinstance(other, SqlCompiledQuery):
+            return NotImplemented
+        return self._identity_hash is not None and self._identity_hash == other._identity_hash
+
+    def __hash__(self):
+        if self._identity_hash is not None:
+            return self._identity_hash
+        return id(self)
 
 
 class SqlQueryCompiler(object):
@@ -121,9 +135,10 @@ class SqlQueryCompiler(object):
                            :meth:`setJoinCondition() <gnr.web.gnrwebpage.GnrWebPage.setJoinCondition>` method)
     :param sqlparams: a dict of parameters used in "WHERE" clause
     :param locale: the current locale (e.g: en, en_us, it)"""
-    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None, query_kw=None, mainquery_kw=None):
+    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None,aliasPrefix = None, mangler=None, query_kw=None, mainquery_kw=None, query=None):
         self.tblobj = tblobj
         self.db = tblobj.db
+        self.query = query
         self.dbmodel = tblobj.db.model
         if tblobj.db.reuse_relation_tree:
             self.relations = tblobj.relations
@@ -253,28 +268,36 @@ class SqlQueryCompiler(object):
 
                 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                # Virtual column dispatch based on subquery presence:
-                #   - A subquery exists only if select, exists, or select_ attributes are present
-                #   - sql_formula alone (str or True) without select/exists = pure formula
-                #   - sql_formula=True delegates to a Python method sql_formula_<fieldname>()
                 attr = dict(fldalias.attributes)
                 formula_kw = dictExtract(attr, 'var_')
                 multi_select = dictExtract(attr, 'select_')
-                has_subquery = fldalias.select or fldalias.exists or multi_select
-                if not has_subquery:
-                    # Pure formula: only $col and @rel.col references, resolved inline
-                    return self._handleFormulaColumn(fldalias, fld, curr_tblobj, alias, curr,
-                                                      attr, formula_kw)
-                elif not multi_select:
-                    # Single subquery (select or exists), with or without a wrapping sql_formula
-                    return self._handleSubQuery(fldalias, fld, curr_tblobj, alias, curr,
-                                                      expandThis, expandEnv, expandPref,
-                                                      attr, formula_kw)
+                sql_formula = fldalias.sql_formula
+                if sql_formula is True:
+                    sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
+                select_dict = dict(multi_select) if multi_select else {}
+                if not sql_formula:
+                    select_dict['default'] = fldalias.select or fldalias.exists
+                if not select_dict:
+                    return self._handleFormulaColumn(fldalias, alias, curr,
+                                                      sql_formula, formula_kw)
+                elif len(select_dict) == 1:
+                    sq_select = select_dict['default']
+                    if isinstance(sq_select, str):
+                        sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
+                    sq_pars = dict(sq_select)
+                    cast = sq_pars.pop('cast', None)
+                    if fldalias.exists:
+                        tpl = ' EXISTS( %s ) '
+                    elif cast:
+                        tpl = ' CAST( ( %s ) AS ' + cast + ') '
+                    else:
+                        tpl = ' ( %s ) '
+                    compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
+                    return tpl % compiled.get_sqltext(self.db)
                 else:
-                    # Multiple subqueries (select_ prefix in attributes)
-                    return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
+                    return self._handleFormulaColumn_legacy(fldalias, alias, curr,
                                                       expandThis, expandEnv, expandPref,
-                                                      attr, formula_kw, multi_select)
+                                                      sql_formula, formula_kw, select_dict)
             elif fldalias.py_method:
                 #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
                 self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
@@ -284,39 +307,13 @@ class SqlQueryCompiler(object):
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
 
-    def _handleFormulaColumn(self, fldalias, fld, curr_tblobj, alias, curr, attr, formula_kw):
+    def _handleFormulaColumn(self, fldalias, alias, curr, sql_formula, formula_kw):
         """Handle pure formula columns with no subquery.
 
-        Translates a sql_formula string containing $col and @rel.col placeholders
-        into valid SQL by resolving each reference to its table alias (e.g. t0.col, t3.col).
-
-        The sql_formula can be either:
-            - A string (e.g. ``"UPPER($title)"`` or ``"$role || ' in ' || @movie_id.title"``).
-            - The boolean ``True``, meaning the formula is defined as a Python method
-              ``sql_formula_<fieldname>(attributes)`` on the table object.
-
-        Resolution is done in two passes via regex substitution:
-            1. RELFINDER resolves ``@relation.column`` references (e.g. ``@movie_id.title`` -> ``t3.title``).
-            2. COLFINDER resolves ``$column`` references (e.g. ``$title`` -> ``t0.title``).
-
-        Both regexes capture a leading non-word character in group(1) and the field path
-        in group(2). The callback delegates to ``getFieldAlias`` which handles join registration.
-
         Args:
-            fldalias: The virtual column definition node from the model.
-            fld: The field name (e.g. ``'title_upper'``).
-            curr_tblobj: The current table object in the model.
-            alias: The SQL table alias for the current table (e.g. ``'t0'``).
-            curr: The current table model node.
-            attr: Pre-extracted dict of fldalias.attributes.
+            sql_formula: The resolved SQL formula string.
             formula_kw: Pre-extracted var_ parameters (dict), for :placeholder resolution.
-
-        Returns:
-            A parenthesized SQL expression string (e.g. ``'( UPPER(t0.title) )'``).
         """
-        sql_formula = fldalias.sql_formula
-        if sql_formula is True:
-            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
         def resolveField(m):
             return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
         sql_formula = RELFINDER.sub(resolveField, sql_formula)
@@ -331,25 +328,65 @@ class SqlQueryCompiler(object):
                                      sql_formula)
         return f'( {sql_formula} )'
 
-    def _handleSubQuery(self, fldalias, fld, curr_tblobj, alias, curr, expandThis, expandEnv, expandPref,
-                        attr, formula_kw):
-        """Handle a single subquery column (select or exists), with or without a wrapping sql_formula.
-        When sql_formula is absent, it defaults to '#default' (or 'EXISTS(#default)').
-        Subquery parameters live inside the select dict and are resolved by queryCompile."""
-        return self._handleFormulaColumn_legacy(fldalias, fld, curr_tblobj, alias, curr,
-                                          expandThis, expandEnv, expandPref,
-                                          attr, formula_kw)
+    def _compiledSubQuery(self, alias, expandThis, sq_pars, tpl=None):
+        """Compile a subquery column (select or exists) into SQL text.
 
-    def _handleFormulaColumn_legacy(self, fldalias, fld, curr_tblobj, alias, curr,
+        Builds and compiles an independent SqlQuery with a mangler prefix,
+        so that subquery parameters (e.g. ``avail='yes'``) are namespaced
+        into the main query's sqlparams without collisions.
+        The compiled SQL is wrapped with the given template (e.g. for CAST).
+
+        Args:
+            alias: The SQL table alias for the current table (e.g. ``'t0'``).
+            expandThis: Callback to replace ``#THIS.col`` with ``alias.col``.
+            sq_pars: The subquery parameters dict (table, where, columns, plus
+                     any extra params like avail='yes'). Already without 'cast'.
+            tpl: SQL template to wrap the subquery (e.g. ``' ( %s ) '`` or
+                 ``' CAST( ( %s ) AS integer) '``).
+
+        Returns:
+            str: the compiled subquery SQL text, wrapped with the template.
+        """
+        # 1. Extract table and where; remaining items are subquery parameters
+        sq_table = sq_pars.pop('table')
+        sq_where = sq_pars.pop('where')
+        sq_pars.setdefault('ignorePartition', True)
+        sq_pars.setdefault('excludeDraft', False)
+        sq_pars.setdefault('excludeLogicalDeleted', False)
+        sq_pars.setdefault('subtable', '*')
+        aliasPrefix = '%s_t' % alias
+
+        # 3. Expand #THIS in the subquery WHERE
+        sq_where = THISFINDER.sub(expandThis, sq_where)
+
+        # 4. Compile the subquery with a mangler for parameter namespacing
+        mangler_prefix = self.query._next_mangler_key('sq')
+        q = self.db.table(sq_table).query(
+            where=sq_where,
+            aliasPrefix=aliasPrefix,
+            addPkeyColumn=False,
+            ignoreTableOrderBy=True,
+            mangler=mangler_prefix,
+            **sq_pars
+        )
+        compiled = q.compileQuery()
+        compiled.tpl = tpl
+
+        # 5. Build identity hash for CTE merge: resolve params in WHERE to get
+        #    a mangler-independent fingerprint
+        resolved_where = compiled.where or ''
+        for k, v in q.sqlparams.items():
+            resolved_where = resolved_where.replace(':%s' % k, str(v))
+        compiled._identity_hash = hash((compiled.maintable, resolved_where))
+
+        # 6. Merge mangled subquery params into main query params
+        self.sqlparams.update(q.sqlparams)
+
+        return compiled
+
+    def _handleFormulaColumn_legacy(self, fldalias, alias, curr,
                               expandThis, expandEnv, expandPref,
-                              attr, formula_kw, multi_select=None):
-        sql_formula = fldalias.sql_formula
-        if sql_formula is True:
-            sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
-        select_dict = multi_select or {}
-        if not sql_formula:
-            sql_formula = '#default' if fldalias.select else 'EXISTS(#default)'
-            select_dict['default'] = fldalias.select or fldalias.exists
+                              sql_formula, formula_kw, select_dict):
         for susbselect,sq_pars in list(select_dict.items()):
             if isinstance(sq_pars, str):
                 sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
@@ -1227,7 +1264,8 @@ class SqlQuery(object):
                                 locale=self.locale,
                                 mangler=self.mangler,
                                 query_kw=self.query_kw,
-                                mainquery_kw=self.mainquery_kw).compiledQuery(count=count,
+                                mainquery_kw=self.mainquery_kw,
+                                query=self).compiledQuery(count=count,
                                                                   relationDict=self.relationDict,
                                                                   **self.querypars)
 
@@ -1469,22 +1507,23 @@ class SqlQuery(object):
             cursor.close()
         return n
 
-    def _next_compound_key(self):
+    def _next_mangler_key(self, prefix):
         env = self.db.currentEnv
-        idx = env.get('_compound_counter', 0)
-        env['_compound_counter'] = idx + 1
-        return 'q%d' % idx
+        counters = env.setdefault('_mangler_counters', {})
+        idx = counters.get(prefix, 0)
+        counters[prefix] = idx + 1
+        return '%s%d' % (prefix, idx)
 
     def _compound(self, other, operator):
         if isinstance(other, SqlCompoundQuery):
-            self_key = self._next_compound_key()
+            self_key = self._next_mangler_key('cq')
             self.mangler = self_key
             queries = dict(other.queries)
             queries[self_key] = self
             template = '{%s} %s SELECT * FROM (%s) AS _cr' % (self_key, operator, other._template)
         else:
-            self_key = self._next_compound_key()
-            other_key = other._next_compound_key()
+            self_key = self._next_mangler_key('cq')
+            other_key = other._next_mangler_key('cq')
             self.mangler = self_key
             other.mangler = other_key
             queries = {self_key: self, other_key: other}
@@ -1537,7 +1576,7 @@ class SqlCompoundQuery(SqlQuery):
             queries.update(other.queries)
             template = 'SELECT * FROM (%s) AS _cl %s SELECT * FROM (%s) AS _cr' % (self._template, operator, other._template)
         else:
-            key = other._next_compound_key()
+            key = other._next_mangler_key('cq')
             other.mangler = key
             queries[key] = other
             template = '%s %s {%s}' % (self._template, operator, key)

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -269,24 +269,24 @@ class SqlQueryCompiler(object):
                 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
                 attr = dict(fldalias.attributes)
+                multi_select = self._preprocess_subqueryes(attr)
                 formula_kw = dictExtract(attr, 'var_')
-                multi_select = dictExtract(attr, 'select_')
                 sql_formula = fldalias.sql_formula
                 if sql_formula is True:
                     sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
-                select_dict = dict(multi_select) if multi_select else {}
                 if not sql_formula:
-                    select_dict['default'] = fldalias.select or fldalias.exists
-                if not select_dict:
-                    return self._handleFormulaColumn_plain(fldalias, alias, curr,
-                                                      sql_formula, formula_kw)
-                elif len(select_dict) == 1:
-                    return self._handleFormulaColumn_oneQuery(fldalias, alias, expandThis,
-                                                      select_dict)
+                    sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select) if multi_select else None
                 else:
-                    return self._handleFormulaColumn_legacy(fldalias, alias, curr,
-                                                      expandThis, expandEnv, expandPref,
-                                                      sql_formula, formula_kw, select_dict)
+                    sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
+                select_dict = dict(multi_select) if multi_select else {}
+                if select_dict:
+                    for sq_name, sq_select in list(select_dict.items()):
+                        if isinstance(sq_select, str):
+                            sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
+                        sq_pars = dict(sq_select)
+                        compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
+                        sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
+                return f'( {sql_formula} )'
             elif fldalias.py_method:
                 #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
                 self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
@@ -296,28 +296,16 @@ class SqlQueryCompiler(object):
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
 
-    def _handleFormulaColumn_oneQuery(self, fldalias, alias, expandThis, select_dict):
-        sq_select = select_dict['default']
-        if isinstance(sq_select, str):
-            sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
-        sq_pars = dict(sq_select)
-        cast = sq_pars.pop('cast', None)
-        if fldalias.exists:
-            tpl = ' EXISTS( %s ) '
-        elif cast:
-            tpl = ' CAST( ( %s ) AS ' + cast + ') '
-        else:
-            tpl = ' ( %s ) '
-        compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
-        return tpl % compiled.get_sqltext(self.db)
+    def _preprocess_subqueryes(self, attr):
+        if 'exists' in attr:
+            exists_sq = attr.pop('exists')
+            exists_sq['exists'] = True
+            attr['select_default'] = exists_sq
+        elif 'select' in attr:
+            attr['select_default'] = attr.pop('select')
+        return dictExtract(attr, 'select_')
 
-    def _handleFormulaColumn_plain(self, fldalias, alias, curr, sql_formula, formula_kw):
-        """Handle pure formula columns with no subquery.
-
-        Args:
-            sql_formula: The resolved SQL formula string.
-            formula_kw: Pre-extracted var_ parameters (dict), for :placeholder resolution.
-        """
+    def _preprocessFormula(self, fldalias, alias, curr, sql_formula, formula_kw):
         def resolveField(m):
             return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
         sql_formula = RELFINDER.sub(resolveField, sql_formula)
@@ -330,9 +318,9 @@ class SqlQueryCompiler(object):
                 sql_formula = re.sub(r"(:)(%s)(\W|$)" % k,
                                      lambda m, mk=mangled_k: f'{m.group(1)}{mk}{m.group(3)}',
                                      sql_formula)
-        return f'( {sql_formula} )'
+        return sql_formula
 
-    def _compiledSubQuery(self, alias, expandThis, sq_pars, tpl=None):
+    def _compiledSubQuery(self, alias, expandThis, sq_pars):
         """Compile a subquery column (select or exists) into SQL text.
 
         Builds and compiles an independent SqlQuery with a mangler prefix,
@@ -351,7 +339,17 @@ class SqlQueryCompiler(object):
         Returns:
             str: the compiled subquery SQL text, wrapped with the template.
         """
-        # 1. Extract table and where; remaining items are subquery parameters
+        # 1. Extract template parameters and table/where
+        tpl = sq_pars.pop('tpl', None)
+        cast = sq_pars.pop('cast', None)
+        is_exists = sq_pars.pop('exists', False)
+        if not tpl:
+            if is_exists:
+                tpl = ' EXISTS( %s ) '
+            elif cast:
+                tpl = ' CAST( ( %s ) AS ' + cast + ') '
+            else:
+                tpl = ' ( %s ) '
         sq_table = sq_pars.pop('table')
         sq_where = sq_pars.pop('where')
         sq_pars.setdefault('ignorePartition', True)
@@ -387,45 +385,6 @@ class SqlQueryCompiler(object):
         self.sqlparams.update(q.sqlparams)
 
         return compiled
-
-    def _handleFormulaColumn_legacy(self, fldalias, alias, curr,
-                              expandThis, expandEnv, expandPref,
-                              sql_formula, formula_kw, select_dict):
-        for susbselect,sq_pars in list(select_dict.items()):
-            if isinstance(sq_pars, str):
-                sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
-            sq_pars = dict(sq_pars)
-            cast = sq_pars.pop('cast',None)
-            tpl = ' CAST( ( %s ) AS ' +cast +') ' if cast else ' ( %s ) '
-            sq_table = sq_pars.pop('table')
-            sq_where = sq_pars.pop('where')
-            sq_pars.setdefault('ignorePartition',True)
-            sq_pars.setdefault('excludeDraft',False)
-            sq_pars.setdefault('excludeLogicalDeleted',False)
-            sq_pars.setdefault('subtable','*')
-            aliasPrefix = '%s_t' %alias
-            sq_where = THISFINDER.sub(expandThis,sq_where)
-            sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
-            sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
-        subreldict = {}
-        sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
-        sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
-        sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
-        sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
-        sql_formula = PREFFINDER.sub(expandPref, sql_formula)
-        sql_formula = THISFINDER.sub(expandThis,sql_formula)
-        if formula_kw:
-            prefix = str(id(fldalias))
-            currentEnv = self.db.currentEnv
-            for k,v in list(formula_kw.items()):
-                newk = f'{prefix}_{self._currColKey}_{k}'
-                currentEnv[newk] = v
-                sql_formula = re.sub("(:)(%s)(\\W|$)" %k,lambda m: '%senv_%s%s'%(m.group(1),newk,m.group(3)), sql_formula)
-        subColPars = {}
-        for key, value in list(subreldict.items()):
-            subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
-        sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
-        return f'( {sql_formula} )'
 
     def _findRelationAlias(self, pathlist, curr, basealias, newpath, parent=None):
         """Internal method: called by getFieldAlias to get the alias (t1, t2...) for the join table.

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -134,10 +134,40 @@ def configurePackage(pkg):
     movie.formulaColumn('dvd_count', select=dict(
         columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
     ), dtype='L')
+    movie.formulaColumn('dvd_count_coalesce', sql_formula='COALESCE(#default, 0)',
+        select=dict(
+        columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
+    ), dtype='L')
     movie.formulaColumn('dvd_count_available', select=dict(
         columns='COUNT(*)', table='video.dvd',
         where='$movie_id=#THIS.id AND $available=:avail', avail='yes'
     ), dtype='L')
+    movie.formulaColumn('has_dvd', exists=dict(
+        table='video.dvd', where='$movie_id=#THIS.id'
+    ))
+    movie.formulaColumn('has_dvd_label', sql_formula="CASE WHEN #default THEN 'YES' ELSE 'NO' END",
+        exists=dict(
+        table='video.dvd', where='$movie_id=#THIS.id'
+    ))
+    movie.formulaColumn('has_dvd_after_2006', sql_formula="CASE WHEN #default THEN 'YES' ELSE 'NO' END",
+        exists=dict(
+        table='video.dvd', where="$movie_id=#THIS.id AND $purchasedate > :cutoff",
+        cutoff='2006-01-01'
+    ))
+    movie.formulaColumn('dvd_count_cast', select=dict(
+        columns='COUNT(*)', table='video.dvd',
+        where='$movie_id=#THIS.id', cast='integer'
+    ), dtype='L')
+    movie.formulaColumn('dvd_stats', sql_formula='#total || :sep || #available',
+        var_sep='/',
+        select_total=dict(
+            columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
+        ),
+        select_available=dict(
+            columns='COUNT(*)', table='video.dvd',
+            where='$movie_id=#THIS.id AND $available=:avail', avail='yes'
+        )
+    )
 
     dvd = pkg.table('dvd', name_short='Dvd', name_long='Dvd', pkey='code')
     dvd.column('code', 'L')

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -134,6 +134,10 @@ def configurePackage(pkg):
     movie.formulaColumn('dvd_count', select=dict(
         columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
     ), dtype='L')
+    movie.formulaColumn('dvd_count_available', select=dict(
+        columns='COUNT(*)', table='video.dvd',
+        where='$movie_id=#THIS.id AND $available=:avail', avail='yes'
+    ), dtype='L')
 
     dvd = pkg.table('dvd', name_short='Dvd', name_long='Dvd', pkey='code')
     dvd.column('code', 'L')

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import os.path
+import subprocess
 import pytest
 from testing.postgresql import Postgresql
 
@@ -72,6 +73,8 @@ class BaseGnrSqlTest:
                                password=os.environ.get("GNR_TEST_PG_PASSWORD"))
             cls.mysql_conf = None
         else:
+            # cleanup stale postgres temp instances from previous interrupted runs
+            subprocess.run(['pkill', '-f', 'postgres.*tmp'], capture_output=True)
             cls.pg_instance = Postgresql()
             cls.pg_conf = cls.pg_instance.dsn()
             cls.mysql_conf = dict(host="localhost",

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -113,6 +113,9 @@ def configurePackage(pkg):
                 name_long='Person id').relation('people.id')
     cast.column('role', name_short='Rl.', name_long='Role')
     cast.column('prizes', name_short='Priz.', name_long='Prizes', size='40')
+    cast.formulaColumn('movie_year', sql_formula='@movie_id.year')
+    cast.formulaColumn('role_in_movie', sql_formula="$role || ' in ' || @movie_id.title")
+    cast.aliasColumn('movie_title', relation_path='@movie_id.title')
 
     movie = pkg.table('movie', name_short='Mv', name_long='Movie',
                       rowcaption='title', pkey='id')
@@ -124,6 +127,13 @@ def configurePackage(pkg):
     movie.column('year', 'L', name_short='Yr', name_long='Year', indexed='y')
     movie.column('nationality', name_short='Ntl', name_long='Nationality')
     movie.column('description', name_short='Dsc', name_long='Movie description')
+
+    movie.formulaColumn('title_upper', sql_formula='UPPER($title)')
+    movie.formulaColumn('title_year', sql_formula="$title || ' (' || $year || ')'")
+    movie.formulaColumn('title_with_label', sql_formula="$title || :label", var_label=' [DVD]')
+    movie.formulaColumn('dvd_count', select=dict(
+        columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
+    ), dtype='L')
 
     dvd = pkg.table('dvd', name_short='Dvd', name_long='Dvd', pkey='code')
     dvd.column('code', 'L')

--- a/gnrpy/tests/sql/data/dbstructure_final.xml
+++ b/gnrpy/tests/sql/data/dbstructure_final.xml
@@ -12,13 +12,19 @@
 <subtables tag="subtable_list"><first_movie _T="BAG" condition="$movie_id=1" tag="subtable"></first_movie>
 <second_movie _T="BAG" condition="$movie_id=2" tag="subtable"></second_movie></subtables>
 <virtual_columns tag="virtual_columns_list"><subtable_first_movie _T="BAG" sql_formula="$movie_id=1" virtual_column="y" dtype="B" name_long="first_movie" group="subtables" _addClass="subtable_first_movie" tag="virtual_column"></subtable_first_movie>
-<subtable_second_movie _T="BAG" sql_formula="$movie_id=2" virtual_column="y" dtype="B" name_long="second_movie" group="subtables" _addClass="subtable_second_movie" tag="virtual_column"></subtable_second_movie></virtual_columns></cast>
+<subtable_second_movie _T="BAG" sql_formula="$movie_id=2" virtual_column="y" dtype="B" name_long="second_movie" group="subtables" _addClass="subtable_second_movie" tag="virtual_column"></subtable_second_movie>
+<movie_year _T="BAG" sql_formula="@movie_id.year" virtual_column="y" dtype="A" tag="virtual_column"></movie_year>
+<role_in_movie _T="BAG" sql_formula="$role || ' in ' || @movie_id.title" virtual_column="y" dtype="A" tag="virtual_column"></role_in_movie>
+<movie_title _T="BAG" relation_path="@movie_id.title" virtual_column="y" tag="virtual_column"></movie_title></virtual_columns></cast>
 <movie name_short="Mv" name_long="Movie" pkey="id" rowcaption="title" pkg="video" fullname="video.movie" tag="table"><columns tag="column_list"><id _T="BAG" dtype="L" tag="column"></id>
 <title _T="BAG" name_short="Ttl." name_long="Title" validate_case="capitalize" validate_len="3:40" tag="column"></title>
 <genre _T="BAG" name_short="Gnr" name_long="Genre" indexed="y" validate_case="upper" validate_len="3:10" tag="column"></genre>
 <year _T="BAG" dtype="L" name_short="Yr" name_long="Year" indexed="y" tag="column"></year>
 <nationality _T="BAG" name_short="Ntl" name_long="Nationality" tag="column"></nationality>
-<description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description></columns></movie>
+<description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description></columns>
+<virtual_columns tag="virtual_columns_list"><title_upper _T="BAG" sql_formula="UPPER($title)" virtual_column="y" dtype="A" tag="virtual_column"></title_upper>
+<title_year _T="BAG" sql_formula="$title || ' (' || $year || ')'" virtual_column="y" dtype="A" tag="virtual_column"></title_year>
+<dvd_count _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count></virtual_columns></movie>
 <dvd name_short="Dvd" name_long="Dvd" pkey="code" pkg="video" fullname="video.dvd" tag="table"><columns tag="column_list"><code _T="BAG" dtype="L" tag="column"></code>
 <movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column"><relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation></movie_id>
 <purchasedate _T="BAG" dtype="D" name_short="Pdt" name_long="Purchase date" tag="column"></purchasedate>

--- a/gnrpy/tests/sql/data/dbstructure_final.xml
+++ b/gnrpy/tests/sql/data/dbstructure_final.xml
@@ -24,7 +24,9 @@
 <description _T="BAG" name_short="Dsc" name_long="Movie description" tag="column"></description></columns>
 <virtual_columns tag="virtual_columns_list"><title_upper _T="BAG" sql_formula="UPPER($title)" virtual_column="y" dtype="A" tag="virtual_column"></title_upper>
 <title_year _T="BAG" sql_formula="$title || ' (' || $year || ')'" virtual_column="y" dtype="A" tag="virtual_column"></title_year>
-<dvd_count _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count></virtual_columns></movie>
+<title_with_label _T="BAG" sql_formula="$title || :label" virtual_column="y" dtype="A" var_label=" [DVD]" tag="virtual_column"></title_with_label>
+<dvd_count _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count>
+<dvd_count_available _T="BAG" select='{"columns": "COUNT(*)", "table": "video.dvd", "where": "$movie_id=#THIS.id AND $available=:avail", "avail": "yes"}' virtual_column="y" dtype="L" tag="virtual_column"></dvd_count_available></virtual_columns></movie>
 <dvd name_short="Dvd" name_long="Dvd" pkey="code" pkg="video" fullname="video.dvd" tag="table"><columns tag="column_list"><code _T="BAG" dtype="L" tag="column"></code>
 <movie_id dtype="L" name_short="Mid" name_long="Movie id" tag="column"><relation _T="BAG" related_column="movie.id" mode="relation" onUpdate_sql="cascade"></relation></movie_id>
 <purchasedate _T="BAG" dtype="D" name_short="Pdt" name_long="Purchase date" tag="column"></purchasedate>

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -34,7 +34,7 @@ hdlr = logging.FileHandler('logs.log')
 gnrlogger.addHandler(hdlr)
 
 from gnr.sql.gnrsql import GnrSqlDb
-from gnr.sql.gnrsqldata import SqlQuery, SqlSelection, SqlCompiledQuery
+from gnr.sql.gnrsqldata import SqlQuery, SqlSelection, SqlCompiledQuery, SqlCompiledSubQuery
 from gnr.sql import gnrsqldata as gsd
 
 from .common import BaseGnrSqlTest, configurePackage
@@ -580,60 +580,60 @@ class BaseSql(BaseGnrSqlTest):
         assert counts == sorted(counts, reverse=True)
         assert counts[0] == 3
 
-    # --- SqlCompiledQuery __eq__ / __hash__ / _identity_hash tests ---
+    # --- SqlCompiledSubQuery __eq__ / __hash__ / _identity_hash tests ---
 
     def test_compiled_eq_same_identity_hash(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a._identity_hash = hash(('video_movie', 'some_where'))
         b._identity_hash = hash(('video_movie', 'some_where'))
         assert a == b
 
     def test_compiled_eq_different_identity_hash(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a._identity_hash = hash(('video_movie', 'where_1'))
         b._identity_hash = hash(('video_movie', 'where_2'))
         assert a != b
 
     def test_compiled_eq_different_table(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_dvd')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_dvd')
         a._identity_hash = hash(('video_movie', 'w'))
         b._identity_hash = hash(('video_dvd', 'w'))
         assert a != b
 
     def test_compiled_eq_none_identity_hash(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         # entrambi hanno _identity_hash=None (default)
         assert a != b
 
     def test_compiled_eq_one_none(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a._identity_hash = hash(('video_movie', 'w'))
         # b._identity_hash resta None
         assert a != b
 
     def test_compiled_eq_not_implemented(self):
-        a = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
         a._identity_hash = 42
         assert a.__eq__("not a compiled") is NotImplemented
 
     def test_compiled_hash_with_identity(self):
-        a = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
         h = hash(('video_movie', 'w'))
         a._identity_hash = h
         assert hash(a) == h
 
     def test_compiled_hash_without_identity(self):
-        a = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
         assert hash(a) == id(a)
 
     def test_compiled_in_set(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         h = hash(('video_movie', 'same_where'))
         a._identity_hash = h
         b._identity_hash = h
@@ -641,8 +641,8 @@ class BaseSql(BaseGnrSqlTest):
         assert len(s) == 1
 
     def test_compiled_as_dict_key(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         h = hash(('video_movie', 'same_where'))
         a._identity_hash = h
         b._identity_hash = h
@@ -650,8 +650,8 @@ class BaseSql(BaseGnrSqlTest):
         assert d[b] == 'value_a'
 
     def test_compiled_different_in_set(self):
-        a = SqlCompiledQuery('video_movie')
-        b = SqlCompiledQuery('video_movie')
+        a = SqlCompiledSubQuery('video_movie')
+        b = SqlCompiledSubQuery('video_movie')
         a._identity_hash = hash(('video_movie', 'w1'))
         b._identity_hash = hash(('video_movie', 'w2'))
         s = {a, b}
@@ -675,10 +675,11 @@ class BaseSql(BaseGnrSqlTest):
         assert compiled.tpl is None
 
     def test_compiled_identity_hash_none_for_main_query(self):
-        """Le query principali non hanno _identity_hash (è per le subquery)"""
+        """Main queries produce SqlCompiledQuery, not SqlCompiledSubQuery"""
         q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
         compiled = q.compileQuery()
-        assert compiled._identity_hash is None
+        assert not isinstance(compiled, SqlCompiledSubQuery)
+        assert not hasattr(compiled, '_identity_hash')
 
     # --- get_sqltext template handling ---
 

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -438,11 +438,71 @@ class BaseSql(BaseGnrSqlTest):
                               where='$id = :id', id=0).fetch()
         assert result[0]['dvd_count'] == 3
 
+    def test_formulaColumn_with_subquery_and_formula(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_coalesce',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count_coalesce'] == 3
+
     def test_formulaColumn_subquery_no_match(self):
         result = self.db.query('video.movie',
                               columns='$title,$dvd_count',
                               where='$id = :id', id=3).fetch()
         assert result[0]['dvd_count'] == 0
+
+    def test_formulaColumn_exists(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$has_dvd',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['has_dvd'] == True
+
+    def test_formulaColumn_exists_false(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$has_dvd',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['has_dvd'] == False
+
+    def test_formulaColumn_exists_with_formula(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$has_dvd_label',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['has_dvd_label'] == 'YES'
+
+    def test_formulaColumn_exists_with_formula_false(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$has_dvd_label',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['has_dvd_label'] == 'NO'
+
+    def test_formulaColumn_exists_with_params_true(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$has_dvd_after_2006',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['has_dvd_after_2006'] == 'YES'
+
+    def test_formulaColumn_exists_with_params_false(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$has_dvd_after_2006',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['has_dvd_after_2006'] == 'NO'
+
+    def test_formulaColumn_subquery_with_cast(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_cast',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count_cast'] == 3
+
+    def test_formulaColumn_multi_select(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_stats',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_stats'] == '3/3'
+
+    def test_formulaColumn_multi_select_partial(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_stats',
+                              where='$id = :id', id=1).fetch()
+        assert result[0]['dvd_stats'] == '2/0'
 
     def test_formulaColumn_mixed(self):
         result = self.db.query('video.movie',

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -414,6 +414,99 @@ class BaseSql(BaseGnrSqlTest):
         titles = sorted([r['title'] for r in result])
         assert titles == ['Match point', 'Munich']
 
+    def test_formulaColumn_pure(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$title_upper',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_upper'] == 'MATCH POINT'
+
+    def test_formulaColumn_pure_relation(self):
+        result = self.db.query('video.cast',
+                              columns='$movie_year,$role',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['movie_year'] == 2005
+
+    def test_aliasColumn(self):
+        result = self.db.query('video.cast',
+                              columns='$movie_title,$role',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['movie_title'] == 'Match point'
+
+    def test_formulaColumn_with_subquery(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count'] == 3
+
+    def test_formulaColumn_subquery_no_match(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['dvd_count'] == 0
+
+    def test_formulaColumn_mixed(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$title_upper,$dvd_count',
+                              where='$id = :id', id=1).fetch()
+        assert result[0]['title_upper'] == 'SCOOP'
+        assert result[0]['dvd_count'] == 2
+
+    def test_formulaColumn_multi_col(self):
+        result = self.db.query('video.movie',
+                              columns='$title_year',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_year'] == 'Match point (2005)'
+
+    def test_formulaColumn_col_and_rel(self):
+        result = self.db.query('video.cast',
+                              columns='$role_in_movie',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['role_in_movie'] == 'director in Match point'
+
+    def test_aliasColumn_in_where(self):
+        result = self.db.query('video.cast',
+                              columns='$movie_title,$role',
+                              where='$movie_title = :title',
+                              title='Match point').fetch()
+        assert len(result) == 3
+        assert all(r['movie_title'] == 'Match point' for r in result)
+
+    def test_formulaColumn_with_var(self):
+        result = self.db.query('video.movie',
+                              columns='$title_with_label',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_with_label'] == 'Match point [DVD]'
+
+    def test_formulaColumn_with_var_via_relation(self):
+        result = self.db.query('video.cast',
+                              columns='@movie_id.title_with_label,$role',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['_movie_id_title_with_label'] == 'Match point [DVD]'
+
+    def test_formulaColumn_with_var_multiple_rows(self):
+        result = self.db.query('video.cast',
+                              columns='@movie_id.title_with_label,$role',
+                              where='$movie_id = :mid', mid=0).fetch()
+        assert len(result) == 3
+        assert all(r['_movie_id_title_with_label'] == 'Match point [DVD]' for r in result)
+
+    def test_formulaColumn_with_var_and_other_formulas(self):
+        result = self.db.query('video.movie',
+                              columns='$title_with_label,$title_upper,$dvd_count',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_with_label'] == 'Match point [DVD]'
+        assert result[0]['title_upper'] == 'MATCH POINT'
+        assert result[0]['dvd_count'] == 3
+
+    def test_formulaColumn_subquery_order_by(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              order_by='$dvd_count DESC',
+                              limit=3).fetch()
+        counts = [r['dvd_count'] for r in result]
+        assert counts == sorted(counts, reverse=True)
+        assert counts[0] == 3
+
     def teardown_class(cls):
         cls.db.closeConnection()
         cls.db.dropDb(cls.dbname)

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -34,7 +34,7 @@ hdlr = logging.FileHandler('logs.log')
 gnrlogger.addHandler(hdlr)
 
 from gnr.sql.gnrsql import GnrSqlDb
-from gnr.sql.gnrsqldata import SqlQuery, SqlSelection
+from gnr.sql.gnrsqldata import SqlQuery, SqlSelection, SqlCompiledQuery
 from gnr.sql import gnrsqldata as gsd
 
 from .common import BaseGnrSqlTest, configurePackage
@@ -349,16 +349,16 @@ class BaseSql(BaseGnrSqlTest):
         assert query.count() == 2
 
     def test_compound_union_sqltext(self):
-        self.db.currentEnv['_compound_counter'] = 0
+        self.db.currentEnv['_mangler_counters'] = {}
         q1 = self.db.query('video.movie', columns='$title', where='$year = :year', year=2005)
         q2 = self.db.query('video.movie', columns='$title', where='$year = :year', year=2006)
         compound = q1 + q2
         sqltext, sqlparams = compound.test()
         assert 'UNION' in sqltext
-        assert ':q0_year' in sqltext
-        assert ':q1_year' in sqltext
-        assert sqlparams['q0_year'] == 2005
-        assert sqlparams['q1_year'] == 2006
+        assert ':cq0_year' in sqltext
+        assert ':cq1_year' in sqltext
+        assert sqlparams['cq0_year'] == 2005
+        assert sqlparams['cq1_year'] == 2006
 
     def test_compound_union_fetch(self):
         q1 = self.db.query('video.movie', columns='$title', where='$year = :year', year=2005)
@@ -498,6 +498,19 @@ class BaseSql(BaseGnrSqlTest):
         assert result[0]['title_upper'] == 'MATCH POINT'
         assert result[0]['dvd_count'] == 3
 
+    def test_formulaColumn_subquery_with_params(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_available',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count_available'] == 3  # movie 0 has 3 dvds with available='yes'
+
+    def test_formulaColumn_subquery_params_and_count(self):
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count,$dvd_count_available',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count'] == 3
+        assert result[0]['dvd_count_available'] == 3
+
     def test_formulaColumn_subquery_order_by(self):
         result = self.db.query('video.movie',
                               columns='$title,$dvd_count',
@@ -506,6 +519,244 @@ class BaseSql(BaseGnrSqlTest):
         counts = [r['dvd_count'] for r in result]
         assert counts == sorted(counts, reverse=True)
         assert counts[0] == 3
+
+    # --- SqlCompiledQuery __eq__ / __hash__ / _identity_hash tests ---
+
+    def test_compiled_eq_same_identity_hash(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'some_where'))
+        b._identity_hash = hash(('video_movie', 'some_where'))
+        assert a == b
+
+    def test_compiled_eq_different_identity_hash(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'where_1'))
+        b._identity_hash = hash(('video_movie', 'where_2'))
+        assert a != b
+
+    def test_compiled_eq_different_table(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_dvd')
+        a._identity_hash = hash(('video_movie', 'w'))
+        b._identity_hash = hash(('video_dvd', 'w'))
+        assert a != b
+
+    def test_compiled_eq_none_identity_hash(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        # entrambi hanno _identity_hash=None (default)
+        assert a != b
+
+    def test_compiled_eq_one_none(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'w'))
+        # b._identity_hash resta None
+        assert a != b
+
+    def test_compiled_eq_not_implemented(self):
+        a = SqlCompiledQuery('video_movie')
+        a._identity_hash = 42
+        assert a.__eq__("not a compiled") is NotImplemented
+
+    def test_compiled_hash_with_identity(self):
+        a = SqlCompiledQuery('video_movie')
+        h = hash(('video_movie', 'w'))
+        a._identity_hash = h
+        assert hash(a) == h
+
+    def test_compiled_hash_without_identity(self):
+        a = SqlCompiledQuery('video_movie')
+        assert hash(a) == id(a)
+
+    def test_compiled_in_set(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        h = hash(('video_movie', 'same_where'))
+        a._identity_hash = h
+        b._identity_hash = h
+        s = {a, b}
+        assert len(s) == 1
+
+    def test_compiled_as_dict_key(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        h = hash(('video_movie', 'same_where'))
+        a._identity_hash = h
+        b._identity_hash = h
+        d = {a: 'value_a'}
+        assert d[b] == 'value_a'
+
+    def test_compiled_different_in_set(self):
+        a = SqlCompiledQuery('video_movie')
+        b = SqlCompiledQuery('video_movie')
+        a._identity_hash = hash(('video_movie', 'w1'))
+        b._identity_hash = hash(('video_movie', 'w2'))
+        s = {a, b}
+        assert len(s) == 2
+
+    # --- compileQuery produce SqlCompiledQuery ---
+
+    def test_compileQuery_returns_compiled_object(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert isinstance(compiled, SqlCompiledQuery)
+
+    def test_compiled_has_maintable(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert 'movie' in compiled.maintable
+
+    def test_compiled_tpl_none_by_default(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert compiled.tpl is None
+
+    def test_compiled_identity_hash_none_for_main_query(self):
+        """Le query principali non hanno _identity_hash (è per le subquery)"""
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        assert compiled._identity_hash is None
+
+    # --- get_sqltext template handling ---
+
+    def test_get_sqltext_without_tpl(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        sql = compiled.get_sqltext(self.db)
+        assert '%s' not in sql
+        assert 'SELECT' in sql.upper()
+
+    def test_get_sqltext_with_tpl(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        compiled.tpl = ' ( %s ) '
+        sql = compiled.get_sqltext(self.db)
+        assert sql.strip().startswith('(')
+        assert sql.strip().endswith(')')
+
+    def test_get_sqltext_cast_tpl(self):
+        q = self.db.query('video.movie', columns='$title', where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        compiled.tpl = ' CAST( ( %s ) AS integer) '
+        sql = compiled.get_sqltext(self.db)
+        assert 'CAST' in sql
+        assert 'integer' in sql
+
+    def test_get_sqltext_exists_tpl(self):
+        q = self.db.query('video.dvd', columns='$code', where='$movie_id = :mid', mid=0)
+        compiled = q.compileQuery()
+        compiled.tpl = ' EXISTS( %s ) '
+        sql = compiled.get_sqltext(self.db)
+        assert 'EXISTS' in sql
+
+    # --- Subquery tramite formulaColumn: risultati corretti ---
+
+    def test_subquery_dvd_count_all_movies(self):
+        """Verifica dvd_count sui film noti — la subquery funziona per ogni riga"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id <= :maxid', maxid=10,
+                              order_by='$id').fetch()
+        expected = {
+            'Match point': 3, 'Scoop': 2, 'Munich': 2,
+            'Saving private Ryan': 0, 'Eyes wide shut': 2,
+            'Barry Lindon': 2, 'Scarface': 1, 'The untouchables': 1,
+            'Psycho': 2, 'The Aviator': 1, 'The Departed': 1
+        }
+        for r in result:
+            assert r['dvd_count'] == expected[r['title']]
+
+    def test_subquery_with_params_all_movies(self):
+        """Verifica dvd_count_available — subquery con parametri extra (:avail)"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_available',
+                              order_by='$id').fetch()
+        for r in result:
+            assert isinstance(r['dvd_count_available'], int)
+
+    def test_subquery_params_preserved_in_sqlparams(self):
+        """I parametri della subquery devono essere nei sqlparams della query principale"""
+        q = self.db.query('video.movie',
+                         columns='$title,$dvd_count_available',
+                         where='$id = :id', id=0)
+        sqltext, sqlparams = q.test()
+        has_avail = any('avail' in k for k in sqlparams)
+        assert has_avail
+
+    def test_subquery_sqltext_contains_subselect(self):
+        """L'SQL generato deve contenere la subquery wrappata tra parentesi"""
+        q = self.db.query('video.movie',
+                         columns='$title,$dvd_count',
+                         where='$id = :id', id=0)
+        sqltext, sqlparams = q.test()
+        upper = sqltext.upper()
+        assert upper.count('SELECT') >= 2  # main query + subquery
+
+    def test_two_subqueries_in_same_query(self):
+        """Due formulaColumn con subquery nella stessa query"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count,$dvd_count_available',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count'] == 3
+        assert result[0]['dvd_count_available'] == 3
+
+    def test_subquery_zero_when_no_match(self):
+        """COUNT deve dare 0 quando non ci sono righe corrispondenti"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['dvd_count'] == 0
+        assert result[0]['title'] == 'Saving private Ryan'
+
+    def test_subquery_available_zero_when_no_match(self):
+        """dvd_count_available deve dare 0 quando nessun dvd è available"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_available',
+                              where='$id = :id', id=1).fetch()
+        # movie_id=1 (Scoop) ha 2 dvd ma entrambi available='no'
+        assert result[0]['dvd_count_available'] == 0
+
+    def test_subquery_mixed_with_formula_and_alias(self):
+        """Combinazione di formulaColumn pura, aliasColumn e subquery nella stessa query"""
+        result = self.db.query('video.movie',
+                              columns='$title,$title_upper,$dvd_count,$title_year',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['title_upper'] == 'MATCH POINT'
+        assert result[0]['dvd_count'] == 3
+        assert result[0]['title_year'] == 'Match point (2005)'
+
+    def test_subquery_with_order_by_subquery_column(self):
+        """ORDER BY su colonna subquery"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              order_by='$dvd_count DESC',
+                              limit=3).fetch()
+        counts = [r['dvd_count'] for r in result]
+        assert counts == sorted(counts, reverse=True)
+
+    def test_subquery_with_where_on_main(self):
+        """Subquery combinata con WHERE sulla tabella principale"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count',
+                              where='$genre = :genre',
+                              genre='DRAMA').fetch()
+        assert len(result) == 4
+        for r in result:
+            assert isinstance(r['dvd_count'], int)
+
+    def test_compiled_sqltext_stable(self):
+        """Due compilazioni identiche producono lo stesso SQL"""
+        q1 = self.db.query('video.movie', columns='$title,$dvd_count',
+                          where='$id = :id', id=0)
+        q2 = self.db.query('video.movie', columns='$title,$dvd_count',
+                          where='$id = :id', id=0)
+        sql1, _ = q1.test()
+        sql2, _ = q2.test()
+        # La struttura dell'SQL deve essere uguale (i mangler possono variare)
+        assert sql1.upper().count('SELECT') == sql2.upper().count('SELECT')
 
     def teardown_class(cls):
         cls.db.closeConnection()


### PR DESCRIPTION
## Summary

- Unified formula column dispatcher: normalize exists/select into select_default via `_preprocess_subqueryes`, preprocess formula, compile subqueries, inject into formula
- `_compiledSubQuery` pops tpl/cast/exists from the subquery dict and builds the local template autonomously
- Extracted `SqlCompiledSubQuery` subclass with identity_hash, __eq__, __hash__ (main queries stay as plain `SqlCompiledQuery`)
- `compileQuery`/`compiledQuery` accept `compiled_class` parameter for subquery factory
- Removed `_handleFormulaColumn_oneQuery` and `_handleFormulaColumn_legacy` (no longer needed)

## Test plan

- [x] 264 tests green (88 per adapter x 3 adapters)
- [x] New tests for exists, exists+formula, exists+formula+params, cast in dict, multi-select with select_total/select_available

Depends on #457