### PR TITLE
refactor(core): docstrings, type hints and review for gnrsys.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,168 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 1751ff8c0
+
+---
+
+## gnrgit.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrgit`
+- **PR**: #512
+- **Decision**: review only — 42-line single class module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 42 → 85 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrGit)
+- **REVIEW markers added**: 2 (BUG, SMELL)
+- **Dead symbols found**: 3 (class and all methods appear unused)
+- **Tests**: pass (1 test, import only)
+- **Commit**: a659d5f92
+
+---
+
+## gnrredbaron.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrredbaron`
+- **PR**: #513
+- **Decision**: review only — 64-line single class module with stub methods
+- **Sub-modules created**: none
+- **Lines**: 64 → 130 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrRedBaron)
+- **REVIEW markers added**: 5 (SMELL, DEAD)
+- **Dead symbols found**: 6 (class entirely unused, 3 stub methods)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ce68070b0
+
+---
+
+## gnrnumber.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrnumber`
+- **PR**: #514
+- **Decision**: review only — 68-line utility module, tightly cohesive
+- **Sub-modules created**: none
+- **Lines**: 68 → 165 (added docstrings, type hints)
+- **Public names exported**: 4 (decimalRound, floatToDecimal, calculateMultiPerc, partitionTotals)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 5e8118199
+
+---
+
+## gnrcaldav.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcaldav`
+- **PR**: #515
+- **Decision**: review only — 79-line DEPRECATED module, cannot be imported
+- **Sub-modules created**: none
+- **Lines**: 79 → 220 (added docstrings, type hints, preserved unreachable code)
+- **Public names exported**: 2 (CalDavConnection, dt) — but unreachable
+- **REVIEW markers added**: 3 (DEAD, SECURITY x2)
+- **Dead symbols found**: 5 (entire module is deprecated)
+- **Tests**: N/A (module cannot be imported)
+- **Commit**: e471aee27
+
+---
+
+## gnranalyzingbag.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnranalyzingbag`
+- **PR**: #516
+- **Decision**: review only — 87-line single class module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 87 → 145 (added docstrings, type hints)
+- **Public names exported**: 1 (AnalyzingBag)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test, import only)
+- **Commit**: e0531f238
+
+---
+
+## gnrdatetime.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrdatetime`
+- **PR**: #517
+- **Decision**: review only — 91-line well-designed module
+- **Sub-modules created**: none
+- **Lines**: 91 → 165 (added type hints, enhanced docstrings)
+- **Public names exported**: 12 (TZDateTime, datetime, date, time, timedelta, timezone, tzinfo, MINYEAR, MAXYEAR, now, utcnow)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (3 tests)
+- **Commit**: df935e289
+
+---
+
+## gnrcrypto.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcrypto`
+- **PR**: #518
+- **Decision**: review only — 98-line authentication token module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 98 → 220 (added docstrings, type hints)
+- **Public names exported**: 3 (AuthTokenError, AuthTokenExpired, AuthTokenGenerator)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 289dbcb35
+
+---
+
+## gnrrlab.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrrlab`
+- **PR**: #519
+- **Decision**: review only — 109-line ReportLab PDF generation base class
+- **Sub-modules created**: none
+- **Lines**: 109 → 240 (added docstrings, type hints)
+- **Public names exported**: 1 (RlabResource)
+- **REVIEW markers added**: 1 (DEAD)
+- **Dead symbols found**: 9 (class and all methods appear unused in codebase)
+- **Tests**: pass (1 test, import only)
+- **Commit**: 1d73675b9
+
+---
+
+## gnrsys.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrsys`
+- **PR**: #520
+- **Decision**: review only — 113-line OS/filesystem utility module
+- **Sub-modules created**: none
+- **Lines**: 113 → 180 (added docstrings, type hints)
+- **Public names exported**: 5 (progress, mkdir, expandpath, listdirs, resolvegenropypath)
+- **REVIEW markers added**: 1 (BUG)
+- **Dead symbols found**: 1 (listdirs is broken and not used except in tests)
+- **Tests**: pass (5 tests)
+- **Commit**: 50511cd04

