### PR TITLE
feat(sql): subquery-as-join conversion and compound queries

### DIFF
--- a/gnrpy/gnr/sql/gnrsql/query.py
+++ b/gnrpy/gnr/sql/gnrsql/query.py
@@ -286,6 +286,7 @@ class QueryMixin:
         aliasPrefix: str | None = None,
         ignoreTableOrderBy: bool | None = None,
         subtable: str | None = None,
+        mainquery_kw: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> str:
         """Compile a query to raw SQL text.
@@ -317,6 +318,8 @@ class QueryMixin:
             aliasPrefix: Prefix for column aliases.
             ignoreTableOrderBy: If set, ignore the table's default ordering.
             subtable: Subtable filter name.
+            mainquery_kw: Optional dict of main query keyword arguments
+                (used by subqueries to access parent parameters).
             **kwargs: Extra parameter bindings injected into ``currentEnv``.
 
         Returns:
@@ -343,6 +346,7 @@ class QueryMixin:
             aliasPrefix=aliasPrefix,
             ignoreTableOrderBy=ignoreTableOrderBy,
             subtable=subtable,
+            mainquery_kw=mainquery_kw,
         )
         result = q.sqltext
         if kwargs:

--- a/gnrpy/gnr/sql/gnrsqldata/__init__.py
+++ b/gnrpy/gnr/sql/gnrsqldata/__init__.py
@@ -27,7 +27,7 @@
 #   gnrsqldata/selection.py - SqlSelection
 #   gnrsqldata/record.py    - SqlRecord, SqlRecordBag, SqlRelatedRecordResolver, SqlRelatedSelectionResolver
 
-from gnr.sql.gnrsqldata.compiler import SqlCompiledQuery, SqlQueryCompiler  # noqa: F401
+from gnr.sql.gnrsqldata.compiler import SqlCompiledQuery, SqlCompiledSubQuery, SqlQueryCompiler  # noqa: F401
 from gnr.sql.gnrsqldata.query import SqlQuery, SqlDataResolver, SqlCompoundQuery  # noqa: F401
 from gnr.sql.gnrsqldata.selection import SqlSelection  # noqa: F401
 from gnr.sql.gnrsqldata.record import (SqlRecord, SqlRecordBag,  # noqa: F401

--- a/gnrpy/gnr/sql/gnrsqldata/__init__.py
+++ b/gnrpy/gnr/sql/gnrsqldata/__init__.py
@@ -28,7 +28,7 @@
 #   gnrsqldata/record.py    - SqlRecord, SqlRecordBag, SqlRelatedRecordResolver, SqlRelatedSelectionResolver
 
 from gnr.sql.gnrsqldata.compiler import SqlCompiledQuery, SqlQueryCompiler  # noqa: F401
-from gnr.sql.gnrsqldata.query import SqlQuery, SqlDataResolver  # noqa: F401
+from gnr.sql.gnrsqldata.query import SqlQuery, SqlDataResolver, SqlCompoundQuery  # noqa: F401
 from gnr.sql.gnrsqldata.selection import SqlSelection  # noqa: F401
 from gnr.sql.gnrsqldata.record import (SqlRecord, SqlRecordBag,  # noqa: F401
                                         SqlRelatedRecordResolver,

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -1339,6 +1339,10 @@ class SqlQueryCompiler(object):
         group_by = gnrstring.templateReplace(group_by, colPars)
         #self.cpl.additional_joins.reverse()
         self.cpl.joins = [gnrstring.templateReplace(j, colPars) for j in self.cpl.joins+self.cpl.additional_joins]
+        if self.cpl.sq_joins:
+            self.cpl.joins.extend(self.cpl.sq_joins)
+        for _h, (sq_compiled, _sq_name, _col_counter) in self.sq_compiled_dct.items():
+            self.cpl.joins.append(sq_compiled.get_sqltext(self.db))
         # --- DISTINCT handling ---
         if distinct:
             # Branch: caller explicitly requested DISTINCT

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -351,6 +351,34 @@ class SqlQueryCompiler(object):
         self.aliases = {self.tblobj.sqlfullname: self.aliasCode(0)}
         self.fieldlist = []
 
+    def expandThis(self, m):
+        fld = m.group(1)
+        return self.getFieldAlias(fld, curr=self._curr, basealias=self._alias)
+
+    def expandPref(self, m):
+        prefpath = m.group(1)
+        dflt = m.group(2)[1:] if m.group(2) else None
+        return str(self._curr_tblobj.pkg.getPreference(prefpath, dflt))
+
+    def expandEnv(self, m):
+        what = m.group(1)
+        par2 = None
+        if m.group(2):
+            par2 = m.group(2)[1:]
+        if what in self.db.currentEnv:
+            return "'%s'" % gnrstring.toText(self.db.currentEnv[what])
+        elif par2 and par2 in self.db.currentEnv:
+            return "'%s'" % gnrstring.toText(self.db.currentEnv[par2])
+        if par2:
+            env_tblobj = self.db.table(par2)
+        else:
+            env_tblobj = self._curr_tblobj
+        handler = getattr(env_tblobj, 'env_%s' % what, None)
+        if handler:
+            return handler()
+        else:
+            return 'Not found %s' % what
+
     def getFieldAlias(self, fieldpath, curr=None, basealias=None, parent=None):
         """Resolve a field path into its SQL ``alias.column`` representation.
 
@@ -389,46 +417,6 @@ class SqlQueryCompiler(object):
                 or py_method).
         """
 
-        def expandThis(m):
-            """Regex callback: resolve ``#THIS.field`` references relative to current alias."""
-            fld = m.group(1)
-            return self.getFieldAlias(fld, curr=curr, basealias=alias)
-
-        def expandPref(m):
-            """Regex callback: resolve ``#PREF(path, default)`` to a literal preference value."""
-            prefpath = m.group(1)
-            dflt = m.group(2)[1:] if m.group(2) else None
-            return str(curr_tblobj.pkg.getPreference(prefpath, dflt))
-
-        def expandEnv(m):
-            """Regex callback: resolve ``#ENV(name, fallback)`` to a quoted env value.
-
-            Resolution order:
-                1. Direct lookup of *name* in ``db.currentEnv``.
-                2. Direct lookup of *fallback* (par2) in ``db.currentEnv``.
-                3. Call ``env_<name>`` method on the table object.
-                4. Return a literal ``'Not found <name>'`` string.
-            """
-            what = m.group(1)
-            par2 = None
-            if m.group(2):
-                par2 = m.group(2)[1:]
-            # Branch 1: direct env lookup
-            if what in self.db.currentEnv:
-                return "'%s'" % gnrstring.toText(self.db.currentEnv[what])
-            # Branch 2: fallback env lookup
-            elif par2 and par2 in self.db.currentEnv:
-                return "'%s'" % gnrstring.toText(self.db.currentEnv[par2])
-            # Branch 3: delegate to table's env_<name> handler
-            if par2:
-                env_tblobj = self.db.table(par2)
-            else:
-                env_tblobj = curr_tblobj
-            handler = getattr(env_tblobj, 'env_%s' % what, None)
-            if handler:
-                return handler()
-            else:
-                return 'Not found %s' % what
         # --- Split the dotted field path into relation segments + final field ---
         pathlist = fieldpath.split('.')
         fld = pathlist.pop()
@@ -442,6 +430,9 @@ class SqlQueryCompiler(object):
         else:
             alias = basealias
         curr_tblobj = self.db.table(curr.tbl_name, pkg=curr.pkg_name)
+        self._curr = curr
+        self._alias = alias
+        self._curr_tblobj = curr_tblobj
 
         # --- Branch: field is NOT a physical column -- check virtual columns ---
         if not fld in curr.keys():
@@ -495,16 +486,16 @@ class SqlQueryCompiler(object):
                         sq_pars.setdefault('excludeLogicalDeleted',False)
                         sq_pars.setdefault('subtable','*')
                         aliasPrefix = '%s_t' %alias
-                        sq_where = THISFINDER.sub(expandThis,sq_where)
+                        sq_where = THISFINDER.sub(self.expandThis,sq_where)
                         sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
                         sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
                 subreldict = {}
                 sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
                 sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
                 sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
-                sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
-                sql_formula = PREFFINDER.sub(expandPref, sql_formula)
-                sql_formula = THISFINDER.sub(expandThis,sql_formula)
+                sql_formula = ENVFINDER.sub(self.expandEnv, sql_formula)
+                sql_formula = PREFFINDER.sub(self.expandPref, sql_formula)
+                sql_formula = THISFINDER.sub(self.expandThis,sql_formula)
                 sql_formula_var = dictExtract(attr,'var_')
                 if sql_formula_var:
                     prefix = str(id(fldalias))

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -203,7 +203,7 @@ class SqlQueryCompiler(object):
         macro_expander: Adapter-specific macro expander instance.
     """
 
-    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None, aliasPrefix=None):
+    def __init__(self, tblobj, joinConditions=None, sqlContextName=None, sqlparams=None, locale=None, aliasPrefix=None, mangler=None, query_kw=None, mainquery_kw=None, query=None):
         """Initialise the compiler for a given table.
 
         Args:
@@ -220,9 +220,17 @@ class SqlQueryCompiler(object):
                 used for date decoding and text formatting.
             aliasPrefix: Optional prefix for generated table aliases.
                 Defaults to ``'t'`` producing ``t0``, ``t1``, ...
+            mangler: Optional prefix for parameter namespacing in
+                compound queries.
+            query_kw: Optional dict of original query keyword arguments.
+            mainquery_kw: Optional dict of main query keyword arguments
+                (used by subqueries to access parent parameters).
+            query: Optional back-reference to the ``SqlQuery`` instance
+                that created this compiler.
         """
         self.tblobj = tblobj
         self.db = tblobj.db
+        self.query = query
         self.dbmodel = tblobj.db.model
         if tblobj.db.reuse_relation_tree:
             self.relations = tblobj.relations
@@ -235,6 +243,10 @@ class SqlQueryCompiler(object):
         self._currColKey = None
         self.aliasPrefix = aliasPrefix or 't'
         self.locale = locale
+        self.mangler = mangler
+        self.query_kw = query_kw or {}
+        self.mainquery_kw = mainquery_kw or {}
+        self.subquery_kw = {}
         self.macro_expander = self.db.adapter.macroExpander(self)
 
     def aliasCode(self, n):
@@ -248,6 +260,48 @@ class SqlQueryCompiler(object):
         """
         return '%s%i' %(self.aliasPrefix,n)
 
