### PR TITLE
refactor(core): docstrings, type hints and review for gnrprinthandler.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,228 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 1751ff8c0
+
+---
+
+## gnrgit.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrgit`
+- **PR**: #512
+- **Decision**: review only — 42-line single class module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 42 → 85 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrGit)
+- **REVIEW markers added**: 2 (BUG, SMELL)
+- **Dead symbols found**: 3 (class and all methods appear unused)
+- **Tests**: pass (1 test, import only)
+- **Commit**: a659d5f92
+
+---
+
+## gnrredbaron.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrredbaron`
+- **PR**: #513
+- **Decision**: review only — 64-line single class module with stub methods
+- **Sub-modules created**: none
+- **Lines**: 64 → 130 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrRedBaron)
+- **REVIEW markers added**: 5 (SMELL, DEAD)
+- **Dead symbols found**: 6 (class entirely unused, 3 stub methods)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ce68070b0
+
+---
+
+## gnrnumber.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrnumber`
+- **PR**: #514
+- **Decision**: review only — 68-line utility module, tightly cohesive
+- **Sub-modules created**: none
+- **Lines**: 68 → 165 (added docstrings, type hints)
+- **Public names exported**: 4 (decimalRound, floatToDecimal, calculateMultiPerc, partitionTotals)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 5e8118199
+
+---
+
+## gnrcaldav.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcaldav`
+- **PR**: #515
+- **Decision**: review only — 79-line DEPRECATED module, cannot be imported
+- **Sub-modules created**: none
+- **Lines**: 79 → 220 (added docstrings, type hints, preserved unreachable code)
+- **Public names exported**: 2 (CalDavConnection, dt) — but unreachable
+- **REVIEW markers added**: 3 (DEAD, SECURITY x2)
+- **Dead symbols found**: 5 (entire module is deprecated)
+- **Tests**: N/A (module cannot be imported)
+- **Commit**: e471aee27
+
+---
+
+## gnranalyzingbag.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnranalyzingbag`
+- **PR**: #516
+- **Decision**: review only — 87-line single class module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 87 → 145 (added docstrings, type hints)
+- **Public names exported**: 1 (AnalyzingBag)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test, import only)
+- **Commit**: e0531f238
+
+---
+
+## gnrdatetime.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrdatetime`
+- **PR**: #517
+- **Decision**: review only — 91-line well-designed module
+- **Sub-modules created**: none
+- **Lines**: 91 → 165 (added type hints, enhanced docstrings)
+- **Public names exported**: 12 (TZDateTime, datetime, date, time, timedelta, timezone, tzinfo, MINYEAR, MAXYEAR, now, utcnow)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (3 tests)
+- **Commit**: df935e289
+
+---
+
+## gnrcrypto.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcrypto`
+- **PR**: #518
+- **Decision**: review only — 98-line authentication token module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 98 → 220 (added docstrings, type hints)
+- **Public names exported**: 3 (AuthTokenError, AuthTokenExpired, AuthTokenGenerator)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 289dbcb35
+
+---
+
+## gnrrlab.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrrlab`
+- **PR**: #519
+- **Decision**: review only — 109-line ReportLab PDF generation base class
+- **Sub-modules created**: none
+- **Lines**: 109 → 240 (added docstrings, type hints)
+- **Public names exported**: 1 (RlabResource)
+- **REVIEW markers added**: 1 (DEAD)
+- **Dead symbols found**: 9 (class and all methods appear unused in codebase)
+- **Tests**: pass (1 test, import only)
+- **Commit**: 1d73675b9
+
+---
+
+## gnrsys.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrsys`
+- **PR**: #520
+- **Decision**: review only — 113-line OS/filesystem utility module
+- **Sub-modules created**: none
+- **Lines**: 113 → 180 (added docstrings, type hints)
+- **Public names exported**: 5 (progress, mkdir, expandpath, listdirs, resolvegenropypath)
+- **REVIEW markers added**: 1 (BUG)
+- **Dead symbols found**: 1 (listdirs is broken and not used except in tests)
+- **Tests**: pass (5 tests)
+- **Commit**: ca843a921
+
+---
+
+## loggingimport.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/loggingimport`
+- **PR**: #521
+- **Decision**: review only — 123-line DEPRECATED module (uses `imp`)
+- **Sub-modules created**: none
+- **Lines**: 123 → 245 (added docstrings, type hints)
+- **Public names exported**: 9 (functions and saved hooks)
+- **REVIEW markers added**: 3 (DEAD, COMPAT, SMELL)
+- **Dead symbols found**: 9 (entire module is unused)
+- **Tests**: N/A (no tests, module has side effects)
+- **Commit**: edf32cad9
+
+---
+
+## gnrvobject.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrvobject`
+- **PR**: #522
+- **Decision**: review only — 134-line vCard handling module
+- **Sub-modules created**: none
+- **Lines**: 134 → 220 (added docstrings, type hints)
+- **Public names exported**: 2 (VCard, VALID_VCARD_TAGS)
+- **REVIEW markers added**: 1 (SMELL)
+- **Dead symbols found**: 1 (doprettyprint unused)
+- **Tests**: pass (1 test)
+- **Commit**: 9ab115467
+
+---
+
+## gnrssh.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrssh`
+- **PR**: #523
+- **Decision**: review only — 143-line SSH tunneling module
+- **Sub-modules created**: none
+- **Lines**: 143 → 360 (added docstrings, type hints)
+- **Public names exported**: 5 (ForwardServer, Handler, IncompleteConfigurationException, SshTunnel, normalized_sshtunnel_parameters)
+- **REVIEW markers added**: 2 (SMELL)
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test)
+- **Commit**: 7e9fb506a
+
+---
+
+## gnrprinthandler.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrprinthandler`
+- **PR**: #524
+- **Decision**: review only — 186-line print handling module
+- **Sub-modules created**: none
+- **Lines**: 186 → 400 (added docstrings, type hints)
+- **Public names exported**: 3 (PrintHandlerError, PrinterConnection, PrintHandler)
+- **REVIEW markers added**: 1 (SMELL - duplicated dicts with NetworkPrintService)
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test)
+- **Commit**: adb428e4b