--- a/gnrpy/gnr/core/gnrsys.py
+++ b/gnrpy/gnr/core/gnrsys.py
@@ -1,104 +1,183 @@
 # -*- coding: utf-8 -*-
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 # package       : GenroPy core - see LICENSE for details
-# module gnrsys : a connection to the os.
-# Copyright (c) : 2004 - 2007 Softwell sas - Milano 
+# module gnrsys : OS and filesystem utilities
+# Copyright (c) : 2004 - 2007 Softwell sas - Milano
 # Written by    : Giovanni Porcari, Michele Bertoldi
-#                 Saverio Porcari, Francesco Porcari , Francesco Cavazzana
-#--------------------------------------------------------------------------
-#This library is free software; you can redistribute it and/or
-#modify it under the terms of the GNU Lesser General Public
-#License as published by the Free Software Foundation; either
-#version 2.1 of the License, or (at your option) any later version.
+#                 Saverio Porcari, Francesco Porcari, Francesco Cavazzana
+# --------------------------------------------------------------------------
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+"""gnrsys - OS and filesystem utilities.
 
-#This library is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-#Lesser General Public License for more details.
+This module provides utility functions for interacting with the operating
+system and filesystem, including path manipulation, directory creation,
+and progress display.
 
-#You should have received a copy of the GNU Lesser General Public
-#License along with this library; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+Functions:
+    progress: Display a progress bar in the terminal.
+    mkdir: Create a directory with specific permissions.
+    expandpath: Expand ~ and environment variables in a path.
+    listdirs: List all files in a directory tree.
+    resolvegenropypath: Resolve paths across different Genro installations.
+"""
+
+from __future__ import annotations
 
 import os
 import sys
+from typing import TextIO
 
-def progress(count, total, status='', fd=sys.stdout):
+
+def progress(
+    count: int,
+    total: int,
+    status: str = "",
+    fd: TextIO = sys.stdout,
+) -> None:
+    """Display a progress bar in the terminal.
+
+    Args:
+        count: Current progress count.
+        total: Total count for 100% completion.
+        status: Optional status message to display.
+        fd: File descriptor to write to. Defaults to stdout.
+
+    Example:
+        >>> for i in range(100):
+        ...     progress(i + 1, 100, status='Processing...')
+    """
     bar_len = 60
     filled_len = int(round(bar_len * count / float(total)))
 
     percents = round(100.0 * count / float(total), 1)
-    bar = '=' * filled_len + '-' * (bar_len - filled_len)
+    bar = "=" * filled_len + "-" * (bar_len - filled_len)
 
-    fd.write('[%s] %s%s ...%s\r' % (bar, percents, '%', status))
-    fd.flush() 
+    fd.write("[%s] %s%s ...%s\r" % (bar, percents, "%", status))
+    fd.flush()
 
 
-def mkdir(path, privileges=0o777):
-    """Create a directory named *path* with numeric mode *privileges*.
-    
-    :param path: the name of the directory
-    :param privileges: the current umask value is first masked out.
-                       Default value is ``0777`` (octal)"""
+def mkdir(path: str, privileges: int = 0o777) -> None:
+    """Create a directory with the specified permissions.
+
+    Creates the directory and all parent directories as needed.
+    Explicitly sets permissions with chmod since some systems
+    ignore the mode parameter to os.mkdir.
+
+    Args:
+        path: The directory path to create.
+        privileges: Numeric permission mode. Defaults to 0o777.
+            The current umask is masked out by the system.
+
+    Example:
+        >>> mkdir('/tmp/my/nested/directory', 0o755)
+    """
     if path and not os.path.isdir(path):
         head, tail = os.path.split(path)
 
         mkdir(head, privileges)
         # on some systems, privileges are ignored, needs explicit call
         os.chmod(head, privileges)
-        
+
         os.mkdir(path, privileges)
         # on some systems, privileges are ignored, needs explicit call
         os.chmod(path, privileges)
-        
-def expandpath(path, full=False):
-    """Expand user home directory (~) and environment variables. Return the
-    expanded path
-    
-    :param path: the path to expand"""
+
+
+def expandpath(path: str, full: bool = False) -> str:
+    """Expand user home directory (~) and environment variables in a path.
+
+    Args:
+        path: The path to expand.
+        full: If True, also normalize and resolve to absolute path.
+
+    Returns:
+        The expanded path string.
+
+    Example:
+        >>> expandpath('~/Documents/$PROJECT/data')
+        '/home/user/Documents/myproject/data'
+        >>> expandpath('~/relative/../path', full=True)
+        '/home/user/path'
+    """
     path = os.path.expanduser(os.path.expandvars(path))
     if full:
         path = os.path.realpath(os.path.normpath(path))
     return path
