### PR TITLE
feat(sql): subquery-as-join transformation for formulaColumn

### DIFF
--- a/docs/development/orm_comparison_subquery.md
+++ b/docs/development/orm_comparison_subquery.md
@@ -1,0 +1,219 @@
+# Genropy vs Django vs SQLAlchemy: Subquery e Colonne Virtuali
+
+## Caso d'uso: Dashboard prodotti con analisi clienti
+
+Per ogni prodotto vogliamo mostrare:
+1. Il fatturato totale del prodotto
+2. Il nome del miglior cliente (chi ha comprato di più quel prodotto)
+3. Il fatturato totale del miglior cliente (su tutti i prodotti, non solo questo)
+4. La percentuale che il prodotto rappresenta nel fatturato di quel cliente
+
+Schema relazionale: `prodotto ← fattura_riga → fattura → cliente`
+
+---
+
+## Genropy
+
+### Definizione nel modello (una volta sola)
+
+```python
+# prodotto.py
+tbl.formulaColumn('totale_fatturato', select=dict(
+    table='fatt.fattura_riga',
+    columns='SUM($prezzo_totale)',
+    where='$prodotto_id=#THIS.id'),
+    dtype='N', name_long='Tot.Fatturato')
+
+tbl.formulaColumn('top_cliente_id', select=dict(
+    table='fatt.fattura_riga',
+    columns='@fattura_id.cliente_id',
+    where='$prodotto_id=#THIS.id',
+    group_by='@fattura_id.cliente_id',
+    order_by='SUM($prezzo_totale) DESC',
+    limit=1),
+    dtype='T', name_long='Top Cliente'
+    ).relation('cliente.id', relation_name='top_prodotti')
+
+# cliente.py
+tbl.formulaColumn('tot_fatturato', select=dict(
+    table='fatt.fattura',
+    columns='SUM($totale_fattura)',
+    where='$cliente_id=#THIS.id'),
+    dtype='N', name_long='Tot.Fatturato')
+```
+
+### Query
+
+```python
+tbl.query(columns="""$descrizione,
+                      $totale_fatturato,
+                      @top_cliente_id.ragione_sociale,
+                      @top_cliente_id.tot_fatturato""",
+          order_by='$descrizione')
+```
+
+Quattro colonne, una riga. La navigazione `@top_cliente_id.tot_fatturato` attraversa una
+relazione logica (non fisica) e accede a una colonna virtuale (non fisica) definita su un'altra
+tabella. Due livelli di astrazione che si compongono trasparentemente.
+
+Con `enable_sq_join=True` le subquery aggregazione vengono automaticamente convertite in
+LEFT JOIN pre-aggregati, e le subquery con `limit` vengono wrappate con ROW_NUMBER()
+OVER (PARTITION BY ...) — tutto senza cambiare il codice applicativo.
+
+---
+
+## Django ORM
+
+### Definizione
+
+Django non ha il concetto di colonne virtuali riusabili nel modello.
+Ogni query deve ricostruire le annotazioni da zero.
+
+```python
+from django.db.models import Subquery, OuterRef, Sum, F, CharField
+from django.db.models.functions import Coalesce
+
+# Step 1: subquery per il top cliente di ogni prodotto
+top_cliente_per_prodotto = (
+    FatturaRiga.objects
+    .filter(prodotto_id=OuterRef('pk'))
+    .values('fattura__cliente_id')
+    .annotate(tot=Sum('prezzo_totale'))
+    .order_by('-tot')
+    .values('fattura__cliente_id')[:1]
+)
+
+# Step 2: subquery per il nome del top cliente
+nome_top_cliente = (
+    Cliente.objects
+    .filter(id=Subquery(top_cliente_per_prodotto))
+    .values('ragione_sociale')[:1]
+)
+
+# Step 3: subquery per il fatturato totale del top cliente
+fatturato_top_cliente = (
+    Fattura.objects
+    .filter(cliente_id=Subquery(top_cliente_per_prodotto))
+    .values('cliente_id')
+    .annotate(tot=Sum('totale_fattura'))
+    .values('tot')[:1]
+)
+
+# Step 4: subquery per il fatturato del prodotto
+fatturato_prodotto = (
+    FatturaRiga.objects
+    .filter(prodotto_id=OuterRef('pk'))
+    .values('prodotto_id')
+    .annotate(tot=Sum('prezzo_totale'))
+    .values('tot')
+)
+
+# Query finale
+Prodotto.objects.annotate(
+    totale_fatturato=Subquery(fatturato_prodotto),
+    top_cliente_nome=Subquery(nome_top_cliente, output_field=CharField()),
+    top_cliente_fatturato=Subquery(fatturato_top_cliente),
+)
+```
+
+Ogni "livello" richiede una Subquery esplicita annidata. La subquery del fatturato
+del top cliente (`fatturato_top_cliente`) non può riusare una definizione sul modello
+Cliente — va riscritta ogni volta che serve in un contesto diverso.
+
+---
+
+## SQLAlchemy
+
+### Definizione
+
+```python
+from sqlalchemy import func, select, and_
+from sqlalchemy.orm import aliased
+
+# Step 1: subquery per il fatturato per prodotto-cliente
+fatt_per_cliente = (
+    select(
+        FatturaRiga.prodotto_id,
+        Fattura.cliente_id,
+        func.sum(FatturaRiga.prezzo_totale).label('tot')
+    )
+    .join(Fattura, FatturaRiga.fattura_id == Fattura.id)
+    .group_by(FatturaRiga.prodotto_id, Fattura.cliente_id)
+    .subquery()
+)
+
+# Step 2: subquery per il top cliente per prodotto (richiede DISTINCT ON o ROW_NUMBER)
+from sqlalchemy import over
+ranked = (
+    select(
+        fatt_per_cliente.c.prodotto_id,
+        fatt_per_cliente.c.cliente_id,
+        fatt_per_cliente.c.tot,
+        func.row_number().over(
+            partition_by=fatt_per_cliente.c.prodotto_id,
+            order_by=fatt_per_cliente.c.tot.desc()
+        ).label('rn')
+    )
+    .subquery()
+)
+top_cliente = (
+    select(ranked.c.prodotto_id, ranked.c.cliente_id)
+    .where(ranked.c.rn == 1)
+    .subquery()
+)
+
+# Step 3: join per il nome
+ClienteAlias = aliased(Cliente)
+
+# Step 4: subquery per il fatturato totale del top cliente
+fatt_totale_cliente = (
+    select(func.sum(Fattura.totale_fattura))
+    .where(Fattura.cliente_id == top_cliente.c.cliente_id)
+    .correlate(top_cliente)
+    .scalar_subquery()
+)
+
+# Step 5: query finale
+query = (
+    select(
+        Prodotto.descrizione,
+        func.sum(FatturaRiga.prezzo_totale).label('totale_fatturato'),
+        ClienteAlias.ragione_sociale,
+        fatt_totale_cliente.label('fatt_top_cliente')
+    )
+    .outerjoin(top_cliente, Prodotto.id == top_cliente.c.prodotto_id)
+    .outerjoin(ClienteAlias, ClienteAlias.id == top_cliente.c.cliente_id)
+    .outerjoin(FatturaRiga, FatturaRiga.prodotto_id == Prodotto.id)
+    .group_by(Prodotto.id, Prodotto.descrizione,
+              ClienteAlias.ragione_sociale, top_cliente.c.cliente_id)
+)
+```
+
+SQLAlchemy è il più verboso: ogni join va esplicitato, il ROW_NUMBER va costruito
+manualmente, e non esiste alcun meccanismo di composizione tra definizioni su modelli diversi.
+
+---
+
+## Confronto sintetico
+
+| Aspetto | Genropy | Django | SQLAlchemy |
+|---|---|---|---|
+| **Colonne virtuali riusabili** | `formulaColumn` nel modello, usata ovunque con `$nome` | Non esiste, annotazioni ogni volta | Non esiste |
+| **Navigazione relazioni** | `@fattura_id.@cliente_id.ragione_sociale` | Join/Subquery esplicite | Join espliciti con alias |
+| **Relazione su colonna calcolata** | `.relation('cliente.id')` → navigabile con `@` | Non esiste | Non esiste |
+| **Composizione trasparente** | Colonna virtuale che naviga altra colonna virtuale | Subquery dentro subquery, manuale | Subquery dentro subquery, manuale |
+| **Ottimizzazione subquery→JOIN** | `enable_sq_join=True`, automatico | Manuale | Manuale |
+| **ROW_NUMBER per limit+JOIN** | Automatico (wrapping trasparente) | Manuale o raw SQL | Manuale |
+| **Righe di codice (questo caso)** | ~15 (modello) + 1 (query) | ~35 (ogni query) | ~45 (ogni query) |
+| **Riuso cross-tabella** | `@top_cliente_id.tot_fatturato` riusa la definizione di `cliente` | Impossibile senza riscrivere | Impossibile senza riscrivere |
+
+## Il punto chiave
+
+La differenza fondamentale non è solo la brevità sintattica. È che in Genropy le colonne
+virtuali e le relazioni logiche **si compongono**: una volta definite nel modello, sono
+disponibili ovunque come se fossero colonne fisiche. In Django e SQLAlchemy ogni query
+deve ricostruire la logica da zero, rendendo il codice fragile (la stessa formula in N posti)
+e difficile da mantenere.
+
+Il pattern `formulaColumn` + `relation` + navigazione `@` crea un livello di astrazione
+che gli altri ORM semplicemente non hanno.

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -21,6 +21,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 
+import copy
 import os
 import shutil
 import re