--- a/gnrpy/gnr/core/gnrprinthandler.py
+++ b/gnrpy/gnr/core/gnrprinthandler.py
@@ -1,186 +1,403 @@
+"""Print handling utilities using CUPS for network printing.
+
+This module provides classes for managing print jobs through CUPS,
+including PDF generation, printer connections, and file conversion.
+
+Note:
+    This module appears to be partially obsolete. The NetworkPrintService
+    in gnr.lib.services.networkprint provides similar functionality and
+    may be the preferred approach.
+
+Dependencies:
+    - cups: Python CUPS bindings (optional, gracefully handled if missing)
+"""
+
+from __future__ import annotations
+
 import os.path
+from typing import TYPE_CHECKING
 
 try:
     import cups
+
     HAS_CUPS = True
 except ImportError:
+    cups = None  # type: ignore[assignment]
     HAS_CUPS = False
-    
+
 from gnr.core import logger
-from gnr.core.gnrlang import  GnrException
+from gnr.core.gnrlang import GnrException
 from gnr.core.gnrbag import Bag
 from gnr.lib.services import GnrBaseService
 from gnr.core.gnrdecorator import extract_kwargs
 
+if TYPE_CHECKING:
+    from typing import Any
+
+
 class PrintHandlerError(GnrException):
+    """Exception raised for print handling errors."""
+
     pass
-    
+
+
 class PrinterConnection(GnrBaseService):