-    
-def listdirs(path, invisible_files=False):
-    """Return a list of all the files contained in a path and its descendant
-    
-    :param path: the path you want to analyze
-    :param invisible_files: boolean. If ``True``, add invisible files to the returned list"""
-    
-    def callb(files, top, names):
+
+
+def listdirs(path: str, invisible_files: bool = False) -> list[str]:
+    """List all files in a directory tree recursively.
+
+    Args:
+        path: The root directory path to traverse.
+        invisible_files: If True, include files starting with '.'.
+            Defaults to False.
+
+    Returns:
+        A list of absolute file paths.
+
+    Note:
+        This function uses os.walk incorrectly (passes a callback
+        that won't be used). Consider using os.walk directly.
+    """
+    # REVIEW:BUG — os.walk doesn't accept a callback; this function
+    # doesn't work as intended. The callback is never called.
+
+    def callb(files: list[str], top: str, names: list[str]) -> None:
         for name in names:
             file_path = os.path.realpath(os.path.join(top, name))
-            if (invisible_files or not name.startswith('.')) and os.path.isfile(file_path):
+            if (invisible_files or not name.startswith(".")) and os.path.isfile(
+                file_path
+            ):
                 files.append(file_path)
-                
-    files = []
-    os.walk(path, callb, files)
+
+    files: list[str] = []
+    os.walk(path, callb, files)  # type: ignore[call-arg]
     return files
 
-def resolvegenropypath(path):
-    """added by Jeff.
-       
-       Relative path may be more appropriate in most cases, but in some cases it may be
-       useful to have this construction.
-       
-       To make it easier to resolve document paths between different installations
-       of genropy where sometimes it is installed in the user path and sometimes
-       at root (i.e. /genropy/... or ~/genropy/.), so that file path given within
-       Genropy will be resolved to be valid if possible and we do not have to edit
-       for example our import files. Of course I expect it to be rejected and/or refactored"""
-       
-    if path.find('~') == 0:
+
+def resolvegenropypath(path: str) -> str | None:
+    """Resolve a path across different Genro installations.
+
+    Attempts to find a valid path by checking multiple locations:
+    1. Expand ~ if path starts with it
+    2. Check absolute paths directly
+    3. Try prepending ~ to absolute paths
+    4. Try prepending ~/ to relative paths
+
+    Args:
+        path: The path to resolve.
+
+    Returns:
+        The resolved path if found, None if no valid path exists.
+
+    Note:
+        Added by Jeff. Useful for resolving document paths between
+        different Genro installations where it may be installed in
+        user path or at root.
+    """
+    if path.find("~") == 0:
         path = expandpath(path)
         if os.path.exists(path):
             return path
-            
-    if path.find('/') == 0:
+
+    if path.find("/") == 0:
         if os.path.exists(path):
             return path
-        else: #try making it into a user directory path
-            path = '%s%s' % ('~', path)
+        else:  # try making it into a user directory path
+            path = "%s%s" % ("~", path)
             path = expandpath(path)
             if os.path.exists(path):
                 return path
@@ -106,8 +185,12 @@ def resolvegenropypath(path):
         if os.path.exists(path):
             return path
         else:
-            path = '%s%s' % ('~/', path)
+            path = "%s%s" % ("~/", path)
             path = expandpath(path)
             if os.path.exists(path):
                 return path
 
+    return None
+
+
+__all__ = ["progress", "mkdir", "expandpath", "listdirs", "resolvegenropypath"]

