### PR TITLE
refactor(core): docstrings, type hints and review for gnrcaldav.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,93 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 1751ff8c0
+
+---
+
+## gnrgit.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrgit`
+- **PR**: #512
+- **Decision**: review only — 42-line single class module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 42 → 85 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrGit)
+- **REVIEW markers added**: 2 (BUG, SMELL)
+- **Dead symbols found**: 3 (class and all methods appear unused)
+- **Tests**: pass (1 test, import only)
+- **Commit**: a659d5f92
+
+---
+
+## gnrredbaron.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrredbaron`
+- **PR**: #513
+- **Decision**: review only — 64-line single class module with stub methods
+- **Sub-modules created**: none
+- **Lines**: 64 → 130 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrRedBaron)
+- **REVIEW markers added**: 5 (SMELL, DEAD)
+- **Dead symbols found**: 6 (class entirely unused, 3 stub methods)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ce68070b0
+
+---
+
+## gnrnumber.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrnumber`
+- **PR**: #514
+- **Decision**: review only — 68-line utility module, tightly cohesive
+- **Sub-modules created**: none
+- **Lines**: 68 → 165 (added docstrings, type hints)
+- **Public names exported**: 4 (decimalRound, floatToDecimal, calculateMultiPerc, partitionTotals)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 5e8118199
+
+---
+
+## gnrcaldav.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcaldav`
+- **PR**: #515
+- **Decision**: review only — 79-line DEPRECATED module, cannot be imported
+- **Sub-modules created**: none
+- **Lines**: 79 → 220 (added docstrings, type hints, preserved unreachable code)
+- **Public names exported**: 2 (CalDavConnection, dt) — but unreachable
+- **REVIEW markers added**: 3 (DEAD, SECURITY x2)
+- **Dead symbols found**: 5 (entire module is deprecated)
+- **Tests**: N/A (module cannot be imported)
+- **Commit**: ac314ba11

--- a/gnrpy/gnr/core/gnrcaldav.py
+++ b/gnrpy/gnr/core/gnrcaldav.py
@@ -1,79 +1,237 @@
-raise DeprecationWarning("Please don't using gnr.core.gnrcaldav module, deprecated. Will be removed soon")
+# -*- coding: utf-8 -*-
+"""gnrcaldav - CalDAV calendar integration (DEPRECATED).
 
-from datetime import datetime
-import caldav
-from caldav.elements import dav
+.. deprecated::
+    This module is deprecated and will be removed in a future version.
+    Do not use ``gnr.core.gnrcaldav``.
 
-from gnr.core.gnrbag import Bag,VObjectBag
-from gnr.core.gnrlang import getUuid
+This module provided CalDAV calendar integration using the caldav library.
+It is no longer maintained and should not be used in new code.
+"""
 
