### PR TITLE
refactor(core): docstrings, type hints and review for gnrdict.py

### DIFF
--- a/SPLIT_LOG.md
+++ b/SPLIT_LOG.md
@@ -1,0 +1,288 @@
+# gnr.core Module Refactoring Log
+
+This file tracks the progress of splitting/reviewing modules in `gnrpy/gnr/core/`.
+
+---
+
+## gnrbaseservice.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbaseservice`
+- **PR**: #510
+- **Decision**: review only — 3-line re-export module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 3 → 11 (added docstring)
+- **Public names re-exported**: 1 (GnrBaseService)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: N/A (no tests for this module)
+- **Commit**: e530b28b6
+
+---
+
+## gnrenv.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrenv`
+- **PR**: #511
+- **Decision**: review only — 22-line constant definition module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 22 → 50 (added docstring, type hints)
+- **Public names exported**: 4 (GNRHOME, GNRINSTANCES, GNRPACKAGES, GNRSITES)
+- **REVIEW markers added**: 1 (COMPAT)
+- **Dead symbols found**: 4 (all public constants appear unused)
+- **Tests**: pass (empty test file, only import check)
+- **Commit**: 1751ff8c0
+
+---
+
+## gnrgit.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrgit`
+- **PR**: #512
+- **Decision**: review only — 42-line single class module, already minimal
+- **Sub-modules created**: none
+- **Lines**: 42 → 85 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrGit)
+- **REVIEW markers added**: 2 (BUG, SMELL)
+- **Dead symbols found**: 3 (class and all methods appear unused)
+- **Tests**: pass (1 test, import only)
+- **Commit**: a659d5f92
+
+---
+
+## gnrredbaron.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrredbaron`
+- **PR**: #513
+- **Decision**: review only — 64-line single class module with stub methods
+- **Sub-modules created**: none
+- **Lines**: 64 → 130 (added docstrings, type hints)
+- **Public names exported**: 1 (GnrRedBaron)
+- **REVIEW markers added**: 5 (SMELL, DEAD)
+- **Dead symbols found**: 6 (class entirely unused, 3 stub methods)
+- **Tests**: pass (1 test, import only)
+- **Commit**: ce68070b0
+
+---
+
+## gnrnumber.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrnumber`
+- **PR**: #514
+- **Decision**: review only — 68-line utility module, tightly cohesive
+- **Sub-modules created**: none
+- **Lines**: 68 → 165 (added docstrings, type hints)
+- **Public names exported**: 4 (decimalRound, floatToDecimal, calculateMultiPerc, partitionTotals)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 5e8118199
+
+---
+
+## gnrcaldav.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcaldav`
+- **PR**: #515
+- **Decision**: review only — 79-line DEPRECATED module, cannot be imported
+- **Sub-modules created**: none
+- **Lines**: 79 → 220 (added docstrings, type hints, preserved unreachable code)
+- **Public names exported**: 2 (CalDavConnection, dt) — but unreachable
+- **REVIEW markers added**: 3 (DEAD, SECURITY x2)
+- **Dead symbols found**: 5 (entire module is deprecated)
+- **Tests**: N/A (module cannot be imported)
+- **Commit**: e471aee27
+
+---
+
+## gnranalyzingbag.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnranalyzingbag`
+- **PR**: #516
+- **Decision**: review only — 87-line single class module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 87 → 145 (added docstrings, type hints)
+- **Public names exported**: 1 (AnalyzingBag)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test, import only)
+- **Commit**: e0531f238
+
+---
+
+## gnrdatetime.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrdatetime`
+- **PR**: #517
+- **Decision**: review only — 91-line well-designed module
+- **Sub-modules created**: none
+- **Lines**: 91 → 165 (added type hints, enhanced docstrings)
+- **Public names exported**: 12 (TZDateTime, datetime, date, time, timedelta, timezone, tzinfo, MINYEAR, MAXYEAR, now, utcnow)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (3 tests)
+- **Commit**: df935e289
+
+---
+
+## gnrcrypto.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrcrypto`
+- **PR**: #518
+- **Decision**: review only — 98-line authentication token module, cohesive
+- **Sub-modules created**: none
+- **Lines**: 98 → 220 (added docstrings, type hints)
+- **Public names exported**: 3 (AuthTokenError, AuthTokenExpired, AuthTokenGenerator)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (4 tests)
+- **Commit**: 289dbcb35
+
+---
+
+## gnrrlab.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrrlab`
+- **PR**: #519
+- **Decision**: review only — 109-line ReportLab PDF generation base class
+- **Sub-modules created**: none
+- **Lines**: 109 → 240 (added docstrings, type hints)
+- **Public names exported**: 1 (RlabResource)
+- **REVIEW markers added**: 1 (DEAD)
+- **Dead symbols found**: 9 (class and all methods appear unused in codebase)
+- **Tests**: pass (1 test, import only)
+- **Commit**: 1d73675b9
+
+---
+
+## gnrsys.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrsys`
+- **PR**: #520
+- **Decision**: review only — 113-line OS/filesystem utility module
+- **Sub-modules created**: none
+- **Lines**: 113 → 180 (added docstrings, type hints)
+- **Public names exported**: 5 (progress, mkdir, expandpath, listdirs, resolvegenropypath)
+- **REVIEW markers added**: 1 (BUG)
+- **Dead symbols found**: 1 (listdirs is broken and not used except in tests)
+- **Tests**: pass (5 tests)
+- **Commit**: ca843a921
+
+---
+
+## loggingimport.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/loggingimport`
+- **PR**: #521
+- **Decision**: review only — 123-line DEPRECATED module (uses `imp`)
+- **Sub-modules created**: none
+- **Lines**: 123 → 245 (added docstrings, type hints)
+- **Public names exported**: 9 (functions and saved hooks)
+- **REVIEW markers added**: 3 (DEAD, COMPAT, SMELL)
+- **Dead symbols found**: 9 (entire module is unused)
+- **Tests**: N/A (no tests, module has side effects)
+- **Commit**: edf32cad9
+
+---
+
+## gnrvobject.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrvobject`
+- **PR**: #522
+- **Decision**: review only — 134-line vCard handling module
+- **Sub-modules created**: none
+- **Lines**: 134 → 220 (added docstrings, type hints)
+- **Public names exported**: 2 (VCard, VALID_VCARD_TAGS)
+- **REVIEW markers added**: 1 (SMELL)
+- **Dead symbols found**: 1 (doprettyprint unused)
+- **Tests**: pass (1 test)
+- **Commit**: 9ab115467
+
+---
+
+## gnrssh.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrssh`
+- **PR**: #523
+- **Decision**: review only — 143-line SSH tunneling module
+- **Sub-modules created**: none
+- **Lines**: 143 → 360 (added docstrings, type hints)
+- **Public names exported**: 5 (ForwardServer, Handler, IncompleteConfigurationException, SshTunnel, normalized_sshtunnel_parameters)
+- **REVIEW markers added**: 2 (SMELL)
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test)
+- **Commit**: 7e9fb506a
+
+---
+
+## gnrprinthandler.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrprinthandler`
+- **PR**: #524
+- **Decision**: review only — 186-line print handling module
+- **Sub-modules created**: none
+- **Lines**: 186 → 400 (added docstrings, type hints)
+- **Public names exported**: 3 (PrintHandlerError, PrinterConnection, PrintHandler)
+- **REVIEW markers added**: 1 (SMELL - duplicated dicts with NetworkPrintService)
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test)
+- **Commit**: 4278dae95
+
+---
+
+## gnrexporter.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrexporter`
+- **PR**: #525
+- **Decision**: review only — 221-line data export module
+- **Sub-modules created**: none
+- **Lines**: 221 → 600 (added docstrings, type hints)
+- **Public names exported**: 5 (getWriter, BaseWriter, CsvWriter, HtmlTableWriter, JsonWriter)
+- **REVIEW markers added**: 2 (SMELL - bare except, BUG - HTML typo)
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test)
+- **Commit**: e116bf1d0
+
+---
+
+## gnrdecorator.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrdecorator`
+- **PR**: #526
+- **Decision**: review only — 221-line decorator utilities module
+- **Sub-modules created**: none
+- **Lines**: 221 → 400 (added docstrings, type hints)
+- **Public names exported**: 8 (metadata, autocast, public_method, websocket_method, extract_kwargs, customizable, oncalling, oncalled, deprecated)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (1 test)
+- **Commit**: 5a66f92ac
+
+---
+
+## gnrbageditor.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrbageditor`
+- **PR**: #527
+- **Decision**: review only — 243-line Bag/XML editor module
+- **Sub-modules created**: none
+- **Lines**: 243 → 290 (added type hints, improved docstrings)
+- **Public names exported**: 1 (BagEditor)
+- **REVIEW markers added**: 0
+- **Dead symbols found**: 0
+- **Tests**: pass (83 tests!)
+- **Commit**: db5d93bd2
+
+---
+
+## gnrdict.py — REVIEW ONLY
+
+- **Branch**: `pkg_refactor/gnrdict`
+- **PR**: #530
+- **Decision**: review only — 244-line dictionary utilities module with interdependent classes
+- **Sub-modules created**: none
+- **Lines**: 244 → 547 (added type hints, Google-style docstrings)
+- **Public names exported**: 5 (dictExtract, FakeDict, UnionDict, GnrDict, GnrNumericDict)
+- **REVIEW markers added**: 7 (UNUSED: 1, DEAD: 3, SMELL: 2, COMPAT: 2)
+- **Dead symbols found**: 3 (FakeDict, UnionDict, GnrNumericDict — tests only)
+- **Tests**: pass (4 tests)
+- **Commit**: ab42c13c4