@@ -60,7 +61,6 @@ BAGCOLSEXPFINDER = re.compile(r"#BAGCOLS\s*\(\s*((?:\$|@)?[\w\.\@]+)\s*\)(\s*AS\
 ENVFINDER = re.compile(r"#ENV\(([^,)]+)(,[^),]+)?\)")
 PREFFINDER = re.compile(r"#PREF\(([^,)]+)(,[^),]+)?\)")
 THISFINDER = re.compile(r'#THIS\.([\w\.@]+)')
-JOINER_FINDER = re.compile(r'(\$\w+\s*=\s*#THIS\.\w+)')
 
 class SqlCompiledQuery(object):
     """SqlCompiledQuery is a private class used by the :class:`SqlQueryCompiler` class.
@@ -81,6 +81,7 @@ class SqlCompiledQuery(object):
         self.columns = ''
         self.joins = []
         self.additional_joins = []
+        self.sq_joins = []
         self.where = None
         self.group_by = None
         self.having = None
@@ -116,8 +117,6 @@ class SqlCompiledSubQuery(SqlCompiledQuery):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._identity_hash = None
-        self.joiner = None
-        self.residual_where = None
 
     def __eq__(self, other):
         if not isinstance(other, SqlCompiledSubQuery):
@@ -288,25 +287,29 @@ class SqlQueryCompiler(object):
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
 
     def _handleFormulaColumn(self, fldalias, fld, alias, curr, curr_tblobj, expandThis):
-        attr = dict(fldalias.attributes)
+        attr = copy.deepcopy(dict(fldalias.attributes))
         as_join = self._should_convert_to_join(fldalias)
-        multi_select = self._preprocess_subqueryes(attr)
         formula_kw = dictExtract(attr, 'var_')
         sql_formula = fldalias.sql_formula
         if sql_formula is True:
             sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
+        if sql_formula:
+            sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
+        multi_select = self._preprocess_subqueryes(attr, as_join, alias, expandThis)
         if not sql_formula:
             sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select) if multi_select else None
-        else:
-            sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
         select_dict = dict(multi_select) if multi_select else {}
         if select_dict:
             for sq_name, sq_select in list(select_dict.items()):
                 if isinstance(sq_select, str):
                     sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
                 sq_pars = dict(sq_select)
-                compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
-                sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
+                compiled = self._compiledSubQuery(alias, expandThis, sq_pars, sq_name=sq_name)
+                if as_join:
+                    self.cpl.sq_joins.append(compiled.get_sqltext(self.db))
+                    sql_formula = re.sub(r'#%s_(\w+)' % sq_name, r'%s.\1' % sq_name, sql_formula)
+                else:
+                    sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
         return f'( {sql_formula} )'
 
     def _should_convert_to_join(self, fldalias):
@@ -315,16 +318,42 @@ class SqlQueryCompiler(object):
             return gnrstring.boolean(sq_as_join)
         return gnrstring.boolean(getattr(self.db, 'extra_kw', {}).get('subquery_as_join', False))
 
-    def _preprocess_subqueryes(self, attr):
+    def _preprocess_subqueryes(self, attr, as_join=False, alias=None, expandThis=None):
         if 'exists' in attr:
             exists_sq = attr.pop('exists')
             exists_sq['exists'] = True
-            attr['select_default'] = exists_sq
+            attr['select_dflt'] = exists_sq
         elif 'select' in attr:
-            attr['select_default'] = attr.pop('select')
-        return dictExtract(attr, 'select_')
+            attr['select_dflt'] = attr.pop('select')
+        sq_dict = dictExtract(attr, 'select_')
+        if not as_join or not sq_dict:
+            return sq_dict
+        for sq_name, sq_pars in sq_dict.items():
+            sq_where = sq_pars.get('where', '')
+            m = re.match(r'(\$\w+)\s*=\s*#THIS\.(\w+)(.*)', sq_where, re.DOTALL)
+            if m:
+                fk_field = m.group(1)
+                joiner = '%s=#THIS.%s' % (fk_field, m.group(2))
+                residual = m.group(3).strip()
+                if residual.upper().startswith('AND '):
+                    residual = residual[4:].strip()
+                sq_pars['where'] = residual or None
+                sq_pars['group_by'] = fk_field
+                # Assign positional aliases (c_0, c_1, ...) to columns without explicit AS
+                col_parts = [c.strip() for c in sq_pars['columns'].split(',')]
+                aliased_cols = []
+                for i, col in enumerate(col_parts):
+                    if ' AS ' in col.upper():
+                        aliased_cols.append(col)
+                    else:
+                        aliased_cols.append('%s AS c_%i' % (col, i))
+                sq_pars['columns'] = '%s AS joiner, %s' % (fk_field, ', '.join(aliased_cols))
+                joiner = THISFINDER.sub(expandThis, joiner)
+                sq_pars['joiner'] = joiner
+        return sq_dict
 
     def _preprocessFormula(self, fldalias, alias, curr, sql_formula, formula_kw):
+        sql_formula = sql_formula.replace('#default', '#dflt')
         def resolveField(m):
             return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
         sql_formula = RELFINDER.sub(resolveField, sql_formula)
@@ -339,7 +368,7 @@ class SqlQueryCompiler(object):
                                      sql_formula)
         return sql_formula
 
-    def _compiledSubQuery(self, alias, expandThis, sq_pars):
+    def _compiledSubQuery(self, alias, expandThis, sq_pars, sq_name=None):
         """Compile a subquery column (select or exists) into SQL text.
 
         Builds and compiles an independent SqlQuery with a mangler prefix,
@@ -359,11 +388,16 @@ class SqlQueryCompiler(object):
             str: the compiled subquery SQL text, wrapped with the template.
         """
         # 1. Extract template parameters and table/where
+        joiner = sq_pars.pop('joiner', None)
         tpl = sq_pars.pop('tpl', None)
         cast = sq_pars.pop('cast', None)
         is_exists = sq_pars.pop('exists', False)
         if not tpl:
-            if is_exists:
+            if joiner:
+                # joiner is like '$movie_id=t0.id' — resolve $field to sq_alias.joiner
+                on_clause = re.sub(r'\$\w+', '%s.joiner' % sq_name, joiner)
+                tpl = ' LEFT JOIN (%%s) AS %s ON (%s) ' % (sq_name, on_clause)
+            elif is_exists:
                 tpl = ' EXISTS( %s ) '
             elif cast:
                 tpl = ' CAST( ( %s ) AS ' + cast + ') '
@@ -377,21 +411,9 @@ class SqlQueryCompiler(object):
         sq_pars.setdefault('subtable', '*')
         aliasPrefix = '%s_t' % alias
 
-        # 3. Wrap joiner condition in parentheses, then expand #THIS
-        sq_where = JOINER_FINDER.sub(r'(\1)', sq_where, count=1)
-        sq_where = THISFINDER.sub(expandThis, sq_where)
-
-        # 3b. Extract joiner and residual_where from expanded WHERE
-        joiner = None
-        residual_where = None
-        if sq_where.startswith('('):
-            close = sq_where.index(')')
-            joiner = sq_where[1:close]
-            rest = sq_where[close+1:].strip()
-            if rest.upper().startswith('AND '):
-                residual_where = rest[4:].strip()
-            elif rest:
-                residual_where = rest
+        # 3. Expand #THIS in the subquery WHERE
+        if sq_where:
+            sq_where = THISFINDER.sub(expandThis, sq_where)
 
         # 4. Compile the subquery with a mangler for parameter namespacing
         mangler_prefix = self.query._next_mangler_key('sq')
@@ -405,8 +427,6 @@ class SqlQueryCompiler(object):
         )
         compiled = q.compileQuery(compiled_class=SqlCompiledSubQuery)
         compiled.tpl = tpl
-        compiled.joiner = joiner
-        compiled.residual_where = residual_where
 
         # 5. Build identity hash for CTE merge: resolve params in WHERE to get
         #    a mangler-independent fingerprint
@@ -850,6 +870,8 @@ class SqlQueryCompiler(object):
         group_by = gnrstring.templateReplace(group_by, colPars)
         #self.cpl.additional_joins.reverse()
         self.cpl.joins = [gnrstring.templateReplace(j, colPars) for j in self.cpl.joins+self.cpl.additional_joins]
+        if self.cpl.sq_joins:
+            self.cpl.joins.extend(self.cpl.sq_joins)
         if distinct:
             distinct = 'DISTINCT '
         elif distinct is None or distinct == '':

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -203,6 +203,34 @@ class SqlQueryCompiler(object):
         self.aliases = {self.tblobj.sqlfullname: self.aliasCode(0)}
         self.fieldlist = []
 
+    def expandThis(self, m):
+        fld = m.group(1)
+        return self.getFieldAlias(fld, curr=self._curr, basealias=self._alias)
+
+    def expandPref(self, m):
+        prefpath = m.group(1)
+        dflt = m.group(2)[1:] if m.group(2) else None
+        return str(self._curr_tblobj.pkg.getPreference(prefpath, dflt))
+
+    def expandEnv(self, m):
+        what = m.group(1)
+        par2 = None
+        if m.group(2):
+            par2 = m.group(2)[1:]
+        if what in self.db.currentEnv:
+            return "'%s'" % gnrstring.toText(self.db.currentEnv[what])
+        elif par2 and par2 in self.db.currentEnv:
+            return "'%s'" % gnrstring.toText(self.db.currentEnv[par2])
+        if par2:
+            env_tblobj = self.db.table(par2)
+        else:
+            env_tblobj = self._curr_tblobj
+        handler = getattr(env_tblobj, 'env_%s' % what, None)
+        if handler:
+            return handler()
+        else:
+            return 'Not found %s' % what
+
     def getFieldAlias(self, fieldpath, curr=None,basealias=None, parent=None):
         """Internal method. Translate fields path and related fields path in a valid sql string for the column.
 
@@ -217,35 +245,6 @@ class SqlQueryCompiler(object):
         :param fieldpath: a field path. (e.g: '$colname'; e.g: '@relname.@rel2name.colname')
         :param curr: TODO.
         :param basealias: TODO. """
-
-        def expandThis(m):
-            fld = m.group(1)
-            return self.getFieldAlias(fld,curr=curr,basealias=alias)
-
-        def expandPref(m):
-            """#PREF(myprefpath,default)"""
-            prefpath = m.group(1)
-            dflt=m.group(2)[1:] if m.group(2) else None
-            return str(curr_tblobj.pkg.getPreference(prefpath,dflt))
-
-        def expandEnv(m):
-            what = m.group(1)
-            par2 = None
-            if m.group(2):
-                par2 = m.group(2)[1:]
-            if what in self.db.currentEnv:
-                return "'%s'" % gnrstring.toText(self.db.currentEnv[what])
-            elif par2 and par2 in self.db.currentEnv:
-                return "'%s'" % gnrstring.toText(self.db.currentEnv[par2])
-            if par2:
-                env_tblobj = self.db.table(par2)
-            else:
-                env_tblobj = curr_tblobj
-            handler = getattr(env_tblobj, 'env_%s' % what, None)
-            if handler:
-                return handler()
-            else:
-                return 'Not found %s' % what
         pathlist = fieldpath.split('.')
         fld = pathlist.pop()
         curr = curr or self.relations
@@ -256,6 +255,9 @@ class SqlQueryCompiler(object):
         else:
             alias = basealias
         curr_tblobj = self.db.table(curr.tbl_name, pkg=curr.pkg_name)
+        self._curr = curr
+        self._alias = alias
+        self._curr_tblobj = curr_tblobj
         if not fld in curr.keys():
             fldalias = curr_tblobj.model.getVirtualColumn(fld,sqlparams=self.sqlparams)
             if fldalias == None:
@@ -276,7 +278,7 @@ class SqlQueryCompiler(object):
 
                 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                return self._handleFormulaColumn(fldalias, fld, alias, curr, curr_tblobj, expandThis)
+                return self._handleFormulaColumn(fldalias, fld, alias, curr, curr_tblobj)
             elif fldalias.py_method:
                 #self.cpl.pyColumns.append((fld,getattr(self.tblobj.dbtable,fldalias.py_method,None)))
                 self.cpl.pyColumns.append((fld,getattr(fldalias.table.dbtable,fldalias.py_method,None)))
@@ -286,7 +288,7 @@ class SqlQueryCompiler(object):
                 fld, curr.pkg_name, curr.tbl_name, '.'.join(newpath)))
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
 
