### PR TITLE
refactor(core): docstrings, type hints and review for gnrbaseservice.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,18 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: 89a91221b70426feb160a11cec96670dee95942d

--- a/gnrpy/gnr/core/gnrbaseservice.py
+++ b/gnrpy/gnr/core/gnrbaseservice.py
@@ -1,3 +1,12 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
+"""gnrbaseservice - Backward-compatibility alias for GnrBaseService.
 
-from gnr.lib.services import GnrBaseService # noqa: F401
+This module re-exports :class:`gnr.lib.services.GnrBaseService` to maintain
+backward compatibility for code that imports from ``gnr.core.gnrbaseservice``.
+
+The canonical location is :mod:`gnr.lib.services`.
+"""
+
+from gnr.lib.services import GnrBaseService  # noqa: F401
+
+__all__ = ["GnrBaseService"]

--- a/gnrpy/gnr/core/gnrbaseservice_review.md
+++ b/gnrpy/gnr/core/gnrbaseservice_review.md
@@ -1,0 +1,46 @@
+# gnrbaseservice.py — Review
+
+## Summary
+
+This module is a backward-compatibility alias that re-exports `GnrBaseService`
+from its canonical location in `gnr.lib.services`.
+
+## Why no split
+
+- Only 3 lines of code (now ~10 with docstring)
+- Single responsibility: re-export one class
+- Already minimal and cohesive
+- Splitting would add complexity without benefit
+
+## Structure
+
+- **Lines**: 11 (including docstring)
+- **Classes**: 0 (re-exports 1)
+- **Functions**: 0
+- **Constants**: 0
+
+## Dependencies
+
+### This module imports from:
+- `gnr.lib.services` — imports `GnrBaseService`
+
+### Other modules that import this:
+- `gnr.web.gnrwsgisite_proxy.gnrservicehandler` — imports `GnrBaseService`
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| — | — | No issues found |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `GnrBaseService` | class (re-export) | USED | `gnr.web.gnrwsgisite_proxy.gnrservicehandler` |
+
+## Recommendations
+
+Consider deprecating this module in favor of direct imports from
+`gnr.lib.services`. The current re-export exists only for backward
+compatibility. A deprecation warning could be added in a future version.


### PR DESCRIPTION
## Summary

Analyzed `gnrbaseservice.py` (3 lines). Module is a backward-compatibility
alias that re-exports `GnrBaseService` from `gnr.lib.services`. Does not
benefit from splitting.

### Quality improvements applied:
- Google-style module docstring (English)
- Added `__all__` declaration
- Formatted with ruff/black

Added `gnrbaseservice_review.md` with structure analysis, dependency map.

## Why no split

This is a 3-line re-export module. Its only purpose is to maintain backward
compatibility for code that imports `GnrBaseService` from `gnr.core.gnrbaseservice`
instead of the canonical location `gnr.lib.services`.

## Issues found

- 0 `# REVIEW:` markers added (no issues found)

## Usage map

- 1 public symbol analyzed (`GnrBaseService` re-export)
- 0 marked as DEAD

## Verification

- [x] ruff check / flake8 zero errors
- [x] ruff format / black applied
- [x] `from gnr.core.gnrbaseservice import GnrBaseService` works

Ref #486