### PR TITLE
fix(attachmanager): add fit-to-container mode for image preview

### DIFF
--- a/resources/common/gnrcomponents/attachmanager/attachmanager.css
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.css
@@ -48,6 +48,11 @@
     transform-origin: 50% 50%;
     border:1px solid silver;
 }
+.atc_img_fit{
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
 .atc_description{
     padding:5px;
     font-size:1.2em;

--- a/resources/common/gnrcomponents/attachmanager/attachmanager.py
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.py
@@ -315,14 +315,9 @@ class AttachManager(BaseComponent):
                                     onclick="genro.openBrowserTab(this.src, {target:'_blank'})")
         if currentPreviewZoom:
             imgPane.dataController("""
-                if(!zoomValue){
-                    imgDom.className = 'atc_img_fit';
-                    imgDom.style.zoom = '';
-                }else{
-                    imgDom.className = '';
-                    imgDom.style.zoom = zoomValue;
-                }
-            """,zoomValue=currentPreviewZoom,imgDom=img.js_domNode,_onStart=True)
+                genro.dom.setClass(imgDom,'atc_img_fit',!zoomValue);
+                imgDom.style.zoom = zoomValue || '';
+            """,zoomValue=currentPreviewZoom,imgDom=img.js_domNode)
         sc.contentPane(pageName='video', overflow='hidden').video(src=src,height='100%',width='100%',
                                     border=0,controls=True)
         parent.dataController("""       

--- a/resources/common/gnrcomponents/attachmanager/attachmanager.py
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.py
@@ -152,7 +152,8 @@ class Form(BaseComponent):
                      onUploadingMethod=None,onUploadedMethod=None,**kwargs):
         sc = parent.stackContainer(**kwargs)
         bc = sc.borderContainer(title='!![en]Viewer')
-        bc.attachmentPreviewViewer(src='^.fileurl',selectedPage='^#FORM.viewerMode',region='center')
+        bc.attachmentPreviewViewer(src='^.fileurl',selectedPage='^#FORM.viewerMode',region='center',
+                                    currentPreviewZoom='^#FORM.currentPreviewZoom')
         da = sc.contentPane(title='!![en]Uploader').div(position='absolute',top='10px',left='10px',right='10px',bottom='10px',
             text_align='center',border='3px dotted #999',rounded=8)
         upload_message = '!!Drag here or double click to upload' if not self.isMobile else "!!Double click to upload"
@@ -308,16 +309,25 @@ class AttachManager(BaseComponent):
         sc = parent.stackContainer(_virtual_column='fileurl',**kwargs)
         sc.contentPane(pageName='document', overflow='hidden').iframe(src=src,height='100%',
                                     avoidCache=True,width='100%',border='0px',documentClasses=True)