-    def _handleFormulaColumn(self, fldalias, fld, alias, curr, curr_tblobj, expandThis):
+    def _handleFormulaColumn(self, fldalias, fld, alias, curr, curr_tblobj):
         attr = copy.deepcopy(dict(fldalias.attributes))
         as_join = self._should_convert_to_join(fldalias)
         formula_kw = dictExtract(attr, 'var_')
@@ -295,7 +297,7 @@ class SqlQueryCompiler(object):
             sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
         if sql_formula:
             sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
-        multi_select = self._preprocess_subqueryes(attr, as_join, alias, expandThis)
+        multi_select = self._preprocess_subqueryes(attr, as_join, alias)
         if not sql_formula:
             sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select) if multi_select else None
         select_dict = dict(multi_select) if multi_select else {}
@@ -304,7 +306,7 @@ class SqlQueryCompiler(object):
                 if isinstance(sq_select, str):
                     sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
                 sq_pars = dict(sq_select)
-                compiled = self._compiledSubQuery(alias, expandThis, sq_pars, sq_name=sq_name)
+                compiled = self._compiledSubQuery(alias, sq_pars, sq_name=sq_name)
                 if as_join:
                     self.cpl.sq_joins.append(compiled.get_sqltext(self.db))
                     sql_formula = re.sub(r'#%s_(\w+)' % sq_name, r'%s.\1' % sq_name, sql_formula)
@@ -318,7 +320,7 @@ class SqlQueryCompiler(object):
             return gnrstring.boolean(sq_as_join)
         return gnrstring.boolean(getattr(self.db, 'extra_kw', {}).get('subquery_as_join', False))
 
-    def _preprocess_subqueryes(self, attr, as_join=False, alias=None, expandThis=None):
+    def _preprocess_subqueryes(self, attr, as_join=False, alias=None):
         if 'exists' in attr:
             exists_sq = attr.pop('exists')
             exists_sq['exists'] = True
@@ -348,7 +350,7 @@ class SqlQueryCompiler(object):
                     else:
                         aliased_cols.append('%s AS c_%i' % (col, i))
                 sq_pars['columns'] = '%s AS joiner, %s' % (fk_field, ', '.join(aliased_cols))
-                joiner = THISFINDER.sub(expandThis, joiner)
+                joiner = THISFINDER.sub(self.expandThis, joiner)
                 sq_pars['joiner'] = joiner
         return sq_dict
 
@@ -358,6 +360,9 @@ class SqlQueryCompiler(object):
             return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
         sql_formula = RELFINDER.sub(resolveField, sql_formula)
         sql_formula = COLFINDER.sub(resolveField, sql_formula)
+        sql_formula = THISFINDER.sub(self.expandThis, sql_formula)
+        sql_formula = ENVFINDER.sub(self.expandEnv, sql_formula)
+        sql_formula = PREFFINDER.sub(self.expandPref, sql_formula)
         if formula_kw:
             prefix = f'{id(fldalias)}_{self._currColKey}'
             for k, v in formula_kw.items():
@@ -368,7 +373,7 @@ class SqlQueryCompiler(object):
                                      sql_formula)
         return sql_formula
 
-    def _compiledSubQuery(self, alias, expandThis, sq_pars, sq_name=None):
+    def _compiledSubQuery(self, alias, sq_pars, sq_name=None):
         """Compile a subquery column (select or exists) into SQL text.
 
         Builds and compiles an independent SqlQuery with a mangler prefix,
@@ -378,14 +383,11 @@ class SqlQueryCompiler(object):
 
         Args:
             alias: The SQL table alias for the current table (e.g. ``'t0'``).
-            expandThis: Callback to replace ``#THIS.col`` with ``alias.col``.
             sq_pars: The subquery parameters dict (table, where, columns, plus
                      any extra params like avail='yes'). Already without 'cast'.
-            tpl: SQL template to wrap the subquery (e.g. ``' ( %s ) '`` or
-                 ``' CAST( ( %s ) AS integer) '``).
 
         Returns:
-            str: the compiled subquery SQL text, wrapped with the template.
+            SqlCompiledSubQuery: the compiled subquery object.
         """
         # 1. Extract template parameters and table/where
         joiner = sq_pars.pop('joiner', None)
@@ -413,7 +415,7 @@ class SqlQueryCompiler(object):
 
         # 3. Expand #THIS in the subquery WHERE
         if sq_where:
-            sq_where = THISFINDER.sub(expandThis, sq_where)
+            sq_where = THISFINDER.sub(self.expandThis, sq_where)
 
         # 4. Compile the subquery with a mangler for parameter namespacing
         mangler_prefix = self.query._next_mangler_key('sq')

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -117,6 +117,34 @@ class SqlCompiledSubQuery(SqlCompiledQuery):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._identity_hash = None
+        self._rn_limit = None
+
+    def get_sqltext(self, db):
+        if self._rn_limit:
+            return self._get_sqltext_with_rn(db)
+        return super().get_sqltext(db)
+
+    def _get_sqltext_with_rn(self, db):
+        kwargs = {}
+        for k in ('maintable', 'distinct', 'columns', 'joins', 'where',
+                   'group_by', 'having', 'order_by', 'limit', 'offset', 'for_update'):
+            kwargs[k] = getattr(self, k)
+        inner_sql = db.adapter.compileSql(maintable_as=self.maintable_as, **kwargs)
+        # Extract the real column expression aliased as "joiner"
+        joiner_match = re.search(r'([\w."]+)\s+AS\s+joiner\b', inner_sql)
+        joiner_col = joiner_match.group(1) if joiner_match else 'joiner'
+        order_match = re.search(r'\sORDER\s+BY\s+(.+)$', inner_sql, re.IGNORECASE)
+        if order_match:
+            order_clause = order_match.group(1).strip()
+            inner_sql = inner_sql[:order_match.start()]
+            inner_sql = inner_sql.replace(
+                'SELECT ',
+                'SELECT ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS _rn, '
+                % (joiner_col, order_clause), 1)
+        result = 'SELECT * FROM (%s) _sub WHERE _sub._rn <= %i' % (inner_sql, self._rn_limit)
+        if self.tpl:
+            result = self.tpl % result
+        return result
 
     def __eq__(self, other):
         if not isinstance(other, SqlCompiledSubQuery):
@@ -297,9 +325,18 @@ class SqlQueryCompiler(object):
             sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
         if sql_formula:
             sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
-        multi_select = self._preprocess_subqueryes(attr, as_join, alias)
-        if not sql_formula:
-            sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select) if multi_select else None
+        multi_select, sql_formula = self._preprocess_subqueryes(attr, as_join, alias,
+                                        formula_column_name=fld, sql_formula=sql_formula)
+        if not sql_formula and multi_select:
+            if as_join:
+                parts = []
+                for sq_name, sq_pars in multi_select.items():
+                    m = re.search(r'AS (c_\d+)', sq_pars.get('columns', ''))
+                    col_ref = m.group(1) if m else 'c_0'
+                    parts.append('%s.%s' % (sq_name, col_ref))
+                sql_formula = " || ' ' || ".join(parts)
+            else:
+                sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select)
         select_dict = dict(multi_select) if multi_select else {}
         if select_dict:
             for sq_name, sq_select in list(select_dict.items()):
@@ -309,8 +346,6 @@ class SqlQueryCompiler(object):
                 compiled = self._compiledSubQuery(alias, sq_pars, sq_name=sq_name)
                 if as_join:
                     self.cpl.sq_joins.append(compiled.get_sqltext(self.db))
-                    sql_formula = re.sub(r'#%s_(\w+)' % sq_name, r'%s.\1' % sq_name, sql_formula)
-                    sql_formula = re.sub(r'#%s\b' % sq_name, r'%s.c_0' % sq_name, sql_formula)
                 else:
                     sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
         return f'( {sql_formula} )'
@@ -323,7 +358,8 @@ class SqlQueryCompiler(object):
             return gnrstring.boolean(self.query.enable_sq_join)
         return gnrstring.boolean(getattr(self.db, 'extra_kw', {}).get('subquery_as_join', False))
 
-    def _preprocess_subqueryes(self, attr, as_join=False, alias=None):
+    def _preprocess_subqueryes(self, attr, as_join=False, alias=None,
+                               formula_column_name=None, sql_formula=None):
         if 'exists' in attr:
             exists_sq = attr.pop('exists')
             exists_sq['exists'] = True
@@ -332,10 +368,23 @@ class SqlQueryCompiler(object):
             attr['select_dflt'] = attr.pop('select')
         sq_dict = dictExtract(attr, 'select_')
         if not as_join or not sq_dict:
-            return sq_dict
+            return sq_dict, sql_formula
+        # Condensation: merge subqueries with same (table, where)
+        sq_dict, sql_formula = self._condense_subqueries(sq_dict, sql_formula)
+        # Prefix keys with formula_column_name for cross-formulaColumn uniqueness
+        if formula_column_name:
+            prefixed = {}
+            for sq_name, sq_pars in sq_dict.items():
+                subquery_name = '%s_%s' % (formula_column_name, sq_name)
+                # Update formula references: #old_name -> #new_name
+                if sql_formula:
+                    sql_formula = sql_formula.replace('%s.' % sq_name, '%s.' % subquery_name)
+                prefixed[subquery_name] = sq_pars
+            sq_dict = prefixed
+        # Extract joiner from WHERE for each subquery
         for sq_name, sq_pars in sq_dict.items():
             sq_where = sq_pars.get('where', '')
