### PR TITLE
fix: require explicit opt-in for remoteRowController_default on empty rows

### DIFF
--- a/gnrjs/gnr_d11/js/genro_wdg.js
+++ b/gnrjs/gnr_d11/js/genro_wdg.js
@@ -826,6 +826,7 @@ dojo.declare("gnr.GridEditor", null, {
             this.autoSave = 3000;
         }
         this.remoteRowController = sourceNode.attr.remoteRowController;
+        this.remoteRowController_onEmptyRow = sourceNode.attr.remoteRowController_onEmptyRow;
         this.remoteRowController_default = sourceNode.attr.remoteRowController_default;
         if(this.remoteRowController_default){
             var caller_kw = {'script':"this.getParentNode().widget.gridEditor.callRemoteControllerBatch('*',null,true)",'_delay':500,
@@ -2304,8 +2305,9 @@ dojo.declare("gnr.GridChangeManager", null, {
                 const hasRemoteController = gridEditor.remoteRowController || rowSelectedQueries.len(rowEditor.data) > 0;
                 const hasMasterEditValue = rowEditor.data.getItem(this.grid.masterEditColumn()) !== null;
                 const hasDefaultController = gridEditor.remoteRowController_default;
+                const onEmptyRow = gridEditor.remoteRowController_onEmptyRow;
 
-                if (hasRemoteController && (hasMasterEditValue || hasDefaultController)) {
+                if (hasRemoteController && (hasMasterEditValue || (hasDefaultController && onEmptyRow))) {
                     gridEditor.callRemoteController(kw.node, null, null, true);
                 }
             }


### PR DESCRIPTION
## Summary
- The `triggerINS` in `GridChangeManager` was calling `callRemoteController` on empty new rows whenever `remoteRowController_default` was configured, even when the `masterEditColumn` had no value yet
- Now `remoteRowController_default` alone no longer triggers the controller on empty rows — the previous behavior (requiring `hasMasterEditValue`) is restored
- A new `remoteRowController_onEmptyRow` attribute can be explicitly set to opt-in to calling the controller on empty new rows when `remoteRowController_default` is configured

## Test plan
- [x] Verify grids with `remoteRowController_default` (e.g. master_detail) no longer fire the controller on empty new rows unless `remoteRowController_onEmptyRow` is also set
- [x] Verify that editing the `masterEditColumn` still triggers the controller as before
- [x] Verify that setting `remoteRowController_onEmptyRow=True` alongside `remoteRowController_default` restores the eager behavior on empty rows