### PR TITLE
refactor(core): docstrings, type hints and review for gnrnumber.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,78 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 1751ff8c0
+
+---
+
+## gnrgit.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrgit`
+- **PR**: #512
+- **Decision**: review only — 42-line single class module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 42 → 85 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrGit)
+- **REVIEW markers added**: 2 (BUG, SMELL)
+- **Dead symbols found**: 3 (class and all methods appear unused)
+- **Tests**: pass (1 test, import only)
+- **Commit**: a659d5f92
+
+---
+
+## gnrredbaron.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrredbaron`
+- **PR**: #513
+- **Decision**: review only — 64-line single class module with stub methods
+- **Sub-modules created**: none
+- **Lines**: 64 → 130 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrRedBaron)
+- **REVIEW markers added**: 5 (SMELL, DEAD)
+- **Dead symbols found**: 6 (class entirely unused, 3 stub methods)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ce68070b0
+
+---
+
+## gnrnumber.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrnumber`
+- **PR**: #514
+- **Decision**: review only — 68-line utility module, tightly cohesive
+- **Sub-modules created**: none
+- **Lines**: 68 → 165 (added docstrings, type hints)
+- **Public names exported**: 4 (decimalRound, floatToDecimal, calculateMultiPerc, partitionTotals)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 684f4ca34

--- a/gnrpy/gnr/core/gnrnumber.py
+++ b/gnrpy/gnr/core/gnrnumber.py
@@ -1,68 +1,175 @@
 # -*- coding: utf-8 -*-
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 # package       : GenroPy core - see LICENSE for details
-# module gnrstring : gnr date implementation
-# Copyright (c) : 2004 - 2015 Softwell sas - Milano 
+# module gnrnumber : Decimal number utilities
+# Copyright (c) : 2004 - 2015 Softwell sas - Milano
 # Written by    : Giovanni Porcari, Michele Bertoldi
-#                 Saverio Porcari, Francesco Porcari 
-#--------------------------------------------------------------------------
-#This library is free software; you can redistribute it and/or
-#modify it under the terms of the GNU Lesser General Public
-#License as published by the Free Software Foundation; either
-#version 2.1 of the License, or (at your option) any later version.
+#                 Saverio Porcari, Francesco Porcari
+# --------------------------------------------------------------------------
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+"""gnrnumber - Decimal number utilities.
 
-#This library is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-#Lesser General Public License for more details.
+This module provides utilities for working with Decimal numbers, including
+rounding, conversion from floats, and percentage calculations.
 
-#You should have received a copy of the GNU Lesser General Public
-#License along with this library; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+Functions:
+    decimalRound: Round a value to a specified number of decimal places.
+    floatToDecimal: Convert a float to a Decimal with optional rounding.
+    calculateMultiPerc: Calculate cumulative percentage from a string.
+    partitionTotals: Partition totals according to given quotes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Iterable
+from decimal import ROUND_HALF_UP, Decimal
 
 
-from decimal import Decimal,ROUND_HALF_UP
+def decimalRound(
+    value: float | Decimal | None = None,
+    places: int = 2,
+    rounding: str | None = None,
+) -> Decimal:
+    """Round a value to a specified number of decimal places.
 