-            m = re.match(r'(\$\w+)\s*=\s*#THIS\.(\w+)(.*)', sq_where, re.DOTALL)
+            m = re.match(r'(@[\w.]+|\$\w+)\s*=\s*#THIS\.(\w+)(.*)', sq_where, re.DOTALL)
             if m:
                 fk_field = m.group(1)
                 joiner = '%s=#THIS.%s' % (fk_field, m.group(2))
@@ -343,19 +392,54 @@ class SqlQueryCompiler(object):
                 if residual.upper().startswith('AND '):
                     residual = residual[4:].strip()
                 sq_pars['where'] = residual or None
-                sq_pars['group_by'] = fk_field
-                # Assign positional aliases (c_0, c_1, ...) to columns without explicit AS
-                col_parts = [c.strip() for c in sq_pars['columns'].split(',')]
-                aliased_cols = []
-                for i, col in enumerate(col_parts):
-                    if ' AS ' in col.upper():
-                        aliased_cols.append(col)
-                    else:
-                        aliased_cols.append('%s AS c_%i' % (col, i))
-                sq_pars['columns'] = '%s AS joiner, %s' % (fk_field, ', '.join(aliased_cols))
+                has_limit = 'limit' in sq_pars
+                existing_group_by = sq_pars.get('group_by')
+                if existing_group_by:
+                    sq_pars['group_by'] = '%s,%s' % (fk_field, existing_group_by)
+                elif not has_limit:
+                    sq_pars['group_by'] = fk_field
+                sq_pars['columns'] = '%s AS joiner, %s' % (fk_field, sq_pars['columns'])
                 joiner = THISFINDER.sub(self.expandThis, joiner)
                 sq_pars['joiner'] = joiner
-        return sq_dict
+        return sq_dict, sql_formula
+
+    def _condense_subqueries(self, sq_dict, sql_formula):
+        groups = {}
+        for sq_name, sq_pars in sq_dict.items():
+            key = (sq_pars['table'], sq_pars.get('where'))
+            groups.setdefault(key, []).append(sq_name)
+        col_counter = 0
+        remap = {}
+        for key, names in groups.items():
+            if len(names) == 1:
+                sq_name = names[0]
+                sq_pars = sq_dict[sq_name]
+                col_alias = 'c_%i' % col_counter
+                sq_pars['columns'] = '%s AS %s' % (sq_pars['columns'], col_alias)
+                col_counter += 1
+                continue
+            master = names[0]
+            master_pars = sq_dict[master]
+            merged_cols = []
+            for name in names:
+                pars = sq_dict[name]
+                col_alias = 'c_%i' % col_counter
+                merged_cols.append('%s AS %s' % (pars['columns'], col_alias))
+                if name != master:
+                    remap[name] = (master, col_alias)
+                col_counter += 1
+            master_pars['columns'] = ', '.join(merged_cols)
+            for name in names[1:]:
+                del sq_dict[name]
+        if sql_formula:
+            for absorbed, (master, col_alias) in remap.items():
+                sql_formula = re.sub(r'#%s\b' % absorbed, '%s.%s' % (master, col_alias), sql_formula)
+            for sq_name, sq_pars in sq_dict.items():
+                m = re.search(r'AS (c_\d+)', sq_pars['columns'])
+                if m:
+                    first_col = m.group(1)
+                    sql_formula = re.sub(r'#%s\b' % sq_name, '%s.%s' % (sq_name, first_col), sql_formula)
+        return sq_dict, sql_formula
 
     def _preprocessFormula(self, fldalias, alias, curr, sql_formula, formula_kw):
         sql_formula = sql_formula.replace('#default', '#dflt')
@@ -397,10 +481,11 @@ class SqlQueryCompiler(object):
         tpl = sq_pars.pop('tpl', None)
         cast = sq_pars.pop('cast', None)
         is_exists = sq_pars.pop('exists', False)
+        sq_limit = sq_pars.pop('limit', None) if joiner else None
         if not tpl:
             if joiner:
                 # joiner is like '$movie_id=t0.id' — resolve $field to sq_alias.joiner
-                on_clause = re.sub(r'\$\w+', '%s.joiner' % sq_name, joiner)
+                on_clause = re.sub(r'@[\w.]+|\$\w+', '%s.joiner' % sq_name, joiner)
                 tpl = ' LEFT JOIN (%%s) AS %s ON (%s) ' % (sq_name, on_clause)
             elif is_exists:
                 tpl = ' EXISTS( %s ) '
@@ -432,6 +517,8 @@ class SqlQueryCompiler(object):
         )
         compiled = q.compileQuery(compiled_class=SqlCompiledSubQuery)
         compiled.tpl = tpl
+        if sq_limit:
+            compiled._rn_limit = int(sq_limit)
 
         # 5. Build identity hash for CTE merge: resolve params in WHERE to get
         #    a mangler-independent fingerprint

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -310,6 +310,7 @@ class SqlQueryCompiler(object):
                 if as_join:
                     self.cpl.sq_joins.append(compiled.get_sqltext(self.db))
                     sql_formula = re.sub(r'#%s_(\w+)' % sq_name, r'%s.\1' % sq_name, sql_formula)
+                    sql_formula = re.sub(r'#%s\b' % sq_name, r'%s.c_0' % sq_name, sql_formula)
                 else:
                     sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
         return f'( {sql_formula} )'
@@ -318,6 +319,8 @@ class SqlQueryCompiler(object):
         sq_as_join = fldalias.attributes.get('sq_as_join')
         if sq_as_join is not None:
             return gnrstring.boolean(sq_as_join)
+        if self.query and getattr(self.query, 'enable_sq_join', None) is not None:
+            return gnrstring.boolean(self.query.enable_sq_join)
         return gnrstring.boolean(getattr(self.db, 'extra_kw', {}).get('subquery_as_join', False))
 
     def _preprocess_subqueryes(self, attr, as_join=False, alias=None):
@@ -1216,6 +1219,7 @@ class SqlQuery(object):
         self.joinConditions = joinConditions or {}
         self.sqlContextName = sqlContextName
         self.relationDict = relationDict or {}
+        self.enable_sq_join = kwargs.pop('enable_sq_join', None)
         self.query_kw = dict(kwargs)
         self.sqlparams.update(kwargs)
         self.excludeLogicalDeleted = excludeLogicalDeleted

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -286,6 +286,7 @@ class SqlQueryCompiler(object):
 
     def _handleFormulaColumn(self, fldalias, fld, alias, curr, curr_tblobj, expandThis):
         attr = dict(fldalias.attributes)
+        as_join = self._should_convert_to_join(fldalias)
         multi_select = self._preprocess_subqueryes(attr)
         formula_kw = dictExtract(attr, 'var_')
         sql_formula = fldalias.sql_formula
@@ -304,6 +305,12 @@ class SqlQueryCompiler(object):
                 compiled = self._compiledSubQuery(alias, expandThis, sq_pars)
                 sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
         return f'( {sql_formula} )'
+
+    def _should_convert_to_join(self, fldalias):
+        sq_as_join = fldalias.attributes.get('sq_as_join')
+        if sq_as_join is not None:
+            return gnrstring.boolean(sq_as_join)
+        return gnrstring.boolean(getattr(self.db, 'extra_kw', {}).get('subquery_as_join', False))
 
     def _preprocess_subqueryes(self, attr):
         if 'exists' in attr:

--- a/gnrpy/gnr/sql/gnrsqldata.py
+++ b/gnrpy/gnr/sql/gnrsqldata.py
@@ -60,6 +60,7 @@ BAGCOLSEXPFINDER = re.compile(r"#BAGCOLS\s*\(\s*((?:\$|@)?[\w\.\@]+)\s*\)(\s*AS\
 ENVFINDER = re.compile(r"#ENV\(([^,)]+)(,[^),]+)?\)")
 PREFFINDER = re.compile(r"#PREF\(([^,)]+)(,[^),]+)?\)")
 THISFINDER = re.compile(r'#THIS\.([\w\.@]+)')
+JOINER_FINDER = re.compile(r'(\$\w+\s*=\s*#THIS\.\w+)')
 
 class SqlCompiledQuery(object):
     """SqlCompiledQuery is a private class used by the :class:`SqlQueryCompiler` class.
@@ -115,6 +116,8 @@ class SqlCompiledSubQuery(SqlCompiledQuery):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._identity_hash = None
+        self.joiner = None
+        self.residual_where = None
 
     def __eq__(self, other):
         if not isinstance(other, SqlCompiledSubQuery):
@@ -374,8 +377,21 @@ class SqlQueryCompiler(object):
         sq_pars.setdefault('subtable', '*')
         aliasPrefix = '%s_t' % alias
 
-        # 3. Expand #THIS in the subquery WHERE
+        # 3. Wrap joiner condition in parentheses, then expand #THIS
+        sq_where = JOINER_FINDER.sub(r'(\1)', sq_where, count=1)
         sq_where = THISFINDER.sub(expandThis, sq_where)
+
+        # 3b. Extract joiner and residual_where from expanded WHERE
+        joiner = None
+        residual_where = None
+        if sq_where.startswith('('):
+            close = sq_where.index(')')
+            joiner = sq_where[1:close]
+            rest = sq_where[close+1:].strip()
+            if rest.upper().startswith('AND '):
+                residual_where = rest[4:].strip()
+            elif rest:
+                residual_where = rest
 
         # 4. Compile the subquery with a mangler for parameter namespacing
         mangler_prefix = self.query._next_mangler_key('sq')
@@ -389,6 +405,8 @@ class SqlQueryCompiler(object):
         )
         compiled = q.compileQuery(compiled_class=SqlCompiledSubQuery)
         compiled.tpl = tpl
+        compiled.joiner = joiner
+        compiled.residual_where = residual_where
 
         # 5. Build identity hash for CTE merge: resolve params in WHERE to get
         #    a mangler-independent fingerprint

--- a/gnrpy/tests/sql/benchmark_subquery_join.py
+++ b/gnrpy/tests/sql/benchmark_subquery_join.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Benchmark: correlated subquery vs LEFT JOIN (sq_as_join).
+
+Generates a large dataset and compares query times for:
+- dvd_count vs dvd_count_join: COUNT(*)
+- dvd_latest vs dvd_latest_join: MAX(purchasedate)
+- dvd_count_available vs dvd_count_avail_join: COUNT(*) with WHERE available='yes'
+- dvd_total_price vs dvd_total_price_join: SUM(price)
+- dvd_count_like vs dvd_count_like_join: COUNT(*) with LIKE condition
+
+Run with:
+    cd gnrpy && PYTHONPATH=. python -m pytest tests/sql/benchmark_subquery_join.py -v -s
+"""
+
+import time
+import random
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from tests.sql.common import BaseGnrSqlTest, configurePackage
+from gnr.sql.gnrsql import GnrSqlDb
+
+
+NUM_MOVIES = 5000
+NUM_DVDS = 50000
+NUM_COUNTRIES = 10
+NUM_SALES = 500000
+
+
+class BaseBenchmark(BaseGnrSqlTest):
+
+    @classmethod
+    def _populate(cls):
+        """Insert movies and dvds using raw SQL executemany."""
+        conn = cls.db.adapter.connection()
+        cursor = cls.db.adapter.cursor(conn)
+        ph = '%s' if cls.db.implementation != 'sqlite' else '?'
+
+        print(f'\nPopulating {NUM_MOVIES} movies...')
+        movies = [(i, f'Movie_{i:05d}', 'ACTION', 2000 + (i % 25), 'US')
+                  for i in range(NUM_MOVIES)]
+        sql_movie = f'INSERT INTO video_movie (id, title, genre, year, nationality) VALUES ({ph}, {ph}, {ph}, {ph}, {ph})'
+        cursor.executemany(sql_movie, movies)
+
+        print(f'Populating {NUM_DVDS} dvds...')
+        random.seed(42)
+        dvds = [(i, random.randint(0, NUM_MOVIES - 1),
+                 f'{2003 + (i % 5)}-{(i % 12) + 1:02d}-{(i % 28) + 1:02d}',
+                 'yes' if i % 3 else 'no',
+                 round(random.uniform(5.0, 30.0), 2))
+                for i in range(NUM_DVDS)]
+        sql_dvd = f'INSERT INTO video_dvd (code, movie_id, purchasedate, available, price) VALUES ({ph}, {ph}, {ph}, {ph}, {ph})'
+        cursor.executemany(sql_dvd, dvds)
+
+        print(f'Populating {NUM_COUNTRIES} countries...')
+        countries = [(i, f'Country_{i}', f'C{i:02d}') for i in range(NUM_COUNTRIES)]
+        sql_country = f'INSERT INTO video_country (id, name, code) VALUES ({ph}, {ph}, {ph})'
+        cursor.executemany(sql_country, countries)
+
+        print(f'Populating {NUM_SALES} sales...')
+        sales = [(i, random.randint(0, NUM_DVDS - 1),
+                  random.randint(0, NUM_COUNTRIES - 1),
+                  f'{2005 + (i % 8)}-{(i % 12) + 1:02d}-{(i % 28) + 1:02d}',
+                  round(random.uniform(10.0, 100.0), 2))
+                 for i in range(NUM_SALES)]
+        sql_sales = f'INSERT INTO video_sales (id, dvd_id, country_id, sale_date, amount) VALUES ({ph}, {ph}, {ph}, {ph}, {ph})'
+        cursor.executemany(sql_sales, sales)
+
+        conn.commit()
+        print(f'Data ready: {NUM_MOVIES} movies, {NUM_DVDS} dvds, {NUM_COUNTRIES} countries, {NUM_SALES} sales\n')
+
+    def _run_query(self, table, columns, label, where=None, iterations=3):
+        """Run query multiple times, return average time."""
+        times = []
+        result = None
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            result = self.db.query(table, columns=columns, where=where).fetch()
+            elapsed = time.perf_counter() - t0
+            times.append(elapsed)
+        avg = sum(times) / len(times)
+        print(f'  {label}: {avg:.3f}s avg ({len(result)} rows, {iterations} iters)')
+        return avg, result
+
+    def _explain(self, table, columns, label):
+        """Print EXPLAIN ANALYZE for a query."""
+        q = self.db.query(table, columns=columns)
+        conn = self.db.adapter.connection()
+        cur = self.db.adapter.cursor(conn)
+        cur.execute('EXPLAIN ANALYZE ' + q.sqltext, q.sqlparams)
+        print(f'\n  EXPLAIN [{label}]:')
+        for row in cur.fetchall():
+            print(f'    {row[0]}')
+
+    def _compare(self, table, inline_col, join_col, label):
+        """Run inline vs join benchmark and verify results match."""
+        print(f'\n--- {label} ---')
+        t_inline, r_inline = self._run_query(table, f'$name,${inline_col}', 'Inline subquery')
+        t_join, r_join = self._run_query(table, f'$name,${join_col}', 'LEFT JOIN')
+
+        inline_vals = {r['name']: r[inline_col] for r in r_inline}
+        join_vals = {r['name']: r[join_col] for r in r_join}
+        mismatches = 0
+        for title in inline_vals:
+            v_i = inline_vals[title]
+            v_j = join_vals[title]
+            if v_i != v_j:
+                # tolerate None vs 0 (COALESCE) and float rounding
+                if v_i is None and v_j == 0 or v_j is None and v_i == 0:
+                    continue
+                if isinstance(v_i, (int, float)) and isinstance(v_j, (int, float)):
+                    if abs(v_i - v_j) < 0.01:
+                        continue
+                mismatches += 1
+                if mismatches <= 5:
+                    print(f'    MISMATCH {title}: inline={v_i!r} join={v_j!r}')
+        assert mismatches == 0, f'{mismatches} mismatches in {label}!'
+
+        speedup = t_inline / t_join if t_join > 0 else float('inf')
+        print(f'  => Speedup: {speedup:.1f}x')
+        return t_inline, t_join
+
+    def _compare_where(self, table, inline_col, join_col, where_inline, where_join, label):
+        """Benchmark with WHERE on the formulaColumn."""
+        print(f'\n--- {label} (WHERE) ---')
+        t_inline, r_inline = self._run_query(table, f'$name,${inline_col}',
+            'Inline subquery', where=where_inline)
+        t_join, r_join = self._run_query(table, f'$name,${join_col}',
+            'LEFT JOIN', where=where_join)
+        print(f'  Inline: {len(r_inline)} rows, JOIN: {len(r_join)} rows')
+        speedup = t_inline / t_join if t_join > 0 else float('inf')
+        print(f'  => Speedup: {speedup:.1f}x')
+        return t_inline, t_join
+
+    def test_benchmark(self):
+        """Benchmark: country→sales (10 countries, 500k sales = 50k sales/country)"""
+        print(f'\n=== Benchmark [{self.name}]: {NUM_COUNTRIES} countries, {NUM_SALES} sales ===')
+
+        T = 'video.country'
+        results = []
+        results.append(('SUM(amount)', *self._compare(
+            T, 'total_sales', 'total_sales_join', 'SUM(amount)')))
+        results.append(('SUM+genre', *self._compare(
+            T, 'action_sales', 'action_sales_join', 'SUM(amount) WHERE genre=ACTION')))
+        results.append(('COUNT(*)', *self._compare(
+            T, 'sale_count', 'sale_count_join', 'COUNT(*)')))
+        results.append(('WHERE SUM>thr', *self._compare_where(
+            T, 'total_sales', 'total_sales_join',
+            '$total_sales > 2500000', '$total_sales_join > 2500000',
+            'SUM(amount) > threshold')))
+
+        print(f'\n=== Summary [{self.name}] ===')
+        print(f'  {"Column":<15} {"Inline":>8} {"JOIN":>8} {"Speedup":>8}')
+        print(f'  {"-"*15} {"-"*8} {"-"*8} {"-"*8}')
+        for label, t_i, t_j in results:
+            sp = t_i / t_j if t_j > 0 else float('inf')
+            print(f'  {label:<15} {t_i:>7.3f}s {t_j:>7.3f}s {sp:>7.1f}x')
+
+        if self.db.implementation != 'sqlite':
+            print(f'\n=== EXPLAIN ANALYZE ===')
+            self._explain(T, '$name,$total_sales', 'SUM inline')
+            self._explain(T, '$name,$total_sales_join', 'SUM join')
+
+    def teardown_class(cls):
+        cls.db.closeConnection()
+        cls.db.dropDb(cls.dbname)
+
+
+class TestBenchmark_sqlite(BaseBenchmark):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.name = 'sqlite'
+        cls.dbname = cls.CONFIG['db.sqlite?filename'] + '_bench'
+        cls.db = GnrSqlDb(dbname=cls.dbname)
+        cls.db.createDb(cls.dbname)
+        configurePackage(cls.db.packageSrc('video'))
+        cls.db.startup()
+        cls.db.checkDb(applyChanges=True)
+        cls._populate()
+
+
+class TestBenchmark_postgres3(BaseBenchmark):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.name = 'postgres3'
+        cls.dbname = 'bench_sqjoin'
+        cls.db = GnrSqlDb(implementation='postgres3',
+                          host=cls.pg_conf.get("host"),
+                          port=cls.pg_conf.get("port"),
+                          dbname=cls.dbname,
+                          user=cls.pg_conf.get("user"),
+                          password=cls.pg_conf.get("password"))
+        cls.db.createDb(cls.dbname)
+        configurePackage(cls.db.packageSrc('video'))
+        cls.db.startup()
+        cls.db.checkDb(applyChanges=True)
+        cls._populate()

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -134,6 +134,9 @@ def configurePackage(pkg):
     movie.formulaColumn('title_upper', sql_formula='UPPER($title)')
     movie.formulaColumn('title_year', sql_formula="$title || ' (' || $year || ')'")
     movie.formulaColumn('title_with_label', sql_formula="$title || :label", var_label=' [DVD]')
+    movie.formulaColumn('dvd_count_raw',
+        sql_formula="(SELECT COUNT(*) FROM video_dvd AS sq WHERE sq.movie_id = #THIS.id)",
+        dtype='L')
     movie.formulaColumn('dvd_count', select=dict(
         columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
     ), dtype='L')

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -161,6 +161,9 @@ def configurePackage(pkg):
         columns='COUNT(*)', table='video.dvd',
         where='$movie_id=#THIS.id', cast='integer'
     ), dtype='L')
+    movie.formulaColumn('dvd_count_join', sq_as_join=True, select=dict(
+        columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
+    ), dtype='L')
     movie.formulaColumn('dvd_stats', sql_formula='#total || :sep || #available',
         var_sep='/',
         select_total=dict(

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -165,7 +165,6 @@ def configurePackage(pkg):
         where='$movie_id=#THIS.id', cast='integer'
     ), dtype='L')
     movie.formulaColumn('dvd_count_join', sq_as_join=True,
-        sql_formula='COALESCE(#dflt_c_0, 0)',
         select=dict(
             columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
         ), dtype='L')
