### PR TITLE
fix(tests): improve test teardown and pytest configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,14 @@
 {
     "python.testing.pytestArgs": [
-        "gnrpy",
         "--cov=gnr",
         "--cov-report=xml"
     ],
+    "python.testing.cwd": "${workspaceFolder}/gnrpy",
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    
+
     "python.linting.enabled": true,
-    
+
     "flake8.ignorePatterns": [
         ".venv"
     ],

--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -189,6 +189,11 @@ packages = [
 "gnr.webtools" = "../webtools"
 
 
+# PYTEST
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["tests"]
+
 # COVERAGE
 [tool.coverage.run]
 omit = [

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -87,6 +87,7 @@ class BaseGnrSqlTest:
         """
         if "GNR_TEST_PG_PASSWORD" in os.environ:
             if hasattr(cls,'dbname'):
+                cls.db.closeConnection()
                 cls.db.dropDb(cls.dbname)
         elif not ("GITHUB_WORKFLOW" in os.environ or "GNR_TEST_PG_PASSWORD" in os.environ):
             cls.pg_instance.stop()


### PR DESCRIPTION
## Summary

- **Close DB connection before dropDb in SQL test teardown**: the test teardown in `BaseGnrSqlTest` was calling `dropDb()` without first closing the test's own database connection, leaving active sessions that prevented PostgreSQL from dropping the database and cascading failures across test classes.
- **Add pytest configuration to `pyproject.toml`**: added `testpaths` and `pythonpath` settings so pytest knows where to find tests and can resolve cross-module imports (e.g. `from sql.common import MockApplication`) regardless of how it's launched (terminal, VSCode, CI).
- **Update VSCode test settings**: set `cwd` to `gnrpy/` so VSCode's Test Explorer uses the `pyproject.toml` configuration, and removed hardcoded test directory args from `pytestArgs`.

## Test plan

- [ ] Run `cd gnrpy && pytest` from terminal — all tests discovered and passing
- [ ] Open VSCode Test Explorer — tests appear in a clean hierarchy under `tests/`
- [ ] CI passes on all Python versions