+    def mangle(self, sql_text):
+        """Prefix bind-parameter names with the mangler string.
+
+        Used by compound queries to namespace parameters from different
+        sub-queries so that they don't collide when merged into a single
+        ``sqlparams`` dict.
+
+        Parameters starting with ``env_`` are left untouched.
+
+        Args:
+            sql_text: SQL fragment potentially containing ``:param``
+                placeholders.
+
+        Returns:
+            str: The fragment with mangled parameter names, or the
+            original text if no mangler is set.
+        """
+        if not self.mangler:
+            return sql_text
+        def replace_param(m):
+            param_name = m.group(2)
+            if param_name.startswith('env_'):
+                return m.group(0)
+            if param_name in self.sqlparams:
+                return '%s%s_%s%s' % (m.group(1), self.mangler, param_name, m.group(3))
+            return m.group(0)
+        return re.sub(r"(:)(\w+)(\W|$)", replace_param, sql_text)
+
+    def mangleParams(self):
+        """Rename entries in ``sqlparams`` with the mangler prefix.
+
+        After mangling the SQL text, the actual parameter keys must be
+        updated to match.  Environment parameters (``env_*``) are skipped.
+        """
+        if not self.mangler:
+            return
+        for k, v in list(self.sqlparams.items()):
+            if not k.startswith('env_'):
+                mangled_key = '%s_%s' % (self.mangler, k)
+                mangled_value = self.query_kw.get(k, self.mainquery_kw.get(k))
+                self.subquery_kw[mangled_key] = mangled_value
+                self.sqlparams[mangled_key] = v
 
     def init(self, lazy=None, eager=None):
         """Reset per-compilation state before a new compilation pass.
@@ -1119,14 +1173,16 @@ class SqlQueryCompiler(object):
 
         # --- Store all compiled fragments into the SqlCompiledQuery ---
         self.cpl.distinct = distinct
-        self.cpl.columns = self.macro_expander.replace(columns,'TSRANK,TSHEADLINE')
-        self.cpl.where = where
-        self.cpl.group_by = group_by
-        self.cpl.having = having
-        self.cpl.order_by = self.macro_expander.replace(order_by,'TSRANK')
+        self.cpl.columns = self.mangle(self.macro_expander.replace(columns,'TSRANK,TSHEADLINE'))
+        self.cpl.where = self.mangle(where)
+        self.cpl.group_by = self.mangle(group_by)
+        self.cpl.having = self.mangle(having)
+        self.cpl.order_by = self.mangle(self.macro_expander.replace(order_by,'TSRANK'))
+        self.cpl.joins = [self.mangle(j) for j in self.cpl.joins]
         self.cpl.limit = limit
         self.cpl.offset = offset
         self.cpl.for_update = for_update
+        self.mangleParams()
         # REVIEW: commented-out debug raise -- remove if no longer needed
         #raise str(self.cpl.get_sqltext(self.db))  # uncomment it for hard debug
         return self.cpl

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -133,6 +133,7 @@ class SqlCompiledQuery(object):
         self.columns = ''
         self.joins = []
         self.additional_joins = []
+        self.sq_joins = []
         self.where = None
         self.group_by = None
         self.having = None
@@ -145,6 +146,7 @@ class SqlCompiledQuery(object):
         self.aggregateDict = {}
         self.pyColumns = []
         self.maintable_as = maintable_as
+        self.tpl = None
 
     def get_sqltext(self, db):
         """Render the final SQL text using the database adapter.
@@ -165,8 +167,33 @@ class SqlCompiledQuery(object):
         'maintable', 'distinct', 'columns', 'joins', 'where', 'group_by', 'having', 'order_by', 'limit', 'offset',
         'for_update'):
             kwargs[k] = getattr(self, k)
-        return db.adapter.compileSql(maintable_as=self.maintable_as,**kwargs)
+        result = db.adapter.compileSql(maintable_as=self.maintable_as,**kwargs)
+        if self.tpl:
+            result = self.tpl % result
+        return result
 
+
+class SqlCompiledSubQuery(SqlCompiledQuery):
+    """A compiled subquery with identity support for merge.
+
+    Used by ``_compiledSubQuery`` to track subquery identity so that
+    identical subqueries (same table, resolved WHERE, GROUP BY) can be
+    merged into a single LEFT JOIN with multiple aggregate columns.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._identity_hash = None
+
+    def __eq__(self, other):
+        if not isinstance(other, SqlCompiledSubQuery):
+            return NotImplemented
+        return self._identity_hash is not None and self._identity_hash == other._identity_hash
+
+    def __hash__(self):
+        if self._identity_hash is not None:
+            return self._identity_hash
+        return id(self)
 
 
 class SqlQueryCompiler(object):
@@ -247,6 +274,7 @@ class SqlQueryCompiler(object):
         self.query_kw = query_kw or {}
         self.mainquery_kw = mainquery_kw or {}
         self.subquery_kw = {}
+        self.sq_compiled_dct = {}
         self.macro_expander = self.db.adapter.macroExpander(self)
 
     def aliasCode(self, n):
@@ -928,7 +956,8 @@ class SqlQueryCompiler(object):
                       storename=None,subtable=None,
                       count=False, excludeLogicalDeleted=True,excludeDraft=True,
                       ignorePartition=False,ignoreTableOrderBy=False,
-                      addPkeyColumn=True):
+                      addPkeyColumn=True,
+                      compiled_class=None):
         """Compile a SELECT query for a multi-row selection.
 
         This is the main entry point used by ``SqlQuery``.  It performs the
@@ -987,7 +1016,8 @@ class SqlQueryCompiler(object):
             rendered to SQL via ``get_sqltext``.
         """
         # get the SqlCompiledQuery: an object that mantains all the informations to build the sql text
-        self.cpl = SqlCompiledQuery(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0))
+        compiled_class = compiled_class or SqlCompiledQuery
+        self.cpl = compiled_class(self.tblobj.sqlfullname,relationDict=relationDict,maintable_as=self.aliasCode(0))
         distinct = distinct or '' # distinct is a text to be inserted in the sql query string
 
         # aggregate: test if the result will aggregate db rows

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -74,6 +74,12 @@ ENVFINDER = re.compile(r"#ENV\(([^,)]+)(,[^),]+)?\)")
 PREFFINDER = re.compile(r"#PREF\(([^,)]+)(,[^),]+)?\)")
 THISFINDER = re.compile(r'#THIS\.([\w\.@]+)')
 
+AGGREGATOR_SQL = {
+    'SUM': 'SUM', 'MAX': 'MAX', 'MIN': 'MIN', 'AVG': 'AVG',
+    'CNT': 'COUNT',
+    'AND': 'BOOL_AND', 'OR': 'BOOL_OR',
+}
+
 class SqlCompiledQuery(object):
     """Value object holding every component of a compiled SQL SELECT statement.
 
@@ -425,6 +431,12 @@ class SqlQueryCompiler(object):
         newpath = []
         basealias = basealias or self.aliasCode(0)
 
+        # --- Preprocess: intercept many-side relations → inline subquery ---
+        if pathlist and self._sqlAggregateEnabled():
+            result = self._preprocessManyRelation(list(pathlist), fld, curr, basealias)
+            if result is not None:
+                return result
+
         # --- If the path has relation segments, resolve JOINs first ---
         if pathlist:
             alias, curr = self._findRelationAlias(list(pathlist), curr, basealias, newpath, parent=parent)
@@ -549,6 +561,136 @@ class SqlQueryCompiler(object):
                                         or getattr(ref_col, 'select', None)):
                 return True
         return False