@@ -173,7 +172,6 @@ def configurePackage(pkg):
         columns='MAX($purchasedate)', table='video.dvd', where='$movie_id=#THIS.id'
     ), dtype='D')
     movie.formulaColumn('dvd_latest_join', sq_as_join=True,
-        sql_formula='#dflt_c_0',
         select=dict(
             columns='MAX($purchasedate)', table='video.dvd', where='$movie_id=#THIS.id'
         ), dtype='D')
@@ -242,7 +240,6 @@ def configurePackage(pkg):
     ), dtype='N')
     # Benchmark: total sales per country (join)
     country.formulaColumn('total_sales_join', sq_as_join=True,
-        sql_formula='COALESCE(#dflt_c_0, 0)',
         select=dict(
             columns='SUM($amount)', table='video.sales',
             where='$country_id=#THIS.id'
@@ -268,7 +265,6 @@ def configurePackage(pkg):
     ), dtype='L')
     # Benchmark: count sales per country (join)
     country.formulaColumn('sale_count_join', sq_as_join=True,
-        sql_formula='COALESCE(#dflt_c_0, 0)',
         select=dict(
             columns='COUNT(*)', table='video.sales',
             where='$country_id=#THIS.id'

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -161,9 +161,47 @@ def configurePackage(pkg):
         columns='COUNT(*)', table='video.dvd',
         where='$movie_id=#THIS.id', cast='integer'
     ), dtype='L')