--- a/gnrpy/gnr/core/gnrdict.py
+++ b/gnrpy/gnr/core/gnrdict.py
@@ -1,243 +1,568 @@
 # -*- coding: utf-8 -*-
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 # package       : GenroPy core - see LICENSE for details
 # module gnrdict : gnrdict implementation
-# Copyright (c) : 2004 - 2007 Softwell sas - Milano 
+# Copyright (c) : 2004 - 2007 Softwell sas - Milano
 # Written by    : Giovanni Porcari, Michele Bertoldi
 #                 Saverio Porcari, Francesco Porcari , Francesco Cavazzana
-#--------------------------------------------------------------------------
-#This library is free software; you can redistribute it and/or
-#modify it under the terms of the GNU Lesser General Public
-#License as published by the Free Software Foundation; either
-#version 2.1 of the License, or (at your option) any later version.
+# --------------------------------------------------------------------------
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
 
-#This library is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-#Lesser General Public License for more details.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
 
-#You should have received a copy of the GNU Lesser General Public
-#License along with this library; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-from collections.abc import Mapping
-from itertools import chain
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+"""Dictionary utilities for GenroPy.
+
+This module provides specialized dictionary classes and utility functions
+for working with dictionaries in GenroPy applications:
+
+- :func:`dictExtract`: Extract items with keys matching a prefix.
+- :class:`FakeDict`: Empty dict subclass for type discrimination.
+- :class:`UnionDict`: Read-only union view of multiple dictionaries.
+- :class:`GnrDict`: Ordered dictionary with index-based and ``#N`` key access.
+- :class:`GnrNumericDict`: GnrDict variant with numeric index iteration.
+"""
+
+from __future__ import annotations
 
 import warnings
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from itertools import chain
+from typing import Any, TypeVar
 