+
+    # --- sql_aggregate: many-side relation → inline subquery ---
+
+    def _sqlAggregateEnabled(self):
+        """Return True when many-side relations should be converted to
+        inline aggregate subqueries instead of exploding JOINs."""
+        if self.query and getattr(self.query, 'sql_aggregate', None) is not None:
+            return gnrstring.boolean(self.query.sql_aggregate)
+        return gnrstring.boolean(getattr(self.db, 'extra_kw', {}).get('sql_aggregate', False))
+
+    def _preprocessManyRelation(self, pathlist, fld, curr, basealias):
+        """Scan *pathlist* for a many-side relation hop.
+
+        If found, build an inline aggregate subquery and return the SQL
+        expression.  If no many-side relation is encountered, return None
+        so that the caller falls through to the standard JOIN path.
+        """
+        segments_before = []
+        scan_curr = curr
+        for i, seg in enumerate(pathlist):
+            node = self._findRuntimeRelationNode(seg, scan_curr) or scan_curr.getNode(seg)
+            if node is None:
+                return None
+            joiner = node.attr.get('joiner')
+            if joiner is None:
+                return None
+            is_many = (joiner['mode'] != 'O' and not joiner.get('one_one', False))
+            if is_many:
+                remaining = list(pathlist[i + 1:])
+                remaining.append(fld)
+                target_field = '.'.join(remaining)
+                return self._compileManyAsSubquery(
+                    joiner, target_field, basealias, segments_before)
+            segments_before.append(seg)
+            scan_curr = node.getValue()
+        return None
+
+    def _compileManyAsSubquery(self, joiner, target_field, basealias,
+                               segments_before):
+        """Build a correlated aggregate subquery for a many-side relation.
+
+        Args:
+            joiner: The joiner dict from the many-side relation node.
+            target_field: Dot-separated field path inside the target table
+                (e.g. ``'total'`` or ``'@product_id.name'``).
+            basealias: SQL alias of the current (one-side) table.
+            segments_before: List of one-side relation segments already
+                traversed before the many-side hop (used to resolve
+                the correlation column via JOINs if needed).
+        """
+        many_rel = joiner['many_relation']
+        one_rel = joiner['one_relation']
+        mpkg, mtbl, mfld = many_rel.split('.')
+        _opkg, _otbl, ofld = one_rel.split('.')
+        target_table = '%s.%s' % (mpkg, mtbl)
+
+        dtype, aggregator = self._resolveTargetColumnInfo(target_table, target_field)
+        if aggregator is False:
+            return None
+
+        col_ref = self._fieldRef(target_field)
+        col_expr = self._buildAggregateExpr(dtype, aggregator, col_ref)
+
+        # Resolve the correlation: if there were one-side hops before the
+        # many-side, the correlation column must reference the alias obtained
+        # by traversing those hops.
+        if segments_before:
+            corr_path = '.'.join(segments_before)
+            corr_alias = self.getFieldAlias(corr_path + '.' + ofld)
+        else:
+            corr_alias = '%s.%s' % (self.db.adapter.asTranslator(basealias),
+                                    self.db.table(
+                                        joiner['one_relation'].rsplit('.', 1)[0]
+                                    ).column(ofld).adapted_sqlname)
+
+        sq_pars = dict(
+            table=target_table,
+            columns=col_expr,
+            where='$%s=%s' % (mfld, corr_alias),
+        )
+        compiled = self._compiledSubQuery(basealias, sq_pars)
+        return compiled.get_sqltext(self.db)
+
+    def _resolveTargetColumnInfo(self, target_table, target_field):
+        """Walk a (possibly deep) field path to find dtype and aggregator.
+
+        Returns:
+            tuple: ``(dtype, aggregator)`` of the leaf column.
+        """
+        parts = target_field.replace('@', '').split('.')
+        tblobj = self.db.table(target_table)
+        for seg in parts[:-1]:
+            col = tblobj.model.column(seg)
+            if col is None:
+                return 'T', None
+            rel = col.relatedColumn()
+            if rel is None:
+                return 'T', None
+            tblobj = rel.table.dbtable
+        leaf = parts[-1]
+        col = tblobj.model.column(leaf)
+        if col is not None:
+            attrs = col.attributes
+            return attrs.get('dtype', 'T'), attrs.get('aggregator')
+        vc = tblobj.model.getVirtualColumn(leaf)
+        if vc is not None:
+            return vc.attributes.get('dtype', 'T'), vc.attributes.get('aggregator')
+        return 'T', None
+
+    @staticmethod
+    def _fieldRef(target_field):
+        """Convert a target_field to the ``$``/``@``-prefixed column
+        reference used inside a subquery ``columns`` expression."""
+        if target_field.startswith('@'):
+            return target_field
+        return '$%s' % target_field
+
+    def _buildAggregateExpr(self, dtype, aggregator, col_ref):
+        """Build the SQL aggregate expression from dtype/aggregator.
+
+        Mirrors the logic of ``SqlTable.fieldAggregate``."""
+        if dtype in ('R', 'L', 'N', 'I'):
+            sql_func = AGGREGATOR_SQL.get(aggregator or 'SUM', 'SUM')
+            return '%s(%s)' % (sql_func, col_ref)
+        if dtype == 'B':
+            sql_func = 'BOOL_AND' if (not aggregator or aggregator == 'AND') else 'BOOL_OR'
+            return '%s(%s)' % (sql_func, col_ref)
+        # Text/other: use adapter-aware string_agg
+        separator = aggregator if (aggregator and aggregator is not False) else ','
+        return self.db.adapter.string_agg('DISTINCT %s::TEXT' % col_ref, separator)
 
     def _preprocess_subqueryes(self, attr, as_join=False, alias=None,
                                formula_column_name=None, sql_formula=None):

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -49,6 +49,7 @@ Module-level constants:
         ``#ENV``, ``#PREF``, and ``#THIS`` macro syntax.
 """
 
+import copy
 import re
 from collections import OrderedDict
 
@@ -460,55 +461,7 @@ class SqlQueryCompiler(object):
 
 
             elif fldalias.sql_formula or fldalias.select or fldalias.exists:
-                # Branch: virtual column with sql_formula / select / exists
-                sql_formula = fldalias.sql_formula
-                attr = dict(fldalias.attributes)
-                # If sql_formula is literally True, delegate to the
-                # table's sql_formula_<fieldname> method
-                if sql_formula is True:
-                    sql_formula = getattr(curr_tblobj,'sql_formula_%s' %fld)(attr)
-                select_dict = dictExtract(attr,'select_')
-                # If no formula was provided, build default sub-select wrapper
-                if not sql_formula:
-                    sql_formula = '#default' if fldalias.select else 'EXISTS(#default)'
-                    select_dict['default'] = fldalias.select or fldalias.exists
-                if select_dict:
-                    for susbselect,sq_pars in list(select_dict.items()):
-                        if isinstance(sq_pars, str):
-                            sq_pars = getattr(self.tblobj.dbtable,'subquery_%s' %sq_pars)()
-                        sq_pars = dict(sq_pars)
-                        cast = sq_pars.pop('cast',None)
-                        tpl = ' CAST( ( %s ) AS ' +cast +') ' if cast else ' ( %s ) '
-                        sq_table = sq_pars.pop('table')
-                        sq_where = sq_pars.pop('where')
-                        sq_pars.setdefault('ignorePartition',True)
-                        sq_pars.setdefault('excludeDraft',False)
-                        sq_pars.setdefault('excludeLogicalDeleted',False)
-                        sq_pars.setdefault('subtable','*')
-                        aliasPrefix = '%s_t' %alias
-                        sq_where = THISFINDER.sub(self.expandThis,sq_where)
-                        sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
-                        sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
-                subreldict = {}
-                sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
-                sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
-                sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
-                sql_formula = ENVFINDER.sub(self.expandEnv, sql_formula)
-                sql_formula = PREFFINDER.sub(self.expandPref, sql_formula)
-                sql_formula = THISFINDER.sub(self.expandThis,sql_formula)
-                sql_formula_var = dictExtract(attr,'var_')
-                if sql_formula_var:
-                    prefix = str(id(fldalias))
-                    currentEnv = self.db.currentEnv
-                    for k,v in list(sql_formula_var.items()):
-                        newk = f'{prefix}_{self._currColKey}_{k}'
-                        currentEnv[newk] = v
-                        sql_formula = re.sub("(:)(%s)(\\W|$)" %k,lambda m: '%senv_%s%s'%(m.group(1),newk,m.group(3)), sql_formula)
-                subColPars = {}
-                for key, value in list(subreldict.items()):
-                    subColPars[key] = self.getFieldAlias(value, curr=curr, basealias=alias)
-                sql_formula = gnrstring.templateReplace(sql_formula, subColPars, safeMode=True)
-                return f'( {sql_formula} )'
+                return self._handleFormulaColumn(fldalias, fld, alias, curr, curr_tblobj)
             elif fldalias.py_method:
                 # Branch: column computed in Python -- emit NULL in SQL
                 # and register the py_method for post-query evaluation
@@ -522,6 +475,229 @@ class SqlQueryCompiler(object):
 
         # --- Field is a physical column: return alias.sqlname ---
         return '%s.%s' % (self.db.adapter.asTranslator(alias), curr_tblobj.column(fld).adapted_sqlname)
+
+    def _handleFormulaColumn(self, fldalias, fld, alias, curr, curr_tblobj):
+        attr = copy.deepcopy(dict(fldalias.attributes))
+        as_join = self._should_convert_to_join(fldalias)
+        if as_join:
+            select_attr = attr.get('select') or attr.get('select_dflt')
+            if isinstance(select_attr, dict) and 'limit' in select_attr:
+                as_join = False
+            elif as_join and isinstance(select_attr, dict):
+                as_join = not self._where_references_formula_column(
+                    select_attr.get('where', ''), curr_tblobj)
+        formula_kw = dictExtract(attr, 'var_')
+        sql_formula = fldalias.sql_formula
+        if sql_formula is True:
+            sql_formula = getattr(curr_tblobj, 'sql_formula_%s' % fld)(attr)
+        if sql_formula:
+            sql_formula = self._preprocessFormula(fldalias, alias, curr, sql_formula, formula_kw)
+        multi_select, sql_formula = self._preprocess_subqueryes(attr, as_join, alias,
+                                        formula_column_name=fld, sql_formula=sql_formula)
+        if not sql_formula and multi_select:
+            if as_join:
+                parts = []
+                for sq_name, sq_pars in multi_select.items():
+                    m = re.search(r'AS (c_\d+)', sq_pars.get('columns', ''))
+                    col_ref = m.group(1) if m else 'c_0'
+                    col_expr = '%s.%s' % (sq_name, col_ref)
+                    if 'COUNT(' in sq_pars.get('columns', '').upper():
+                        col_expr = 'COALESCE(%s, 0)' % col_expr
+                    parts.append(col_expr)
+                sql_formula = " || ' ' || ".join(parts)
+            else:
+                sql_formula = " || ' ' || ".join('#%s' % k for k in multi_select)
+        select_dict = dict(multi_select) if multi_select else {}
+        if select_dict:
+            for sq_name, sq_select in list(select_dict.items()):
+                if isinstance(sq_select, str):
+                    sq_select = getattr(self.tblobj.dbtable, 'subquery_%s' % sq_select)()
+                sq_pars = dict(sq_select)
+                compiled = self._compiledSubQuery(alias, sq_pars, sq_name=sq_name)
+                if as_join:
+                    h = compiled._identity_hash
+                    if h in self.sq_compiled_dct:
+                        existing, existing_name, col_counter = self.sq_compiled_dct[h]
+                        new_col = self._extract_aggregate_column(compiled.columns)
+                        new_alias = 'c_%i' % col_counter
+                        existing.columns += ', %s AS %s' % (new_col, new_alias)
+                        self.sq_compiled_dct[h] = (existing, existing_name, col_counter + 1)
+                        sql_formula = sql_formula.replace(
+                            '%s.c_0' % sq_name,
+                            '%s.%s' % (existing_name, new_alias))
+                    else:
+                        self.sq_compiled_dct[h] = (compiled, sq_name, 1)
+                else:
+                    sql_formula = re.sub(r'#%s\b' % sq_name, compiled.get_sqltext(self.db), sql_formula)
+        return f'( {sql_formula} )'
+
+    def _should_convert_to_join(self, fldalias):
+        sq_as_join = fldalias.attributes.get('sq_as_join')
+        if sq_as_join is not None:
+            return gnrstring.boolean(sq_as_join)
+        if self.query and getattr(self.query, 'enable_sq_join', None) is not None:
+            return gnrstring.boolean(self.query.enable_sq_join)
+        return gnrstring.boolean(getattr(self.db, 'extra_kw', {}).get('subquery_as_join', False))
+
+    def _where_references_formula_column(self, where_str, tblobj):
+        if not where_str:
+            return False
+        for m in THISFINDER.finditer(where_str):
+            ref_field = m.group(1).split('.')[0]
+            ref_col = tblobj.column(ref_field)
+            if ref_col is not None and (getattr(ref_col, 'sql_formula', None)
+                                        or getattr(ref_col, 'select', None)):
+                return True
+        return False
+
+    def _preprocess_subqueryes(self, attr, as_join=False, alias=None,
+                               formula_column_name=None, sql_formula=None):
+        if 'exists' in attr:
+            exists_sq = attr.pop('exists')
+            exists_sq['exists'] = True
+            attr['select_dflt'] = exists_sq
+        elif 'select' in attr:
+            attr['select_dflt'] = attr.pop('select')
+        sq_dict = dictExtract(attr, 'select_')
+        if not as_join or not sq_dict:
+            return sq_dict, sql_formula
+        sq_dict, sql_formula = self._condense_subqueries(sq_dict, sql_formula)
+        if formula_column_name:
+            prefixed = {}
+            for sq_name, sq_pars in sq_dict.items():
+                subquery_name = '%s_%s' % (formula_column_name, sq_name)
+                if sql_formula:
+                    sql_formula = sql_formula.replace('%s.' % sq_name, '%s.' % subquery_name)
+                prefixed[subquery_name] = sq_pars
+            sq_dict = prefixed
+        for sq_name, sq_pars in sq_dict.items():
+            sq_where = sq_pars.get('where', '')
+            m = re.match(r'(@[\w.]+|\$\w+)\s*=\s*#THIS\.(\w+)(.*)', sq_where, re.DOTALL)
+            if m:
+                fk_field = m.group(1)
+                joiner = '%s=#THIS.%s' % (fk_field, m.group(2))
+                residual = m.group(3).strip()
+                if residual.upper().startswith('AND '):
+                    residual = residual[4:].strip()
+                sq_pars['where'] = residual or None
+                has_limit = 'limit' in sq_pars
+                existing_group_by = sq_pars.get('group_by')
+                if existing_group_by:
+                    sq_pars['group_by'] = '%s,%s' % (fk_field, existing_group_by)
+                elif not has_limit:
+                    sq_pars['group_by'] = fk_field
+                sq_pars['columns'] = '%s AS joiner, %s' % (fk_field, sq_pars['columns'])
+                joiner = THISFINDER.sub(self.expandThis, joiner)
+                sq_pars['joiner'] = joiner
+        return sq_dict, sql_formula
+
+    def _condense_subqueries(self, sq_dict, sql_formula):
+        groups = {}
+        for sq_name, sq_pars in sq_dict.items():
+            key = (sq_pars['table'], sq_pars.get('where'))
+            groups.setdefault(key, []).append(sq_name)
+        col_counter = 0
+        remap = {}
+        for key, names in groups.items():
+            if len(names) == 1:
+                sq_name = names[0]
+                sq_pars = sq_dict[sq_name]
+                col_alias = 'c_%i' % col_counter
+                sq_pars['columns'] = '%s AS %s' % (sq_pars['columns'], col_alias)
+                col_counter += 1
+                continue
+            master = names[0]
+            master_pars = sq_dict[master]
+            merged_cols = []
+            for name in names:
+                pars = sq_dict[name]
+                col_alias = 'c_%i' % col_counter
+                merged_cols.append('%s AS %s' % (pars['columns'], col_alias))
+                if name != master:
+                    remap[name] = (master, col_alias)
+                col_counter += 1
+            master_pars['columns'] = ', '.join(merged_cols)
+            for name in names[1:]:
+                del sq_dict[name]
+        if sql_formula:
+            for absorbed, (master, col_alias) in remap.items():
+                sql_formula = re.sub(r'#%s\b' % absorbed, '%s.%s' % (master, col_alias), sql_formula)
+            for sq_name, sq_pars in sq_dict.items():
+                m = re.search(r'AS (c_\d+)', sq_pars['columns'])
+                if m:
+                    first_col = m.group(1)
+                    sql_formula = re.sub(r'#%s\b' % sq_name, '%s.%s' % (sq_name, first_col), sql_formula)
+        return sq_dict, sql_formula
+
+    def _preprocessFormula(self, fldalias, alias, curr, sql_formula, formula_kw):
+        sql_formula = sql_formula.replace('#default', '#dflt')
+        def resolveField(m):
+            return m.group(1) + self.getFieldAlias(m.group(2), curr=curr, basealias=alias)
+        sql_formula = RELFINDER.sub(resolveField, sql_formula)
+        sql_formula = COLFINDER.sub(resolveField, sql_formula)
+        sql_formula = THISFINDER.sub(self.expandThis, sql_formula)
+        sql_formula = ENVFINDER.sub(self.expandEnv, sql_formula)
+        sql_formula = PREFFINDER.sub(self.expandPref, sql_formula)
+        if formula_kw:
+            prefix = f'{id(fldalias)}_{self._currColKey}'
+            for k, v in formula_kw.items():
+                mangled_k = f'{prefix}_{k}'
+                self.sqlparams[mangled_k] = v
+                sql_formula = re.sub(r"(:)(%s)(\W|$)" % k,
+                                     lambda m, mk=mangled_k: f'{m.group(1)}{mk}{m.group(3)}',
+                                     sql_formula)
+        return sql_formula
+
+    def _extract_aggregate_column(self, columns_str):
+        m = re.search(r'AS\s+joiner\s*,\s*', columns_str)
+        if m:
+            col_part = columns_str[m.end():]
+            col_part = re.sub(r'\s+AS\s+c_\d+\s*$', '', col_part.strip())
+            return col_part
+        return columns_str
+
+    def _compiledSubQuery(self, alias, sq_pars, sq_name=None):
+        joiner = sq_pars.pop('joiner', None)
+        tpl = sq_pars.pop('tpl', None)
+        cast = sq_pars.pop('cast', None)
+        is_exists = sq_pars.pop('exists', False)
+        sq_limit = sq_pars.pop('limit', None) if joiner else None
+        if not tpl:
+            if joiner:
+                on_clause = re.sub(r'@[\w.]+|\$\w+', '%s.joiner' % sq_name, joiner)
+                tpl = ' LEFT JOIN (%%s) AS %s ON (%s) ' % (sq_name, on_clause)
+            elif is_exists:
+                tpl = ' EXISTS( %s ) '
+            elif cast:
+                tpl = ' CAST( ( %s ) AS ' + cast + ') '
+            else:
+                tpl = ' ( %s ) '
+        sq_table = sq_pars.pop('table')
+        sq_where = sq_pars.pop('where')
+        sq_pars.setdefault('ignorePartition', True)
+        sq_pars.setdefault('excludeDraft', False)
+        sq_pars.setdefault('excludeLogicalDeleted', False)
+        sq_pars.setdefault('subtable', '*')
+        aliasPrefix = '%s_t' % alias
+        if sq_where:
+            sq_where = THISFINDER.sub(self.expandThis, sq_where)
+        mangler_prefix = self.query._next_mangler_key('sq')
+        q = self.db.table(sq_table).query(
+            where=sq_where,
+            aliasPrefix=aliasPrefix,
+            addPkeyColumn=False,
+            ignoreTableOrderBy=True,
+            mangler=mangler_prefix,
+            **sq_pars
+        )
+        compiled = q.compileQuery(compiled_class=SqlCompiledSubQuery)
+        compiled.tpl = tpl
+        resolved_where = compiled.where or ''
+        for k, v in q.sqlparams.items():
+            resolved_where = resolved_where.replace(':%s' % k, str(v))
+        compiled._identity_hash = hash((compiled.maintable, resolved_where, compiled.group_by or ''))
+        self.sqlparams.update(q.sqlparams)
+        return compiled
 
     def _findRuntimeRelationNode(self, segment, curr):
         """Look up a relation segment in the active RuntimeModel.