-    movie.formulaColumn('dvd_count_join', sq_as_join=True, select=dict(
-        columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
+    movie.formulaColumn('dvd_count_join', sq_as_join=True,
+        sql_formula='COALESCE(#dflt_c_0, 0)',
+        select=dict(
+            columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'
+        ), dtype='L')
+    movie.formulaColumn('dvd_latest', select=dict(
+        columns='MAX($purchasedate)', table='video.dvd', where='$movie_id=#THIS.id'
+    ), dtype='D')
+    movie.formulaColumn('dvd_latest_join', sq_as_join=True,
+        sql_formula='#dflt_c_0',
+        select=dict(
+            columns='MAX($purchasedate)', table='video.dvd', where='$movie_id=#THIS.id'
+        ), dtype='D')
+    movie.formulaColumn('dvd_count_avail_join', sq_as_join=True,
+        sql_formula='COALESCE(#dflt_c_0, 0)',
+        select=dict(
+            columns='COUNT(*)', table='video.dvd',
+            where='$movie_id=#THIS.id AND $available=:avail', avail='yes'
+        ), dtype='L')
+    # Benchmark: SUM(price) inline
+    movie.formulaColumn('dvd_total_price', select=dict(
+        columns='SUM($price)', table='video.dvd', where='$movie_id=#THIS.id'
+    ), dtype='N')
+    # Benchmark: SUM(price) join
+    movie.formulaColumn('dvd_total_price_join', sq_as_join=True,
+        sql_formula='COALESCE(#dflt_c_0, 0)',
+        select=dict(
+            columns='SUM($price)', table='video.dvd', where='$movie_id=#THIS.id'
+        ), dtype='N')
+    # Benchmark: COUNT with LIKE condition inline
+    movie.formulaColumn('dvd_count_like', select=dict(
+        columns='COUNT(*)', table='video.dvd',
+        where="$movie_id=#THIS.id AND $available LIKE :pattern", pattern='y%'
     ), dtype='L')
+    # Benchmark: COUNT with LIKE condition join
+    movie.formulaColumn('dvd_count_like_join', sq_as_join=True,
+        sql_formula='COALESCE(#dflt_c_0, 0)',
+        select=dict(
+            columns='COUNT(*)', table='video.dvd',
+            where="$movie_id=#THIS.id AND $available LIKE :pattern", pattern='y%'
+        ), dtype='L')
     movie.formulaColumn('dvd_stats', sql_formula='#total || :sep || #available',
         var_sep='/',
         select_total=dict(
@@ -180,6 +218,7 @@ def configurePackage(pkg):
     dvd.column('movie_id', 'L',name_short='Mid', name_long='Movie id').relation('movie.id')
     dvd.column('purchasedate', 'D', name_short='Pdt', name_long='Purchase date')
     dvd.column('available', name_short='Avl', name_long='Available')
+    dvd.column('price', 'N', name_short='Prc', name_long='Price')
 
     location = pkg.table('location',
                          name_short='Loc',
@@ -189,14 +228,52 @@ def configurePackage(pkg):
     location.column('name', name_short='Name', name_long='Name')
     location.column('rating', 'I', name_short='Rt', name_long='Rating')
 
-    # loc_allocation = pkg.table('loc_allocation',
-    #                            name_short='Loc. Alloc',
-    #                            name_long='Location Allocation',
-    #                            pkey='id')
-    # loc_allocation.column('id', 'L')
-    # loc_allocation.column('location_id', 'L', name_short='Loc', name_long='Location'
-    #                         ).relation('location.id')
-    # loc_allocation.column('movie_id', 'L', name_short='Movie', name_long='Movie ID'
-    #                         ).relation('movie.id')
-    # loc_allocation.column('from_date', 'D', name_short='From', name_long='From Date')
-    # loc_allocation.column('to_date', 'D', name_short='To', name_long='To Date')
+    country = pkg.table('country', name_short='Ctr', name_long='Country', pkey='id')
+    country.column('id', 'L')
+    country.column('name', name_short='Name', name_long='Name')
+    country.column('code', name_short='Cd', name_long='Code')
+    # Benchmark: total sales per country (inline)
+    country.formulaColumn('total_sales', select=dict(
+        columns='SUM($amount)', table='video.sales',
+        where='$country_id=#THIS.id'
+    ), dtype='N')
+    # Benchmark: total sales per country (join)
+    country.formulaColumn('total_sales_join', sq_as_join=True,
+        sql_formula='COALESCE(#dflt_c_0, 0)',
+        select=dict(
+            columns='SUM($amount)', table='video.sales',
+            where='$country_id=#THIS.id'
+        ), dtype='N')
+    # Benchmark: action movie sales per country (inline)
+    country.formulaColumn('action_sales', select=dict(
+        columns='SUM($amount)', table='video.sales',
+        where="$country_id=#THIS.id AND @dvd_id.@movie_id.genre=:genre",
+        genre='ACTION'
+    ), dtype='N')
+    # Benchmark: action movie sales per country (join)
+    country.formulaColumn('action_sales_join', sq_as_join=True,
+        sql_formula='COALESCE(#dflt_c_0, 0)',
+        select=dict(
+            columns='SUM($amount)', table='video.sales',
+            where="$country_id=#THIS.id AND @dvd_id.@movie_id.genre=:genre",
+            genre='ACTION'
+        ), dtype='N')
+    # Benchmark: count sales per country (inline)
+    country.formulaColumn('sale_count', select=dict(
+        columns='COUNT(*)', table='video.sales',
+        where='$country_id=#THIS.id'
+    ), dtype='L')
+    # Benchmark: count sales per country (join)
+    country.formulaColumn('sale_count_join', sq_as_join=True,
+        sql_formula='COALESCE(#dflt_c_0, 0)',
+        select=dict(
+            columns='COUNT(*)', table='video.sales',
+            where='$country_id=#THIS.id'
+        ), dtype='L')
+
+    sales = pkg.table('sales', name_short='Sls', name_long='Sales', pkey='id')
+    sales.column('id', 'L')
+    sales.column('dvd_id', 'L', name_short='Dvd', name_long='Dvd').relation('dvd.code')
+    sales.column('country_id', 'L', name_short='Ctr', name_long='Country').relation('country.id')
+    sales.column('sale_date', 'D', name_short='Sdt', name_long='Sale date')
+    sales.column('amount', 'N', name_short='Amt', name_long='Amount')

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -37,7 +37,7 @@ from gnr.sql.gnrsql import GnrSqlDb
 from gnr.sql.gnrsqldata import SqlQuery, SqlSelection, SqlCompiledQuery, SqlCompiledSubQuery
 from gnr.sql import gnrsqldata as gsd
 
-from .common import BaseGnrSqlTest, configurePackage
+from .common import BaseGnrSqlTest, configureDb
 
 class BaseSql(BaseGnrSqlTest):
     @classmethod
@@ -47,9 +47,7 @@ class BaseSql(BaseGnrSqlTest):
         # create database (actually create the DB file or structure)
 
         cls.db.createDb(cls.dbname)
-        # read the structure of the db from xml file: this is the recipe only
-        # cls.db.loadModel(cls.SAMPLE_XMLSTRUCT)
-        configurePackage(cls.db.packageSrc('video'))
+        configureDb(cls.db)
 
         # build the python db structure from the recipe
         cls.db.startup()
@@ -884,10 +882,11 @@ class BaseSql(BaseGnrSqlTest):
         compiler._alias = alias
         compiler._curr = tblobj.model.relations
         compiler._curr_tblobj = tblobj
-        result = compiler._preprocess_subqueryes(attr, as_join=True, alias=alias)
+        result, formula = compiler._preprocess_subqueryes(attr, as_join=True, alias=alias)
         print('\n=== preprocess output ===')
         for k, v in result.items():
             print(f'{k}: {v}')
+        print(f'formula: {formula}')
 
     def test_enable_sq_join_query_level(self):
         """Verify enable_sq_join=True at query level converts subquery to JOIN"""

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -854,18 +854,37 @@ class BaseSql(BaseGnrSqlTest):
                               where='$id = :id', id=3).fetch()
         assert result[0]['dvd_count_join'] == 0
 
+    def test_formulaColumn_raw_subquery_with_this(self):
+        """Verify legacy pattern: sql_formula with inline subselect and #THIS"""
+        q = self.db.query('video.movie', columns='$title,$dvd_count_raw',
+                          where='$id = :id', id=1)
+        result = q.fetch()
+        assert len(result) == 1
+        # compare with dvd_count (same logic via select=dict)
+        q2 = self.db.query('video.movie', columns='$title,$dvd_count',
+                           where='$id = :id', id=1)
+        result2 = q2.fetch()
+        assert result[0]['dvd_count_raw'] == result2[0]['dvd_count']
+
+    def test_formulaColumn_raw_subquery_sqltext(self):
+        """Verify #THIS is expanded in sql_formula (legacy pattern)"""
+        q = self.db.query('video.movie', columns='$title,$dvd_count_raw')
+        assert '#THIS' not in q.sqltext, f'#THIS not expanded in: {q.sqltext}'
+
     def test_sq_as_join_preprocess_output(self):
         """Verify _preprocess_subqueryes output when as_join=True"""
-        from gnr.sql.gnrsqldata import SqlQueryCompiler, THISFINDER
-        tblobj = self.db.table('video.movie').model
-        fldalias = tblobj.column('dvd_count_join')
+        from gnr.sql.gnrsqldata import SqlQueryCompiler
+        tblobj = self.db.table('video.movie')
+        fldalias = tblobj.model.column('dvd_count_join')
         import copy
         attr = copy.deepcopy(dict(fldalias.attributes))
         alias = 't0'
-        def expandThis(m):
-            return '%s.%s' % (alias, m.group(1))
         compiler = SqlQueryCompiler.__new__(SqlQueryCompiler)
-        result = compiler._preprocess_subqueryes(attr, as_join=True, alias=alias, expandThis=expandThis)
+        compiler.db = self.db
+        compiler._alias = alias
+        compiler._curr = tblobj.model.relations
+        compiler._curr_tblobj = tblobj
+        result = compiler._preprocess_subqueryes(attr, as_join=True, alias=alias)
         print('\n=== preprocess output ===')
         for k, v in result.items():
             print(f'{k}: {v}')

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -819,6 +819,30 @@ class BaseSql(BaseGnrSqlTest):
         # La struttura dell'SQL deve essere uguale (i mangler possono variare)
         assert sql1.upper().count('SELECT') == sql2.upper().count('SELECT')
 
+    # --- sq_as_join flag tests ---
+
+    def test_sq_as_join_flag_per_column(self):
+        """sq_as_join=True on formulaColumn is readable"""
+        tblobj = self.db.table('video.movie').model
+        fldalias_join = tblobj.column('dvd_count_join')
+        fldalias_plain = tblobj.column('dvd_count')
+        assert fldalias_join.attributes.get('sq_as_join') == True
+        assert fldalias_plain.attributes.get('sq_as_join') is None
+
+    def test_sq_as_join_same_result(self):
+        """dvd_count_join gives same result as dvd_count (still inline for now)"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count,$dvd_count_join',
+                              where='$id = :id', id=0).fetch()
+        assert result[0]['dvd_count_join'] == result[0]['dvd_count']
+
+    def test_sq_as_join_no_match(self):
+        """dvd_count_join returns 0 when no dvds"""
+        result = self.db.query('video.movie',
+                              columns='$title,$dvd_count_join',
+                              where='$id = :id', id=3).fetch()
+        assert result[0]['dvd_count_join'] == 0
+
     def teardown_class(cls):
         cls.db.closeConnection()
         cls.db.dropDb(cls.dbname)

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -848,11 +848,11 @@ class BaseSql(BaseGnrSqlTest):
         assert 'LEFT JOIN' in sqltext
 
     def test_sq_as_join_no_match(self):
-        """dvd_count_join returns 0 when no dvds"""
+        """dvd_count_join returns None when no dvds (no COALESCE without sql_formula)"""
         result = self.db.query('video.movie',
                               columns='$title,$dvd_count_join',
                               where='$id = :id', id=3).fetch()
-        assert result[0]['dvd_count_join'] == 0
+        assert result[0]['dvd_count_join'] is None
 
     def test_formulaColumn_raw_subquery_with_this(self):
         """Verify legacy pattern: sql_formula with inline subselect and #THIS"""
@@ -888,6 +888,19 @@ class BaseSql(BaseGnrSqlTest):
         print('\n=== preprocess output ===')
         for k, v in result.items():
             print(f'{k}: {v}')
+
+    def test_enable_sq_join_query_level(self):
+        """Verify enable_sq_join=True at query level converts subquery to JOIN"""
+        q_inline = self.db.query('video.movie', columns='$title,$dvd_count',
+                                  where='$id = :id', id=1)
+        q_join = self.db.query('video.movie', columns='$title,$dvd_count',
+                                where='$id = :id', id=1, enable_sq_join=True)
+        assert 'LEFT JOIN' in q_join.sqltext
+        assert '#dflt' not in q_join.sqltext
+        r_inline = q_inline.fetch()
+        r_join = q_join.fetch()
+        assert len(r_inline) == 1
+        assert r_inline[0]['dvd_count'] == r_join[0]['dvd_count']
 
     def teardown_class(cls):
         cls.db.closeConnection()

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -836,12 +836,39 @@ class BaseSql(BaseGnrSqlTest):
                               where='$id = :id', id=0).fetch()
         assert result[0]['dvd_count_join'] == result[0]['dvd_count']
 
+    def test_sq_as_join_sqltext(self):
+        """Check generated SQL contains LEFT JOIN"""
+        q = self.db.query('video.movie',
+                          columns='$title,$dvd_count_join',
+                          where='$id = :id', id=0)
+        compiled = q.compileQuery()
+        sqltext = compiled.get_sqltext(self.db)
+        print('\n=== SQL ===')
+        print(sqltext)
+        assert 'LEFT JOIN' in sqltext
+
     def test_sq_as_join_no_match(self):
         """dvd_count_join returns 0 when no dvds"""
         result = self.db.query('video.movie',
                               columns='$title,$dvd_count_join',
                               where='$id = :id', id=3).fetch()
         assert result[0]['dvd_count_join'] == 0
+
+    def test_sq_as_join_preprocess_output(self):
+        """Verify _preprocess_subqueryes output when as_join=True"""
+        from gnr.sql.gnrsqldata import SqlQueryCompiler, THISFINDER
+        tblobj = self.db.table('video.movie').model
+        fldalias = tblobj.column('dvd_count_join')
+        import copy
+        attr = copy.deepcopy(dict(fldalias.attributes))
+        alias = 't0'
+        def expandThis(m):
+            return '%s.%s' % (alias, m.group(1))
+        compiler = SqlQueryCompiler.__new__(SqlQueryCompiler)
+        result = compiler._preprocess_subqueryes(attr, as_join=True, alias=alias, expandThis=expandThis)
+        print('\n=== preprocess output ===')
+        for k, v in result.items():
+            print(f'{k}: {v}')
 
     def teardown_class(cls):
         cls.db.closeConnection()

--- a/gnrpy/tests/sql/test_condensation.py
+++ b/gnrpy/tests/sql/test_condensation.py
@@ -1,0 +1,191 @@
+"""Test standalone della logica di condensazione subquery.
+
+Funzione pura: riceve sq_dict e sql_formula, restituisce sq_dict condensato e formula adeguata.
+"""
+import re
+
+
+def condense_subqueries(sq_dict, sql_formula):
+    """Condensa subquery con stessa (table, where) in un unico entry.
+
+    Args:
+        sq_dict: dict {sq_name: {columns, table, where, ...}}
+        sql_formula: stringa con #nome riferimenti
+
+    Returns:
+        (sq_dict_condensato, formula_adeguata)
+    """
+    # Raggruppa per (table, where)
+    groups = {}
+    for sq_name, sq_pars in sq_dict.items():
+        key = (sq_pars['table'], sq_pars.get('where'))
+        groups.setdefault(key, []).append(sq_name)
+
+    col_counter = 0
+    remap = {}  # {absorbed_name: (master_name, col_alias)}
+
+    for key, names in groups.items():
+        if len(names) == 1:
+            # Singola subquery: assegna c_N alla colonna
+            sq_name = names[0]
+            sq_pars = sq_dict[sq_name]
+            col_alias = 'c_%i' % col_counter
+            sq_pars['columns'] = '%s AS %s' % (sq_pars['columns'], col_alias)
+            col_counter += 1
+            continue
+
+        # Gruppo condensabile: master = primo, assorbi gli altri
+        master = names[0]
+        master_pars = sq_dict[master]
+        merged_cols = []
+
+        for name in names:
+            pars = sq_dict[name]
+            col_alias = 'c_%i' % col_counter
+            merged_cols.append('%s AS %s' % (pars['columns'], col_alias))
+            if name != master:
+                remap[name] = (master, col_alias)
+            else:
+                master_col_alias = col_alias
+            col_counter += 1
+
+        master_pars['columns'] = ', '.join(merged_cols)
+
+        # Rimuovi assorbiti
+        for name in names[1:]:
+            del sq_dict[name]
+
+    # Adegua la formula
+    for absorbed, (master, col_alias) in remap.items():
+        sql_formula = re.sub(r'#%s\b' % absorbed, '%s.%s' % (master, col_alias), sql_formula)
+
+    # Sostituisci i riferimenti rimasti (non assorbiti) con nome.c_N
+    for sq_name, sq_pars in sq_dict.items():
+        # Estrai il primo c_N dalle colonne
+        m = re.search(r'AS (c_\d+)', sq_pars['columns'])
+        if m:
+            first_col = m.group(1)
+            sql_formula = re.sub(r'#%s\b' % sq_name, '%s.%s' % (sq_name, first_col), sql_formula)
+
+    return sq_dict, sql_formula
+
+
+# ============================================================
+# TEST
+# ============================================================
+
+class TestCondensation:
+
+    def test_no_condensation_different_where(self):
+        """Due subquery con where diversa: nessuna condensazione."""
+        sq_dict = {
+            'total': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                      'where': '$cliente_id=#THIS.id'},
+            'available': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                          'where': '$cliente_id=#THIS.id AND $available=:avail'},
+        }
+        formula = '#total || :sep || #available'
+
+        result, new_formula = condense_subqueries(sq_dict, formula)
+
+        # Entrambe presenti, nessuna assorbita
+        assert 'total' in result
+        assert 'available' in result
+        assert 'total.c_0' in new_formula
+        assert 'available.c_1' in new_formula
+
+    def test_condensation_same_table_where(self):
+        """Due subquery con stessa table+where: condensazione."""
+        sq_dict = {
+            'nfat': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                     'where': '$cliente_id=#THIS.id'},
+            'valfat': {'columns': 'SUM($totale_fattura)', 'table': 'fatt.fattura',
+                       'where': '$cliente_id=#THIS.id'},
+        }
+        formula = '#nfat || :sep || #valfat'
+
+        result, new_formula = condense_subqueries(sq_dict, formula)
+
+        # Solo nfat resta (master), valfat assorbita
+        assert 'nfat' in result
+        assert 'valfat' not in result
+        # Colonne fuse
+        assert 'COUNT(*) AS c_0' in result['nfat']['columns']
+        assert 'SUM($totale_fattura) AS c_1' in result['nfat']['columns']
+        # Formula adeguata
+        assert 'nfat.c_0' in new_formula
+        assert 'nfat.c_1' in new_formula
+        assert '#' not in new_formula
+
+    def test_single_subquery(self):
+        """Una sola subquery: nessuna condensazione, alias c_0."""
+        sq_dict = {
+            'dflt': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                     'where': '$cliente_id=#THIS.id'},
+        }
+        formula = '#dflt'
+
+        result, new_formula = condense_subqueries(sq_dict, formula)
+
+        assert 'dflt' in result
+        assert result['dflt']['columns'] == 'COUNT(*) AS c_0'
+        assert new_formula == 'dflt.c_0'
+
+    def test_single_subquery_in_coalesce(self):
+        """Una sola subquery dentro COALESCE."""
+        sq_dict = {
+            'dflt': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                     'where': '$cliente_id=#THIS.id'},
+        }
+        formula = 'COALESCE(#dflt, 0)'
+
+        result, new_formula = condense_subqueries(sq_dict, formula)
+
+        assert new_formula == 'COALESCE(dflt.c_0, 0)'
+
+    def test_three_subqueries_two_condensable(self):
+        """Tre subquery: due condensabili, una no."""
+        sq_dict = {
+            'nfat': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                     'where': '$cliente_id=#THIS.id'},
+            'valfat': {'columns': 'SUM($totale_fattura)', 'table': 'fatt.fattura',
+                       'where': '$cliente_id=#THIS.id'},
+            'nfat2014': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                         'where': "$cliente_id=#THIS.id AND $data>='2014-01-01'"},
+        }
+        formula = '#nfat || :s1 || #valfat || :s2 || #nfat2014'
+
+        result, new_formula = condense_subqueries(sq_dict, formula)
+
+        # nfat e valfat condensati, nfat2014 separato
+        assert 'nfat' in result
+        assert 'valfat' not in result
+        assert 'nfat2014' in result
+        assert 'nfat.c_0' in new_formula
+        assert 'nfat.c_1' in new_formula
+        assert 'nfat2014.c_2' in new_formula
+
+    def test_no_subqueries(self):
+        """Dict vuoto: nessun crash."""
+        sq_dict = {}
+        formula = 'UPPER($title)'
+
+        result, new_formula = condense_subqueries(sq_dict, formula)
+
+        assert result == {}
+        assert new_formula == 'UPPER($title)'
+
+    def test_formula_with_existing_qualified_ref(self):
+        """Formula che ha gia un riferimento qualificato #nome_colonna."""
+        sq_dict = {
+            'dflt': {'columns': 'COUNT(*)', 'table': 'fatt.fattura',
+                     'where': '$cliente_id=#THIS.id'},
+        }
+        # Utente scrive #dflt_c_0 esplicitamente
+        formula = 'COALESCE(#dflt_c_0, 0)'
+
+        result, new_formula = condense_subqueries(sq_dict, formula)
+
+        # #dflt NON deve matchare dentro #dflt_c_0 (word boundary)
+        # #dflt\b non matcha #dflt_c_0 perche _ e un word char
+        assert '#dflt_c_0' in new_formula  # resta invariato


