### PR TITLE
refactor(core): docstrings, type hints and review for gnrenv.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,33 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 25cf171af

--- a/gnrpy/gnr/core/gnrenv.py
+++ b/gnrpy/gnr/core/gnrenv.py
@@ -1,22 +1,51 @@
-import sys, os
+# -*- coding: utf-8 -*-
+"""gnrenv - Genro environment path constants.
+
+This module defines the default paths for the Genro framework directories:
+
+- ``GNRHOME``: Root directory of the Genro installation
+- ``GNRINSTANCES``: Directory containing Genro instances
+- ``GNRPACKAGES``: Directory containing Genro packages
+- ``GNRSITES``: Directory containing Genro sites
+
+Paths are resolved from environment variables (``GNRHOME``, ``GNRINSTANCES``,
+``GNRPACKAGES``, ``GNRSITES``) or fall back to platform-specific defaults.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
 
 try:
     from gnr.core import gnrhome
-    _PLATFORM_DEFAULT_PATH = gnrhome.PATH # pragma: no cover
-except:
-    # FIXME: testing in win32 env?
-    if sys.platform == 'win32': # pragma: no cover
-        _PLATFORM_DEFAULT_PATH = r'C:\genro'
-    else:
-        _PLATFORM_DEFAULT_PATH = '/usr/local/genro'
 
-_GNRHOME = os.path.split(os.environ.get('GNRHOME', _PLATFORM_DEFAULT_PATH))
-GNRHOME = os.path.join(*_GNRHOME)
-_GNRINSTANCES = (os.environ.get('GNRINSTANCES') and os.path.split(os.environ.get('GNRINSTANCES'))) or (
-_GNRHOME + ('data', 'instances'))
-GNRINSTANCES = os.path.join(*_GNRINSTANCES)
-_GNRPACKAGES = (os.environ.get('GNRPACKAGES') and os.path.split(os.environ.get('GNRPACKAGES'))) or (
-_GNRHOME + ('packages',))
-GNRPACKAGES = os.path.join(*_GNRPACKAGES)
-_GNRSITES = (os.environ.get('GNRSITES') and os.path.split(os.environ.get('GNRSITES'))) or (_GNRHOME + ('data', 'sites'))
-GNRSITES = os.path.join(*_GNRSITES)
+    _PLATFORM_DEFAULT_PATH: str = gnrhome.PATH  # pragma: no cover
+except Exception:  # REVIEW:COMPAT — bare except catches too broadly
+    # FIXME: testing in win32 env?
+    if sys.platform == "win32":  # pragma: no cover
+        _PLATFORM_DEFAULT_PATH = r"C:\genro"
+    else:
+        _PLATFORM_DEFAULT_PATH = "/usr/local/genro"
+
+_GNRHOME: tuple[str, ...] = os.path.split(
+    os.environ.get("GNRHOME", _PLATFORM_DEFAULT_PATH)
+)
+GNRHOME: str = os.path.join(*_GNRHOME)
+
+_GNRINSTANCES: tuple[str, ...] = (
+    os.environ.get("GNRINSTANCES") and os.path.split(os.environ.get("GNRINSTANCES"))  # type: ignore[arg-type]
+) or (_GNRHOME + ("data", "instances"))
+GNRINSTANCES: str = os.path.join(*_GNRINSTANCES)
+
+_GNRPACKAGES: tuple[str, ...] = (
+    os.environ.get("GNRPACKAGES") and os.path.split(os.environ.get("GNRPACKAGES"))  # type: ignore[arg-type]
+) or (_GNRHOME + ("packages",))
+GNRPACKAGES: str = os.path.join(*_GNRPACKAGES)
+
+_GNRSITES: tuple[str, ...] = (
+    os.environ.get("GNRSITES") and os.path.split(os.environ.get("GNRSITES"))  # type: ignore[arg-type]
+) or (_GNRHOME + ("data", "sites"))
+GNRSITES: str = os.path.join(*_GNRSITES)
+
+__all__ = ["GNRHOME", "GNRINSTANCES", "GNRPACKAGES", "GNRSITES"]

--- a/gnrpy/gnr/core/gnrenv_review.md
+++ b/gnrpy/gnr/core/gnrenv_review.md
@@ -1,0 +1,60 @@
+# gnrenv.py — Review
+
+## Summary
+
+This module defines default paths for Genro framework directories by reading
+environment variables and falling back to platform-specific defaults.
+
+## Why no split
+
+- Only 22 lines of code (now ~50 with docstring and type hints)
+- Single responsibility: define path constants
+- All code is tightly interdependent (paths depend on `_GNRHOME`)
+- Splitting would add complexity without benefit
+
+## Structure
+
+- **Lines**: 50 (including docstring and type hints)
+- **Classes**: 0
+- **Functions**: 0
+- **Constants**: 8 (4 public: `GNRHOME`, `GNRINSTANCES`, `GNRPACKAGES`, `GNRSITES`)
+
+## Dependencies
+
+### This module imports from:
+- `os` — path manipulation
+- `sys` — platform detection
+- `gnr.core.gnrhome` — (optional) platform-specific default path
+
+### Other modules that import this:
+- `gnr.tests.core.gnrenv_test` — imports module for existence test only
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| 23 | COMPAT | Bare `except` catches too broadly; should use `except Exception` or specific types |
+
+**Note**: The COMPAT issue has been addressed in this refactoring by changing
+`except:` to `except Exception:`.
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `GNRHOME` | str constant | DEAD | (none found in codebase) |
+| `GNRINSTANCES` | str constant | DEAD | (none found in codebase) |
+| `GNRPACKAGES` | str constant | DEAD | (none found in codebase) |
+| `GNRSITES` | str constant | DEAD | (none found in codebase) |
+
+## Recommendations
+
+1. **Investigate usage**: The public constants appear to have zero callers in
+   the current codebase. They may be used by external code or may be obsolete.
+   Consider deprecating if truly unused.
+
+2. **Use `pathlib`**: Modern Python code should prefer `pathlib.Path` over
+   `os.path.join`. Consider migrating in a future refactoring.
+
+3. **Remove FIXME**: The comment about win32 testing should be investigated
+   and either fixed or the comment removed if no longer relevant.


### PR DESCRIPTION
## Summary

Analyzed `gnrenv.py` (22 lines). Module defines Genro environment path
constants (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES). Does not
benefit from splitting.

### Quality improvements applied:
- Google-style module docstring (English)
- Type hints for all constants
- Added `__all__` declaration
- Formatted with ruff/black
- Changed bare `except:` to `except Exception:`

Added `gnrenv_review.md` with structure analysis, dependency map.

## Why no split

This is a 22-line module that defines path constants. All constants are
interdependent (`_GNRHOME` is used as base for others). The module has
a single, clear responsibility.

## Issues found

- 1 `# REVIEW:COMPAT` marker added (bare except was too broad)

## Usage map

- 4 public symbols analyzed
- 4 marked as DEAD (zero callers found in codebase)

**Note**: These constants may be used by external code not in this repository.

## Verification

- [x] ruff check / flake8 zero errors
- [x] ruff format / black applied
- [x] `from gnr.core.gnrenv import *` works
- [x] Existing tests pass (empty test file, import only)

Ref #486