### PR TITLE
Refactor: extract freezed selection into dedicated proxy

### DIFF
--- a/gnrpy/gnr/web/_gnrbasewebpage.py
+++ b/gnrpy/gnr/web/_gnrbasewebpage.py
@@ -189,97 +189,25 @@ class GnrBaseWebPage(GnrObject):
             os.makedirs(folder)
         return os.path.join(folder, docname)
         
-    def freezeSelection(self, selection, name,**kwargs):
-        """TODO
-        
-        :param selection: TODO
-        :param name: TODO"""
-        path = self.pageLocalDocument(name)
-        selection.freeze(path, autocreate=True,**kwargs)
-        return path
+    def freezeSelection(self, selection, name, **kwargs):
+        return self.gnrfreezedselections.freezeSelection(selection, name, **kwargs)
 
-    def freezeSelectionUpdate(self,selection):
-        selection.freezeUpdate()
-        
+    def freezeSelectionUpdate(self, selection):
+        self.gnrfreezedselections.freezeSelectionUpdate(selection)
+
     def unfreezeSelection(self, dbtable=None, name=None, page_id=None):
-        """TODO
-        
-        :param dbtable: specify the :ref:`database table <table>`. More information in the
-                        :ref:`dbtable` section (:ref:`dbselect_examples_simple`)
-        :param name: TODO
-        :param page_id: TODO"""
-        assert name, 'name is mandatory'
-        if isinstance(dbtable, str):
-            dbtable = self.db.table(dbtable)
-        selection = self.db.unfreezeSelection(self.pageLocalDocument(name,page_id=page_id))
-        if dbtable and selection is not None:
-            assert dbtable == selection.dbtable, 'unfrozen selection does not belong to the given table'
-        return selection
-    
-    def freezedPkeys(self,dbtable=None,name=None,page_id=None):
-        assert name, 'name is mandatory'
-        if isinstance(dbtable, str):
-            dbtable = self.db.table(dbtable)
-        return self.db.freezedPkeys(self.pageLocalDocument(name,page_id=page_id))
+        return self.gnrfreezedselections.unfreezeSelection(dbtable=dbtable, name=name, page_id=page_id)
+
+    def freezedPkeys(self, dbtable=None, name=None, page_id=None):
+        return self.gnrfreezedselections.freezedPkeys(dbtable=dbtable, name=name, page_id=page_id)
 
     @public_method
     def getUserSelection(self, selectionName=None, selectedRowidx=None, filterCb=None, columns=None,
-                         sortBy=None,condition=None, table=None, condition_args=None,limit=None):
-        """TODO
-        
-        :param selectionName: TODO
-        :param selectedRowidx: TODO
-        :param filterCb: TODO
-        :param columns: it represents the :ref:`columns` to be returned by the "SELECT"
-                        clause in the traditional sql query. For more information, check the
-                        :ref:`sql_columns` section
-        :param condition: set a :ref:`sql_condition` for the selection
-        :param table: the :ref:`database table <table>` name on which the query will be executed,
-                      in the form ``packageName.tableName`` (packageName is the name of the
-                      :ref:`package <packages>` to which the table belongs to)
-        :param condition_args: the arguments of the *condition* parameter. Their syntax
-                               is ``condition_`` followed by the name of the argument"""
-        # table is for checking if the selection belong to the table
-        assert selectionName, 'selectionName is mandatory'
-        page_id = self.sourcepage_id or self.page_id
-        if isinstance(table, str):
-            table = self.db.table(table)
-        selection = self.unfreezeSelection(dbtable=table, name=selectionName,page_id=page_id)
-        table = table or selection.dbtable
-        if not columns and limit is not None:
-            qpars = dict(selection.querypars)
-            selection_limit = qpars.get('limit')
-            if selection_limit!=limit:
-                qpars['limit'] = limit
-                selection = table.query(**qpars).selection(_aggregateRows=True)
-        if filterCb:
-            filterCb = self.getPublicMethod('rpc',filterCb)
-            selection.filter(filterCb)
-        elif selectedRowidx:
-            if isinstance(selectedRowidx, str):
-                selectedRowidx = [int(x) for x  in selectedRowidx.split(',')]
-                selectedRowidx = set(selectedRowidx) #use uniquify (gnrlang) instead
-            selection.filter(lambda r: r['rowidx'] in selectedRowidx)
-        if sortBy:
-            selection.sort(sortBy)
-        if not columns:
-            return selection
-        if columns=='pkey':
-            return selection.output('pkeylist')
-        condition_args = condition_args or {}
-        pkeys = selection.output('pkeylist')
-        where = 't0.%s in :pkeys' % table.pkey
-        if condition:
-            where = '%s AND %s' % (where, condition)
-        selection = table.query(columns=columns, where=where,
-                                pkeys=pkeys, addPkeyColumn=False,
-                                excludeLogicalDeleted=False,
-                                ignorePartition=True,subtable='*',
-                                excludeDraft=False,limit=limit,
-                                **condition_args).selection(_aggregateRows=True)
-        if sortBy:
-            selection.sort(sortBy)
-        return selection
+                         sortBy=None, condition=None, table=None, condition_args=None, limit=None):
+        return self.gnrfreezedselections.getUserSelection(selectionName=selectionName,
+                         selectedRowidx=selectedRowidx, filterCb=filterCb, columns=columns,
+                         sortBy=sortBy, condition=condition, table=table,
+                         condition_args=condition_args, limit=limit)
         
     def getAbsoluteUrl(self, path, **kwargs):
         """Get TODO. Return an external link to the page

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -58,6 +58,7 @@ from gnr.web.gnrwebpage_proxy.gnrpdb import GnrPdbClient
 from gnr.web.gnrwebpage_proxy.utils import GnrWebUtils
 from gnr.web.gnrwebpage_proxy.pluginhandler import GnrWebPluginHandler
 from gnr.web.gnrwebpage_proxy.jstools import GnrWebJSTools
+from gnr.web.gnrwebpage_proxy.gnrfreezedselections import GnrFreezedSelections
 from gnr.web.gnrwebstruct import GnrGridStruct
 
  # DO NOT REMOVE, old code relies on BaseComponent being defined in this file
@@ -1548,6 +1549,12 @@ class GnrWebPage(GnrBaseWebPage):
         if not hasattr(self, '_app'):
             self._app = GnrWebAppHandler(self)
         return self._app
+
+    @property
+    def gnrfreezedselections(self):
+        if not hasattr(self, '_gnrfreezedselections'):
+            self._gnrfreezedselections = GnrFreezedSelections(self)
+        return self._gnrfreezedselections
         
     @property
     def menu(self):

--- a/gnrpy/gnr/web/gnrwebpage_proxy/apphandler.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/apphandler.py
@@ -572,76 +572,19 @@ class GnrWebAppHandler(GnrBaseProxy):
         return result
 
     @public_method
-    def freezedSelectionPkeys(self,table=None,selectionName=None,caption_field=None):
-        selection = self.page.unfreezeSelection(dbtable=table, name=selectionName)
-        l = selection.output('dictlist')
-        return [dict(pkey=r['pkey'],caption=r['caption_field']) if caption_field else r['pkey'] for r in l]
+    def freezedSelectionPkeys(self, table=None, selectionName=None, caption_field=None):
+        return self.page.gnrfreezedselections.freezedSelectionPkeys(
+            table=table, selectionName=selectionName, caption_field=caption_field)
 
     @public_method
-    def sumOnFreezedSelection(self,selectionName=None,where=None,table=None,sum_column=None,**kwargs):
-        """TODO
-        
-        ``sumOnFreezedSelection()`` method is decorated with the :meth:`public_method
-        <gnr.core.gnrdecorator.public_method>` decorator
-        
-        :param changelist: TODO
-        :param selectionName: TODO
-        :param where: the sql "WHERE" clause. For more information check the :ref:`sql_where` section
-        :param table: the :ref:`database table <table>` name on which the query will be executed,
-                      in the form ``packageName.tableName`` (packageName is the name of the
-                      :ref:`package <packages>` to which the table belongs to)"""
-        selection = self.page.unfreezeSelection(dbtable=table, name=selectionName)
-        if selection is None:
-            return 0
-        return selection.sum(sum_column)
-    
+    def sumOnFreezedSelection(self, selectionName=None, where=None, table=None, sum_column=None, **kwargs):
+        return self.page.gnrfreezedselections.sumOnFreezedSelection(
+            selectionName=selectionName, where=where, table=table, sum_column=sum_column, **kwargs)
+
     @public_method
-    def checkFreezedSelection(self,changelist=None,selectionName=None,where=None,table=None,**kwargs):
-        """TODO
-        
-        ``checkFreezedSelection()`` method is decorated with the :meth:`public_method
-        <gnr.core.gnrdecorator.public_method>` decorator
-        
-        :param changelist: TODO
-        :param selectionName: TODO
-        :param where: the sql "WHERE" clause. For more information check the :ref:`sql_where` section
-        :param table: the :ref:`database table <table>` name on which the query will be executed,
-                      in the form ``packageName.tableName`` (packageName is the name of the
-                      :ref:`package <packages>` to which the table belongs to)"""
-        selection = self.page.unfreezeSelection(dbtable=table, name=selectionName)
-        if selection is None:
-            return False #no update required
-        eventdict = {}
-        for change in changelist:
-            eventdict.setdefault(change['dbevent'],[]).append(change['pkey'])
-        deleted = eventdict.get('D',[])
-        if deleted:
-            if bool([r for r in selection.data if r['pkey'] in deleted]):
-                return True #update required delete in selection
-
-        updated = eventdict.get('U',[])
-        if updated:
-            if bool([r for r in selection.data if r['pkey'] in updated]):
-                return True #update required update in selection
-
-        inserted = eventdict.get('I',[])
-        kwargs.pop('where_attr',None)
-        tblobj = self.db.table(table)
-        wherelist = ['( $%s IN :_pkeys )' %tblobj.pkey]
-        if isinstance(where,Bag):
-            where, kwargs = self._decodeWhereBag(tblobj, where, kwargs)
-        if where:
-            wherelist.append(' ( %s ) ' %where)
-        condition = kwargs.pop('condition',None)
-        if condition:
-            wherelist.append(condition)
-        where = ' AND '.join(wherelist)
-        kwargs.pop('columns',None)
-        kwargs['limit'] = 1
-        if bool(tblobj.query(where=where,_pkeys=inserted+updated,**kwargs).fetch()):
-            return True #update required: insert or update not in selection but satisfying query
-
-        return False
+    def checkFreezedSelection(self, changelist=None, selectionName=None, where=None, table=None, **kwargs):
+        return self.page.gnrfreezedselections.checkFreezedSelection(
+            changelist=changelist, selectionName=selectionName, where=where, table=table, **kwargs)
 
 
     @public_method

--- a/gnrpy/gnr/web/gnrwebpage_proxy/gnrfreezedselections.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/gnrfreezedselections.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+#--------------------------------------------------------------------------
+# package           : GenroPy web - see LICENSE for details
+# module gnrfreezedselections : proxy for freezed selection lifecycle
+# Copyright (c)     : 2004 - 2007 Softwell sas - Milano
+# Written by    : Giovanni Porcari, Michele Bertoldi
+#                 Saverio Porcari, Francesco Porcari , Francesco Cavazzana
+#--------------------------------------------------------------------------
+#This library is free software; you can redistribute it and/or
+#modify it under the terms of the GNU Lesser General Public
+#License as published by the Free Software Foundation; either
+#version 2.1 of the License, or (at your option) any later version.
+
+#This library is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#Lesser General Public License for more details.
+
+#You should have received a copy of the GNU Lesser General Public
+#License along with this library; if not, write to the Free Software
+#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrdecorator import public_method
+from gnr.web.gnrwebpage_proxy.gnrbaseproxy import GnrBaseProxy
+
+
+class GnrFreezedSelections(GnrBaseProxy):
+
+    def freezeSelection(self, selection, name, **kwargs):
+        """Freeze a selection to disk.
+
+        :param selection: the SqlSelection to freeze
+        :param name: the document name used as freeze path"""
+        path = self.pageLocalDocument(name)
+        selection.freeze(path, autocreate=True, **kwargs)
+        return path
+
+    def freezeSelectionUpdate(self, selection):
+        """Update the frozen files for a previously frozen selection.
+
+        :param selection: the SqlSelection to update"""
+        selection.freezeUpdate()
+
+    def unfreezeSelection(self, dbtable=None, name=None, page_id=None):
+        """Restore a previously frozen selection from disk.
+
+        :param dbtable: specify the :ref:`database table <table>`. More information in the
+                        :ref:`dbtable` section (:ref:`dbselect_examples_simple`)
+        :param name: the document name used as freeze path
+        :param page_id: optional page_id override"""
+        assert name, 'name is mandatory'
+        if isinstance(dbtable, str):
+            dbtable = self.db.table(dbtable)
+        selection = self.db.unfreezeSelection(self.pageLocalDocument(name, page_id=page_id))
+        if dbtable and selection is not None:
+            assert dbtable == selection.dbtable, 'unfrozen selection does not belong to the given table'
+        return selection
+
+    def freezedPkeys(self, dbtable=None, name=None, page_id=None):
+        """Return the list of primary keys from a frozen selection.
+
+        :param dbtable: the database table
+        :param name: the document name used as freeze path
+        :param page_id: optional page_id override"""
+        assert name, 'name is mandatory'
+        if isinstance(dbtable, str):
+            dbtable = self.db.table(dbtable)
+        return self.db.freezedPkeys(self.pageLocalDocument(name, page_id=page_id))
+
+    @public_method
+    def getUserSelection(self, selectionName=None, selectedRowidx=None, filterCb=None, columns=None,
+                         sortBy=None, condition=None, table=None, condition_args=None, limit=None):
+        """Return a previously frozen selection, optionally filtered/sorted/re-queried.
+
+        :param selectionName: the name of the frozen selection
+        :param selectedRowidx: comma-separated row indices to filter
+        :param filterCb: a public method name to use as filter callback
+        :param columns: columns to re-query with
+        :param sortBy: sort expression
+        :param condition: additional WHERE condition
+        :param table: the database table name
+        :param condition_args: arguments for the condition
+        :param limit: limit the number of rows"""
+        assert selectionName, 'selectionName is mandatory'
+        page_id = self.sourcepage_id or self.page_id
+        if isinstance(table, str):
+            table = self.db.table(table)
+        selection = self.unfreezeSelection(dbtable=table, name=selectionName, page_id=page_id)
+        table = table or selection.dbtable
+        if not columns and limit is not None:
+            qpars = dict(selection.querypars)
+            selection_limit = qpars.get('limit')
+            if selection_limit != limit:
+                qpars['limit'] = limit
+                selection = table.query(**qpars).selection(_aggregateRows=True)
+        if filterCb:
+            filterCb = self.getPublicMethod('rpc', filterCb)
+            selection.filter(filterCb)
+        elif selectedRowidx:
+            if isinstance(selectedRowidx, str):
+                selectedRowidx = [int(x) for x in selectedRowidx.split(',')]
+                selectedRowidx = set(selectedRowidx)
+            selection.filter(lambda r: r['rowidx'] in selectedRowidx)
+        if sortBy:
+            selection.sort(sortBy)
+        if not columns:
+            return selection
+        if columns == 'pkey':
+            return selection.output('pkeylist')
+        condition_args = condition_args or {}
+        pkeys = selection.output('pkeylist')
+        where = 't0.%s in :pkeys' % table.pkey
+        if condition:
+            where = '%s AND %s' % (where, condition)
+        selection = table.query(columns=columns, where=where,
+                                pkeys=pkeys, addPkeyColumn=False,
+                                excludeLogicalDeleted=False,
+                                ignorePartition=True, subtable='*',
+                                excludeDraft=False, limit=limit,
+                                **condition_args).selection(_aggregateRows=True)
+        if sortBy:
+            selection.sort(sortBy)
+        return selection
+
+    @public_method
+    def freezedSelectionPkeys(self, table=None, selectionName=None, caption_field=None):
+        """Return pkeys (and optionally captions) from a frozen selection.
+
+        :param table: the database table
+        :param selectionName: the name of the frozen selection
+        :param caption_field: if truthy, return dicts with pkey and caption"""
+        selection = self.unfreezeSelection(dbtable=table, name=selectionName)
+        l = selection.output('dictlist')
+        return [dict(pkey=r['pkey'], caption=r['caption_field']) if caption_field else r['pkey'] for r in l]
+
+    @public_method
+    def sumOnFreezedSelection(self, selectionName=None, where=None, table=None, sum_column=None, **kwargs):
+        """Return the sum of a column on a frozen selection.
+
+        :param selectionName: the name of the frozen selection
+        :param where: the sql WHERE clause
+        :param table: the database table
+        :param sum_column: the column to sum"""
+        selection = self.unfreezeSelection(dbtable=table, name=selectionName)
+        if selection is None:
+            return 0
+        return selection.sum(sum_column)
+
+    @public_method
+    def checkFreezedSelection(self, changelist=None, selectionName=None, where=None, table=None, **kwargs):
+        """Check if a frozen selection needs to be refreshed given a list of DB changes.
+
+        :param changelist: list of dicts with 'dbevent' and 'pkey' keys
+        :param selectionName: the name of the frozen selection
+        :param where: the sql WHERE clause
+        :param table: the database table"""
+        selection = self.unfreezeSelection(dbtable=table, name=selectionName)
+        if selection is None:
+            return False
+        eventdict = {}
+        for change in changelist:
+            eventdict.setdefault(change['dbevent'], []).append(change['pkey'])
+        deleted = eventdict.get('D', [])
+        if deleted:
+            if bool([r for r in selection.data if r['pkey'] in deleted]):
+                return True
+        updated = eventdict.get('U', [])
+        if updated:
+            if bool([r for r in selection.data if r['pkey'] in updated]):
+                return True
+        inserted = eventdict.get('I', [])
+        kwargs.pop('where_attr', None)
+        tblobj = self.db.table(table)
+        wherelist = ['( $%s IN :_pkeys )' % tblobj.pkey]
+        if isinstance(where, Bag):
+            where, kwargs = self.page.app._decodeWhereBag(tblobj, where, kwargs)
+        if where:
+            wherelist.append(' ( %s ) ' % where)
+        condition = kwargs.pop('condition', None)
+        if condition:
+            wherelist.append(condition)
+        where = ' AND '.join(wherelist)
+        kwargs.pop('columns', None)
+        kwargs['limit'] = 1
+        if bool(tblobj.query(where=where, _pkeys=inserted + updated, **kwargs).fetch()):
+            return True
+        return False


### PR DESCRIPTION
## Summary

- Extract all freeze/unfreeze selection methods into a new `GnrFreezedSelections(GnrBaseProxy)` proxy at `gnrwebpage_proxy/gnrfreezedselections.py`
- 5 methods moved from `_gnrbasewebpage.py`: `freezeSelection`, `freezeSelectionUpdate`, `unfreezeSelection`, `freezedPkeys`, `getUserSelection`
- 3 methods moved from `apphandler.py`: `freezedSelectionPkeys`, `sumOnFreezedSelection`, `checkFreezedSelection`
- Original methods replaced with one-liner delegates for full backward compatibility
- Proxy can subscribe to page lifecycle events (`event_` pattern) for future selection cleanup

## Backward compatibility

All existing callers (`page.freezeSelection()`, `page.app.freezedSelectionPkeys()`, `batch/btcbase.py`) continue to work unchanged.

## Test plan

- [x] All 25 freeze/unfreeze tests pass
- [x] flake8 clean
- [ ] **Manual testing recommended**: test in a real application scenario (grid selection, batch operations, export from grid) before merging to verify full backward compatibility in production-like conditions

Ref #481