### PR TITLE
fix(sqlite): correct notnull detection in getColInfo

### DIFF
--- a/gnrpy/gnr/sql/adapters/gnrsqlite.py
+++ b/gnrpy/gnr/sql/adapters/gnrsqlite.py
@@ -269,7 +269,7 @@ class SqlDbAdapter(SqlDbBaseAdapter):
                 colType = colType[:colType.find('(')]
             colType = colType.strip()
             col['dtype'] = self.typesDict[colType] if colType else 'T'
-            col['notnull'] = (col['notnull'] == 'NO')
+            col['notnull'] = bool(col['notnull'])
             col = self._filterColInfo(col, '_sl_')
             if col['dtype'] in ('A','C') and col.get('length'):
                 col['size'] = col['_sl_size'] if col['dtype']=='C' else '0:%s' %col['_sl_size']


### PR DESCRIPTION
## Summary

- Fix bug in `gnrsqlite.py:272` where `PRAGMA table_info` returns `notnull` as integer (1/0) but the code compared it to the string `'NO'`, always yielding `False`
- This caused `gnrdbsetup` to generate spurious `ALTER COLUMN SET NOT NULL` for every NOT NULL column on SQLite, which SQLite does not support

## Root cause

```python
# BUG: always False because int != str
col['notnull'] = (col['notnull'] == 'NO')

# FIX:
col['notnull'] = bool(col['notnull'])
```

## Test plan

- [x] Run `gnrdbsetup test_invoice` on a fresh SQLite DB — should no longer fail on NOT NULL ALTER
- [x] Verify existing SQL tests still pass

Ref #478