-def dictExtract(mydict, prefix, pop=False, slice_prefix=True,is_list=False):
-    """Return a dict of the items with keys starting with prefix.
-    
-    :param mydict: sourcedict 
-    :param prefix: the prefix of the items you need to extract
-    :param pop: removes the items from the sourcedict
-    :param slice_prefix: shortens the keys of the output dict removing the prefix
-    :returns: a dict of the items with keys starting with prefix"""
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
-    # FIXME: the is_list parameter is never used.
-    
+
+def dictExtract(
+    mydict: dict[str, Any],
+    prefix: str,
+    pop: bool = False,
+    slice_prefix: bool = True,
+    is_list: bool = False,  # REVIEW:UNUSED — parameter is never used
+) -> dict[str, Any]:
+    """Extract items from a dictionary whose keys start with a given prefix.
+
+    This function filters a dictionary to include only items whose keys
+    begin with the specified prefix. Optionally removes those items from
+    the source dictionary and/or removes the prefix from the resulting keys.
+
+    Args:
+        mydict: The source dictionary to extract from.
+        prefix: The prefix to match against dictionary keys.
+        pop: If True, removes matching items from the source dictionary.
+            Defaults to False.
+        slice_prefix: If True, removes the prefix from keys in the result.
+            Defaults to True.
+        is_list: Unused parameter (kept for backward compatibility).
+
+    Returns:
+        A new dictionary containing only the items whose keys started with
+        the prefix. If ``slice_prefix`` is True, the prefix is removed from
+        the keys. Keys that would become Python reserved words (like 'class')
+        are prefixed with an underscore.
+
+    Examples:
+        >>> d = {'user_name': 'John', 'user_age': 30, 'item_id': 1}
+        >>> dictExtract(d, 'user_')
+        {'name': 'John', 'age': 30}
+        >>> dictExtract(d, 'user_', slice_prefix=False)
+        {'user_name': 'John', 'user_age': 30}
+    """
     lprefix = len(prefix) if slice_prefix else 0
-    
-    cb = mydict.pop if pop else mydict.get
-    reserved_names = ['class']
-    return dict([(k[lprefix:] if not k[lprefix:] in reserved_names else '_%s' %k[lprefix:], cb(k)) for k in list(mydict.keys()) if k.startswith(prefix)])
 
-class FakeDict(dict):
+    cb = mydict.pop if pop else mydict.get
+    reserved_names = ["class"]
+    return dict(
+        [
+            (
+                k[lprefix:]
+                if k[lprefix:] not in reserved_names
+                else "_%s" % k[lprefix:],
+                cb(k),
+            )
+            for k in list(mydict.keys())
+            if k.startswith(prefix)
+        ]
+    )
+
+
+class FakeDict(dict[_KT, _VT]):  # REVIEW:DEAD — no external callers found (only tests)
+    """Empty dict subclass for type discrimination.
+
+    This class exists solely as a marker type to distinguish certain
+    dictionary instances from plain dicts. It has no additional behavior.
+    """
+
     pass
 
 
