### PR TITLE
refactor(core): docstrings, type hints and review for gnrrlab.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,153 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 1751ff8c0
+
+---
+
+## gnrgit.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrgit`
+- **PR**: #512
+- **Decision**: review only — 42-line single class module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 42 → 85 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrGit)
+- **REVIEW markers added**: 2 (BUG, SMELL)
+- **Dead symbols found**: 3 (class and all methods appear unused)
+- **Tests**: pass (1 test, import only)
+- **Commit**: a659d5f92
+
+---
+
+## gnrredbaron.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrredbaron`
+- **PR**: #513
+- **Decision**: review only — 64-line single class module with stub methods
+- **Sub-modules created**: none
+- **Lines**: 64 → 130 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrRedBaron)
+- **REVIEW markers added**: 5 (SMELL, DEAD)
+- **Dead symbols found**: 6 (class entirely unused, 3 stub methods)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ce68070b0
+
+---
+
+## gnrnumber.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrnumber`
+- **PR**: #514
+- **Decision**: review only — 68-line utility module, tightly cohesive
+- **Sub-modules created**: none
+- **Lines**: 68 → 165 (added docstrings, type hints)
+- **Public names exported**: 4 (decimalRound, floatToDecimal, calculateMultiPerc, partitionTotals)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 5e8118199
+
+---
+
+## gnrcaldav.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcaldav`
+- **PR**: #515
+- **Decision**: review only — 79-line DEPRECATED module, cannot be imported
+- **Sub-modules created**: none
+- **Lines**: 79 → 220 (added docstrings, type hints, preserved unreachable code)
+- **Public names exported**: 2 (CalDavConnection, dt) — but unreachable
+- **REVIEW markers added**: 3 (DEAD, SECURITY x2)
+- **Dead symbols found**: 5 (entire module is deprecated)
+- **Tests**: N/A (module cannot be imported)
+- **Commit**: e471aee27
+
+---
+
+## gnranalyzingbag.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnranalyzingbag`
+- **PR**: #516
+- **Decision**: review only — 87-line single class module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 87 → 145 (added docstrings, type hints)
+- **Public names exported**: 1 (AnalyzingBag)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test, import only)
+- **Commit**: e0531f238
+
+---
+
+## gnrdatetime.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrdatetime`
+- **PR**: #517
+- **Decision**: review only — 91-line well-designed module
+- **Sub-modules created**: none
+- **Lines**: 91 → 165 (added type hints, enhanced docstrings)
+- **Public names exported**: 12 (TZDateTime, datetime, date, time, timedelta, timezone, tzinfo, MINYEAR, MAXYEAR, now, utcnow)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (3 tests)
+- **Commit**: df935e289
+
+---
+
+## gnrcrypto.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcrypto`
+- **PR**: #518
+- **Decision**: review only — 98-line authentication token module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 98 → 220 (added docstrings, type hints)
+- **Public names exported**: 3 (AuthTokenError, AuthTokenExpired, AuthTokenGenerator)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 289dbcb35
+
+---
+
+## gnrrlab.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrrlab`
+- **PR**: #519
+- **Decision**: review only — 109-line ReportLab PDF generation base class
+- **Sub-modules created**: none
+- **Lines**: 109 → 240 (added docstrings, type hints)
+- **Public names exported**: 1 (RlabResource)
+- **REVIEW markers added**: 1 (DEAD)
+- **Dead symbols found**: 9 (class and all methods appear unused in codebase)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ae4539b96

--- a/gnrpy/gnr/core/gnrrlab.py
+++ b/gnrpy/gnr/core/gnrrlab.py
@@ -1,96 +1,235 @@
-from reportlab.pdfgen import canvas
+# -*- coding: utf-8 -*-
+"""gnrrlab - ReportLab PDF generation resource.
+
+This module provides a base class for generating PDF documents using
+ReportLab. It integrates with the Genro page system and storage nodes.
+
+Classes:
+    RlabResource: Base class for PDF generation resources.
+
+Note:
+    This module depends on the `reportlab` package.
+"""
+
+from __future__ import annotations
+
 from io import BytesIO
+from typing import TYPE_CHECKING, Any
+
+from reportlab.pdfgen import canvas
+
 from gnr.core.gnrstring import slugify
 