--- a/gnrpy/gnr/sql/gnrsqldata/query.py
+++ b/gnrpy/gnr/sql/gnrsqldata/query.py
@@ -151,6 +151,8 @@ class SqlQuery(object):
                  locale=None,_storename=None,
                  checkPermissions=None,
                  aliasPrefix=None,
+                 mangler=None,
+                 mainquery_kw=None,
                  **kwargs):
         self.dbtable = dbtable
         self.sqlparams = sqlparams or {}
@@ -159,6 +161,8 @@ class SqlQuery(object):
         self.joinConditions = joinConditions or {}
         self.sqlContextName = sqlContextName
         self.relationDict = relationDict or {}
+        self.enable_sq_join = kwargs.pop('enable_sq_join', None)
+        self.query_kw = dict(kwargs)
         self.sqlparams.update(kwargs)
         self.excludeLogicalDeleted = excludeLogicalDeleted
         self.excludeDraft = excludeDraft
@@ -169,6 +173,8 @@ class SqlQuery(object):
         self.storename = _storename
         self.checkPermissions = checkPermissions
         self.aliasPrefix = aliasPrefix
+        self.mangler = mangler
+        self.mainquery_kw = mainquery_kw or {}
         test = " ".join([v for v in (columns, where, order_by, group_by, having) if v])
         rels = set(re.findall(r'\$(\w*)', test))
         params = set(re.findall(r'\:(\w*)', test))
@@ -228,9 +234,13 @@ class SqlQuery(object):
                                 sqlContextName=self.sqlContextName,
                                 sqlparams=self.sqlparams,
                                 aliasPrefix=self.aliasPrefix,
-                                locale=self.locale).compiledQuery(count=count,
-                                                                  relationDict=self.relationDict,
-                                                                  **self.querypars)
+                                locale=self.locale,
+                                mangler=self.mangler,
+                                query_kw=self.query_kw,
+                                mainquery_kw=self.mainquery_kw,
+                                query=self).compiledQuery(count=count,
+                                                          relationDict=self.relationDict,
+                                                          **self.querypars)
 
     def cursor(self):
         """Get a cursor of the current selection."""
@@ -570,6 +580,25 @@ class SqlQuery(object):
                 n = l[0][0]
             cursor.close()
         return n
+
+    def _next_mangler_key(self, prefix):
+        """Generate a unique mangler key for parameter namespacing.
+
+        Each call increments a per-prefix counter stored in the database
+        environment, producing keys like ``sq0``, ``sq1``, ``cq0``, etc.
+
+        Args:
+            prefix: Short string prefix (e.g. ``'sq'`` for subqueries,
+                ``'cq'`` for compound queries).
+
+        Returns:
+            str: A unique key like ``'cq0'``, ``'cq1'``, etc.
+        """
+        env = self.db.currentEnv
+        counters = env.setdefault('_mangler_counters', {})
+        idx = counters.get(prefix, 0)
+        counters[prefix] = idx + 1
+        return '%s%d' % (prefix, idx)
 
 
 # ===========================================================================

--- a/gnrpy/gnr/sql/gnrsqldata/query.py
+++ b/gnrpy/gnr/sql/gnrsqldata/query.py
@@ -225,10 +225,11 @@ class SqlQuery(object):
 
     compiled = property(_get_compiled)
 