### PR DESCRIPTION
## Summary

This PR implements the **subquery-to-JOIN transformation** for `formulaColumn` virtual columns, converting correlated inline subqueries (N+1 pattern) into pre-aggregated `LEFT JOIN` subqueries.

Additionally, it refactors the expand functions (`expandThis`, `expandPref`, `expandEnv`) from local closures into proper compiler methods, enabling `#THIS` expansion in legacy `sql_formula` with inline subselects.

## Commits

### STEP 3 — Transform correlated subqueries into LEFT JOIN (`d6fc9d6`)

Core implementation of the subquery-to-JOIN conversion.

### Refactor — Promote expand closures to compiler methods (`a0d702d`)

- `expandThis`, `expandPref`, `expandEnv` moved from closures inside `getFieldAlias` to methods on `SqlQueryCompiler`
- `expandThis` parameter removed from `_handleFormulaColumn`, `_preprocess_subqueryes`, `_compiledSubQuery`
- `#THIS`, `#ENV`, `#PREF` expansion added to `_preprocessFormula` — legacy `sql_formula` with inline subselects now resolved correctly

### Fix — Resolve `#dflt` placeholder and add `enable_sq_join` (`31ee76c`)

- Fixed: `#dflt` placeholder was not substituted when `formulaColumn` has only `select=dict(...)` without explicit `sql_formula` (the most common pattern in production code)
- Added: `enable_sq_join` parameter at query level for programmatic activation
- Updated tests: mix of production form (no formula) and expert form (explicit formula)

## How it works

### Activation

Three levels, with priority chain: **per-column > per-query > global**

- **Per-column**: `formulaColumn('name', sq_as_join=True, select=dict(...))`
- **Per-query**: `db.table('x').query(columns='...', enable_sq_join=True)`
- **Global**: `GnrSqlDb(..., subquery_as_join=True)` (passed via `extra_kw`)

### What happens

When `sq_as_join=True`, `_preprocess_subqueryes` extracts the correlation pattern (`$fk = #THIS.pk`) from the WHERE clause, splits it into a **joiner** (for the ON clause) and a **residual** (remaining WHERE conditions). It then adds `GROUP BY` on the FK field and assigns positional column aliases.

`_compiledSubQuery` builds the LEFT JOIN template:

```sql
LEFT JOIN (SELECT fk AS joiner, AGG(...) AS c_0 FROM ... GROUP BY fk) AS sq_name ON (...)
```

### Usage patterns

**Production form** (recommended — no `sql_formula` needed):
```python
tbl.formulaColumn('n_fatture', select=dict(
    table='fatt.fattura', columns='COUNT(*)', where='$cliente_id=#THIS.id'
), dtype='L')

# Activate at query level:
db.table('fatt.cliente').query(columns='$ragione_sociale,$n_fatture', enable_sq_join=True)
```

**Expert form** (with explicit `sql_formula` for wrapping):
```python
tbl.formulaColumn('dvd_count_join', sq_as_join=True,
    sql_formula='COALESCE(#dflt_c_0, 0)',
    select=dict(columns='COUNT(*)', table='video.dvd', where='$movie_id=#THIS.id'),
    dtype='L')
```

### SQL examples

**Inline (default)**:
```sql
SELECT t0.title,
  (SELECT COUNT(*) FROM video_dvd AS t0_t0 WHERE t0_t0.movie_id = t0.id) AS dvd_count
FROM video_movie AS t0
```

**LEFT JOIN (with enable_sq_join=True)**:
```sql
SELECT t0.title,
  (dflt.c_0) AS dvd_count
FROM video_movie AS t0
LEFT JOIN (
  SELECT t0_t0.movie_id AS joiner, COUNT(*) AS c_0
  FROM video_dvd AS t0_t0
  GROUP BY t0_t0.movie_id
) AS dflt ON (dflt.joiner = t0.id)
```

**With extra WHERE conditions** (e.g. `available='yes'`):
```sql
LEFT JOIN (
  SELECT t0_t0.movie_id AS joiner, COUNT(*) AS c_0
  FROM video_dvd AS t0_t0
  WHERE t0_t0.available = :sq0_avail
  GROUP BY t0_t0.movie_id
) AS dflt ON (dflt.joiner = t0.id)
```

**With cross-table joins** (e.g. sales -> dvd -> movie.genre):
```sql
LEFT JOIN (
  SELECT t0_t0.country_id AS joiner, SUM(t0_t0.amount) AS c_0
  FROM video_sales AS t0_t0
  INNER JOIN video_dvd AS t0_t1 ON t0_t0.dvd_id = t0_t1.code
  INNER JOIN video_movie AS t0_t2 ON t0_t1.movie_id = t0_t2.id
  WHERE t0_t2.genre = :sq0_genre
  GROUP BY t0_t0.country_id
) AS dflt ON (dflt.joiner = t0.id)
```

### Legacy sql_formula with #THIS

After the refactor, `sql_formula` containing inline subselects with `#THIS` are now properly expanded:

```python
movie.formulaColumn('dvd_count_raw',
    sql_formula="(SELECT COUNT(*) FROM video_dvd AS sq WHERE sq.movie_id = #THIS.id)",
    dtype='L')
```

`#THIS.id` is resolved to the current table alias (e.g. `t0.id`).

## Benchmark results

Tested with 10 countries, 500k sales (50k sales/country):

| Scenario | Inline | JOIN | Speedup |
|---|---|---|---|
| SUM(amount) | 0.098s | 0.029s | **3.4x** |
| SUM + genre filter | 0.036s | 0.058s | **0.6x** |
| COUNT(*) | 0.093s | 0.029s | **3.2x** |
| WHERE on SUM > threshold | 0.096s | 0.016s | **6.0x** |

### Key findings

- **Simple aggregations** (COUNT, SUM): 3-4x speedup
- **WHERE on virtual column**: **6x speedup** (inline evaluates subquery twice per row — once in SELECT, once in WHERE)
- **Cross-table joins with filters** (SUM + genre): can be **slower** as JOIN because the LEFT JOIN aggregates the entire dataset with all internal joins, while inline only processes rows matching the FK index
- PostgreSQL's Bitmap Index Scan makes correlated subqueries surprisingly efficient when FK columns are indexed

### Recommendation

The real benefit depends on the specific scenario. We recommend testing on real databases with real data and real views — especially views with many virtual columns used in WHERE/ORDER BY clauses, where the JOIN approach avoids repeated subquery evaluation.

## Test plan

- [x] 288 tests passing (0 regressions)
- [x] `test_sq_as_join_flag_per_column` — flag readable
- [x] `test_sq_as_join_same_result` — identical results to inline
- [x] `test_sq_as_join_sqltext` — SQL contains LEFT JOIN
- [x] `test_sq_as_join_no_match` — returns None without COALESCE
- [x] `test_formulaColumn_raw_subquery_with_this` — legacy #THIS expansion works
- [x] `test_formulaColumn_raw_subquery_sqltext` — #THIS absent from generated SQL
- [x] `test_enable_sq_join_query_level` — query-level activation works
- [x] Verified on real database (sandboxpg) with `fatt.cliente.n_fatture`
- [ ] Test on real application databases with complex views