-def test():
-    return CalDavConnection(user='giovanni.porcari@softwell.it',password='toporaton',host='p04-caldav.icloud.com',root='/9403090/calendars/')
-def test1():
-    return CalDavConnection(user='gpo@localhost',password='',host='localhost',port=5232,root='/gpo/calendard',protocol='http')
-    
-def testcal():
-    s=test()
-    personale=s.calendars['Personale']
-    events= personale.events()
-    e0=events[0]
+from __future__ import annotations
+
+# REVIEW:DEAD — entire module is deprecated (line 1 raises DeprecationWarning)
+raise DeprecationWarning(
+    "Please don't using gnr.core.gnrcaldav module, deprecated. Will be removed soon"
+)
+
+# The code below is unreachable due to the raise above, but is preserved
+# for reference during the deprecation period.
+
+from datetime import datetime  # noqa: E402, F401
+from typing import TYPE_CHECKING, Any  # noqa: E402, F401
+
+import caldav  # noqa: E402, F401
+from caldav.elements import dav  # noqa: E402, F401
+
+from gnr.core.gnrbag import Bag, VObjectBag  # noqa: E402, F401
+from gnr.core.gnrlang import getUuid  # noqa: E402, F401
+
+if TYPE_CHECKING:
+    from caldav import Calendar, DAVClient, Principal
+
+
+def test() -> "CalDavConnection":  # pragma: no cover
+    """Test function with hardcoded credentials (DO NOT USE).
+
+    Returns:
+        A CalDavConnection instance.
+
+    Warning:
+        Contains hardcoded credentials. For testing only.
+    """
+    # REVIEW:SECURITY — hardcoded credentials in source code
+    return CalDavConnection(
+        user="giovanni.porcari@softwell.it",
+        password="toporaton",
+        host="p04-caldav.icloud.com",
+        root="/9403090/calendars/",
+    )
+
+
+def test1() -> "CalDavConnection":  # pragma: no cover
+    """Test function for local CalDAV server.
+
+    Returns:
+        A CalDavConnection instance.
+    """
+    return CalDavConnection(
+        user="gpo@localhost",
+        password="",
+        host="localhost",
+        port=5232,
+        root="/gpo/calendard",
+        protocol="http",
+    )
+
+
+def testcal() -> Any:  # pragma: no cover
+    """Test function to fetch calendar events.
+
+    Returns:
+        Event data from the first event in 'Personale' calendar.
+    """
+    s = test()
+    personale = s.calendars["Personale"]
+    events = personale.events()
+    e0 = events[0]
     e0.load()
-    data=e0.data
+    data = e0.data
     return data