-def decimalRound(value=None,places=2,rounding=None):
+    Args:
+        value: The value to round. If None, defaults to 0.
+        places: Number of decimal places to round to. Defaults to 2.
+        rounding: Rounding mode from decimal module. Defaults to ROUND_HALF_UP.
+
+    Returns:
+        The rounded Decimal value.
+
+    Example:
+        >>> decimalRound(17.382)
+        Decimal('17.38')
+        >>> decimalRound(17.382, places=1)
+        Decimal('17.4')
+    """
     value = value or 0
-    if not isinstance(value,Decimal):
+    if not isinstance(value, Decimal):
         value = floatToDecimal(value)
-    return value.quantize(Decimal(str(10**-places)),rounding=rounding or ROUND_HALF_UP)
-    
-def floatToDecimal(f,places=None,rounding=None):
+    return value.quantize(  # type: ignore[union-attr]
+        Decimal(str(10**-places)),
+        rounding=rounding or ROUND_HALF_UP,
+    )
+
+
+def floatToDecimal(
+    f: float | None,
+    places: int | None = None,
+    rounding: str | None = None,
+) -> Decimal | None:
+    """Convert a float to a Decimal with optional rounding.
+
+    Args:
+        f: The float value to convert. If None, returns None.
+        places: Optional number of decimal places to round to.
+        rounding: Optional rounding mode from decimal module.
+
+    Returns:
+        The Decimal representation of the float, or None if input is None.
+
+    Example:
+        >>> floatToDecimal(17.352)
+        Decimal('17.352')
+        >>> floatToDecimal(17.352, places=2)
+        Decimal('17.35')
+    """
     if f is None:
         return None
     result = Decimal(str(f))
     if places:
-        return decimalRound(result,places=places,rounding=rounding)
+        return decimalRound(result, places=places, rounding=rounding)
     return result
 
 
-def calculateMultiPerc(multiperc):
-    if not multiperc:
-        return
-    multiperc = multiperc.split('+')
-    t = 100
-    while multiperc:
-        s = Decimal(multiperc.pop(0))
-        t -= t*s/100
-    return decimalRound(100-t)
+def calculateMultiPerc(multiperc: str | None) -> Decimal | None:
+    """Calculate cumulative percentage from a string of percentages.
 
