### PR TITLE
fix: remove indexed=True from email.message to_address

### DIFF
--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -24,7 +24,7 @@ class Table(object):
         self.sysFields(tbl,draftField=True,ldel=False)
         
         tbl.column('in_out', size='1', name_long='!!I/O', name_short='!!I/O',values='I:Input,O:Output')
-        tbl.column('to_address',name_long='!!To',indexed=True,_sendback=True)
+        tbl.column('to_address',name_long='!!To',_sendback=True)
         tbl.column('from_address',name_long='!!From',_sendback=True)
         tbl.column('cc_address',name_long='!!Cc',_sendback=True)
         tbl.column('bcc_address',name_long='!!Bcc',_sendback=True)


### PR DESCRIPTION
## Summary
- Remove `indexed=True` from the `to_address` column in `email.message` model
- The `to_address` field can contain multiple comma-separated email addresses (especially for bulk sends), making a database index on this column ineffective and wasteful

Reverts part of the change introduced in #447.