--- a/gnrpy/gnr/core/gnrsys_review.md
+++ b/gnrpy/gnr/core/gnrsys_review.md
@@ -1,0 +1,81 @@
+# gnrsys.py — Review
+
+## Summary
+
+This module provides utility functions for interacting with the operating
+system and filesystem, including path manipulation, directory creation,
+and progress display.
+
+## Why no split
+
+- Only 113 lines of code (now ~180 with docstrings and type hints)
+- All functions are related (OS/filesystem utilities)
+- Functions are small and independent
+- Splitting would add complexity without benefit
+
+## Structure
+
+- **Lines**: 180 (including docstrings and type hints)
+- **Classes**: 0
+- **Functions**: 5 (`progress`, `mkdir`, `expandpath`, `listdirs`, `resolvegenropypath`)
+- **Constants**: 0
+
+## Dependencies
+
+### This module imports from:
+- `os` — filesystem operations
+- `sys` — stdout for progress display
+
+### Other modules that import this:
+- `gnr.app.gnrapp` — imports `expandpath`
+- `gnr.app.gnrdeploy` — imports `expandpath`
+- `gnr.app.cli.gnrdbsetup` — imports `expandpath`
+- `gnr.app.cli.gnrdbsetupparallel` — imports `expandpath`
+- `gnr.app.cli.gnrheartbeat` — imports `expandpath`
+- `gnr.app.cli.gnrmkapachesite` — imports `expandpath`
+- `gnr.app.cli.gnrremotebagserve` — imports `expandpath`
+- `gnr.core.gnrconfig` — imports `expandpath`
+- `gnr.core.gnrhtml` — imports `expandpath`
+- `gnr.db.cli.gnrmigrate` — imports `expandpath`
+- `gnr.dev.cli.gnraddprojectrepo` — imports `expandpath`
+- `gnr.lib.services.storage` — imports `expandpath`
+- `gnr.web.gnrwsgisite` — imports `expandpath`
+- `gnr.web.gnrdaemonhandler` — imports `expandpath`
+- `gnr.web.cli.gnrsyncstorage` — imports `expandpath`
+- `gnr.web.gnrwsgisite_proxy.gnrresourceloader` — imports `expandpath`
+- `gnr.web.gnrwsgisite_proxy.gnrstatichandler` — imports `expandpath`
+- `gnr.web.gnrwsgisite_proxy.gnrstoragehandler` — imports `expandpath`
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| 127-136 | BUG | `listdirs` uses `os.walk` incorrectly — os.walk doesn't accept a callback function; the callback is never invoked |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `progress` | function | USED | tests |
+| `mkdir` | function | USED | tests |
+| `expandpath` | function | USED | 18+ modules across the codebase |
+| `listdirs` | function | DEAD | tests only (and broken) |
+| `resolvegenropypath` | function | USED | tests only (may have external callers) |
+
+## Recommendations
+
+1. **Fix listdirs**: The `listdirs` function is broken — it tries to pass a
+   callback to `os.walk`, but `os.walk` is a generator that doesn't accept
+   callbacks. It should be rewritten to use `os.walk` correctly:
+   ```python
+   def listdirs(path, invisible_files=False):
+       files = []
+       for root, dirs, names in os.walk(path):
+           for name in names:
+               if invisible_files or not name.startswith('.'):
+                   files.append(os.path.realpath(os.path.join(root, name)))
+       return files
+   ```
+
+2. **Consider pathlib**: Modern Python code should prefer `pathlib.Path` for
+   path manipulation. The `expandpath` function could be simplified using pathlib.


### PR DESCRIPTION
## Summary

Analyzed `gnrsys.py` (113 lines). Module provides OS/filesystem utilities.
Does not benefit from splitting.

### Quality improvements applied:
- Google-style docstrings (English) for module and all functions
- Type hints for all function signatures
- Added `__all__` declaration
- Formatted with ruff/black

Added `gnrsys_review.md` with structure analysis, dependency map.

## Why no split

This is a 113-line module with 5 utility functions for OS/filesystem
operations. All functions are related and independent. Splitting would
add complexity without benefit.

## Issues found

- 1 `# REVIEW:BUG` marker added (`listdirs` uses `os.walk` incorrectly)

## Usage map

- 5 public symbols analyzed
- 1 marked as DEAD (`listdirs` is broken and only used in tests)
- `expandpath` is heavily used (18+ modules import it)

## Verification

- [x] ruff check / flake8 zero errors
- [x] ruff format / black applied
- [x] `from gnr.core.gnrsys import expandpath` works
- [x] Existing tests pass (5 tests)

Ref #486