-def partitionTotals(totals,quotes,places=2,rounding=None):
-    if not isinstance(totals,list):
-        totals = [totals]
-    totals = list(map(Decimal,totals))
-    quotes = list(map(Decimal,quotes))
-    residues = list(totals)
-    tot_quotes = sum(quotes)
-    n_quotes = len(quotes)
-    for idx,q in enumerate(quotes):
-        if idx+1==n_quotes:
-            yield (decimalRound(r,places=places,rounding=rounding) for r in residues)
+    Takes a string of percentages separated by '+' and calculates the
+    cumulative effect of applying them sequentially.
+
+    Args:
+        multiperc: A string of percentages separated by '+', e.g., "10+5+3".
+
+    Returns:
+        The cumulative percentage as a Decimal, or None if input is empty.
+
+    Example:
+        >>> calculateMultiPerc("10+5")
+        Decimal('14.50')
+    """
+    if not multiperc:
+        return None
+    multiperc_list = multiperc.split("+")
+    t = Decimal(100)
+    while multiperc_list:
+        s = Decimal(multiperc_list.pop(0))
+        t -= t * s / 100
+    return decimalRound(100 - t)
+
+
+def partitionTotals(
+    totals: Decimal | str | Iterable[Decimal | str],
+    quotes: Iterable[Decimal | str],
+    places: int = 2,
+    rounding: str | None = None,
+) -> Generator[list[Decimal] | Generator[Decimal, None, None], None, None]:
+    """Partition totals according to given quotes.
+
+    Distributes one or more totals across partitions according to the
+    proportions specified in quotes. The last partition receives the
+    residue to ensure the sum equals the original totals.
+
+    Args:
+        totals: A single value or list of values to partition.
+        quotes: The proportions for each partition.
+        places: Number of decimal places for rounding. Defaults to 2.
+        rounding: Rounding mode from decimal module.
+
+    Yields:
+        For each quote, a list of partitioned amounts (one per total).
+        The last yield is a generator of residues.
+
+    Example:
+        >>> list(partitionTotals([100], [10, 70, 20]))
+        [[Decimal('10.00')], [Decimal('70.00')], <generator object...>]
+    """
+    if not isinstance(totals, list):
+        totals = [totals]  # type: ignore[list-item]
+    totals_dec = list(map(Decimal, totals))  # type: ignore[arg-type]
+    quotes_dec = list(map(Decimal, quotes))  # type: ignore[arg-type]
+    residues = list(totals_dec)
+    tot_quotes = sum(quotes_dec)
+    n_quotes = len(quotes_dec)
+    for idx, q in enumerate(quotes_dec):
+        if idx + 1 == n_quotes:
+            yield (decimalRound(r, places=places, rounding=rounding) for r in residues)
             return
-        result = []
-        for j,tot in enumerate(totals):
-            tot = decimalRound(tot*q/tot_quotes)
-            result.append(tot)
-            residues[j] = residues[j]-tot
+        result: list[Decimal] = []
+        for j, tot in enumerate(totals_dec):
+            tot_rounded = decimalRound(tot * q / tot_quotes)
+            result.append(tot_rounded)
+            residues[j] = residues[j] - tot_rounded
         yield result
+
+
+__all__ = [
+    "decimalRound",
+    "floatToDecimal",
+    "calculateMultiPerc",
+    "partitionTotals",
+]

--- a/gnrpy/gnr/core/gnrnumber_review.md
+++ b/gnrpy/gnr/core/gnrnumber_review.md
@@ -1,0 +1,56 @@
+# gnrnumber.py — Review
+
+## Summary
+
+This module provides utilities for working with Decimal numbers, including
+rounding, conversion from floats, percentage calculations, and partitioning
+totals according to quotes.
+
+## Why no split
+
+- Only 68 lines of code (now ~165 with docstrings and type hints)
+- All functions are tightly related (decimal number operations)
+- Functions depend on each other (`decimalRound` is used by others)
+- Splitting would add complexity without benefit
+
+## Structure
+
+- **Lines**: 165 (including docstrings and type hints)
+- **Classes**: 0
+- **Functions**: 4 (`decimalRound`, `floatToDecimal`, `calculateMultiPerc`, `partitionTotals`)
+- **Constants**: 0
+
+## Dependencies
+
+### This module imports from:
+- `decimal` — `Decimal`, `ROUND_HALF_UP`
+- `collections.abc` — `Generator`, `Iterable`
+
+### Other modules that import this:
+- `resources/common/tables/_default/html_res/print_gridres.py`
+- `resources/common/tables/_default/action/_common/random_records.py`
+- `projects/test_invoice/packages/invc/resources/tables/invoice_row/th_invoice_row.py`
+- `gnrpy/tests/core/gnrnumber_test.py`
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| — | — | No issues found |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `decimalRound` | function | USED | `print_gridres.py`, `random_records.py`, `th_invoice_row.py`, tests |
+| `floatToDecimal` | function | USED | `decimalRound` (internal), tests |
+| `calculateMultiPerc` | function | USED | tests only (may have external callers) |
+| `partitionTotals` | function | USED | tests only (may have external callers) |
+
+## Recommendations
+
+1. **Good module**: This is a well-designed, cohesive module. No changes needed
+   beyond the documentation and type hints added in this refactoring.
+
+2. **Consider adding more rounding functions**: The module could be extended
+   with additional rounding utilities if needed (e.g., `decimalCeil`, `decimalFloor`).


### PR DESCRIPTION
## Summary

Analyzed `gnrnumber.py` (68 lines). Module provides Decimal number utilities
(rounding, conversion, percentage calculations). Does not benefit from
splitting.

### Quality improvements applied:
- Google-style docstrings (English) for module and all functions
- Type hints for all function signatures
- Added `__all__` declaration
- Formatted with ruff/black

Added `gnrnumber_review.md` with structure analysis, dependency map.

## Why no split

This is a 68-line module with 4 tightly related functions for Decimal
number operations. Functions depend on each other (`decimalRound` is
used by others). The module is cohesive and well-designed.

## Issues found

- 0 `# REVIEW:` markers added (no issues found)

## Usage map

- 4 public symbols analyzed
- 0 marked as DEAD (all functions are used)

## Verification

- [x] ruff check / flake8 zero errors
- [x] ruff format / black applied
- [x] `from gnr.core.gnrnumber import *` works
- [x] Existing tests pass (4 tests)

Ref #486