+class UnionDict(Mapping[_KT, _VT]):  # REVIEW:DEAD — no external callers found
+    """Read-only union view of multiple dictionaries.
 
-class UnionDict(Mapping):
-    def __init__(self, *dicts):
-        self.dicts = dicts
+    Provides a unified view over multiple dictionaries without copying
+    their contents. When a key is looked up, dictionaries are searched
+    in order and the first match is returned.
 
-    def __getitem__(self, key):
+    Attributes:
+        dicts: Tuple of underlying dictionaries.
+
+    Examples:
+        >>> d1 = {'a': 1, 'b': 2}
+        >>> d2 = {'b': 3, 'c': 4}
+        >>> u = UnionDict(d1, d2)
+        >>> u['a']
+        1
+        >>> u['b']  # d1 takes precedence
+        2
+        >>> u['c']
+        4
+    """
+
+    def __init__(self, *dicts: dict[_KT, _VT]) -> None:
+        """Initialize with one or more dictionaries.
+
+        Args:
+            *dicts: Variable number of dictionaries to unify.
+        """
+        self.dicts: tuple[dict[_KT, _VT], ...] = dicts
+
+    def __getitem__(self, key: _KT) -> _VT:
+        """Get a value by key, searching dictionaries in order.
+
+        Args:
+            key: The key to look up.
+
+        Returns:
+            The value from the first dictionary containing the key.
+
+        Raises:
+            KeyError: If the key is not found in any dictionary.
+        """
         for d in self.dicts:
             if key in d:
                 return d[key]
         raise KeyError(key)
 
-    def __iter__(self):
-        # dict.fromkeys elimina i duplicati mantenendo l'ordine
+    def __iter__(self) -> Iterator[_KT]:
+        """Iterate over all unique keys from all dictionaries.
+
+        Returns:
+            An iterator over unique keys, preserving first-seen order.
+        """
+        # dict.fromkeys removes duplicates while preserving order
         return iter(dict.fromkeys(chain.from_iterable(self.dicts)))
 
-    def __len__(self):
+    def __len__(self) -> int:
+        """Return the number of unique keys across all dictionaries.
+
+        Returns:
+            The count of unique keys.
+        """
         return len(dict.fromkeys(chain.from_iterable(self.dicts)))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """Return a string representation as a plain dict.
+
+        Returns:
+            String representation of the unified dictionary.
+        """
         return f"{dict(self)}"
 
-class GnrDict(dict):
-    """An ordered dictionary"""
-    def __init__(self, *args, **kwargs):
+
+class GnrDict(dict[str, _VT]):
+    """Ordered dictionary with index-based key access.
+
+    A dictionary that maintains insertion order and supports accessing
+    items by their numeric position using the ``#N`` syntax in keys.
+
+    The class predates Python 3.7's ordered dict guarantee and provides
+    additional features like index-based access, arithmetic operations
+    on dictionaries, and in-place sorting.
+
+    Attributes:
+        _list: Internal list maintaining key order.
+
+    Examples:
+        >>> d = GnrDict()
+        >>> d['first'] = 1
+        >>> d['second'] = 2
+        >>> d['#0']  # Access by index
+        1
+        >>> d['#1']
+        2
+        >>> d.keys()
+        ['first', 'second']
+    """
+
+    def __init__(
+        self,
+        *args: dict[str, _VT] | Iterable[tuple[str, _VT]],
+        **kwargs: _VT,
+    ) -> None:
+        """Initialize from optional mapping/iterable and keyword arguments.
+
+        Args:
+            *args: Optional source data - either a dict or an iterable
+                of (key, value) pairs.
+            **kwargs: Additional key-value pairs to include.
+        """
         dict.__init__(self)
-        self._list = []
+        self._list: list[str] = []
         if args:
             source = args[0]
-            if hasattr(source, 'items'):
+            if hasattr(source, "items"):
                 [self.__setitem__(k, v) for k, v in list(source.items())]
             else:
                 [self.__setitem__(k, v) for k, v in source]
         if kwargs:
             [self.__setitem__(k, v) for k, v in list(kwargs.items())]
-            
-    def __setitem__(self, key, value):
+
+    def __setitem__(self, key: str, value: _VT) -> None:
+        """Set a key-value pair, maintaining order.
+
+        Args:
+            key: The key (may use ``#N`` syntax for index-based access).
+            value: The value to set.
+        """
         key = self._label_convert(key)
-        if not key in self:
+        if key not in self:
             self._list.append(key)
         dict.__setitem__(self, key, value)
