### PR TITLE
feat(sql): SqlCompoundQuery for UNION/INTERSECT/EXCEPT operations

### DIFF
--- a/gnrpy/gnr/sql/gnrsql.py
+++ b/gnrpy/gnr/sql/gnrsql.py
@@ -1043,7 +1043,7 @@ class GnrSqlDb(GnrObject):
               relationDict=None, sqlparams=None, excludeLogicalDeleted=True,
               excludeDraft=True,
               addPkeyColumn=True,ignorePartition=False, locale=None,
-              mode=None,_storename=None,aliasPrefix=None,ignoreTableOrderBy=None, subtable=None,**kwargs):
+              mode=None,_storename=None,aliasPrefix=None,ignoreTableOrderBy=None, subtable=None,mainquery_kw=None,**kwargs):
         q = self.table(table).query(columns=columns, where=where, order_by=order_by,
                          distinct=distinct, limit=limit, offset=offset,
                          group_by=group_by, having=having, for_update=for_update,
@@ -1051,7 +1051,8 @@ class GnrSqlDb(GnrObject):
                          excludeLogicalDeleted=excludeLogicalDeleted,excludeDraft=excludeDraft,
                          ignorePartition=ignorePartition,
                          addPkeyColumn=addPkeyColumn, locale=locale,_storename=_storename,
-                         aliasPrefix=aliasPrefix,ignoreTableOrderBy=ignoreTableOrderBy,subtable=subtable)
+                         aliasPrefix=aliasPrefix,ignoreTableOrderBy=ignoreTableOrderBy,subtable=subtable,
+                         mainquery_kw=mainquery_kw)
         result = q.sqltext
         if kwargs:
             prefix = str(id(kwargs))

--- a/gnrpy/gnr/sql/gnrsqldata/__init__.py
+++ b/gnrpy/gnr/sql/gnrsqldata/__init__.py
@@ -28,7 +28,7 @@
 #   gnrsqldata/record.py    - SqlRecord, SqlRecordBag, SqlRelatedRecordResolver, SqlRelatedSelectionResolver
 
 from gnr.sql.gnrsqldata.compiler import SqlCompiledQuery, SqlQueryCompiler  # noqa: F401