-    """TODO"""
-    service_name='print'
-    
-    def __init__(self, parent, printer_name=None, printerParams=None, **kwargs):
+    """Connection to a printer or PDF output.
+
+    Manages printing through CUPS or PDF file generation.
+    Supports both direct printing to network printers and
+    PDF output with optional zip compression.
+
+    Args:
+        parent: Parent PrintHandler instance.
+        printer_name: Name of the printer or 'PDF' for PDF output.
+        printerParams: Printer configuration parameters.
+        **kwargs: Additional configuration options.
+
+    Attributes:
+        parent: Parent PrintHandler instance.
+        orientation: Page orientation setting.
+        printAgent: Method used for printing (printPdf or printCups).
+    """
+
+    service_name = "print"
+
+    def __init__(
+        self,
+        parent: PrintHandler,
+        printer_name: str | None = None,
+        printerParams: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize printer connection.
+
+        Args:
+            parent: Parent PrintHandler instance.
+            printer_name: Name of the printer or 'PDF' for PDF output.
+            printerParams: Printer configuration parameters.
+            **kwargs: Additional configuration options.
+        """
         self.parent = parent
-        self.orientation = printerParams.pop('orientation',None)
-        if printer_name == 'PDF':
+        printerParams = printerParams or {}
+        self.orientation = printerParams.pop("orientation", None)
+        if printer_name == "PDF":
             self.initPdf(printerParams=printerParams, **kwargs)
         else:
             self.initPrinter(printer_name, printerParams, **kwargs)
-            
-    def initPdf(self, printerParams=None, **kwargs):
-        """TODO
-        
-        :param printerParams: TODO. """
+
+    def initPdf(
+        self, printerParams: dict[str, Any] | None = None, **kwargs: Any
+    ) -> None:
+        """Initialize PDF output mode.
+
+        Args:
+            printerParams: Configuration including 'zipped' option.
+            **kwargs: Additional options (ignored).
+        """
         printerParams = printerParams or dict()
-        self.zipped = printerParams.pop('zipped',None)
+        self.zipped = printerParams.pop("zipped", None)
         self.printAgent = self.printPdf
-        
-    def printPdf(self, pdf_list, jobname, outputFilePath=None):
-        """TODO
-        
-        :param pdf_list: TODO
-        :param jobname: TODO
-        :param outputFilePath: TODO. """
+
+    def printPdf(
+        self,
+        pdf_list: list[str],
+        jobname: str,
+        outputFilePath: str | None = None,
+    ) -> str:
+        """Output PDFs to a file.
+
+        Either joins PDFs into a single file or creates a zip archive.
+
+        Args:
+            pdf_list: List of PDF file paths.
+            jobname: Name of the print job (unused for PDF output).
+            outputFilePath: Base path for output file (extension added).
+
+        Returns:
+            Base filename of the created output file.
+        """
         if self.zipped:
-            outputFilePath += '.zip'
+            outputFilePath += ".zip"  # type: ignore[operator]
             self.parent.zipPdf(pdf_list, outputFilePath)
         else:
-            outputFilePath += '.pdf'
+            outputFilePath += ".pdf"  # type: ignore[operator]
             self.parent.joinPdf(pdf_list, outputFilePath)
-        return os.path.basename(outputFilePath)
-        
-    def printCups(self, pdf_list, jobname, **kwargs):
-        """TODO
-        
-        :param pdf_list: TODO
-        :param jobname: TODO"""
-        self.cups_connection.printFiles(self.printer_name, pdf_list, jobname, self.printer_options)
-        
-    def initPrinter(self, printer_name=None, printerParams=None, **kwargs):
-        """TODO
-        
-        :param printer_name: TODO
-        :param printerParams: TODO"""
+        return os.path.basename(outputFilePath)  # type: ignore[arg-type]
+
+    def printCups(self, pdf_list: list[str], jobname: str, **kwargs: Any) -> None:
+        """Print PDFs through CUPS.
+
+        Args:
+            pdf_list: List of PDF file paths to print.
+            jobname: Name of the print job.
+            **kwargs: Additional options (ignored).
+        """
+        self.cups_connection.printFiles(
+            self.printer_name, pdf_list, jobname, self.printer_options
+        )
+
+    def initPrinter(
+        self,
+        printer_name: str | None = None,
+        printerParams: Bag | dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize CUPS printer connection.
+
+        Args:
+            printer_name: Name of the CUPS printer.
+            printerParams: Printer options including paper, tray, source.
+            **kwargs: Additional options (ignored).
+        """
         printerParams = printerParams or Bag()
-        self.cups_connection = cups.Connection()
+        self.cups_connection = cups.Connection()  # type: ignore[union-attr]
         self.printer_name = printer_name
         printer_media = []
-        for media_option in ('paper', 'tray', 'source'):
-            media_value = printerParams['printer_options'] and printerParams['printer_options'].pop(media_option)
+        for media_option in ("paper", "tray", "source"):
+            media_value = printerParams["printer_options"] and printerParams[
+                "printer_options"
+            ].pop(media_option)
             if media_value:
                 printer_media.append(media_value)
-        self.printer_options = printerParams['printer_options'] or {}
+        self.printer_options = printerParams["printer_options"] or {}
         if printer_media:
-            self.printer_options['media'] = str(','.join(printer_media))
+            self.printer_options["media"] = str(",".join(printer_media))
         self.printAgent = self.printCups
-        
-    def printFiles(self, file_list, jobname='GenroPrint', storeFolder=None, outputFilePath=None):
-        """TODO
-        
-        :param file_list: TODO
-        :param job_name: TODO
-        :param storeFolder: TODO
-        :param outputFilePath: TODO"""
-        pdf_list = self.parent.autoConvertFiles(file_list, storeFolder, orientation=self.orientation)
+
+    def printFiles(
+        self,
+        file_list: list[str],
+        jobname: str = "GenroPrint",
+        storeFolder: str | None = None,
+        outputFilePath: str | None = None,
+    ) -> str | None:
+        """Print or output files.
+
+        Converts HTML files to PDF if needed, then prints or outputs.
+
+        Args:
+            file_list: List of file paths to print.
+            jobname: Name of the print job.
+            storeFolder: Folder for temporary PDF storage.
+            outputFilePath: Output path for PDF mode.
+
+        Returns:
+            Output filename for PDF mode, None for CUPS printing.
+        """
+        pdf_list = self.parent.autoConvertFiles(
+            file_list, storeFolder, orientation=self.orientation
+        )
         return self.printAgent(pdf_list, jobname, outputFilePath=outputFilePath)
-        
-class PrintHandler(object):
-    """TODO"""
-    paper_size = {
-        'A4': '!!A4',
-        'Legal': '!!Legal',
-        'A4Small': '!!A4 with margins',
-        'COM10': '!!COM10',
-        'DL': '!!DL',
-        'Letter': '!!Letter',
-        'ISOB5': 'ISOB5',
-        'JISB5': 'JISB5',
-        'LetterSmall': 'LetterSmall',
-        'LegalSmall': 'LegalSmall'
+
+
+class PrintHandler:
+    """Handler for print operations.
+
+    Provides methods for printer discovery, PDF conversion, and
+    managing print connections. Supports both CUPS printing and
+    PDF file output.
+
+    Note:
+        Consider using NetworkPrintService from gnr.lib.services.networkprint
+        for new implementations.
+
+    Args:
+        parent: Parent object providing services (site or application).
+
+    Attributes:
+        hasCups: Whether CUPS is available.
+        parent: Parent service provider.
+        paper_size: Dictionary of supported paper sizes.
+        paper_tray: Dictionary of supported paper trays.
+    """
+
+    # REVIEW:SMELL - These dicts are duplicated in NetworkPrintService
+    paper_size: dict[str, str] = {
+        "A4": "!!A4",
+        "Legal": "!!Legal",
+        "A4Small": "!!A4 with margins",
+        "COM10": "!!COM10",
+        "DL": "!!DL",
+        "Letter": "!!Letter",
+        "ISOB5": "ISOB5",
+        "JISB5": "JISB5",
+        "LetterSmall": "LetterSmall",
+        "LegalSmall": "LegalSmall",
     }
-    paper_tray = {
-        'MultiPurpose': '!!MultiPurpose',
-        'Transparency': '!!Transparency',
-        'Upper': '!!Upper',
-        'Lower': '!!Lower',
-        'LargeCapacity': '!!LargeCapacity'
+    paper_tray: dict[str, str] = {
+        "MultiPurpose": "!!MultiPurpose",
+        "Transparency": "!!Transparency",
+        "Upper": "!!Upper",
+        "Lower": "!!Lower",
+        "LargeCapacity": "!!LargeCapacity",
     }
-        
-    def __init__(self, parent=None):
+
+    def __init__(self, parent: Any = None) -> None:
+        """Initialize print handler.
+
+        Args:
+            parent: Parent object providing services.
+        """
         global HAS_CUPS
         self.hasCups = HAS_CUPS
         self.parent = parent
 
     @extract_kwargs(pdf=True)
-    def htmlToPdf(self, srcPath, destPath, orientation=None, page_height=None, page_width=None, pdf_kwargs=None,htmlTemplate=None,bodyStyle=None): #srcPathList per ridurre i processi?
-        return self.parent.getService('htmltopdf').htmlToPdf(srcPath, destPath, orientation=orientation, page_height=page_height,
-                                                     page_width=page_width, pdf_kwargs=pdf_kwargs,
-                                                     htmlTemplate=htmlTemplate,bodyStyle=bodyStyle)
+    def htmlToPdf(
+        self,
+        srcPath: str,
+        destPath: str,
+        orientation: str | None = None,
+        page_height: int | None = None,
+        page_width: int | None = None,
+        pdf_kwargs: dict[str, Any] | None = None,
+        htmlTemplate: str | None = None,
+        bodyStyle: str | None = None,
+    ) -> str:
+        """Convert HTML file to PDF.
 
+        Args:
+            srcPath: Path to source HTML file.
+            destPath: Destination path for PDF.
+            orientation: Page orientation ('portrait' or 'landscape').
+            page_height: Custom page height.
+            page_width: Custom page width.
+            pdf_kwargs: Additional PDF conversion options.
+            htmlTemplate: HTML template to use.
+            bodyStyle: CSS body style to apply.
 
-    def autoConvertFiles(self, files, storeFolder, orientation=None):
-        """TODO
-        
-        :param files: TODO
-        :param storeFolder: TODO
-        :param orientation: TODO"""
+        Returns:
+            Path to the created PDF file.
+        """
+        return self.parent.getService("htmltopdf").htmlToPdf(
+            srcPath,
+            destPath,
+            orientation=orientation,
+            page_height=page_height,
+            page_width=page_width,
+            pdf_kwargs=pdf_kwargs,
+            htmlTemplate=htmlTemplate,
+            bodyStyle=bodyStyle,
+        )
+
+    def autoConvertFiles(
+        self,
+        files: list[str],
+        storeFolder: str | None,
+        orientation: str | None = None,
+    ) -> list[str]:
+        """Convert files to PDF format as needed.
+
+        HTML files are converted to PDF; PDF files pass through unchanged.
+
+        Args:
+            files: List of file paths to process.
+            storeFolder: Folder for storing converted PDFs.
+            orientation: Page orientation for conversion.
+
+        Returns:
+            List of PDF file paths.
+
+        Raises:
+            PrintHandlerError: If a file is neither HTML nor PDF.
+        """
         resultList = []
         for filename in files:
             baseName, ext = os.path.splitext(os.path.basename(filename))
-            if ext.lower() == '.html':
-                resultList.append(self.htmlToPdf(filename, storeFolder, orientation=orientation))
-            elif ext.lower() == '.pdf':
+            if ext.lower() == ".html":
+                resultList.append(
+                    self.htmlToPdf(filename, storeFolder, orientation=orientation)
+                )
+            elif ext.lower() == ".pdf":
                 resultList.append(filename)
             else:
-                raise PrintHandlerError('not pdf file')
+                raise PrintHandlerError("not pdf file")
         return resultList
-        
-    def getPrinters(self):
-        """TODO"""
+
+    def getPrinters(self) -> Bag:
+        """Get available printers from CUPS.
+
+        Returns:
+            Bag containing printer information organized by location.
+        """
         printersBag = Bag()
         if self.hasCups:
-            cups_connection = cups.Connection()
+            cups_connection = cups.Connection()  # type: ignore[union-attr]
             for printer_name, printer in list(cups_connection.getPrinters().items()):
                 printer.update(dict(name=printer_name))
-                printersBag.setItem('%s.%s' % (printer['printer-location'], printer_name.replace(':','_')), None, printer)
+                printersBag.setItem(
+                    "%s.%s"
+                    % (printer["printer-location"], printer_name.replace(":", "_")),
+                    None,
+                    printer,
+                )
         else:
-            logger.error('pyCups is not installed')
+            logger.error("pyCups is not installed")
         return printersBag
-        
-    def getPrinterAttributes(self, printer_name):
-        """TODO
-        
-        :param printer_name: TODO"""
-        cups_connection = cups.Connection()
+
+    def getPrinterAttributes(self, printer_name: str) -> Bag:
+        """Get attributes for a specific printer.
+
+        Args:
+            printer_name: Name of the CUPS printer.
+
+        Returns:
+            Bag containing supported paper sizes and trays.
+        """
+        cups_connection = cups.Connection()  # type: ignore[union-attr]
         printer_attributes = cups_connection.getPrinterAttributes(printer_name)
         attributesBag = Bag()
         for i, (media, description) in enumerate(self.paper_size.items()):
-            if media in printer_attributes['media-supported']:
-                attributesBag.setItem('paper_supported.%i' % i, None, id=media, caption=description)
+            if media in printer_attributes["media-supported"]:
+                attributesBag.setItem(
+                    "paper_supported.%i" % i, None, id=media, caption=description
+                )
         for i, (tray, description) in enumerate(self.paper_tray.items()):
-            if tray in printer_attributes['media-supported']:
-                attributesBag.setItem('tray_supported.%i' % i, None, id=tray, caption=description)
+            if tray in printer_attributes["media-supported"]:
+                attributesBag.setItem(
+                    "tray_supported.%i" % i, None, id=tray, caption=description
+                )
         return attributesBag
-        
-    def getPrinterConnection(self, printer_name=None, printerParams=None, **kwargs):
-        """TODO
-        
-        :param printer_name: TODO
-        :param printerParams: TODO"""
-        return PrinterConnection(self, printer_name=printer_name, printerParams=printerParams or dict(), **kwargs)
-        
-    def joinPdf(self, pdf_list, output_filepath):
-        """TODO
-        
-        :param pdf_list: TODO
-        :param output_filepath: TODO"""
-        self.parent.getService('pdf').joinPdf(pdf_list, output_filepath)
-            
-    def zipPdf(self, file_list=None, zipPath=None):
-        """TODO
-        
-        :param file_list: TODO
-        :param zipPath: TODO"""
+
+    def getPrinterConnection(
+        self,
+        printer_name: str | None = None,
+        printerParams: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> PrinterConnection:
+        """Create a printer connection.
+
+        Args:
+            printer_name: Name of printer or 'PDF' for file output.
+            printerParams: Printer configuration.
+            **kwargs: Additional options.
+
+        Returns:
+            PrinterConnection configured for the specified printer.
+        """
+        return PrinterConnection(
+            self,
+            printer_name=printer_name,
+            printerParams=printerParams or dict(),
+            **kwargs,
+        )
+
+    def joinPdf(self, pdf_list: list[str], output_filepath: str) -> None:
+        """Join multiple PDFs into a single file.
+
+        Args:
+            pdf_list: List of PDF file paths.
+            output_filepath: Path for the combined output.
+        """
+        self.parent.getService("pdf").joinPdf(pdf_list, output_filepath)
+
+    def zipPdf(
+        self, file_list: list[str] | None = None, zipPath: str | None = None
+    ) -> None:
+        """Create a zip archive of PDF files.
+
+        Args:
+            file_list: List of file paths to include.
+            zipPath: Path for the output zip file.
+        """
         self.parent.zipFiles(file_list=file_list, zipPath=zipPath)
-        
-        

--- a/gnrpy/gnr/core/gnrprinthandler_review.md
+++ b/gnrpy/gnr/core/gnrprinthandler_review.md
@@ -1,0 +1,73 @@
+# gnrprinthandler.py — Review
+
+## Summary
+
+This module provides print handling utilities using CUPS for network printing,
+including PDF generation, printer connections, and file conversion. It appears
+to be partially obsolete with similar functionality in NetworkPrintService.
+
+## Why no split
+
+- Only 186 lines of code (now ~400 with docstrings and type hints)
+- Two tightly coupled classes (PrintHandler, PrinterConnection)
+- Single cohesive responsibility (print handling)
+- Splitting would add complexity without benefit
+
+## Structure
+
+- **Lines**: 400 (including docstrings and type hints)
+- **Classes**: 3 (`PrintHandlerError`, `PrinterConnection`, `PrintHandler`)
+- **Functions**: 0
+- **Constants**: 1 (`HAS_CUPS`)
+
+## Dependencies
+
+### This module imports from:
+- `cups` — Python CUPS bindings (optional)
+- `gnr.core.logger` — logging
+- `gnr.core.gnrlang` — GnrException
+- `gnr.core.gnrbag` — Bag
+- `gnr.lib.services` — GnrBaseService
+- `gnr.core.gnrdecorator` — extract_kwargs
+
+### Other modules that import this:
+- `gnr.tests.core.gnrprinthandler_test` — tests (import only)
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| 214-229 | SMELL | `paper_size` and `paper_tray` dicts duplicated in NetworkPrintService |
+| - | SMELL | Module appears partially obsolete (NetworkPrintService provides similar functionality) |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `HAS_CUPS` | constant | INTERNAL | `PrintHandler.__init__` |
+| `PrintHandlerError` | class | USED | `autoConvertFiles` |
+| `PrinterConnection` | class | USED | `PrintHandler.getPrinterConnection` |
+| `PrinterConnection.initPdf` | method | USED | `__init__` |
+| `PrinterConnection.printPdf` | method | USED | via `printAgent` |
+| `PrinterConnection.printCups` | method | USED | via `printAgent` |
+| `PrinterConnection.initPrinter` | method | USED | `__init__` |
+| `PrinterConnection.printFiles` | method | USED | external callers |
+| `PrintHandler` | class | USED | (external, tests) |
+| `PrintHandler.htmlToPdf` | method | USED | `autoConvertFiles` |
+| `PrintHandler.autoConvertFiles` | method | USED | `PrinterConnection.printFiles` |
+| `PrintHandler.getPrinters` | method | USED | (external) |
+| `PrintHandler.getPrinterAttributes` | method | USED | (external) |
+| `PrintHandler.getPrinterConnection` | method | USED | (external) |
+| `PrintHandler.joinPdf` | method | USED | `PrinterConnection.printPdf` |
+| `PrintHandler.zipPdf` | method | USED | `PrinterConnection.printPdf` |
+
+## Recommendations
+
+1. **Investigate relationship with NetworkPrintService**: The `paper_size` and
+   `paper_tray` dictionaries are duplicated. Consider consolidating or
+   deprecating one of the implementations.
+
+2. **Remove duplicate in gnrwsgisite.py**: There's a `PrintHandlerError`
+   class defined in gnrwsgisite.py that appears unused.
+
+3. **Add proper tests**: Current test only verifies import works.


### PR DESCRIPTION
## Summary

- Added comprehensive docstrings for module, classes, and methods
- Added type hints for all parameters and return values
- Identified potential duplication with NetworkPrintService
- Module provides CUPS printing and PDF output functionality

## Changes

- **Lines**: 186 → 400 (added docstrings, type hints)
- **Public names**: 3 (PrintHandlerError, PrinterConnection, PrintHandler)
- **REVIEW markers**: 1 (SMELL - duplicated dicts)
- **Dead symbols found**: 0

## Decision

**REVIEW ONLY** — 186-line print handling module with cohesive responsibility

## Testing

- Import test: ✅
- Existing tests: ✅ (1 test)

## Review Document

See `gnrprinthandler_review.md` for full analysis.

## Notes

This module may be partially obsolete - NetworkPrintService in gnr.lib.services.networkprint provides similar functionality. The paper_size and paper_tray dictionaries are duplicated between the two.