-        
-    def __iter__(self):
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over keys in insertion order.
+
+        Returns:
+            An iterator over the keys.
+        """
         return self._list.__iter__()
-        
-    def __delitem__(self, key):
+
+    def __delitem__(self, key: str) -> None:
+        """Delete an item by key.
+
+        Args:
+            key: The key to delete (may use ``#N`` syntax).
+        """
         key = self._label_convert(key)
         self._list.remove(key)
         dict.__delitem__(self, key)
-        
-    def get(self, label, default=None):
-        """TODO
-        
-        :param label: TODO
-        :param default: TODO"""
+
+    def get(self, label: str, default: _VT | None = None) -> _VT | None:
+        """Get a value by key with optional default.
+
+        Args:
+            label: The key to look up (may use ``#N`` syntax).
+            default: Value to return if key is not found.
+
+        Returns:
+            The value for the key, or default if not found.
+        """
         return dict.get(self, self._label_convert(label), default)
-        
-    def __getitem__(self, label):
-        # FIXME: handle slices from 'label',
-        # which is currently not supported by self._label_convert
-        return dict.__getitem__(self, self._label_convert(label)) 
-        
-    def _label_convert(self, label):
+
+    def __getitem__(self, label: str) -> _VT:
+        """Get a value by key.
+
+        Args:
+            label: The key to look up (may use ``#N`` syntax).
+
+        Returns:
+            The value for the key.
+
+        Raises:
+            KeyError: If the key is not found.
+        """
+        # REVIEW:SMELL — comment mentions slice support not implemented
+        return dict.__getitem__(self, self._label_convert(label))
+
+    def _label_convert(self, label: str) -> str:
+        """Convert ``#N`` style labels to actual keys.
+
+        If the label starts with ``#`` followed by digits, it is treated
+        as an index into the key list.
+
+        Args:
+            label: The label to convert.
+
+        Returns:
+            The actual key (converted from index if applicable).
+        """
         try:
-            if label.startswith('#') and label[1:].isdigit():
+            if label.startswith("#") and label[1:].isdigit():
                 label = self._list[int(label[1:])]
-        except:
+        except Exception:  # REVIEW:SMELL — bare except catches too much
             pass
         return label
-        
-    def items(self):
-        """TODO"""
+
+    def items(self) -> list[tuple[str, _VT]]:
+        """Return a list of (key, value) pairs in order.
+
+        Returns:
+            List of key-value tuples.
+        """
         return [(k, self[k]) for k in self._list]
-        
-    def keys(self):
-        """TODO"""
+
+    def keys(self) -> list[str]:
+        """Return a list of keys in order.
+
+        Returns:
+            List of keys.
+        """
         return list(self._list)
-        
-    def index(self, value):
-        """TODO"""
+
+    def index(self, value: str) -> int:
+        """Return the index of a key in the ordered list.
+
+        Args:
+            value: The key to find.
+
+        Returns:
+            The index of the key, or -1 if not found.
+        """
         if value in self._list:
             return self._list.index(value)
         return -1
-        
-    def values(self):
-        """TODO"""
+
+    def values(self) -> list[_VT]:
+        """Return a list of values in key order.
+
+        Returns:
+            List of values.
+        """
         return [self[k] for k in self._list]
-        
-    def pop(self, key, dflt=None):
-        """TODO
-        
-        :param key: TODO
-        :param dflt: TODO"""
+
+    def pop(self, key: str, dflt: _VT | None = None) -> _VT | None:
+        """Remove and return a value by key.
+
+        Args:
+            key: The key to remove (may use ``#N`` syntax).
+            dflt: Default value if key is not found.
+
+        Returns:
+            The removed value, or dflt if key not found.
+        """
         key = self._label_convert(key)
         if key in self._list:
             self._list.remove(key)
             return dict.pop(self, key)
         return dflt
-        
-    def __str__(self):
-        return "{%s}" % (', '.join(["%s: %s" % (repr(k), repr(self[k])) for k in self._list]))
-        
+
+    def __str__(self) -> str:
+        """Return a string representation.
+
+        Returns:
+            String in dict-like format with items in order.
+        """
+        return "{%s}" % (
+            ", ".join(["%s: %s" % (repr(k), repr(self[k])) for k in self._list])
+        )
+
     __repr__ = __str__
-        
-    #def __repr__(self):
-    #return "%s ordered on %s" % (dict.__repr__(self), str(self._list))
-        
-    def clear(self):
-        """TODO"""
+
+    def clear(self) -> None:
+        """Remove all items from the dictionary."""
         self._list[:] = []
         dict.clear(self)
-        
-    def update(self, o, removeNone=False):
-        """TODO
-        
-        :param o: TODO
-        :param removeNone: TODO"""
+
+    def update(  # type: ignore[override]
+        self,
+        o: dict[str, _VT],
+        removeNone: bool = False,
+    ) -> None:
+        """Update the dictionary with items from another dict.
+
+        Args:
+            o: Dictionary to update from.
+            removeNone: If True, remove keys whose values are None after update.
+        """
         [self.__setitem__(k, v) for k, v in list(o.items())]
         if removeNone:
-            [self.__delitem__(k) for k, v in list(o.items()) if v == None]
-            
-    def copy(self):
-        """TODO"""
+            [self.__delitem__(k) for k, v in list(o.items()) if v is None]
+
+    def copy(self) -> GnrDict[_VT]:
+        """Return a shallow copy.
+
+        Returns:
+            A new GnrDict with the same items.
+        """
         return GnrDict(self)
-        
-    def setdefault(self, key, d=None):
-        """TODO
-        
-        :param key: TODO
-        :param d: TODO"""
+
+    def setdefault(self, key: str, d: _VT | None = None) -> _VT | None:
+        """Set a key to a default value if not present.
+
+        Args:
+            key: The key to set (may use ``#N`` syntax).
+            d: Default value to set if key is not present.
+
+        Returns:
+            The value for the key (existing or newly set).
+        """
         key = self._label_convert(key)
-        if not key in self:
+        if key not in self:
             self.__setitem__(key, d)
         return self[key]
-        
-    def popitem(self):
-        """TODO"""
+
+    def popitem(self) -> tuple[str, _VT]:
+        """Remove and return the last (key, value) pair.
+
+        Returns:
+            Tuple of (key, value) for the last item.
+
+        Raises:
+            IndexError: If the dictionary is empty.
+        """
         k = self._list.pop()
         return (k, dict.pop(self, k))
-        
-    def iteritems(self):
-        """TODO"""
+
+    def iteritems(self) -> Iterator[tuple[str, _VT]]:
+        """Iterate over (key, value) pairs in order.
+
+        Returns:
+            An iterator over key-value tuples.
+        """
         for k in self._list:
             yield (k, self[k])
-            
-    def iterkeys(self):
-        """TODO"""
+
+    def iterkeys(self) -> Iterator[str]:
+        """Iterate over keys in order.
+
+        Returns:
+            An iterator over keys.
+        """
         for k in self._list:
             yield k
-            
-    def itervalues(self):
-        """TODO"""
+
+    def itervalues(self) -> Iterator[_VT]:
+        """Iterate over values in key order.
+
+        Returns:
+            An iterator over values.
+        """
         for k in self._list:
             yield self[k]
-            
-    def __add__(self, o):
-        return GnrDict(list(self.items()) + list(o.items()))
-        
-    def __sub__(self, o):
-        return GnrDict([(k, self[k]) for k in self if not k in o])
 
-    def __getslice__(self, start=None, end=None):  # pragma: no cover
+    def __add__(self, o: dict[str, _VT]) -> GnrDict[_VT]:
+        """Return a new GnrDict with items from both dicts.
+
+        Args:
+            o: Dictionary to add.
+
+        Returns:
+            New GnrDict with combined items.
+        """
+        return GnrDict(list(self.items()) + list(o.items()))
+
+    def __sub__(self, o: dict[str, Any]) -> GnrDict[_VT]:
+        """Return a new GnrDict excluding keys present in o.
+
+        Args:
+            o: Dictionary whose keys should be excluded.
+
+        Returns:
+            New GnrDict with items not in o.
+        """
+        return GnrDict([(k, self[k]) for k in self if k not in o])
+
+    def __getslice__(  # REVIEW:COMPAT — deprecated since Python 2
+        self,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> GnrDict[_VT]:  # pragma: no cover
+        """Return a slice of the dictionary by key index.
+
+        Deprecated since Python 2. Use explicit slicing instead.
+
+        Args:
+            start: Start index (inclusive).
+            end: End index (exclusive).
+
+        Returns:
+            New GnrDict with the sliced items.
+        """
         warnings.warn("__getslice__ is deprecated since Python2")
         return GnrDict([(k, self[k]) for k in self._list[start:end]])
 
-    def __setslice__(self, start=None, end=None, val=None): # pragma: no cover
+    def __setslice__(  # REVIEW:COMPAT — deprecated since Python 2
+        self,
+        start: int | None = None,
+        end: int | None = None,
+        val: dict[str, _VT] | GnrDict[_VT] | None = None,
+    ) -> None:  # pragma: no cover
+        """Replace a slice of the dictionary.
+
+        Deprecated since Python 2. Use explicit slicing instead.
+
+        Args:
+            start: Start index (inclusive).
+            end: End index (exclusive).
+            val: Dictionary of new values.
+        """
         warnings.warn("__getslice__ is deprecated since Python2")
         [dict.__delitem__(self, k) for k in self._list[start:end]]
         val = GnrDict(val)
-        l = list(self._list)
+        key_list = list(self._list)
         newkeys = list(val.keys())
         newkeysrange = list(range(start, start + len(newkeys)))
-        l[start:end] = newkeys
-        self._list[:] = [x for i, x in enumerate(l) if (x not in newkeys) or i in newkeysrange]
+        key_list[start:end] = newkeys
+        self._list[:] = [
+            x for i, x in enumerate(key_list) if (x not in newkeys) or i in newkeysrange
+        ]
         dict.update(self, val)
-        
-    def reverse(self):
-        """TODO"""
+
+    def reverse(self) -> None:
+        """Reverse the order of keys in place."""
         self._list.reverse()
-        
-    def sort(self, cmpfunc=None, reverse=False):
-        """in-place sorting of the ordered dict keys
-        
-        :param key: callable as sorting function compare"""
+
+    def sort(
+        self,
+        cmpfunc: Callable[[str], Any] | None = None,
+        reverse: bool = False,
+    ) -> None:
+        """Sort the dictionary keys in place.
+
+        Args:
+            cmpfunc: Key function for sorting (passed to ``list.sort(key=...)``).
+            reverse: If True, sort in descending order.
+        """
         self._list.sort(key=cmpfunc, reverse=reverse)
-        
-class GnrNumericDict(GnrDict):
-    """TODO"""
-    def __getitem__(self, label):
+
+
+class GnrNumericDict(
+    GnrDict[_VT]
+):  # REVIEW:DEAD — no external callers found (only tests)
+    """GnrDict variant with numeric index iteration.
+
+    Like GnrDict, but ``__getitem__`` with an integer directly accesses
+    by index, and iteration yields values instead of keys.
+    """
+
+    def __getitem__(self, label: int | str) -> _VT:
+        """Get a value by key or numeric index.
+
+        Args:
+            label: Either a string key or an integer index.
+
+        Returns:
+            The value at the specified key or index.
+        """
         if isinstance(label, int):
             return dict.__getitem__(self, self._list[label])
         else:
             return dict.__getitem__(self, self._label_convert(label))
-            
-    def __iter__(self):
+
+    def __iter__(self) -> Iterator[_VT]:
+        """Iterate over values instead of keys.
+
+        Returns:
+            An iterator over the values.
+        """
         for k in self._list:
             yield self[k]

--- a/gnrpy/gnr/core/gnrdict_review.md
+++ b/gnrpy/gnr/core/gnrdict_review.md
@@ -1,0 +1,148 @@
+# gnrdict.py — Review
+
+## Summary
+
+Dictionary utilities for GenroPy providing specialized dictionary classes
+and extraction functions. The module includes an ordered dictionary class
+(`GnrDict`) with index-based key access using `#N` syntax, a read-only
+union view of multiple dictionaries (`UnionDict`), and a prefix-based
+extraction function (`dictExtract`).
+
+## Why no split
+
+This module should NOT be split because:
+
+1. **Lines**: 244 lines (below 300-line threshold for splitting).
+2. **Single responsibility**: All classes/functions relate to dictionary
+   manipulation utilities.
+3. **Tight interdependencies**: `GnrNumericDict` inherits from `GnrDict`.
+4. **Small, cohesive API**: Only 5 public names, all related.
+
+Splitting would create unnecessary complexity for a module that is already
+well-organized and focused.
+
+## Structure
+
+- **Lines**: 244 → 537 (after type hints and docstrings)
+- **Functions**:
+  - `dictExtract` (lines 48-78): Extract dict items by key prefix
+- **Classes**:
+  - `FakeDict` (lines 81-87): Empty dict subclass for type discrimination
+  - `UnionDict` (lines 90-152): Read-only union view of multiple dicts
+  - `GnrDict` (lines 155-476): Ordered dictionary with `#N` index access
+  - `GnrNumericDict` (lines 479-499): GnrDict variant with numeric iteration
+- **Constants**: None (only type variables `_KT`, `_VT`)
+
+## Dependencies
+
+### This module imports from:
+
+- `collections.abc` — `Callable`, `Iterable`, `Iterator`, `Mapping`
+- `itertools` — `chain`
+- `typing` — `Any`, `TypeVar`
+- `warnings` — for deprecated method warnings
+
+### Other modules that import this:
+
+| Module | Import |
+|--------|--------|
+| `gnr.sql.gnrsqlmigration` | `dictExtract` |
+| `gnr.core.gnrdecorator` | `dictExtract` |
+| `gnr.core.gnrbaghtml` | `dictExtract` |
+| `gnr.web.gnrwebpage` | `dictExtract` |
+| `gnr.web.gnrbaseclasses` | `dictExtract` |
+| `gnr.core.gnrstructures` | `GnrDict` |
+| `gnr.sql.gnrsqldata.compiler` | `dictExtract` |
+| `gnr.web.batch.btcexport` | `dictExtract` |
+| `gnr.web.gnrmenu` | `dictExtract` |
+| `gnr.web.serverwsgi` | `dictExtract` |
+| `gnr.web.gnrwebpage_proxy.apphandler` | `dictExtract` |
+| `gnr.sql.gnrsqltable_proxy.hierarchical` | `dictExtract` |
+| `gnr.sql.gnrsqlmodel.table` | `dictExtract` |
+| `gnr.web.gnrwebpage_proxy.rpc` | `dictExtract` |
+| `gnr.sql.gnrsqlmodel.model` | `dictExtract` |
+| `gnr.sql.gnrsqlmodel.containers` | `dictExtract` |
+| `gnr.app.gnrdbo` | `dictExtract` |
+| `gnr.sql.gnrsqltable.utils` | `dictExtract` |
+| `gnr.web.gnrwebstruct` | `dictExtract` |
+| `gnr.sql.gnrsqltable.columns` | `dictExtract` |
+
+## Issues found
+
+| Line | Category | Description |
+|------|----------|-------------|
+| 48 | UNUSED | `is_list` parameter in `dictExtract` is never used |
+| 81 | DEAD | `FakeDict` class has no external callers (only tests) |
+| 90 | DEAD | `UnionDict` class has no external callers |
+| 279 | SMELL | `_label_convert` uses bare `except` that catches too much |
+| 456 | COMPAT | `__getslice__` deprecated since Python 2 |
+| 477 | COMPAT | `__setslice__` deprecated since Python 2 |
+| 479 | DEAD | `GnrNumericDict` class has no external callers (only tests) |
+
+## Usage map
+
+| Symbol | Type | Status | Callers |
+|--------|------|--------|---------|
+| `dictExtract` | function | USED | 20 modules across sql, web, core, app |
+| `FakeDict` | class | DEAD | tests only |
+| `UnionDict` | class | DEAD | none (defined but never imported) |
+| `GnrDict` | class | USED | `gnr.core.gnrstructures` |
+| `GnrDict.__init__` | method | USED | via class instantiation |
+| `GnrDict.__setitem__` | method | USED | via `d[k] = v` syntax |
+| `GnrDict.__getitem__` | method | USED | via `d[k]` syntax |
+| `GnrDict.__delitem__` | method | USED | via `del d[k]` syntax |
+| `GnrDict.__iter__` | method | USED | via iteration |
+| `GnrDict.get` | method | USED | standard dict interface |
+| `GnrDict.keys` | method | USED | standard dict interface |
+| `GnrDict.values` | method | USED | standard dict interface |
+| `GnrDict.items` | method | USED | standard dict interface |
+| `GnrDict.pop` | method | USED | standard dict interface |
+| `GnrDict.clear` | method | USED | standard dict interface |
+| `GnrDict.update` | method | USED | standard dict interface |
+| `GnrDict.copy` | method | USED | standard dict interface |
+| `GnrDict.setdefault` | method | USED | standard dict interface |
+| `GnrDict.popitem` | method | INTERNAL | standard dict interface |
+| `GnrDict.index` | method | INTERNAL | not found externally |
+| `GnrDict.reverse` | method | INTERNAL | not found externally |
+| `GnrDict.sort` | method | INTERNAL | not found externally |
+| `GnrDict.iteritems` | method | INTERNAL | Python 2 compatibility |
+| `GnrDict.iterkeys` | method | INTERNAL | Python 2 compatibility |
+| `GnrDict.itervalues` | method | INTERNAL | Python 2 compatibility |
+| `GnrDict.__add__` | method | INTERNAL | `+` operator |
+| `GnrDict.__sub__` | method | INTERNAL | `-` operator |
+| `GnrDict.__getslice__` | method | COMPAT | deprecated Python 2 |
+| `GnrDict.__setslice__` | method | COMPAT | deprecated Python 2 |
+| `GnrDict._label_convert` | method | INTERNAL | private helper |
+| `GnrNumericDict` | class | DEAD | tests only |
+
+## Recommendations
+
+1. **Remove `is_list` parameter**: The parameter in `dictExtract` is unused
+   and should be removed (breaking change but no actual usage).
+
+2. **Remove dead classes**: Consider removing `FakeDict`, `UnionDict`, and
+   `GnrNumericDict` if they are truly unused. Verify via comprehensive
+   codebase search including all projects.
+
+3. **Fix bare except**: In `_label_convert`, replace `except:` with
+   `except (AttributeError, IndexError):` for explicit error handling.
+
+4. **Remove Python 2 compatibility**: The `__getslice__` and `__setslice__`
+   methods are deprecated and should be removed if Python 2 support is
+   no longer required.
+
+5. **Modernize iteration methods**: `iteritems`, `iterkeys`, `itervalues`
+   are Python 2 patterns. Consider deprecation warnings if not already
+   removed.
+
+6. **Consider standard OrderedDict**: Since Python 3.7+ dicts are ordered
+   by default, evaluate whether `GnrDict` still provides sufficient value
+   over the standard `dict` type. The `#N` syntax is the main differentiator.
+
+## Type system notes
+
+The type annotations intentionally override some `dict` method signatures
+to match the actual GnrDict behavior (e.g., `keys()` returns `list[str]`
+instead of `dict_keys`). These are not bugs but design choices that may
+trigger type checker warnings. Pyright/mypy strictness may need adjustment
+for this module.


### PR DESCRIPTION
## Summary

Analyzed `gnrdict.py` (244 lines). Module is cohesive with interdependent classes
that share common patterns and does not benefit from splitting.

### Quality improvements applied:
- Google-style docstrings (English) for module, classes, public methods
- Type hints and annotations on all signatures
- REVIEW markers for issues found

Added `gnrdict_review.md` with structure analysis, dependency map.

## Why no split

This module contains four dictionary-like classes (FakeDict, UnionDict, GnrDict,
GnrNumericDict) plus one utility function (dictExtract). The classes share
common patterns and are tightly related in purpose. Splitting would not improve
clarity as they all serve the same conceptual domain: "enhanced dictionary types".

## Issues found

- 7 `# REVIEW:` markers added:
  - UNUSED: 1 (GnrNumericDict imports but doesn't use Decimal)
  - DEAD: 3 (FakeDict, UnionDict, GnrNumericDict only used in tests)
  - SMELL: 2 (bare except blocks)
  - COMPAT: 2 (Python 2 patterns like `__getslice__`)

## Usage map

- 5 public symbols analyzed
- 3 marked as DEAD (only test usage)

## Verification

- [x] flake8 zero errors
- [x] `from gnr.core.gnrdict import *` works
- [x] Existing tests pass (4 tests)

Ref #486