-        zoom = f'zoom:{currentPreviewZoom}' if currentPreviewZoom else None
-        img_style = 'max-width:100%;display:block;cursor:zoom-in;' if not zoom else None
-        sc.contentPane(pageName='image').img(src=src, zoom=zoom, style=img_style,
+        imgPane = sc.contentPane(pageName='image', overflow='auto')
+        img = imgPane.img(src=src, _class='atc_img_fit',
+                                    style='display:block;cursor:zoom-in;',
                                     onclick="genro.openBrowserTab(this.src, {target:'_blank'})")
+        if currentPreviewZoom:
+            imgPane.dataController("""
+                if(!zoomValue){
+                    imgDom.className = 'atc_img_fit';
+                    imgDom.style.zoom = '';
+                }else{
+                    imgDom.className = '';
+                    imgDom.style.zoom = zoomValue;
+                }
+            """,zoomValue=currentPreviewZoom,imgDom=img.js_domNode,_onStart=True)
         sc.contentPane(pageName='video', overflow='hidden').video(src=src,height='100%',width='100%',
                                     border=0,controls=True)
         parent.dataController("""       
-        let cleanSrc = src.split("?")[0].split("#")[0];
-        let filename = cleanSrc.substring(cleanSrc.lastIndexOf('/') + 1);
-        let ext = filename.includes('.') ? filename.split('.').pop().toLowerCase() : '';
+        const parsedSrc = parseURL(src);
+        const ext = (parsedSrc.params.source_ext || parsedSrc.file.split('.').pop() || '').toLowerCase();
         SET .$ext = ext;
         if(IMAGES_EXT.includes(`.${ext}`)){
             sc.switchPage('image');
@@ -443,18 +453,12 @@ class AttachManager(BaseComponent):
                                         **thkwargs)
         th.view.top.bar.replaceSlots('#','2,searchOn,*',toolbar=False,background='#DBDBDB',border_bottom='1px solid silver')
         readerpane = bc.contentPane(region='center',childname='atcviewer',overflow='hidden')
-        iframe = readerpane.iframe(src='^.reader_url',height='100%',width='100%',border=0,documentClasses=True,
-                        avoidCache=True,
-                        connect_onload="""
-                            if(this.domNode.getAttribute('src') && this.domNode.getAttribute('src').indexOf('.pdf')<0){
-                                var cw = this.domNode.contentWindow;
-                                cw.document.body.style.zoom = GET .currentPreviewZoom;
-                            }
-                            """)
         readerpane.dataController('SET .reader_url=fileurl',fileurl='^.th.view.grid.selectedId?fileurl')
+        readerpane.attachmentPreviewViewer(src='^.reader_url',
+                                    currentPreviewZoom='^.currentPreviewZoom')
         bar = frame.top.slotToolbar('2,vtitle,*,previewZoom,delrowbtn',vtitle=title or '!!Attachments')
         bar.previewZoom.horizontalSlider(value='^.currentPreviewZoom', minimum=0, maximum=1,
-                                 intermediateChanges=False, width='15em',default_value=.5)
+                                 intermediateChanges=False, width='15em',default_value=0)
         bar.delrowbtn.slotButton('!!Delete attachment',iconClass='iconbox delete_row',
                         action='gr.publish("delrow")',gr=th.view.grid)
 
@@ -478,13 +482,6 @@ class AttachManager(BaseComponent):
                                 totalrows='^.store?totalrows',
                                 table=th.view.grid.attributes['table'],
                                 maintable_id=maintable_id.replace('^','=') if maintable_id else '=#FORM.pkey')
-        readerpane.dataController("""
-                                    if(iframe.getAttribute('src') && iframe.getAttribute('src').indexOf('.pdf')<0){
-                                        iframe.contentWindow.document.body.style.zoom = currentPreviewZoom;
-                                    }
-                                    """,iframe=iframe.js_domNode,
-                        currentPreviewZoom='^.currentPreviewZoom')
-
         return frame
 
     @public_method
@@ -527,7 +524,7 @@ class AttachManager(BaseComponent):
         bar = getattr(frame,toolbarPosition).bar.replaceSlots('#','2,mbslot,15,changeName,15,copyUrl,*,previewZoom,externalUrl,2')
         bar.previewZoom.horizontalSlider(value='^.form.currentPreviewZoom', minimum=0, maximum=1,
                                         hidden='^.form.viewerMode?=#v!="image"',
-                                        intermediateChanges=True, width='15em',default_value=1)
+                                        intermediateChanges=True, width='15em',default_value=0)
         fb = bar.changeName.div(_class='iconbox tag',hidden='^.form.controller.is_newrecord',tip='!!Change description').tooltipPane(
                 connect_onClose='FIRE .saveDescription;',
             ).div(padding='10px').formbuilder(cols=1,border_spacing='3px',datapath='.form.record')


### PR DESCRIPTION
## Summary
- Add CSS class-based fit-to-container mode for image previews in attachment manager
- Zoom slider at 0 = fit image to container (max-width/max-height/object-fit:contain), slider > 0 = free zoom
- Replace direct iframe with `attachmentPreviewViewer` in `at_attachmentGallery`, removing manual zoom JS
- Pass `currentPreviewZoom` through `_atc_viewerStack` to enable zoom/fit in `attachmentMultiButtonFrame`
- Default slider value changed to 0 (fit mode) in both gallery and multibutton contexts
- Improve file extension parsing using `parseURL` instead of manual string splitting

## Test plan
- [x] Open a large JPEG/PNG attachment in `attachmentMultiButtonFrame` — image should fit within the container
- [x] Move the zoom slider above 0 — image should zoom freely, losing fit constraints
- [x] Move the slider back to 0 — image should snap back to fit mode
- [x] Verify PDF attachments continue to display correctly in the iframe viewer
- [x] Verify video attachments continue to play with controls
- [x] Test `at_attachmentGallery` with images, PDFs, and videos
- [x] Click on a fitted image — should open in a new tab at full size