-from gnr.sql.gnrsqldata.query import SqlQuery, SqlDataResolver  # noqa: F401
+from gnr.sql.gnrsqldata.query import SqlQuery, SqlDataResolver, SqlCompoundQuery  # noqa: F401
 from gnr.sql.gnrsqldata.selection import SqlSelection  # noqa: F401
 from gnr.sql.gnrsqldata.record import (SqlRecord, SqlRecordBag,  # noqa: F401
                                         SqlRelatedRecordResolver,

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -203,7 +203,7 @@ class SqlQueryCompiler(object):
         macro_expander: Adapter-specific macro expander instance.
     """
 
-    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None, aliasPrefix=None):
+    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None, aliasPrefix=None, mangler=None, query_kw=None, mainquery_kw=None, query=None):
         """Initialise the compiler for a given table.
 
         Args:
@@ -220,9 +220,17 @@ class SqlQueryCompiler(object):
                 used for date decoding and text formatting.
             aliasPrefix: Optional prefix for generated table aliases.
                 Defaults to ``'t'`` producing ``t0``, ``t1``, ...
+            mangler: Optional prefix for parameter namespacing in
+                compound queries.
+            query_kw: Optional dict of original query keyword arguments.
+            mainquery_kw: Optional dict of main query keyword arguments
+                (used by subqueries to access parent parameters).
+            query: Optional back-reference to the ``SqlQuery`` instance
+                that created this compiler.
         """
         self.tblobj = tblobj
         self.db = tblobj.db
+        self.query = query
         self.dbmodel = tblobj.db.model
         if tblobj.db.reuse_relation_tree:
             self.relations = tblobj.relations
@@ -235,6 +243,10 @@ class SqlQueryCompiler(object):
         self._currColKey = None
         self.aliasPrefix = aliasPrefix or 't'
         self.locale = locale
+        self.mangler = mangler
+        self.query_kw = query_kw or {}
+        self.mainquery_kw = mainquery_kw or {}
+        self.subquery_kw = {}
         self.macro_expander = self.db.adapter.macroExpander(self)
 
     def aliasCode(self, n):
@@ -248,6 +260,48 @@ class SqlQueryCompiler(object):
         """
         return '%s%i' %(self.aliasPrefix,n)
 
+    def mangle(self, sql_text):
+        """Prefix bind-parameter names with the mangler string.
+
+        Used by compound queries to namespace parameters from different
+        sub-queries so that they don't collide when merged into a single
+        ``sqlparams`` dict.
+
+        Parameters starting with ``env_`` are left untouched.
+
+        Args:
+            sql_text: SQL fragment potentially containing ``:param``
+                placeholders.
+
+        Returns:
+            str: The fragment with mangled parameter names, or the
+            original text if no mangler is set.
+        """
+        if not self.mangler:
+            return sql_text
+        def replace_param(m):
+            param_name = m.group(2)
+            if param_name.startswith('env_'):
+                return m.group(0)
+            if param_name in self.sqlparams:
+                return '%s%s_%s%s' % (m.group(1), self.mangler, param_name, m.group(3))
+            return m.group(0)
+        return re.sub(r"(:)(\w+)(\W|$)", replace_param, sql_text)
+
+    def mangleParams(self):
+        """Rename entries in ``sqlparams`` with the mangler prefix.
+
+        After mangling the SQL text, the actual parameter keys must be
+        updated to match.  Environment parameters (``env_*``) are skipped.
+        """
+        if not self.mangler:
+            return
+        for k, v in list(self.sqlparams.items()):
+            if not k.startswith('env_'):
+                mangled_key = '%s_%s' % (self.mangler, k)
+                mangled_value = self.query_kw.get(k, self.mainquery_kw.get(k))
+                self.subquery_kw[mangled_key] = mangled_value
+                self.sqlparams[mangled_key] = v
 
     def init(self, lazy=None, eager=None):
         """Reset per-compilation state before a new compilation pass.
@@ -1094,14 +1148,16 @@ class SqlQueryCompiler(object):
 
         # --- Store all compiled fragments into the SqlCompiledQuery ---
         self.cpl.distinct = distinct
-        self.cpl.columns = self.macro_expander.replace(columns,'TSRANK,TSHEADLINE')
-        self.cpl.where = where
-        self.cpl.group_by = group_by
-        self.cpl.having = having
-        self.cpl.order_by = self.macro_expander.replace(order_by,'TSRANK')
+        self.cpl.columns = self.mangle(self.macro_expander.replace(columns,'TSRANK,TSHEADLINE'))
+        self.cpl.where = self.mangle(where)
+        self.cpl.group_by = self.mangle(group_by)
+        self.cpl.having = self.mangle(having)
+        self.cpl.order_by = self.mangle(self.macro_expander.replace(order_by,'TSRANK'))
+        self.cpl.joins = [self.mangle(j) for j in self.cpl.joins]
         self.cpl.limit = limit
         self.cpl.offset = offset
         self.cpl.for_update = for_update
+        self.mangleParams()
         # REVIEW: commented-out debug raise -- remove if no longer needed
         #raise str(self.cpl.get_sqltext(self.db))  # uncomment it for hard debug
         return self.cpl

--- a/gnrpy/gnr/sql/gnrsqldata/query.py
+++ b/gnrpy/gnr/sql/gnrsqldata/query.py
@@ -151,6 +151,8 @@ class SqlQuery(object):
                  locale=None,_storename=None,
                  checkPermissions=None,
                  aliasPrefix=None,
+                 mangler=None,
+                 mainquery_kw=None,
                  **kwargs):
         self.dbtable = dbtable
         self.sqlparams = sqlparams or {}
@@ -159,6 +161,8 @@ class SqlQuery(object):
         self.joinConditions = joinConditions or {}
         self.sqlContextName = sqlContextName
         self.relationDict = relationDict or {}
+        self.enable_sq_join = kwargs.pop('enable_sq_join', None)
+        self.query_kw = dict(kwargs)
         self.sqlparams.update(kwargs)
         self.excludeLogicalDeleted = excludeLogicalDeleted
         self.excludeDraft = excludeDraft
@@ -169,6 +173,8 @@ class SqlQuery(object):
         self.storename = _storename
         self.checkPermissions = checkPermissions
         self.aliasPrefix = aliasPrefix
+        self.mangler = mangler
+        self.mainquery_kw = mainquery_kw or {}
         test = " ".join([v for v in (columns, where, order_by, group_by, having) if v])
         rels = set(re.findall(r'\$(\w*)', test))
         params = set(re.findall(r'\:(\w*)', test))
@@ -228,9 +234,13 @@ class SqlQuery(object):
                                 sqlContextName=self.sqlContextName,
                                 sqlparams=self.sqlparams,
                                 aliasPrefix=self.aliasPrefix,
-                                locale=self.locale).compiledQuery(count=count,
-                                                                  relationDict=self.relationDict,
-                                                                  **self.querypars)
+                                locale=self.locale,
+                                mangler=self.mangler,
+                                query_kw=self.query_kw,
+                                mainquery_kw=self.mainquery_kw,
+                                query=self).compiledQuery(count=count,
+                                                          relationDict=self.relationDict,
+                                                          **self.querypars)
 
     def cursor(self):
         """Get a cursor of the current selection."""
@@ -570,6 +580,25 @@ class SqlQuery(object):
                 n = l[0][0]
             cursor.close()
         return n
+
+    def _next_mangler_key(self, prefix):
+        """Generate a unique mangler key for parameter namespacing.
+
+        Each call increments a per-prefix counter stored in the database
+        environment, producing keys like ``sq0``, ``sq1``, ``cq0``, etc.
+
+        Args:
+            prefix: Short string prefix (e.g. ``'sq'`` for subqueries,
+                ``'cq'`` for compound queries).
+
+        Returns:
+            str: A unique key like ``'cq0'``, ``'cq1'``, etc.
+        """
+        env = self.db.currentEnv
+        counters = env.setdefault('_mangler_counters', {})
+        idx = counters.get(prefix, 0)
+        counters[prefix] = idx + 1
+        return '%s%d' % (prefix, idx)
 
 
 # ===========================================================================

--- a/gnrpy/gnr/sql/gnrsqldata/query.py
+++ b/gnrpy/gnr/sql/gnrsqldata/query.py
@@ -600,6 +600,113 @@ class SqlQuery(object):
         counters[prefix] = idx + 1
         return '%s%d' % (prefix, idx)
 
+    def _compound(self, other, operator):
+        """Combine this query with *other* using a SQL set operator.
+
+        Args:
+            other: Another ``SqlQuery`` or ``SqlCompoundQuery``.
+            operator: SQL set operator string (``'UNION'``,
+                ``'UNION ALL'``, ``'INTERSECT'``, ``'EXCEPT'``).
+
+        Returns:
+            SqlCompoundQuery: A new compound query combining both.
+        """
+        if isinstance(other, SqlCompoundQuery):
+            self_key = self._next_mangler_key('cq')
+            self.mangler = self_key
+            queries = dict(other.queries)
+            queries[self_key] = self
+            template = '{%s} %s SELECT * FROM (%s) AS _cr' % (self_key, operator, other._template)
+        else:
+            self_key = self._next_mangler_key('cq')
+            other_key = other._next_mangler_key('cq')
+            self.mangler = self_key
+            other.mangler = other_key
+            queries = {self_key: self, other_key: other}
+            template = '{%s} %s {%s}' % (self_key, operator, other_key)
+        return SqlCompoundQuery(queries=queries, template=template,
+                                dbtable=self.dbtable, db=self.db)
+
+    def __add__(self, other):
+        return self._compound(other, 'UNION')
+
+    def __or__(self, other):
+        return self._compound(other, 'UNION ALL')
+
+    def __and__(self, other):
+        return self._compound(other, 'INTERSECT')
+
+    def __sub__(self, other):
+        return self._compound(other, 'EXCEPT')
+
+
+class SqlCompoundQuery(SqlQuery):
+    """A query built from multiple ``SqlQuery`` instances combined with
+    SQL set operators (UNION, INTERSECT, EXCEPT).
+
+    Created via the ``+``, ``|``, ``&``, ``-`` operators on ``SqlQuery``::
+
+        q_union     = q1 + q2   # UNION
+        q_union_all = q1 | q2   # UNION ALL
+        q_intersect = q1 & q2   # INTERSECT
+        q_except    = q1 - q2   # EXCEPT
+
+    Each sub-query is compiled independently with a mangler prefix so
+    that bind parameters don't collide.
+    """
+
+    def __init__(self, queries, template, dbtable, db):
+        self.queries = queries
+        self._template = template
+        self.dbtable = dbtable
+        self.db = db
+        self.storename = None
+
+    def _get_sqltext(self):
+        return self._template.format(**{k: q.sqltext for k, q in self.queries.items()})
+
+    sqltext = property(_get_sqltext)
+
+    def _get_compiled(self):
+        return next(iter(self.queries.values())).compiled
+
+    compiled = property(_get_compiled)
+
+    @property
+    def sqlparams(self):
+        result = {}
+        for q in self.queries.values():
+            result.update(q.sqlparams)
+        return result
+
+    def _compound(self, other, operator):
+        queries = dict(self.queries)
+        if isinstance(other, SqlCompoundQuery):
+            queries.update(other.queries)
+            template = 'SELECT * FROM (%s) AS _cl %s SELECT * FROM (%s) AS _cr' % (
+                self._template, operator, other._template)
+        else:
+            key = other._next_mangler_key('cq')
+            other.mangler = key
+            queries[key] = other
+            template = '%s %s {%s}' % (self._template, operator, key)
+        return SqlCompoundQuery(queries=queries, template=template,
+                                dbtable=self.dbtable, db=self.db)
+
+    def count(self):
+        """Return the total number of rows in the compound result.
+
+        Wraps the compound SQL in a ``SELECT count(*)`` wrapper.
+
+        Returns:
+            int: The total row count.
+        """
+        count_sql = 'SELECT count(*) AS gnr_row_count FROM (%s) AS _compound' % self.sqltext
+        cursor = self.db.execute(count_sql, self.sqlparams,
+                                 dbtable=self.dbtable.fullname,
+                                 storename=self.storename)
+        return cursor.fetchall()[0][0]
+
 
 # ===========================================================================
 # REVIEW NOTES (query.py)

--- a/gnrpy/tests/sql/test_compound_query.py
+++ b/gnrpy/tests/sql/test_compound_query.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for SqlCompoundQuery — UNION, INTERSECT, EXCEPT via Python operators.
+
+Uses the standard video test database with movie, dvd, cast, people tables.
+
+Movie data reference (11 movies, id 0..10):
+    id=0  Match point        year=2005  genre=DRAMA      nationality=USA,UK
+    id=1  Scoop              year=2006  genre=COMEDY     nationality=USA,UK
+    id=2  Munich             year=2005  genre=DRAMA      nationality=USA
+    id=3  Saving private Ryan year=1998 genre=WAR        nationality=USA
+    id=4  Eyes wide shut     year=1999  genre=DRAMA      nationality=UK
+    id=5  Barry Lindon       year=1975  genre=DRAMA      nationality=UK
+    id=6  Scarface           year=1983  genre=CRIME      nationality=USA
+    id=7  The untouchables   year=1987  genre=CRIME      nationality=USA
+    id=8  Psycho             year=1960  genre=THRILLER   nationality=UK
+    id=9  The Aviator        year=2004  genre=BIOGRAPHY  nationality=USA
+    id=10 The Departed       year=2006  genre=CRIME      nationality=USA
+"""
+
+from gnr.sql.gnrsql import GnrSqlDb
+from gnr.sql.gnrsqldata import SqlCompoundQuery
+
+from .common import BaseGnrSqlTest, configureDb
+
+
+class BaseCompoundQuery(BaseGnrSqlTest):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.init()
+        cls.db.createDb(cls.dbname)
+        configureDb(cls.db)
+        cls.db.startup()
+        cls.db.checkDb(applyChanges=True)
+        cls.db.importXmlData(cls.SAMPLE_XMLDATA)
+        cls.db.commit()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.closeConnection()
+        cls.db.dropDb(cls.dbname)
+
+    # -- helpers --
+
+    def _movie_query(self, **kwargs):
+        return self.db.query('video.movie', columns='$id,$title,$year,$genre,$nationality', **kwargs)
+
+    def _ids(self, compound_q):
+        """Execute a compound query and return sorted list of movie ids."""
+        rows = self.db.execute(compound_q.sqltext, compound_q.sqlparams,
+                               dbtable='video.movie').fetchall()
+        return sorted(r[0] for r in rows)
+
+    def _id_list(self, compound_q):
+        """Execute and return ids preserving order (with duplicates)."""
+        rows = self.db.execute(compound_q.sqltext, compound_q.sqlparams,
+                               dbtable='video.movie').fetchall()
+        return [r[0] for r in rows]
+
+    # ================================================================
+    # 1. UNION (+) — removes duplicates
+    # ================================================================
+
+    def test_union_basic(self):
+        """UNION of year=2005 and year=2006 gives 4 distinct movies."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        cq = q1 + q2
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 10}
+
+    def test_union_removes_duplicates(self):
+        """UNION with overlapping sets removes duplicates."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 + q2
+        ids = self._ids(cq)
+        # DRAMA: {0,2,4,5} ∪ year2005: {0,2} → {0,2,4,5}
+        assert set(ids) == {0, 2, 4, 5}
+
+    # ================================================================
+    # 2. UNION ALL (|) — keeps duplicates
+    # ================================================================
+
+    def test_union_all_basic(self):
+        """UNION ALL of year=2005 and year=2006 gives 4 rows (no overlap)."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        cq = q1 | q2
+        assert isinstance(cq, SqlCompoundQuery)
+        assert cq.count() == 4
+
+    def test_union_all_keeps_duplicates(self):
+        """UNION ALL with overlapping sets keeps duplicate rows."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 | q2
+        all_ids = self._id_list(cq)
+        # DRAMA: 4 rows + year2005: 2 rows = 6 total
+        assert len(all_ids) == 6
+
+    # ================================================================
+    # 3. INTERSECT (&) — only common rows
+    # ================================================================
+
+    def test_intersect_basic(self):
+        """INTERSECT of DRAMA and year=2005 gives only dramas from 2005."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 & q2
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        # DRAMA ∩ year2005: Match point (0) and Munich (2)
+        assert set(ids) == {0, 2}
+
+    def test_intersect_empty(self):
+        """INTERSECT of disjoint sets gives 0 rows."""
+        q1 = self._movie_query(where="$genre=:g", g='COMEDY')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 & q2
+        assert cq.count() == 0
+
+    # ================================================================
+    # 4. EXCEPT (-) — set difference
+    # ================================================================
+
+    def test_except_basic(self):
+        """EXCEPT removes rows present in second query."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 - q2
+        ids = self._ids(cq)
+        # DRAMA\year2005: {0,2,4,5} \ {0,2} → {4,5}
+        assert set(ids) == {4, 5}
+
+    def test_except_all_removed(self):
+        """EXCEPT where second set contains all of first gives 0 rows."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where="$genre=:g", g='DRAMA')
+        cq = q1 - q2
+        # year2005={0,2} both DRAMA → empty
+        assert cq.count() == 0
+
+    # ================================================================
+    # 5. Chains of 3 queries
+    # ================================================================
+
+    def test_chain_three_union(self):
+        """q1 + q2 + q3 chains three UNION operations."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1999)
+        cq = q1 + q2 + q3
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 4, 10}
+
+    def test_chain_mixed_operators(self):
+        """(q1 + q2) - q3 removes from a union."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where="$genre=:g", g='DRAMA')
+        cq = (q1 + q2) - q3
+        ids = self._ids(cq)
+        # {0,1,2,10} \ {0,2,4,5} → {1,10}
+        assert set(ids) == {1, 10}
+
+    # ================================================================
+    # 6. Parentheses change evaluation order
+    # ================================================================
+
+    def test_parentheses_union_then_except(self):
+        """(DRAMA + CRIME) - year2005 gives different result than DRAMA + (CRIME - year2005)."""
+        # Case A: (DRAMA + CRIME) - year2005
+        q1a = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2a = self._movie_query(where="$genre=:g", g='CRIME')
+        q3a = self._movie_query(where='$year=:y', y=2005)
+        cq_a = (q1a + q2a) - q3a
+        ids_a = set(self._ids(cq_a))
+        # DRAMA∪CRIME = {0,2,4,5,6,7,10}, minus year2005={0,2} → {4,5,6,7,10}
+        assert ids_a == {4, 5, 6, 7, 10}
+
+        # Case B: DRAMA + (CRIME - year2005)
+        q1b = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2b = self._movie_query(where="$genre=:g", g='CRIME')
+        q3b = self._movie_query(where='$year=:y', y=2005)
+        cq_b = q1b + (q2b - q3b)
+        ids_b = set(self._ids(cq_b))
+        # CRIME\year2005 = {6,7,10} (no CRIME in 2005), DRAMA∪{6,7,10} = {0,2,4,5,6,7,10}
+        assert ids_b == {0, 2, 4, 5, 6, 7, 10}
+
+        assert ids_a != ids_b
+
+    # ================================================================
+    # 7. Mangler — same param names, different values
+    # ================================================================
+
+    def test_mangler_different_values(self):
+        """Two queries with same param name :y but different values produce correct results."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=1960)
+        cq = q1 + q2
+        ids = self._ids(cq)
+        # year2005={0,2} ∪ year1960={8}
+        assert set(ids) == {0, 2, 8}
+
+    def test_mangler_same_param_name_three_queries(self):
+        """Three queries all using :y with different values."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1960)
+        cq = q1 + q2 + q3
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 8, 10}
+
+    def test_mangler_mixed_param_names(self):
+        """Two queries with different param names don't interfere."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where="$genre=:g", g='CRIME')
+        cq = q1 + q2
+        ids = self._ids(cq)
+        # year2005={0,2} ∪ CRIME={6,7,10}
+        assert set(ids) == {0, 2, 6, 7, 10}
+
+    # ================================================================
+    # 8. count() method
+    # ================================================================
+
+    def test_count_union(self):
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        cq = q1 + q2
+        assert cq.count() == 4
+
+    def test_count_intersect(self):
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 & q2
+        assert cq.count() == 2
+
+    def test_count_except(self):
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 - q2
+        assert cq.count() == 2
+
+    def test_count_chain(self):
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1999)
+        cq = q1 + q2 + q3
+        assert cq.count() == 5
+
+    # ================================================================
+    # 9. CompoundQuery + SqlQuery
+    # ================================================================
+
+    def test_compound_plus_simple(self):
+        """(q1 + q2) + q3 — compound extended with a simple query."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1960)
+        cq = (q1 + q2) + q3
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 8, 10}
+
+    def test_compound_minus_simple(self):
+        """(q1 | q2) - q3 — except a simple query from a compound."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where="$genre=:g", g='DRAMA')
+        cq = (q1 | q2) - q3
+        ids = self._ids(cq)
+        # UNION ALL(2005,2006)={0,2,1,10} EXCEPT DRAMA={0,2,4,5} → {1,10}
+        assert set(ids) == {1, 10}
+
+    # ================================================================
+    # 10. CompoundQuery + CompoundQuery
+    # ================================================================
+
+    def test_compound_plus_compound(self):
+        """(q1 + q2) + (q3 + q4) merges two compound queries."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1960)
+        q4 = self._movie_query(where='$year=:y', y=1975)
+        cq = (q1 + q2) + (q3 + q4)
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        # {0,2} ∪ {1,10} ∪ {8} ∪ {5}
+        assert set(ids) == {0, 1, 2, 5, 8, 10}
+
+    def test_compound_intersect_compound(self):
+        """(DRAMA | CRIME) & (UK | USA) — intersect of two compound queries."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where="$genre=:g", g='CRIME')
+        q3 = self._movie_query(where="$nationality=:n", n='UK')
+        q4 = self._movie_query(where="$nationality=:n", n='USA')
+        cq = (q1 | q2) & (q3 | q4)
+        ids = self._ids(cq)
+        # DRAMA|CRIME (all): {0,2,4,5,6,7,10}
+        # UK|USA (exact match): UK={4,5,8}, USA={2,3,6,7,9,10}
+        # intersection: {2,4,5,6,7,10}
+        assert set(ids) == {2, 4, 5, 6, 7, 10}
+
+
+# ================================================================
+# Backend-specific test classes
+# ================================================================
+
+class TestCompoundQuery_sqlite(BaseCompoundQuery):
+    @classmethod
+    def init(cls):
+        cls.name = 'sqlite'
+        cls.dbname = cls.CONFIG['db.sqlite?filename']
+        cls.db = GnrSqlDb(dbname=cls.dbname)
+
+
+class TestCompoundQuery_postgres(BaseCompoundQuery):
+    @classmethod
+    def init(cls):
+        cls.name = 'postgres'
+        cls.dbname = 'test_compound'
+        cls.db = GnrSqlDb(implementation='postgres',
+                          host=cls.pg_conf.get("host"),
+                          port=cls.pg_conf.get("port"),
+                          dbname=cls.dbname,
+                          user=cls.pg_conf.get("user"),
+                          password=cls.pg_conf.get("password"))
+
+
+class TestCompoundQuery_postgres3(BaseCompoundQuery):
+    @classmethod
+    def init(cls):
+        cls.name = 'postgres3'
+        cls.dbname = 'test_compound'
+        cls.db = GnrSqlDb(implementation='postgres3',
+                          host=cls.pg_conf.get("host"),
+                          port=cls.pg_conf.get("port"),
+                          dbname=cls.dbname,
+                          user=cls.pg_conf.get("user"),
+                          password=cls.pg_conf.get("password"))


### PR DESCRIPTION
## Summary

- Add mangler infrastructure to `SqlQueryCompiler` for parameter namespacing in compound queries
- Add `SqlCompoundQuery` class enabling SQL set operations via Python operators: `+` (UNION), `|` (UNION ALL), `&` (INTERSECT), `-` (EXCEPT)
- Operators are chainable (`q1 + q2 + q3`) and respect Python parentheses for evaluation order
- 66 tests (22 × 3 backends: sqlite, postgres, postgres3) covering all operators, chains, parentheses, mangler namespacing, count(), and compound-compound composition

## Test plan

- [x] All 601 existing tests pass (18 pre-existing failures unchanged)
- [x] 66 new compound query tests pass on sqlite, postgres, postgres3

Ref #467