### PR TITLE
refactor(core): type hints and review for gnrdatetime.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,123 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 1751ff8c0
+
+---
+
+## gnrgit.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrgit`
+- **PR**: #512
+- **Decision**: review only — 42-line single class module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 42 → 85 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrGit)
+- **REVIEW markers added**: 2 (BUG, SMELL)
+- **Dead symbols found**: 3 (class and all methods appear unused)
+- **Tests**: pass (1 test, import only)
+- **Commit**: a659d5f92
+
+---
+
+## gnrredbaron.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrredbaron`
+- **PR**: #513
+- **Decision**: review only — 64-line single class module with stub methods
+- **Sub-modules created**: none
+- **Lines**: 64 → 130 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrRedBaron)
+- **REVIEW markers added**: 5 (SMELL, DEAD)
+- **Dead symbols found**: 6 (class entirely unused, 3 stub methods)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ce68070b0
+
+---
+
+## gnrnumber.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrnumber`
+- **PR**: #514
+- **Decision**: review only — 68-line utility module, tightly cohesive
+- **Sub-modules created**: none
+- **Lines**: 68 → 165 (added docstrings, type hints)
+- **Public names exported**: 4 (decimalRound, floatToDecimal, calculateMultiPerc, partitionTotals)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 5e8118199
+
+---
+
+## gnrcaldav.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcaldav`
+- **PR**: #515
+- **Decision**: review only — 79-line DEPRECATED module, cannot be imported
+- **Sub-modules created**: none
+- **Lines**: 79 → 220 (added docstrings, type hints, preserved unreachable code)
+- **Public names exported**: 2 (CalDavConnection, dt) — but unreachable
+- **REVIEW markers added**: 3 (DEAD, SECURITY x2)
+- **Dead symbols found**: 5 (entire module is deprecated)
+- **Tests**: N/A (module cannot be imported)
+- **Commit**: e471aee27
+
+---
+
+## gnranalyzingbag.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnranalyzingbag`
+- **PR**: #516
+- **Decision**: review only — 87-line single class module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 87 → 145 (added docstrings, type hints)
+- **Public names exported**: 1 (AnalyzingBag)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test, import only)
+- **Commit**: e0531f238
+
+---
+
+## gnrdatetime.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrdatetime`
+- **PR**: #517
+- **Decision**: review only — 91-line well-designed module
+- **Sub-modules created**: none
+- **Lines**: 91 → 165 (added type hints, enhanced docstrings)
+- **Public names exported**: 12 (TZDateTime, datetime, date, time, timedelta, timezone, tzinfo, MINYEAR, MAXYEAR, now, utcnow)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (3 tests)
+- **Commit**: cbca3357d

--- a/gnrpy/gnr/core/gnrdatetime.py
+++ b/gnrpy/gnr/core/gnrdatetime.py
@@ -1,56 +1,118 @@
-# gnr/core/gnrdatetime.py
+# -*- coding: utf-8 -*-
+"""gnrdatetime - Timezone-aware datetime utilities.
+
+This module provides timezone-aware datetime handling with sensible defaults.
+It offers a drop-in replacement for the standard ``datetime`` module that
+ensures all datetime objects are timezone-aware (UTC by default).
+
+The main class :class:`TZDateTime` extends ``datetime.datetime`` with
+factories that always return aware datetimes.
+
+Example:
+    >>> from gnr.core.gnrdatetime import datetime
+    >>> now = datetime.now()  # Returns UTC-aware datetime
+    >>> from gnr.core.gnrdatetime import now as adesso
+    >>> adesso()  # Alternative functional interface
+"""
+
+from __future__ import annotations
 
 import datetime as _dt
+from typing import Self
 
 
 class TZDateTime(_dt.datetime):
-    """
-    Helper class whose factories return standard timezone-aware datetimes.
+    """A datetime subclass whose factories return timezone-aware datetimes.
+
     Goals:
-      - Always return aware datetimes (UTC by default).
-      - Public factories (.now/.utcnow/.fromiso) yield _dt.datetime, not TZDateTime.
-      - Keep call sites unchanged: `from gnr.core.gnrdatetime import datetime; datetime.now()`.
+        - Always return aware datetimes (UTC by default).
+        - Public factories (.now/.utcnow/.fromiso) yield standard datetime, not TZDateTime.
+        - Keep call sites unchanged: ``from gnr.core.gnrdatetime import datetime``.
+
+    Note:
+        The factories return standard ``datetime.datetime`` objects, not
+        ``TZDateTime`` instances, to prevent the subclass from leaking
+        into user code.
     """
 
-    # ---- Factories (return standard datetime) ----
     @classmethod
-    def now(cls, tz=None):
-        """
-        Return an aware datetime (UTC by default) as a standard _dt.datetime.
+    def now(cls, tz: _dt.tzinfo | None = None) -> _dt.datetime:
+        """Return an aware datetime (UTC by default) as a standard datetime.
+
+        Args:
+            tz: Timezone to use. Defaults to UTC if not specified.
+
+        Returns:
+            A timezone-aware datetime object.
         """
         tz = tz or _dt.timezone.utc
         return _dt.datetime.now(tz)
 
     @classmethod
-    def utcnow(cls):
-        """
-        Return an aware UTC datetime as a standard _dt.datetime.
+    def utcnow(cls) -> _dt.datetime:
+        """Return an aware UTC datetime as a standard datetime.
+
+        Returns:
+            A UTC timezone-aware datetime object.
+
+        Note:
+            Unlike the deprecated ``datetime.datetime.utcnow()``, this method
+            returns an aware datetime with UTC timezone info.
         """
         return _dt.datetime.now(_dt.timezone.utc)
 
     @classmethod
-    def fromiso(cls, iso_str, tz=None):
-        """
-        Parse ISO 8601. If naive, attach tz (default UTC).
-        If aware, convert to tz if provided.
-        Always returns a standard _dt.datetime.
+    def fromiso(
+        cls,
+        iso_str: str,
+        tz: _dt.tzinfo | None = None,
+    ) -> _dt.datetime:
+        """Parse an ISO 8601 datetime string.
+
+        If the parsed datetime is naive, attaches the specified timezone
+        (default UTC). If aware, converts to the specified timezone if
+        provided, otherwise keeps the original timezone.
+
+        Args:
+            iso_str: An ISO 8601 formatted datetime string.
+            tz: Timezone to apply or convert to. Defaults to UTC for naive datetimes.
+
+        Returns:
+            A timezone-aware datetime object.
+
+        Example:
+            >>> TZDateTime.fromiso("2024-01-15T10:30:00")
+            datetime.datetime(2024, 1, 15, 10, 30, tzinfo=datetime.timezone.utc)
         """
         dt = _dt.datetime.fromisoformat(iso_str)
         if dt.tzinfo is None:
             return dt.replace(tzinfo=(tz or _dt.timezone.utc))
         return dt.astimezone(tz or dt.tzinfo)
 
-    # ---- Constructor bridge ----
-    def __new__(cls, *args, **kwargs):
+    def __new__(
+        cls,
+        *args: int,
+        tz: _dt.tzinfo | None = None,
+        **kwargs: int | _dt.tzinfo | None,
+    ) -> Self:
+        """Construct a TZDateTime ensuring timezone info is set.
+
+        Allows ``TZDateTime(...)`` to behave like ``datetime.datetime(...)``
+        but ensures tzinfo is set (defaults to UTC).
+
+        Args:
+            *args: Positional arguments for datetime (year, month, day, etc.).
+            tz: Timezone to apply if not specified in kwargs.
+            **kwargs: Keyword arguments for datetime.
+
+        Returns:
+            A timezone-aware datetime object.
         """