-class RlabResource(object):
-    """TODO"""
-    rows_table = None
-    virtual_columns = None
-    pdf_folder = 'page:pdf'
-    cached = None
-    client_locale = False
-    row_relation = None
-    subtotal_caption_prefix = '!![en]Totals'
+if TYPE_CHECKING:
+    from gnr.web.gnrwebpage import GnrWebPage
 
 
-    def __init__(self, page=None, resource_table=None, parent=None, **kwargs):
+class RlabResource:
+    """Base class for ReportLab PDF generation resources.
+
+    Provides infrastructure for generating PDF documents with ReportLab,
+    integrating with Genro's page system and storage nodes.
+
+    Subclasses should override the :meth:`main` method to implement
+    their specific PDF generation logic.
+
+    Args:
+        page: The Genro web page instance.
+        resource_table: The database table object.
+        parent: Optional parent resource.
+        **kwargs: Additional keyword arguments.
+
+    Attributes:
+        rows_table: Table for row data (class attribute).
+        virtual_columns: Virtual columns to include (class attribute).
+        pdf_folder: Storage folder for PDFs. Defaults to 'page:pdf'.
+        cached: Caching configuration (class attribute).
+        client_locale: Whether to use client locale. Defaults to False.
+        row_relation: Relation for row data (class attribute).
+        subtotal_caption_prefix: Prefix for subtotal captions.
+
+    Example:
+        >>> class MyPdfResource(RlabResource):
+        ...     def main(self):
+        ...         self.canvas.drawString(100, 750, "Hello, World!")
+    """
+
+    rows_table: str | None = None
+    virtual_columns: list[str] | None = None
+    pdf_folder: str = "page:pdf"
+    cached: bool | None = None
+    client_locale: bool = False
+    row_relation: str | None = None
+    subtotal_caption_prefix: str = "!![en]Totals"
+
+    def __init__(
+        self,
+        page: "GnrWebPage | None" = None,
+        resource_table: Any | None = None,
+        parent: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.parent = parent
         self.page = page
-        self.site = page.site
-        self.db = page.db
-        self.locale = self.page.locale if self.client_locale else self.site.server_locale
+        self.site = page.site  # type: ignore[union-attr]
+        self.db = page.db  # type: ignore[union-attr]
+        self.locale = (
+            self.page.locale  # type: ignore[union-attr]
+            if self.client_locale
+            else self.site.server_locale
+        )
         self.tblobj = resource_table
         self.maintable = resource_table.fullname if resource_table else None
-        self.templateLoader = self.db.table('adm.htmltemplate').getTemplate
-        self.thermo_wrapper = self.page.btc.thermo_wrapper
-        self.letterhead_sourcedata = None
-        self._gridStructures = {}
-        self.record = None
-        
+        self.templateLoader = self.db.table("adm.htmltemplate").getTemplate
+        self.thermo_wrapper = self.page.btc.thermo_wrapper  # type: ignore[union-attr]
+        self.letterhead_sourcedata: Any = None
+        self._gridStructures: dict[str, Any] = {}
+        self.record: Any = None
+        self.canvas: canvas.Canvas | None = None
+        self.pdfSn: Any = None
+        self.thermo_kwargs: Any = None
+        self.record_idx: int | None = None
+        self.language: str | None = None
 
-    def __call__(self, record=None, pdf=None, downloadAs=None, thermo=None,record_idx=None, resultAs=None,
-                    language=None,locale=None,**kwargs):
+    def __call__(
+        self,
+        record: Any | None = None,
+        pdf: Any | None = None,
+        downloadAs: str | None = None,
+        thermo: Any | None = None,
+        record_idx: int | None = None,
+        resultAs: str | None = None,
+        language: str | None = None,
+        locale: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Generate PDF for a record.
+
+        Args:
+            record: The record to generate PDF for. Use '*' for no record.
+            pdf: PDF configuration (unused).
+            downloadAs: If set, return PDF as download.
+            thermo: Thermo wrapper kwargs.
+            record_idx: Index of record in batch processing.
+            resultAs: 'url' to return URL, otherwise returns file path.
+            language: Language code for localization.
+            locale: Locale override.
+            **kwargs: Additional arguments passed to makePdf.
+
+        Returns:
+            PDF file path, URL, or binary content depending on arguments.
+        """
         if not record:
-            return
+            return None
         self.thermo_kwargs = thermo
         self.record_idx = record_idx
-        if record=='*':
+        if record == "*":
             record = None
         else:
             record = self.tblobj.recordAs(record, virtual_columns=self.virtual_columns)
         if locale:
-            self.locale = locale #locale forced
-        self.language = language    
+            self.locale = locale  # locale forced
+        self.language = language
         if self.language:
             self.language = self.language.lower()
-            self.locale = locale or '{language}-{languageUPPER}'.format(language=self.language,
-                                        languageUPPER=self.language.upper())
+            self.locale = locale or "{language}-{languageUPPER}".format(
+                language=self.language, languageUPPER=self.language.upper()
+            )
         elif self.locale:
             self.language = self.locale[:2].lower()
-        result = self.makePdf(record=record, **kwargs) 
+        self.makePdf(record=record, **kwargs)
 
         if downloadAs:
-            with self.pdfSn.open('rb') as f:
-                self.page.response.add_header("Content-Disposition", str("attachment; filename=%s" % self.pdfSn.basename))
-                self.page.response.content_type = 'application/pdf'
+            with self.pdfSn.open("rb") as f:
+                self.page.response.add_header(  # type: ignore[union-attr]
+                    "Content-Disposition",
+                    str("attachment; filename=%s" % self.pdfSn.basename),
+                )
+                self.page.response.content_type = "application/pdf"  # type: ignore[union-attr]
                 result = f.read()
-            return result            
+            return result
         else:
-            return self.pdfSn.url() if resultAs=='url' else self.pdfSn.fullpath
+            return self.pdfSn.url() if resultAs == "url" else self.pdfSn.fullpath
 
-    def getPdfPath(self, *args, **kwargs):
-        """potrebbe essere ereditato"""
+    def getPdfPath(self, *args: Any, **kwargs: Any) -> str:
+        """Get internal path for PDF storage.
+
+        Args:
+            *args: Arguments passed to storage node.
+            **kwargs: Keyword arguments passed to storage node.
+
+        Returns:
+            Internal file system path.
+
+        Note:
+            May be overridden in subclasses.
+        """
         return self.site.getPdfStorageNode(*args, **kwargs).internal_path
 
-    def getPdfStorageNode(self, *args, **kwargs):
+    def getPdfStorageNode(self, *args: Any, **kwargs: Any) -> Any:
+        """Get storage node for PDF.
+
+        Args:
+            *args: Arguments for storage node path.
+            **kwargs: Keyword arguments for storage node.
+
+        Returns:
+            Storage node instance.
+        """
         return self.site.storageNode(self.pdf_folder, *args, **kwargs)
 
-    def makePdfIO(self, record=None, **kwargs):
+    def makePdfIO(self, record: Any | None = None, **kwargs: Any) -> bytes:
+        """Generate PDF and return as bytes (in-memory).
+
+        Args:
+            record: The record to generate PDF for.
+            **kwargs: Additional arguments.
+
+        Returns:
+            PDF content as bytes.
+
+        Note:
+            Sets response headers for inline PDF display.
+        """
         pdf = BytesIO()
         self.canvas = canvas.Canvas(pdf)
         self.main()
         self.canvas.showPage()
         self.canvas.save()
         pdf.seek(0)
-        self.response.add_header("Content-Disposition", str("inline; filename=%s" % 'test_pdf.pdf'))
-        self.response.content_type = 'application/pdf'
+        self.response.add_header(  # type: ignore[attr-defined]
+            "Content-Disposition", str("inline; filename=%s" % "test_pdf.pdf")
+        )
+        self.response.content_type = "application/pdf"  # type: ignore[attr-defined]
         return pdf.read()
 
-    def outputDocName(self, ext='pdf'):
-        """TODO
-        :param ext: TODO"""
-        if ext and not ext[0] == '.':
-            ext = '.%s' % ext
-        caption = ''
+    def outputDocName(self, ext: str = "pdf") -> str:
+        """Generate output document filename.
+
+        Args:
+            ext: File extension. Defaults to 'pdf'.
+
+        Returns:
+            Generated filename based on table and record caption.
+        """
+        if ext and not ext[0] == ".":
+            ext = ".%s" % ext
+        caption = ""
         if self.record is not None:
             caption = slugify(self.tblobj.recordCaption(self.record))
             idx = self.record_idx
             if idx is not None:
-                caption = '%s_%i' %(caption,idx)
-        doc_name = '%s_%s%s' % (self.tblobj.name, caption, ext)
+                caption = "%s_%i" % (caption, idx)
+        doc_name = "%s_%s%s" % (self.tblobj.name, caption, ext)
         return doc_name
 
-    def makePdf(self, record=None, **kwargs):
+    def makePdf(self, record: Any | None = None, **kwargs: Any) -> None:
+        """Generate PDF to storage node.
+
+        Args:
+            record: The record to generate PDF for.
+            **kwargs: Additional arguments.
+        """
         self.record = record
         self.pdfSn = self.getPdfStorageNode(self.outputDocName())
         with self.pdfSn.local_path() as pdf_path:
@@ -99,11 +238,19 @@ class RlabResource(object):
             self.canvas.showPage()
             self.canvas.save()
 
-    def main(self):
-        """must be overridden"""
+    def main(self) -> None:
+        """Main PDF generation method.
+
+        Must be overridden in subclasses to implement specific PDF
+        generation logic. Use ``self.canvas`` to draw on the PDF.
+
+        Example:
+            >>> def main(self):
+            ...     self.canvas.drawString(100, 750, "Title")
+            ...     self.canvas.drawString(100, 700, "Content...")
+        """
+        # REVIEW:DEAD — stub method, must be overridden
         pass
 
-    
 
-
-
+__all__ = ["RlabResource"]

--- a/gnrpy/gnr/core/gnrrlab_review.md
+++ b/gnrpy/gnr/core/gnrrlab_review.md
@@ -1,0 +1,63 @@
+# gnrrlab.py — Review
+
+## Summary
+
+This module provides a base class (`RlabResource`) for generating PDF documents
+using ReportLab, integrating with Genro's page system and storage nodes.
+
+## Why no split
+
+- Only 109 lines of code (now ~240 with docstrings and type hints)
+- Single class with a single responsibility
+- Already minimal and cohesive
+- Splitting would add complexity without benefit
+
+## Structure
+
+- **Lines**: 240 (including docstrings and type hints)
+- **Classes**: 1 (`RlabResource`)
+- **Functions**: 0
+- **Constants**: 0
+
+## Dependencies
+
+### This module imports from:
+- `io` — `BytesIO` for in-memory PDF
+- `reportlab.pdfgen` — `canvas` for PDF generation
+- `gnr.core.gnrstring` — `slugify` for filename generation
+
+### Other modules that import this:
+- `gnr.tests.core.gnrrlab_test` — imports module for existence test only
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| 235 | DEAD | `main()` method is a stub that must be overridden |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `RlabResource` | class | DEAD | (none found in codebase) |
+| `RlabResource.__init__` | method | DEAD | (none found) |
+| `RlabResource.__call__` | method | DEAD | (none found) |
+| `RlabResource.getPdfPath` | method | DEAD | (none found) |
+| `RlabResource.getPdfStorageNode` | method | DEAD | (none found) |
+| `RlabResource.makePdfIO` | method | DEAD | (none found) |
+| `RlabResource.outputDocName` | method | DEAD | (none found) |
+| `RlabResource.makePdf` | method | DEAD | (none found) |
+| `RlabResource.main` | method | DEAD | stub, must be overridden |
+
+## Recommendations
+
+1. **Investigate usage**: The `RlabResource` class appears to have zero callers
+   in the current codebase. It may be used by external code/projects or may
+   be obsolete. Consider deprecating if truly unused.
+
+2. **Add tests**: The current test only checks import. Adding tests for basic
+   PDF generation would improve coverage and validate the class works correctly.
+
+3. **Consider modernization**: ReportLab is still actively maintained, but
+   consider if weasyprint or other libraries might be more suitable for
+   modern use cases.


### PR DESCRIPTION
## Summary

Analyzed `gnrrlab.py` (109 lines). Module provides `RlabResource` base class
for ReportLab PDF generation. Does not benefit from splitting.

### Quality improvements applied:
- Google-style docstrings (English) for module and class
- Type hints for all methods
- Added `__all__` declaration
- Formatted with ruff/black

Added `gnrrlab_review.md` with structure analysis, dependency map.

## Why no split

This is a 109-line module with a single class (`RlabResource`) that provides
a base for PDF generation. The class has a single, clear responsibility.
Splitting would add complexity without benefit.

## Issues found

- 1 `# REVIEW:DEAD` marker added (`main()` stub method)

## Usage map

- 1 public symbol analyzed (`RlabResource`)
- 9 marked as DEAD (class and all methods appear unused in codebase)

**Note**: This class may be used by external projects or may be obsolete.

## Verification

- [x] ruff check / flake8 zero errors
- [x] ruff format / black applied
- [x] `from gnr.core.gnrrlab import RlabResource` works
- [x] Existing tests pass (1 test, import only)

Ref #486