-def dt(dt):
-    if isinstance(dt,datetime):
-        return dt.strftime('%Y%m%dT%H%M%SZ')
-    return dt
-class CalDavConnection(object):
-    def __init__(self,host=None,user=None,password=None,root=None,port=443,protocol='https'):
-        self.host=host
-        self.port=port
-        self.user=user
-        self.password=password
-        self.root=root or '/'
-        self.protocol=protocol
-        self.url='%s://%s:%s@%s:%s%s' %(self.protocol,self.user,self.password,self.host,self.port,self.root)
-        
+
+
+def dt(dt_val: datetime | str) -> str:
+    """Convert datetime to iCalendar format string.
+
+    Args:
+        dt_val: A datetime object or string.
+
+    Returns:
+        The datetime formatted as iCalendar string (YYYYMMDDTHHMMSSz).
+    """
+    if isinstance(dt_val, datetime):
+        return dt_val.strftime("%Y%m%dT%H%M%SZ")
+    return dt_val  # type: ignore[return-value]
+
+
+class CalDavConnection:
+    """CalDAV server connection wrapper.
+
+    Provides methods to connect to a CalDAV server and manage calendars
+    and events.
+
+    Args:
+        host: CalDAV server hostname.
+        user: Username for authentication.
+        password: Password for authentication.
+        root: Root path on the server.
+        port: Server port. Defaults to 443.
+        protocol: Protocol to use ('http' or 'https'). Defaults to 'https'.
+
+    Attributes:
+        host: Server hostname.
+        port: Server port.
+        user: Username.
+        password: Password.
+        root: Root path.
+        protocol: Connection protocol.
+        url: Full connection URL.
+    """
+
+    def __init__(
+        self,
+        host: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        root: str | None = None,
+        port: int = 443,
+        protocol: str = "https",
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.root = root or "/"
+        self.protocol = protocol
+        # REVIEW:SECURITY — password in URL is not secure
+        self.url = (
+            f"{self.protocol}://{self.user}:{self.password}@"
+            f"{self.host}:{self.port}{self.root}"
+        )
+
     @property
-    def client(self):
-        if not hasattr(self,'_client'):
-            self._client=caldav.DAVClient(self.url)
+    def client(self) -> "DAVClient":
+        """Lazily create and return the DAV client."""
+        if not hasattr(self, "_client"):
+            self._client: DAVClient = caldav.DAVClient(self.url)
         return self._client
-        
+
     @property
-    def principal(self):
-        if not hasattr(self,'_principal'):
-            self._principal=caldav.Principal(self.client, self.url)
+    def principal(self) -> "Principal":
+        """Lazily create and return the principal."""
+        if not hasattr(self, "_principal"):
+            self._principal: Principal = caldav.Principal(self.client, self.url)
         return self._principal
-        
+
     @property
-    def calendars(self):
-        if not hasattr(self,'_calendars'):
-            calendars=self.principal.calendars()
-            self._calendars={}
+    def calendars(self) -> dict[str, "Calendar"]:
+        """Lazily load and return calendars as a dict by name."""
+        if not hasattr(self, "_calendars"):
+            calendars = self.principal.calendars()
+            self._calendars: dict[str, Calendar] = {}
             for calendar in calendars:
-                p=calendar.get_properties([dav.DisplayName(),])
+                p = calendar.get_properties([dav.DisplayName()])
                 if p:
-                    calname=p[dav.DisplayName().tag]
-                    self._calendars[calname]=calendar
+                    calname = p[dav.DisplayName().tag]
+                    self._calendars[calname] = calendar
         return self._calendars
-        
-    def createEvent(self,uid=None,dtstamp=None,dtstart=None,dtend=None,summary=None,calendar=None):
-        tpl = """BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:%(prodid)s\r\nBEGIN:VEVENT\r\nUID:%(uid)s\r\nDTSTAMP:%(dtstamp)s\r\nDTSTART:%(dtstart)s\r\nDTEND:%(dtend)s\r\nSUMMARY:%(summary)s\r\nEND:VEVENT\r\nEND:VCALENDAR"""
-        calendar=self.calendars.get(calendar)
-        assert calendar, 'Missing calendar'
-        data=tpl%dict(uid=uid or getUuid(),dtstamp=dt(dtstamp or datetime.now()),dtstart=dt(dtstart),dtend=dt(dtend),summary=summary,prodid='VCALENDAR genropy')
-        event = caldav.Event(self.client, data = data, parent = calendar).save()
-    def eventsBag(self,calendarName):
-        result=Bag()
-        calendar=self.calendars.get(calendarName)
+
+    def createEvent(
+        self,
+        uid: str | None = None,
+        dtstamp: datetime | None = None,
+        dtstart: datetime | str | None = None,
+        dtend: datetime | str | None = None,
+        summary: str | None = None,
+        calendar: str | None = None,
+    ) -> None:
+        """Create a new calendar event.
+
+        Args:
+            uid: Unique identifier for the event. Auto-generated if not provided.
+            dtstamp: Timestamp of event creation. Defaults to now.
+            dtstart: Event start time.
+            dtend: Event end time.
+            summary: Event summary/title.
+            calendar: Name of the calendar to add the event to.
+
+        Raises:
+            AssertionError: If the calendar is not found.
+        """
+        tpl = (
+            "BEGIN:VCALENDAR\r\n"
+            "VERSION:2.0\r\n"
+            "PRODID:%(prodid)s\r\n"
+            "BEGIN:VEVENT\r\n"
+            "UID:%(uid)s\r\n"
+            "DTSTAMP:%(dtstamp)s\r\n"
+            "DTSTART:%(dtstart)s\r\n"
+            "DTEND:%(dtend)s\r\n"
+            "SUMMARY:%(summary)s\r\n"
+            "END:VEVENT\r\n"
+            "END:VCALENDAR"
+        )
+        cal = self.calendars.get(calendar)  # type: ignore[arg-type]
+        assert cal, "Missing calendar"
+        data = tpl % dict(
+            uid=uid or getUuid(),
+            dtstamp=dt(dtstamp or datetime.now()),
+            dtstart=dt(dtstart),  # type: ignore[arg-type]
+            dtend=dt(dtend),  # type: ignore[arg-type]
+            summary=summary,
+            prodid="VCALENDAR genropy",
+        )
+        caldav.Event(self.client, data=data, parent=cal).save()
+
+    def eventsBag(self, calendarName: str) -> Bag:
+        """Get all events from a calendar as a Bag.
+
+        Args:
+            calendarName: Name of the calendar.
+
+        Returns:
+            A Bag containing all events from the calendar.
+        """
+        result = Bag()
+        calendar = self.calendars.get(calendarName)
         if calendar:
-            events=calendar.events()
+            events = calendar.events()
             for event in events:
                 event.load()
-                data=VObjectBag(event.data)
-                result.addItem('evento',data)
+                data = VObjectBag(event.data)
+                result.addItem("evento", data)
         return result
-        
-            
 
+
+__all__ = ["CalDavConnection", "dt"]

--- a/gnrpy/gnr/core/gnrcaldav_review.md
+++ b/gnrpy/gnr/core/gnrcaldav_review.md
@@ -1,0 +1,64 @@
+# gnrcaldav.py — Review
+
+## Summary
+
+This module provided CalDAV calendar integration using the caldav library.
+**It is deprecated** — the first line raises `DeprecationWarning` to prevent
+any import.
+
+## Why no split
+
+- Module is deprecated and should be removed
+- Only 79 lines of code
+- Single class with related test functions
+- All code is unreachable due to the raise at module start
+
+## Structure
+
+- **Lines**: 79 (original), ~220 (with docstrings, type hints, unreachable)
+- **Classes**: 1 (`CalDavConnection`)
+- **Functions**: 4 (`test`, `test1`, `testcal`, `dt`)
+- **Constants**: 0
+
+## Dependencies
+
+### This module imports from:
+- `datetime` — `datetime`
+- `caldav` — CalDAV client library
+- `caldav.elements.dav` — DAV elements
+- `gnr.core.gnrbag` — `Bag`, `VObjectBag`
+- `gnr.core.gnrlang` — `getUuid`
+
+### Other modules that import this:
+- **None** — module is deprecated and not imported anywhere
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| 1 | DEAD | Entire module is deprecated (raises DeprecationWarning on import) |
+| 11 | SECURITY | Hardcoded credentials in `test()` function |
+| 35 | SECURITY | Password included in URL (visible in logs, history) |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `CalDavConnection` | class | DEAD | (none — module cannot be imported) |
+| `test` | function | DEAD | (none) |
+| `test1` | function | DEAD | (none) |
+| `testcal` | function | DEAD | (none) |
+| `dt` | function | DEAD | (none) |
+
+## Recommendations
+
+1. **Remove the module**: Since it's deprecated and has zero callers, it should
+   be removed entirely in a future cleanup.
+
+2. **Security audit**: Before removal, ensure no credentials from the test
+   functions have been committed to git history.
+
+3. **If revival is needed**: The CalDAV integration should be rewritten with:
+   - No hardcoded credentials
+   - Proper authentication handling (not password in URL)
+   - Modern Python practices


### PR DESCRIPTION
## Summary

Analyzed `gnrcaldav.py` (79 lines). Module is **DEPRECATED** — the first line
raises `DeprecationWarning` to prevent any import. Does not benefit from
splitting (should be removed entirely in future cleanup).

### Quality improvements applied:
- Google-style docstrings (English) for module and all classes/functions
- Type hints for all signatures
- Added `__all__` declaration
- Formatted with ruff/black
- Code preserved but remains unreachable due to raise at module start

Added `gnrcaldav_review.md` with structure analysis, dependency map.

## Why no split

This is a 79-line deprecated module. The first line raises `DeprecationWarning`
making all code unreachable. The module should be removed entirely in a
future cleanup rather than split.

## Issues found

- 3 `# REVIEW:` markers added:
  - DEAD: entire module is deprecated
  - SECURITY: hardcoded credentials in `test()` function
  - SECURITY: password included in URL (visible in logs)

## Usage map

- 5 public symbols analyzed
- 5 marked as DEAD (entire module cannot be imported)

## Verification

- [x] ruff check / flake8 zero errors
- [x] ruff format / black applied
- [x] Module cannot be imported (by design — deprecated)

Ref #486