-        Allow `TZDateTime(...)` to behave like _dt.datetime(...) but ensure tzinfo.
-        Returns a standard _dt.datetime (not the subclass) to prevent leaking TZDateTime.
-        """
-        tz = kwargs.pop("tz", None) or _dt.timezone.utc
+        tz = tz or _dt.timezone.utc
         base = _dt.datetime.__new__(cls, *args, **kwargs)
         if base.tzinfo is None:
             base = base.replace(tzinfo=tz)
-        return base  # standard datetime object
+        return base  # type: ignore[return-value]
 
 
 # ---- Public surface mirroring `datetime` where useful ----
@@ -69,14 +131,32 @@ MINYEAR = _dt.MINYEAR
 MAXYEAR = _dt.MAXYEAR
 
 
-# Flat helpers: importable as functions (e.g., `from ... import now as adesso`)
-def now(tz=None):
-    """Module-level helper: aware now (UTC by default), standard datetime."""
+def now(tz: _dt.tzinfo | None = None) -> _dt.datetime:
+    """Return an aware datetime (UTC by default).
+
+    Module-level helper that can be imported directly.
+
+    Args:
+        tz: Timezone to use. Defaults to UTC if not specified.
+
+    Returns:
+        A timezone-aware datetime object.
+
+    Example:
+        >>> from gnr.core.gnrdatetime import now as adesso
+        >>> adesso()
+    """
     return TZDateTime.now(tz)
 
 
-def utcnow():
-    """Module-level helper: aware UTC now, standard datetime."""
+def utcnow() -> _dt.datetime:
+    """Return an aware UTC datetime.
+
+    Module-level helper that can be imported directly.
+
+    Returns:
+        A UTC timezone-aware datetime object.
+    """
     return TZDateTime.utcnow()
 
 
@@ -84,8 +164,15 @@ __all__ = [
     # Classes / constants
     "TZDateTime",
     # datetime-like surface
-    "datetime", "date", "time", "timedelta", "timezone", "tzinfo",
-    "MINYEAR", "MAXYEAR",
+    "datetime",
+    "date",
+    "time",
+    "timedelta",
+    "timezone",
+    "tzinfo",
+    "MINYEAR",
+    "MAXYEAR",
     # helpers
-    "now", "utcnow",
+    "now",
+    "utcnow",
 ]

--- a/gnrpy/gnr/core/gnrdatetime_review.md
+++ b/gnrpy/gnr/core/gnrdatetime_review.md
@@ -1,0 +1,62 @@
+# gnrdatetime.py — Review
+
+## Summary
+
+This module provides timezone-aware datetime handling with sensible defaults.
+It offers a drop-in replacement for the standard ``datetime`` module that
+ensures all datetime objects are timezone-aware (UTC by default).
+
+## Why no split
+
+- Only 91 lines of code (now ~165 with enhanced docstrings and type hints)
+- Single class with related helper functions
+- Already well-designed with clear responsibilities
+- Splitting would add complexity without benefit
+
+## Structure
+
+- **Lines**: 165 (including docstrings and type hints)
+- **Classes**: 1 (`TZDateTime`)
+- **Functions**: 2 (`now`, `utcnow`)
+- **Constants**: 7 (re-exports from datetime module)
+
+## Dependencies
+
+### This module imports from:
+- `datetime` — standard library datetime module
+
+### Other modules that import this:
+- `gnr.tests.core.gnrdatetime_test` — imports for testing
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| — | — | No issues found |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `TZDateTime` | class | USED | tests, module aliases |
+| `TZDateTime.now` | classmethod | USED | `now()` helper, tests |
+| `TZDateTime.utcnow` | classmethod | USED | `utcnow()` helper, tests |
+| `TZDateTime.fromiso` | classmethod | USED | tests |
+| `datetime` | alias | USED | provides drop-in compatibility |
+| `date` | alias | USED | re-export from datetime |
+| `time` | alias | USED | re-export from datetime |
+| `timedelta` | alias | USED | re-export from datetime |
+| `timezone` | alias | USED | re-export from datetime |
+| `tzinfo` | alias | USED | re-export from datetime |
+| `now` | function | USED | module-level helper |
+| `utcnow` | function | USED | module-level helper |
+
+## Recommendations
+
+1. **Excellent module**: This is a well-designed, cohesive module with clear
+   documentation and purpose. No changes needed beyond the type hints added
+   in this refactoring.
+
+2. **Good design pattern**: The approach of returning standard `datetime`
+   objects from the `TZDateTime` factories prevents the subclass from
+   "leaking" into user code, which is a good encapsulation pattern.


### PR DESCRIPTION
## Summary

Analyzed `gnrdatetime.py` (91 lines). Module provides timezone-aware datetime
utilities with sensible defaults (UTC by default). Already well-designed with
clear docstrings. Does not benefit from splitting.

### Quality improvements applied:
- Type hints for all methods and functions
- Enhanced Google-style docstrings with examples
- Formatted with ruff/black

Added `gnrdatetime_review.md` with structure analysis, dependency map.

## Why no split

This is a 91-line module with a single class (`TZDateTime`) and two helper
functions. The module is well-designed and cohesive, providing a drop-in
replacement for the standard `datetime` module with timezone awareness.

## Issues found

- 0 `# REVIEW:` markers added (no issues found)

## Usage map

- 12 public symbols analyzed
- 0 marked as DEAD (all symbols are used or provide compatibility)

## Verification

- [x] ruff check / flake8 zero errors
- [x] ruff format / black applied
- [x] `from gnr.core.gnrdatetime import datetime, now` works
- [x] Existing tests pass (3 tests)

Ref #486