-    def compileQuery(self, count=False):
+    def compileQuery(self, count=False, compiled_class=None):
         """Return the :meth:`compiledQuery() <SqlQueryCompiler.compiledQuery()>` method.
 
-        :param count: boolean. If ``True``, optimize the sql query to get the number of resulting rows (like count(*))"""
+        :param count: boolean. If ``True``, optimize the sql query to get the number of resulting rows (like count(*))
+        :param compiled_class: optional factory class for the compiled query object."""
         return SqlQueryCompiler(self.dbtable.model,
                                 joinConditions=self.joinConditions,
                                 sqlContextName=self.sqlContextName,
@@ -239,6 +240,7 @@ class SqlQuery(object):
                                 query_kw=self.query_kw,
                                 mainquery_kw=self.mainquery_kw,
                                 query=self).compiledQuery(count=count,
+                                                          compiled_class=compiled_class,
                                                           relationDict=self.relationDict,
                                                           **self.querypars)
 

--- a/gnrpy/gnr/sql/gnrsqldata/query.py
+++ b/gnrpy/gnr/sql/gnrsqldata/query.py
@@ -162,6 +162,7 @@ class SqlQuery(object):
         self.sqlContextName = sqlContextName
         self.relationDict = relationDict or {}
         self.enable_sq_join = kwargs.pop('enable_sq_join', None)
+        self.sql_aggregate = kwargs.pop('sql_aggregate', None)
         self.query_kw = dict(kwargs)
         self.sqlparams.update(kwargs)
         self.excludeLogicalDeleted = excludeLogicalDeleted

--- a/gnrpy/gnr/sql/gnrsqldata/query.py
+++ b/gnrpy/gnr/sql/gnrsqldata/query.py
@@ -600,6 +600,113 @@ class SqlQuery(object):
         counters[prefix] = idx + 1
         return '%s%d' % (prefix, idx)
 
+    def _compound(self, other, operator):
+        """Combine this query with *other* using a SQL set operator.
+
+        Args:
+            other: Another ``SqlQuery`` or ``SqlCompoundQuery``.
+            operator: SQL set operator string (``'UNION'``,
+                ``'UNION ALL'``, ``'INTERSECT'``, ``'EXCEPT'``).
+
+        Returns:
+            SqlCompoundQuery: A new compound query combining both.
+        """
+        if isinstance(other, SqlCompoundQuery):
+            self_key = self._next_mangler_key('cq')
+            self.mangler = self_key
+            queries = dict(other.queries)
+            queries[self_key] = self
+            template = '{%s} %s SELECT * FROM (%s) AS _cr' % (self_key, operator, other._template)
+        else:
+            self_key = self._next_mangler_key('cq')
+            other_key = other._next_mangler_key('cq')
+            self.mangler = self_key
+            other.mangler = other_key
+            queries = {self_key: self, other_key: other}
+            template = '{%s} %s {%s}' % (self_key, operator, other_key)
+        return SqlCompoundQuery(queries=queries, template=template,
+                                dbtable=self.dbtable, db=self.db)
+
+    def __add__(self, other):
+        return self._compound(other, 'UNION')
+
+    def __or__(self, other):
+        return self._compound(other, 'UNION ALL')
+
+    def __and__(self, other):
+        return self._compound(other, 'INTERSECT')
+
+    def __sub__(self, other):
+        return self._compound(other, 'EXCEPT')
+
+
+class SqlCompoundQuery(SqlQuery):
+    """A query built from multiple ``SqlQuery`` instances combined with
+    SQL set operators (UNION, INTERSECT, EXCEPT).
+
+    Created via the ``+``, ``|``, ``&``, ``-`` operators on ``SqlQuery``::
+
+        q_union     = q1 + q2   # UNION
+        q_union_all = q1 | q2   # UNION ALL
+        q_intersect = q1 & q2   # INTERSECT
+        q_except    = q1 - q2   # EXCEPT
+
+    Each sub-query is compiled independently with a mangler prefix so
+    that bind parameters don't collide.
+    """
+
+    def __init__(self, queries, template, dbtable, db):
+        self.queries = queries
+        self._template = template
+        self.dbtable = dbtable
+        self.db = db
+        self.storename = None
+
+    def _get_sqltext(self):
+        return self._template.format(**{k: q.sqltext for k, q in self.queries.items()})
+
+    sqltext = property(_get_sqltext)
+
+    def _get_compiled(self):
+        return next(iter(self.queries.values())).compiled
+
+    compiled = property(_get_compiled)
+
+    @property
+    def sqlparams(self):
+        result = {}
+        for q in self.queries.values():
+            result.update(q.sqlparams)
+        return result
+
+    def _compound(self, other, operator):
+        queries = dict(self.queries)
+        if isinstance(other, SqlCompoundQuery):
+            queries.update(other.queries)
+            template = 'SELECT * FROM (%s) AS _cl %s SELECT * FROM (%s) AS _cr' % (
+                self._template, operator, other._template)
+        else:
+            key = other._next_mangler_key('cq')
+            other.mangler = key
+            queries[key] = other
+            template = '%s %s {%s}' % (self._template, operator, key)
+        return SqlCompoundQuery(queries=queries, template=template,
+                                dbtable=self.dbtable, db=self.db)
+
+    def count(self):
+        """Return the total number of rows in the compound result.
+
+        Wraps the compound SQL in a ``SELECT count(*)`` wrapper.
+
+        Returns:
+            int: The total row count.
+        """
+        count_sql = 'SELECT count(*) AS gnr_row_count FROM (%s) AS _compound' % self.sqltext
+        cursor = self.db.execute(count_sql, self.sqlparams,
+                                 dbtable=self.dbtable.fullname,
+                                 storename=self.storename)
+        return cursor.fetchall()[0][0]
+
 
 # ===========================================================================
 # REVIEW NOTES (query.py)

--- a/gnrpy/tests/sql/test_compound_query.py
+++ b/gnrpy/tests/sql/test_compound_query.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for SqlCompoundQuery — UNION, INTERSECT, EXCEPT via Python operators.
+
+Uses the standard video test database with movie, dvd, cast, people tables.
+
+Movie data reference (11 movies, id 0..10):
+    id=0  Match point        year=2005  genre=DRAMA      nationality=USA,UK
+    id=1  Scoop              year=2006  genre=COMEDY     nationality=USA,UK
+    id=2  Munich             year=2005  genre=DRAMA      nationality=USA
+    id=3  Saving private Ryan year=1998 genre=WAR        nationality=USA
+    id=4  Eyes wide shut     year=1999  genre=DRAMA      nationality=UK
+    id=5  Barry Lindon       year=1975  genre=DRAMA      nationality=UK
+    id=6  Scarface           year=1983  genre=CRIME      nationality=USA
+    id=7  The untouchables   year=1987  genre=CRIME      nationality=USA
+    id=8  Psycho             year=1960  genre=THRILLER   nationality=UK
+    id=9  The Aviator        year=2004  genre=BIOGRAPHY  nationality=USA
+    id=10 The Departed       year=2006  genre=CRIME      nationality=USA
+"""
+
+from gnr.sql.gnrsql import GnrSqlDb
+from gnr.sql.gnrsqldata import SqlCompoundQuery
+
+from .common import BaseGnrSqlTest, configureDb
+
+
+class BaseCompoundQuery(BaseGnrSqlTest):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.init()
+        cls.db.createDb(cls.dbname)
+        configureDb(cls.db)
+        cls.db.startup()
+        cls.db.checkDb(applyChanges=True)
+        cls.db.importXmlData(cls.SAMPLE_XMLDATA)
+        cls.db.commit()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.closeConnection()
+        cls.db.dropDb(cls.dbname)
+
+    # -- helpers --
+
+    def _movie_query(self, **kwargs):
+        return self.db.query('video.movie', columns='$id,$title,$year,$genre,$nationality', **kwargs)
+
+    def _ids(self, compound_q):
+        """Execute a compound query and return sorted list of movie ids."""
+        rows = self.db.execute(compound_q.sqltext, compound_q.sqlparams,
+                               dbtable='video.movie').fetchall()
+        return sorted(r[0] for r in rows)
+
+    def _id_list(self, compound_q):
+        """Execute and return ids preserving order (with duplicates)."""
+        rows = self.db.execute(compound_q.sqltext, compound_q.sqlparams,
+                               dbtable='video.movie').fetchall()
+        return [r[0] for r in rows]
+
+    # ================================================================
+    # 1. UNION (+) — removes duplicates
+    # ================================================================
+
+    def test_union_basic(self):
+        """UNION of year=2005 and year=2006 gives 4 distinct movies."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        cq = q1 + q2
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 10}
+
+    def test_union_removes_duplicates(self):
+        """UNION with overlapping sets removes duplicates."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 + q2
+        ids = self._ids(cq)
+        # DRAMA: {0,2,4,5} ∪ year2005: {0,2} → {0,2,4,5}
+        assert set(ids) == {0, 2, 4, 5}
+
+    # ================================================================
+    # 2. UNION ALL (|) — keeps duplicates
+    # ================================================================
+
+    def test_union_all_basic(self):
+        """UNION ALL of year=2005 and year=2006 gives 4 rows (no overlap)."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        cq = q1 | q2
+        assert isinstance(cq, SqlCompoundQuery)
+        assert cq.count() == 4
+
+    def test_union_all_keeps_duplicates(self):
+        """UNION ALL with overlapping sets keeps duplicate rows."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 | q2
+        all_ids = self._id_list(cq)
+        # DRAMA: 4 rows + year2005: 2 rows = 6 total
+        assert len(all_ids) == 6
+
+    # ================================================================
+    # 3. INTERSECT (&) — only common rows
+    # ================================================================
+
+    def test_intersect_basic(self):
+        """INTERSECT of DRAMA and year=2005 gives only dramas from 2005."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 & q2
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        # DRAMA ∩ year2005: Match point (0) and Munich (2)
+        assert set(ids) == {0, 2}
+
+    def test_intersect_empty(self):
+        """INTERSECT of disjoint sets gives 0 rows."""
+        q1 = self._movie_query(where="$genre=:g", g='COMEDY')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 & q2
+        assert cq.count() == 0
+
+    # ================================================================
+    # 4. EXCEPT (-) — set difference
+    # ================================================================
+
+    def test_except_basic(self):
+        """EXCEPT removes rows present in second query."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 - q2
+        ids = self._ids(cq)
+        # DRAMA\year2005: {0,2,4,5} \ {0,2} → {4,5}
+        assert set(ids) == {4, 5}
+
+    def test_except_all_removed(self):
+        """EXCEPT where second set contains all of first gives 0 rows."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where="$genre=:g", g='DRAMA')
+        cq = q1 - q2
+        # year2005={0,2} both DRAMA → empty
+        assert cq.count() == 0
+
+    # ================================================================
+    # 5. Chains of 3 queries
+    # ================================================================
+
+    def test_chain_three_union(self):
+        """q1 + q2 + q3 chains three UNION operations."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1999)
+        cq = q1 + q2 + q3
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 4, 10}
+
+    def test_chain_mixed_operators(self):
+        """(q1 + q2) - q3 removes from a union."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where="$genre=:g", g='DRAMA')
+        cq = (q1 + q2) - q3
+        ids = self._ids(cq)
+        # {0,1,2,10} \ {0,2,4,5} → {1,10}
+        assert set(ids) == {1, 10}
+
+    # ================================================================
+    # 6. Parentheses change evaluation order
+    # ================================================================
+
+    def test_parentheses_union_then_except(self):
+        """(DRAMA + CRIME) - year2005 gives different result than DRAMA + (CRIME - year2005)."""
+        # Case A: (DRAMA + CRIME) - year2005
+        q1a = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2a = self._movie_query(where="$genre=:g", g='CRIME')
+        q3a = self._movie_query(where='$year=:y', y=2005)
+        cq_a = (q1a + q2a) - q3a
+        ids_a = set(self._ids(cq_a))
+        # DRAMA∪CRIME = {0,2,4,5,6,7,10}, minus year2005={0,2} → {4,5,6,7,10}
+        assert ids_a == {4, 5, 6, 7, 10}
+
+        # Case B: DRAMA + (CRIME - year2005)
+        q1b = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2b = self._movie_query(where="$genre=:g", g='CRIME')
+        q3b = self._movie_query(where='$year=:y', y=2005)
+        cq_b = q1b + (q2b - q3b)
+        ids_b = set(self._ids(cq_b))
+        # CRIME\year2005 = {6,7,10} (no CRIME in 2005), DRAMA∪{6,7,10} = {0,2,4,5,6,7,10}
+        assert ids_b == {0, 2, 4, 5, 6, 7, 10}
+
+        assert ids_a != ids_b
+
+    # ================================================================
+    # 7. Mangler — same param names, different values
+    # ================================================================
+
+    def test_mangler_different_values(self):
+        """Two queries with same param name :y but different values produce correct results."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=1960)
+        cq = q1 + q2
+        ids = self._ids(cq)
+        # year2005={0,2} ∪ year1960={8}
+        assert set(ids) == {0, 2, 8}
+
+    def test_mangler_same_param_name_three_queries(self):
+        """Three queries all using :y with different values."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1960)
+        cq = q1 + q2 + q3
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 8, 10}
+
+    def test_mangler_mixed_param_names(self):
+        """Two queries with different param names don't interfere."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where="$genre=:g", g='CRIME')
+        cq = q1 + q2
+        ids = self._ids(cq)
+        # year2005={0,2} ∪ CRIME={6,7,10}
+        assert set(ids) == {0, 2, 6, 7, 10}
+
+    # ================================================================
+    # 8. count() method
+    # ================================================================
+
+    def test_count_union(self):
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        cq = q1 + q2
+        assert cq.count() == 4
+
+    def test_count_intersect(self):
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 & q2
+        assert cq.count() == 2
+
+    def test_count_except(self):
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where='$year=:y', y=2005)
+        cq = q1 - q2
+        assert cq.count() == 2
+
+    def test_count_chain(self):
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1999)
+        cq = q1 + q2 + q3
+        assert cq.count() == 5
+
+    # ================================================================
+    # 9. CompoundQuery + SqlQuery
+    # ================================================================
+
+    def test_compound_plus_simple(self):
+        """(q1 + q2) + q3 — compound extended with a simple query."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1960)
+        cq = (q1 + q2) + q3
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        assert set(ids) == {0, 1, 2, 8, 10}
+
+    def test_compound_minus_simple(self):
+        """(q1 | q2) - q3 — except a simple query from a compound."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where="$genre=:g", g='DRAMA')
+        cq = (q1 | q2) - q3
+        ids = self._ids(cq)
+        # UNION ALL(2005,2006)={0,2,1,10} EXCEPT DRAMA={0,2,4,5} → {1,10}
+        assert set(ids) == {1, 10}
+
+    # ================================================================
+    # 10. CompoundQuery + CompoundQuery
+    # ================================================================
+
+    def test_compound_plus_compound(self):
+        """(q1 + q2) + (q3 + q4) merges two compound queries."""
+        q1 = self._movie_query(where='$year=:y', y=2005)
+        q2 = self._movie_query(where='$year=:y', y=2006)
+        q3 = self._movie_query(where='$year=:y', y=1960)
+        q4 = self._movie_query(where='$year=:y', y=1975)
+        cq = (q1 + q2) + (q3 + q4)
+        assert isinstance(cq, SqlCompoundQuery)
+        ids = self._ids(cq)
+        # {0,2} ∪ {1,10} ∪ {8} ∪ {5}
+        assert set(ids) == {0, 1, 2, 5, 8, 10}
+
+    def test_compound_intersect_compound(self):
+        """(DRAMA | CRIME) & (UK | USA) — intersect of two compound queries."""
+        q1 = self._movie_query(where="$genre=:g", g='DRAMA')
+        q2 = self._movie_query(where="$genre=:g", g='CRIME')
+        q3 = self._movie_query(where="$nationality=:n", n='UK')
+        q4 = self._movie_query(where="$nationality=:n", n='USA')
+        cq = (q1 | q2) & (q3 | q4)
+        ids = self._ids(cq)
+        # DRAMA|CRIME (all): {0,2,4,5,6,7,10}
+        # UK|USA (exact match): UK={4,5,8}, USA={2,3,6,7,9,10}
+        # intersection: {2,4,5,6,7,10}
+        assert set(ids) == {2, 4, 5, 6, 7, 10}
+
+
+# ================================================================
+# Backend-specific test classes
+# ================================================================
+
+class TestCompoundQuery_sqlite(BaseCompoundQuery):
+    @classmethod
+    def init(cls):
+        cls.name = 'sqlite'
+        cls.dbname = cls.CONFIG['db.sqlite?filename']
+        cls.db = GnrSqlDb(dbname=cls.dbname)
+
+
+class TestCompoundQuery_postgres(BaseCompoundQuery):
+    @classmethod
+    def init(cls):
+        cls.name = 'postgres'
+        cls.dbname = 'test_compound'
+        cls.db = GnrSqlDb(implementation='postgres',
+                          host=cls.pg_conf.get("host"),
+                          port=cls.pg_conf.get("port"),
+                          dbname=cls.dbname,
+                          user=cls.pg_conf.get("user"),
+                          password=cls.pg_conf.get("password"))
+
+
+class TestCompoundQuery_postgres3(BaseCompoundQuery):
+    @classmethod
+    def init(cls):
+        cls.name = 'postgres3'
+        cls.dbname = 'test_compound'
+        cls.db = GnrSqlDb(implementation='postgres3',
+                          host=cls.pg_conf.get("host"),
+                          port=cls.pg_conf.get("port"),
+                          dbname=cls.dbname,
+                          user=cls.pg_conf.get("user"),
+                          password=cls.pg_conf.get("password"))

--- a/projects/test_invoice/data/generate_invoices.py
+++ b/projects/test_invoice/data/generate_invoices.py
@@ -5,15 +5,24 @@ Uses GnrApp to connect to a Genropy instance and generates realistic
 invoice data for an Australian hardware store.
 
 Usage:
-    python generate_invoices.py <instance_name>
-    python generate_invoices.py test_invoice          # SQLite
-    python generate_invoices.py test_invoice_pg        # PostgreSQL
+    # Small dataset (sqlite / pg):
+    python generate_invoices.py test_invoice \\
+        --customers-per-state 2:3:5 \\
+        --invoices-per-year 1:2:5 \\
+        --rows-per-invoice 2:3:6
+
+    # XL dataset (pg_xl):
+    python generate_invoices.py test_invoice_pg_xl \\
+        --customers-per-state 300:400:500 \\
+        --invoices-per-year 14:30:80 \\
+        --rows-per-invoice 6:15:50
+
+Parameters use triangular distribution (min:mode:max) for natural variation.
 
 Features:
-    - 0-30 invoices per customer (5% exceptional customers get 30-60)
+    - Iterates state → customer → year for structured data generation
     - Dates spread across 2022-01-01 to 2025-06-30
     - Price history with semester-based multipliers (inflation simulation)
-    - 1-20 rows per invoice (5% get 30-50 rows)
     - Invoices sorted by date before insert (required by Genropy counter)
     - Triggers disabled for bulk insert performance
 """
@@ -36,8 +45,7 @@ PRICE_MULTIPLIERS = {
     (2025, 2): Decimal('1.15'),
 }
 
-DATE_START = date(2022, 1, 1)
-DATE_END = date(2025, 6, 30)
+YEARS = [2022, 2023, 2024, 2025]
 
 
 def get_semester(d):
@@ -50,12 +58,30 @@ def get_price_for_date(base_price, invoice_date):
     return (base_price * multiplier).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
 
 
-def random_date():
-    days_range = (DATE_END - DATE_START).days
-    return DATE_START + timedelta(days=random.randint(0, days_range))
+def random_date_in_year(year):
+    start = date(year, 1, 1)
+    end = min(date(year, 12, 31), date(2025, 6, 30))
+    if start > end:
+        return None
+    days_range = (end - start).days
+    return start + timedelta(days=random.randint(0, days_range))
 
 
-def generate(instance_name, seed=42):
+def tri(low, mode, high):
+    return int(random.triangular(low, high, mode))
+
+
+def parse_range(s):
+    """Parse 'min:mode:max' into (low, mode, high) tuple of ints."""
+    parts = s.split(':')
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError(
+            f"Expected min:mode:max, got '{s}'")
+    return int(parts[0]), int(parts[1]), int(parts[2])
+
+
+def generate(instance_name, seed=42, customers_per_state=(2, 3, 5),
+             invoices_per_year=(1, 2, 5), rows_per_invoice=(2, 3, 6)):
     from gnr.app.gnrapp import GnrApp
 
     random.seed(seed)
@@ -69,78 +95,97 @@ def generate(instance_name, seed=42):
     original_trigger = getattr(tbl_row, 'trigger_onInserted', None)
     tbl_row.trigger_onInserted = lambda record=None: None
 
-    # Load customers and products
-    customers = db.table('invc.customer').query(columns='$id').fetch()
+    # Load states
+    states = db.table('invc.state').query(
+        columns='$code', order_by='$code').fetch()
+
+    # Load products
     products = db.table('invc.product').query(
         columns='$id, $unit_price, @vat_type_code.vat_rate AS prod_vat_rate'
     ).fetch()
 
-    if not customers:
-        print('No customers found. Import base data first.')
+    if not states:
+        print('No states found. Import base data first.')
         sys.exit(1)
     if not products:
         print('No products found. Import base data first.')
         sys.exit(1)
 
-    print(f'Customers: {len(customers)}, Products: {len(products)}')
+    print(f'States: {len(states)}, Products: {len(products)}')
 
-    # Pre-generate all invoices with their rows (unsorted)
+    # Iterate state → customer → year
     all_invoices = []
-    for cust in customers:
-        customer_id = cust['id']
-        if random.random() < 0.05:
-            num_invoices = random.randint(30, 60)
-        else:
-            num_invoices = random.randint(0, 30)
+    selected_customers = []
 
-        for _ in range(num_invoices):
-            inv_date = random_date()
+    for state_row in states:
+        state_code = state_row['code']
+        customers = db.table('invc.customer').query(
+            columns='$id',
+            where='$state=:state', state=state_code,
+            order_by='$id').fetch()
 
-            if random.random() < 0.05:
-                num_rows = random.randint(30, 50)
-            else:
-                num_rows = random.randint(1, 20)
+        if not customers:
+            print(f'  State {state_code}: no customers, skipping')
+            continue
 
-            rows = []
-            total = Decimal('0')
-            vat_total = Decimal('0')
+        n_cust = min(tri(*customers_per_state), len(customers))
+        chosen = random.sample(list(customers), n_cust)
+        selected_customers.extend(chosen)
+        print(f'  State {state_code}: {len(customers)} customers, selected {n_cust}')
 
-            for _ in range(num_rows):
-                prod = random.choice(products)
-                quantity = random.randint(1, 50)
-                base_price = Decimal(str(prod['unit_price']))
-                unit_price = get_price_for_date(base_price, inv_date)
-                prod_vat_rate = Decimal(str(prod['prod_vat_rate'] or 0))
-                tot_price = (unit_price * quantity).quantize(
-                    Decimal('0.01'), rounding=ROUND_HALF_UP)
-                vat = (tot_price * prod_vat_rate / Decimal('100')).quantize(
-                    Decimal('0.01'), rounding=ROUND_HALF_UP)
+        for cust in chosen:
+            customer_id = cust['id']
 
-                total += tot_price
-                vat_total += vat
+            for year in YEARS:
+                n_inv = tri(*invoices_per_year)
 
-                rows.append({
-                    'product_id': prod['id'],
-                    'quantity': quantity,
-                    'unit_price': unit_price,
-                    'tot_price': tot_price,
-                    'vat': vat,
-                    'vat_rate': prod_vat_rate,
-                })
+                for _ in range(n_inv):
+                    inv_date = random_date_in_year(year)
+                    if inv_date is None:
+                        continue
 
-            all_invoices.append({
-                'customer_id': customer_id,
-                'date': inv_date,
-                'total': total,
-                'vat_total': vat_total,
-                'gross_total': total + vat_total,
-                '_rows': rows,
-            })
+                    n_rows = tri(*rows_per_invoice)
+                    rows = []
+                    total = Decimal('0')
+                    vat_total = Decimal('0')
+
+                    for _ in range(n_rows):
+                        prod = random.choice(products)
+                        quantity = random.randint(1, 50)
+                        base_price = Decimal(str(prod['unit_price']))
+                        unit_price = get_price_for_date(base_price, inv_date)
+                        prod_vat_rate = Decimal(str(prod['prod_vat_rate'] or 0))
+                        tot_price = (unit_price * quantity).quantize(
+                            Decimal('0.01'), rounding=ROUND_HALF_UP)
+                        vat = (tot_price * prod_vat_rate / Decimal('100')).quantize(
+                            Decimal('0.01'), rounding=ROUND_HALF_UP)
+
+                        total += tot_price
+                        vat_total += vat
+
+                        rows.append({
+                            'product_id': prod['id'],
+                            'quantity': quantity,
+                            'unit_price': unit_price,
+                            'tot_price': tot_price,
+                            'vat': vat,
+                            'vat_rate': prod_vat_rate,
+                        })
+
+                    all_invoices.append({
+                        'customer_id': customer_id,
+                        'date': inv_date,
+                        'total': total,
+                        'vat_total': vat_total,
+                        'gross_total': total + vat_total,
+                        '_rows': rows,
+                    })
 
     # Sort by date for counter compatibility
     all_invoices.sort(key=lambda x: x['date'])
 
-    print(f'Generated {len(all_invoices)} invoices. Inserting...')
+    print(f'\nGenerated {len(all_invoices)} invoices '
+          f'for {len(selected_customers)} customers. Inserting...')
     total_rows = 0
     for i, inv_data in enumerate(all_invoices):
         rows = inv_data.pop('_rows')
@@ -171,8 +216,20 @@ def main():
     parser.add_argument('instance', help='Genropy instance name')
     parser.add_argument('--seed', type=int, default=42,
                         help='Random seed for reproducibility (default: 42)')
+    parser.add_argument('--customers-per-state', type=parse_range,
+                        default=(2, 3, 5),
+                        help='min:mode:max customers per state (default: 2:3:5)')
+    parser.add_argument('--invoices-per-year', type=parse_range,
+                        default=(1, 2, 5),
+                        help='min:mode:max invoices per customer per year (default: 1:2:5)')
+    parser.add_argument('--rows-per-invoice', type=parse_range,
+                        default=(2, 3, 6),
+                        help='min:mode:max rows per invoice (default: 2:3:6)')
     args = parser.parse_args()
-    generate(args.instance, seed=args.seed)
+    generate(args.instance, seed=args.seed,
+             customers_per_state=args.customers_per_state,
+             invoices_per_year=args.invoices_per_year,
+             rows_per_invoice=args.rows_per_invoice)
 
 
 if __name__ == '__main__':

--- a/projects/test_invoice/instances/test_invoice_pg_xl/instanceconfig.xml
+++ b/projects/test_invoice/instances/test_invoice_pg_xl/instanceconfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<GenRoBag>
+	<db dbname="test_invoice_pg_xl" implementation="postgres" host="localhost" port="5432"/>
+
+	<packages>
+		<gnrcore_sys pkgcode="gnrcore:sys"/>
+		<gnrcore_adm pkgcode="gnrcore:adm"/>
+		<invc/>
+	</packages>
+
+	<authentication pkg="gnrcore:sys">
+		<py_auth defaultTags="user" method="authenticate" pkg="adm"/>
+	</authentication>
+</GenRoBag>

--- a/projects/test_invoice/tests/test_sql_aggregate.py
+++ b/projects/test_invoice/tests/test_sql_aggregate.py
@@ -1,0 +1,134 @@
+"""Test sql_aggregate: many-side relations as inline aggregate subqueries.
+
+When sql_aggregate=True, traversing a many-side relation (e.g. @invoices.total
+on customer) produces a correlated subquery with the appropriate SQL aggregate
+function instead of an exploding LEFT JOIN + Python post-processing.
+
+The aggregate function is determined by the target column's dtype:
+  - numeric (R, L, N, I): SUM (default)
+  - boolean (B): BOOL_AND
+  - text: string_agg / group_concat (adapter-dependent)
+
+The tests compare sql_aggregate results against the same query executed
+without the flag, using selection(_aggregateRows=True) for Python-side
+aggregation.
+"""
+
+
+class TestSqlAggregateSumNumeric:
+    """Many-side relation on numeric columns: sql_aggregate vs _aggregateRows."""
+
+    def test_customer_invoices_total(self, db):
+        """SUM of invoice.total via @invoices.total: SQL vs Python aggregation."""
+        cols = '$account_name,@invoices.total'
+        where = '$n_invoices > 0'
+        sel_py = db.query('invc.customer', columns=cols,
+                          where=where,
+                          order_by='$id').selection(_aggregateRows=True)
+        r_py = sel_py.output('dictlist')
+        r_sql = db.query('invc.customer', columns=cols,
+                         where=where,
+                         order_by='$id',
+                         sql_aggregate=True).fetch()
+        assert len(r_py) == len(r_sql)
+        for rp, rs in zip(r_py, r_sql):
+            assert rp['account_name'] == rs['account_name']
+            # sqlite SUM in subquery returns float, _aggregateRows sums Decimal
+            assert round(float(rp['_invoices_total']), 2) == round(float(rs['_invoices_total']), 2), (
+                f"{rp['account_name']}: py={rp['_invoices_total']} sql={rs['_invoices_total']}")
+
+    def test_invoice_rows_tot_price(self, db):
+        """SUM of invoice_row.tot_price via @rows.tot_price."""
+        cols = '$inv_number,@rows.tot_price'
+        sel_py = db.query('invc.invoice', columns=cols,
+                          order_by='$inv_number').selection(_aggregateRows=True)
+        r_py = sel_py.output('dictlist')
+        r_sql = db.query('invc.invoice', columns=cols,
+                         order_by='$inv_number',
+                         sql_aggregate=True).fetch()
+        assert len(r_py) == len(r_sql)
+        for rp, rs in zip(r_py, r_sql):
+            assert rp['inv_number'] == rs['inv_number']
+
+    def test_invoice_rows_quantity(self, db):
+        """SUM of invoice_row.quantity via @rows.quantity."""
+        cols = '$inv_number,@rows.quantity'
+        sel_py = db.query('invc.invoice', columns=cols,
+                          order_by='$inv_number').selection(_aggregateRows=True)
+        r_py = sel_py.output('dictlist')
+        r_sql = db.query('invc.invoice', columns=cols,
+                         order_by='$inv_number',
+                         sql_aggregate=True).fetch()
+        assert len(r_py) == len(r_sql)
+        for rp, rs in zip(r_py, r_sql):
+            assert rp['inv_number'] == rs['inv_number']
+
+    def test_product_invoice_rows_tot_price(self, db):
+        """SUM of invoice_row.tot_price via @invoice_rows.tot_price on product."""
+        cols = '$code,@invoice_rows.tot_price'
+        sel_py = db.query('invc.product', columns=cols,
+                          order_by='$code').selection(_aggregateRows=True)
+        r_py = sel_py.output('dictlist')
+        r_sql = db.query('invc.product', columns=cols,
+                         order_by='$code',
+                         sql_aggregate=True).fetch()
+        assert len(r_py) == len(r_sql)
+        for rp, rs in zip(r_py, r_sql):
+            assert rp['code'] == rs['code']
+
+
+class TestSqlAggregateCountViaFormula:
+    """Compare sql_aggregate COUNT with existing formulaColumn n_invoices."""
+
+    def test_customer_count_invoices(self, db):
+        """RuntimeModel COUNT via @invoices matches n_invoices formula."""
+        rm = db.runtimeModel()
+        cust = rm.table('invc.customer')
+        cust.formulaColumn('n_inv_agg',
+                           select=dict(table='invc.invoice',
+                                       columns='COUNT(*)',
+                                       where='$customer_id=#THIS.id'),
+                           dtype='L')
+        with rm:
+            cols = '$account_name,$n_invoices,$n_inv_agg'
+            rows = db.query('invc.customer', columns=cols,
+                            order_by='$id', limit=20).fetch()
+        for r in rows:
+            assert r['n_invoices'] == r['n_inv_agg'], (
+                f"{r['account_name']}: n_invoices={r['n_invoices']} n_inv_agg={r['n_inv_agg']}")
+
+
+class TestSqlAggregateDisabledByDefault:
+    """sql_aggregate=False (default): many-side relations use standard JOIN."""
+
+    def test_default_no_aggregate(self, db):
+        """Without sql_aggregate, @invoices.total uses JOIN (exploding)."""
+        cols = '$account_name,@invoices.total'
+        q = db.query('invc.customer', columns=cols,
+                     order_by='$id', limit=5)
+        sql = q.sqltext.upper()
+        assert 'LEFT JOIN' in sql
+        assert sql.count('SELECT') == 1
+
+
+class TestSqlAggregateSqlText:
+    """Verify the generated SQL contains a subquery when sql_aggregate=True."""
+
+    def test_has_subselect(self, db):
+        """sql_aggregate=True should produce a correlated subquery."""
+        cols = '$account_name,@invoices.total'
+        q = db.query('invc.customer', columns=cols,
+                     where='$id = :id', id='dummy',
+                     sql_aggregate=True)
+        sql = q.sqltext.upper()
+        assert sql.count('SELECT') >= 2
+        assert 'SUM' in sql
+
+    def test_no_left_join_for_many(self, db):
+        """sql_aggregate=True should NOT produce LEFT JOIN for the many relation."""
+        cols = '$account_name,@invoices.total'
+        q = db.query('invc.customer', columns=cols,
+                     where='$id = :id', id='dummy',
+                     sql_aggregate=True)
+        sql = q.sqltext.upper()
+        assert 'LEFT JOIN' not in sql or sql.count('SELECT') >= 2

--- a/projects/test_invoice/tests/test_subquery_join.py
+++ b/projects/test_invoice/tests/test_subquery_join.py
@@ -1,0 +1,212 @@
+"""Test subquery inline vs LEFT JOIN via enable_sq_join=True.
+
+Each test queries the same formulaColumn twice:
+  1. inline (default)
+  2. as LEFT JOIN (enable_sq_join=True)
+and asserts the results match.
+
+FormulaColumns already defined in the model (n_invoices, invoiced_total)
+are tested directly. Additional columns (last_invoice_date, avg_invoice_total,
+n_sold, total_sold, n_rows, row_total) are added via RuntimeModel.
+"""
+
+
+def _add_customer_extra(rm):
+    """Add extra formulaColumns to customer via RuntimeModel."""
+    cust = rm.table('invc.customer')
+    cust.formulaColumn('last_invoice_date',
+                       select=dict(table='invc.invoice',
+                                   columns='MAX($date)',
+                                   where='$customer_id=#THIS.id'),
+                       dtype='D')
+    cust.formulaColumn('avg_invoice_total',
+                       select=dict(table='invc.invoice',
+                                   columns='AVG($total)',
+                                   where='$customer_id=#THIS.id'),
+                       dtype='N')
+
+
+def _add_product_extra(rm):
+    """Add extra formulaColumns to product via RuntimeModel."""
+    prod = rm.table('invc.product')
+    prod.formulaColumn('n_sold',
+                       select=dict(table='invc.invoice_row',
+                                   columns='SUM($quantity)',
+                                   where='$product_id=#THIS.id'),
+                       dtype='L')
+    prod.formulaColumn('total_sold',
+                       select=dict(table='invc.invoice_row',
+                                   columns='SUM($tot_price)',
+                                   where='$product_id=#THIS.id'),
+                       dtype='N')
+
+
+def _add_invoice_extra(rm):
+    """Add extra formulaColumns to invoice via RuntimeModel."""
+    inv = rm.table('invc.invoice')
+    inv.formulaColumn('n_rows',
+                      select=dict(table='invc.invoice_row',
+                                  columns='COUNT(*)',
+                                  where='$invoice_id=#THIS.id'),
+                      dtype='L')
+    inv.formulaColumn('row_total',
+                      select=dict(table='invc.invoice_row',
+                                  columns='SUM($tot_price)',
+                                  where='$invoice_id=#THIS.id'),
+                      dtype='N')
+
+
+class TestCustomerSubqueryJoin:
+    """formulaColumn on customer: n_invoices, invoiced_total (model),
+    last_invoice_date, avg_invoice_total (runtime)."""
+
+    def test_n_invoices(self, db):
+        cols = '$account_name,$n_invoices'
+        r_inline = db.query('invc.customer', columns=cols,
+                            order_by='$id', limit=20).fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          order_by='$id', limit=20,
+                          enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['n_invoices'] == rj['n_invoices'], (
+                f"{ri['account_name']}: inline={ri['n_invoices']} join={rj['n_invoices']}")
+
+    def test_invoiced_total(self, db):
+        cols = '$account_name,$invoiced_total'
+        r_inline = db.query('invc.customer', columns=cols,
+                            order_by='$id', limit=20).fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          order_by='$id', limit=20,
+                          enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['invoiced_total'] == rj['invoiced_total'], (
+                f"{ri['account_name']}: inline={ri['invoiced_total']} join={rj['invoiced_total']}")
+
+    def test_last_invoice_date(self, db):
+        rm = db.runtimeModel()
+        _add_customer_extra(rm)
+        with rm:
+            cols = '$account_name,$last_invoice_date'
+            r_inline = db.query('invc.customer', columns=cols,
+                                order_by='$id', limit=20).fetch()
+            r_join = db.query('invc.customer', columns=cols,
+                              order_by='$id', limit=20,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['last_invoice_date'] == rj['last_invoice_date'], (
+                f"{ri['account_name']}: inline={ri['last_invoice_date']} join={rj['last_invoice_date']}")
+
+    def test_avg_invoice_total(self, db):
+        rm = db.runtimeModel()
+        _add_customer_extra(rm)
+        with rm:
+            cols = '$account_name,$avg_invoice_total'
+            r_inline = db.query('invc.customer', columns=cols,
+                                order_by='$id', limit=20).fetch()
+            r_join = db.query('invc.customer', columns=cols,
+                              order_by='$id', limit=20,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            vi = ri['avg_invoice_total']
+            vj = rj['avg_invoice_total']
+            if vi is None and vj is None:
+                continue
+            assert abs(float(vi) - float(vj)) < 0.01, (
+                f"{ri['account_name']}: inline={vi} join={vj}")
+
+    def test_multiple_formulas_together(self, db):
+        rm = db.runtimeModel()
+        _add_customer_extra(rm)
+        with rm:
+            cols = '$account_name,$n_invoices,$invoiced_total,$last_invoice_date,$avg_invoice_total'
+            r_inline = db.query('invc.customer', columns=cols,
+                                order_by='$id', limit=10).fetch()
+            r_join = db.query('invc.customer', columns=cols,
+                              order_by='$id', limit=10,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['n_invoices'] == rj['n_invoices']
+            assert ri['invoiced_total'] == rj['invoiced_total']
+            assert ri['last_invoice_date'] == rj['last_invoice_date']
+
+
+class TestProductSubqueryJoin:
+    """formulaColumn on product: n_sold, total_sold (runtime)."""
+
+    def test_n_sold(self, db):
+        rm = db.runtimeModel()
+        _add_product_extra(rm)
+        with rm:
+            cols = '$description,$n_sold'
+            r_inline = db.query('invc.product', columns=cols,
+                                order_by='$code', limit=20).fetch()
+            r_join = db.query('invc.product', columns=cols,
+                              order_by='$code', limit=20,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['n_sold'] == rj['n_sold'], (
+                f"{ri['description']}: inline={ri['n_sold']} join={rj['n_sold']}")
+
+    def test_total_sold(self, db):
+        rm = db.runtimeModel()
+        _add_product_extra(rm)
+        with rm:
+            cols = '$description,$total_sold'
+            r_inline = db.query('invc.product', columns=cols,
+                                order_by='$code', limit=20).fetch()
+            r_join = db.query('invc.product', columns=cols,
+                              order_by='$code', limit=20,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['total_sold'] == rj['total_sold'], (
+                f"{ri['description']}: inline={ri['total_sold']} join={rj['total_sold']}")
+
+
+class TestInvoiceSubqueryJoin:
+    """formulaColumn on invoice: n_rows, row_total (runtime)."""
+
+    def test_n_rows(self, db):
+        rm = db.runtimeModel()
+        _add_invoice_extra(rm)
+        with rm:
+            cols = '$inv_number,$n_rows'
+            r_inline = db.query('invc.invoice', columns=cols,
+                                order_by='$inv_number', limit=50).fetch()
+            r_join = db.query('invc.invoice', columns=cols,
+                              order_by='$inv_number', limit=50,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['n_rows'] == rj['n_rows'], (
+                f"{ri['inv_number']}: inline={ri['n_rows']} join={rj['n_rows']}")
+
+    def test_row_total(self, db):
+        rm = db.runtimeModel()
+        _add_invoice_extra(rm)
+        with rm:
+            cols = '$inv_number,$row_total'
+            r_inline = db.query('invc.invoice', columns=cols,
+                                order_by='$inv_number', limit=50).fetch()
+            r_join = db.query('invc.invoice', columns=cols,
+                              order_by='$inv_number', limit=50,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['row_total'] == rj['row_total'], (
+                f"{ri['inv_number']}: inline={ri['row_total']} join={rj['row_total']}")
+
+
+class TestSqlTextGeneration:
+    """Verify the generated SQL contains LEFT JOIN when enable_sq_join=True."""
+
+    def test_inline_has_subselect(self, db):
+        q = db.query('invc.customer', columns='$account_name,$n_invoices',
+                      where='$id = :id', id='dummy')
+        sql = q.sqltext.upper()
+        assert sql.count('SELECT') >= 2
+
+    def test_join_has_left_join(self, db):
+        q = db.query('invc.customer', columns='$account_name,$n_invoices',
+                      where='$id = :id', id='dummy',
+                      enable_sq_join=True)
+        sql = q.sqltext
+        assert 'LEFT JOIN' in sql

--- a/projects/test_invoice/tests/test_subquery_where_orderby.py
+++ b/projects/test_invoice/tests/test_subquery_where_orderby.py
@@ -1,0 +1,245 @@
+"""Test subquery formulaColumn used in WHERE and ORDER BY clauses.
+
+Verifica che inline e JOIN (enable_sq_join=True) producano gli stessi
+risultati quando la formulaColumn è usata in WHERE o ORDER BY.
+
+FormulaColumns already in the model (n_invoices, invoiced_total) are used
+directly. Additional columns are added via RuntimeModel where needed.
+"""
+
+
+def _add_customer_extra(rm):
+    cust = rm.table('invc.customer')
+    cust.formulaColumn('last_invoice_date',
+                       select=dict(table='invc.invoice',
+                                   columns='MAX($date)',
+                                   where='$customer_id=#THIS.id'),
+                       dtype='D')
+
+
+def _add_product_extra(rm):
+    prod = rm.table('invc.product')
+    prod.formulaColumn('n_sold',
+                       select=dict(table='invc.invoice_row',
+                                   columns='SUM($quantity)',
+                                   where='$product_id=#THIS.id'),
+                       dtype='L')
+    prod.formulaColumn('total_sold',
+                       select=dict(table='invc.invoice_row',
+                                   columns='SUM($tot_price)',
+                                   where='$product_id=#THIS.id'),
+                       dtype='N')
+
+
+def _add_invoice_extra(rm):
+    inv = rm.table('invc.invoice')
+    inv.formulaColumn('n_rows',
+                      select=dict(table='invc.invoice_row',
+                                  columns='COUNT(*)',
+                                  where='$invoice_id=#THIS.id'),
+                      dtype='L')
+
+
+class TestWhereOnFormulaColumn:
+    """Usare formulaColumn con subquery nella clausola WHERE."""
+
+    def test_where_n_invoices_gt(self, db):
+        """Clienti con più di 25 fatture."""
+        cols = '$account_name,$n_invoices'
+        where = '$n_invoices > :min_inv'
+        r_inline = db.query('invc.customer', columns=cols,
+                            where=where, min_inv=25,
+                            order_by='$id').fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          where=where, min_inv=25,
+                          order_by='$id',
+                          enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['account_name'] == rj['account_name']
+            assert ri['n_invoices'] == rj['n_invoices']
+
+    def test_where_invoiced_total_gt(self, db):
+        """Clienti con fatturato superiore a 50000."""
+        cols = '$account_name,$invoiced_total'
+        where = '$invoiced_total > :min_tot'
+        r_inline = db.query('invc.customer', columns=cols,
+                            where=where, min_tot=50000,
+                            order_by='$id').fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          where=where, min_tot=50000,
+                          order_by='$id',
+                          enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['account_name'] == rj['account_name']
+            assert ri['invoiced_total'] == rj['invoiced_total']
+
+    def test_where_n_sold_eq_zero(self, db):
+        """Prodotti mai venduti (n_sold = 0)."""
+        rm = db.runtimeModel()
+        _add_product_extra(rm)
+        with rm:
+            cols = '$code,$description,$n_sold'
+            where = '$n_sold = :val'
+            r_inline = db.query('invc.product', columns=cols,
+                                where=where, val=0,
+                                order_by='$code').fetch()
+            r_join = db.query('invc.product', columns=cols,
+                              where=where, val=0,
+                              order_by='$code',
+                              enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['code'] == rj['code']
+
+    def test_where_combined_formula_and_column(self, db):
+        """WHERE su colonna reale + formulaColumn."""
+        cols = '$account_name,$state,$n_invoices'
+        where = "$state = :st AND $n_invoices > :min_inv"
+        r_inline = db.query('invc.customer', columns=cols,
+                            where=where, st='NSW', min_inv=10,
+                            order_by='$id').fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          where=where, st='NSW', min_inv=10,
+                          order_by='$id',
+                          enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['account_name'] == rj['account_name']
+            assert ri['n_invoices'] == rj['n_invoices']
+
+    def test_where_last_invoice_date(self, db):
+        """Clienti con ultima fattura dopo una certa data."""
+        rm = db.runtimeModel()
+        _add_customer_extra(rm)
+        with rm:
+            cols = '$account_name,$last_invoice_date'
+            where = "$last_invoice_date > :cutoff"
+            r_inline = db.query('invc.customer', columns=cols,
+                                where=where, cutoff='2024-01-01',
+                                order_by='$id').fetch()
+            r_join = db.query('invc.customer', columns=cols,
+                              where=where, cutoff='2024-01-01',
+                              order_by='$id',
+                              enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['account_name'] == rj['account_name']
+            assert ri['last_invoice_date'] == rj['last_invoice_date']
+
+
+class TestOrderByFormulaColumn:
+    """Usare formulaColumn con subquery nella clausola ORDER BY."""
+
+    def test_order_by_n_invoices_desc(self, db):
+        """Top 20 clienti per numero fatture."""
+        cols = '$account_name,$n_invoices'
+        r_inline = db.query('invc.customer', columns=cols,
+                            order_by='$n_invoices DESC,$id', limit=20).fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          order_by='$n_invoices DESC,$id', limit=20,
+                          enable_sq_join=True).fetch()
+        assert len(r_inline) == 20
+        assert len(r_join) == 20
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['account_name'] == rj['account_name']
+            assert ri['n_invoices'] == rj['n_invoices']
+
+    def test_order_by_invoiced_total_desc(self, db):
+        """Top 20 clienti per fatturato."""
+        cols = '$account_name,$invoiced_total'
+        r_inline = db.query('invc.customer', columns=cols,
+                            order_by='$invoiced_total DESC,$id', limit=20).fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          order_by='$invoiced_total DESC,$id', limit=20,
+                          enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['account_name'] == rj['account_name']
+            assert ri['invoiced_total'] == rj['invoiced_total']
+
+    def test_order_by_n_sold_desc(self, db):
+        """Top 20 prodotti più venduti."""
+        rm = db.runtimeModel()
+        _add_product_extra(rm)
+        with rm:
+            cols = '$code,$description,$n_sold'
+            r_inline = db.query('invc.product', columns=cols,
+                                order_by='$n_sold DESC,$code', limit=20).fetch()
+            r_join = db.query('invc.product', columns=cols,
+                              order_by='$n_sold DESC,$code', limit=20,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['code'] == rj['code']
+            assert ri['n_sold'] == rj['n_sold']
+
+    def test_order_by_total_sold_asc(self, db):
+        """Prodotti con meno vendite (ASC), primi 20."""
+        rm = db.runtimeModel()
+        _add_product_extra(rm)
+        with rm:
+            cols = '$code,$description,$total_sold'
+            r_inline = db.query('invc.product', columns=cols,
+                                order_by='$total_sold ASC,$code', limit=20).fetch()
+            r_join = db.query('invc.product', columns=cols,
+                              order_by='$total_sold ASC,$code', limit=20,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['code'] == rj['code']
+            assert ri['total_sold'] == rj['total_sold']
+
+    def test_order_by_n_rows_desc(self, db):
+        """Top 50 fatture per numero righe."""
+        rm = db.runtimeModel()
+        _add_invoice_extra(rm)
+        with rm:
+            cols = '$inv_number,$n_rows'
+            r_inline = db.query('invc.invoice', columns=cols,
+                                order_by='$n_rows DESC,$inv_number', limit=50).fetch()
+            r_join = db.query('invc.invoice', columns=cols,
+                              order_by='$n_rows DESC,$inv_number', limit=50,
+                              enable_sq_join=True).fetch()
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['inv_number'] == rj['inv_number']
+            assert ri['n_rows'] == rj['n_rows']
+
+
+class TestWhereAndOrderByCombined:
+    """WHERE + ORDER BY entrambi su formulaColumn."""
+
+    def test_where_gt_order_desc(self, db):
+        """Clienti con >15 fatture, ordinati per fatturato DESC."""
+        cols = '$account_name,$n_invoices,$invoiced_total'
+        where = '$n_invoices > :min_inv'
+        r_inline = db.query('invc.customer', columns=cols,
+                            where=where, min_inv=15,
+                            order_by='$invoiced_total DESC,$id').fetch()
+        r_join = db.query('invc.customer', columns=cols,
+                          where=where, min_inv=15,
+                          order_by='$invoiced_total DESC,$id',
+                          enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['account_name'] == rj['account_name']
+            assert ri['n_invoices'] == rj['n_invoices']
+            assert ri['invoiced_total'] == rj['invoiced_total']
+
+    def test_where_formula_order_formula_limit(self, db):
+        """Prodotti venduti >100 volte, ordinati per total_sold, top 10."""
+        rm = db.runtimeModel()
+        _add_product_extra(rm)
+        with rm:
+            cols = '$code,$description,$n_sold,$total_sold'
+            where = '$n_sold > :min_sold'
+            r_inline = db.query('invc.product', columns=cols,
+                                where=where, min_sold=100,
+                                order_by='$total_sold DESC,$code', limit=10).fetch()
+            r_join = db.query('invc.product', columns=cols,
+                              where=where, min_sold=100,
+                              order_by='$total_sold DESC,$code', limit=10,
+                              enable_sq_join=True).fetch()
+        assert len(r_inline) == len(r_join)
+        for ri, rj in zip(r_inline, r_join):
+            assert ri['code'] == rj['code']
+            assert ri['n_sold'] == rj['n_sold']
+            assert ri['total_sold'] == rj['total_sold']


### PR DESCRIPTION
## Summary

- **Mangler infrastructure**: parameter namespacing for compound/sub queries (`sq0_`, `sq1_`, ...)
- **SqlCompoundQuery**: UNION/INTERSECT/EXCEPT via Python operators (`+`, `|`, `&`, `-`)
- **Subquery-as-JOIN conversion**: opt-in conversion of correlated subqueries in `formulaColumn` to LEFT JOINs, with identity hash condensation to merge identical subqueries
- **Promote expand* to class methods**: `expandThis`/`expandPref`/`expandEnv` moved from closures to `SqlQueryCompiler` methods
- **sql_aggregate flag**: opt-in `sql_aggregate=True` on `db.query()` converts many-side relation traversals (e.g. `@invoices.total`) into correlated aggregate subqueries (SUM, COUNT, BOOL_AND, string_agg) instead of exploding LEFT JOINs with Python post-processing. Aggregate function auto-detected from dtype/aggregator attribute.
- **Test data tooling**: `generate_invoices.py` reworked with triangular distribution parameters for flexible dataset sizing; added `test_invoice_pg_xl` instance for benchmarks

### Opt-in levels for subquery-as-JOIN

1. Per-column: `sq_as_join=True` on formulaColumn
2. Per-query: `enable_sq_join=True` on `db.query()`
3. Global: `db.extra_kw['subquery_as_join'] = True`

### Opt-in for sql_aggregate

1. Per-query: `sql_aggregate=True` on `db.query()`
2. Global: `db.extra_kw['sql_aggregate'] = True`

### Test results

- `gnrpy/tests/sql/`: 628 passed (3 pre-existing failures on `test_outputMode`)
- `projects/test_invoice/tests/`: 166 passed, 4 skipped

## Draft notice

This PR targets `feature/runtime_virtual_columns` (PR #542). It will be moved to review **after PR #542 is merged** into `develop`. The subsequent extraction of `ColumnCompiler`/`AliasManager`/`CompiledColumn` classes will follow in a separate PR.

## Test plan

- [x] All existing SQL tests pass (628/631)
- [x] All test_invoice tests pass (166 passed, 4 skipped)
- [x] New subquery-as-join tests validate inline vs JOIN parity
- [x] New sql_aggregate tests validate SQL vs Python aggregation parity
- [x] flake8 clean on all modified files

Ref #490, Ref #496