### PR TITLE
fix(sql): update GnrSqlMissingTable import path in ep_table.py

### DIFF
--- a/projects/gnrcore/packages/sys/webpages/ep_table.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from gnr.sql.gnrsql import GnrSqlMissingTable
+from gnr.sql.gnrsql_exceptions import GnrSqlMissingTable
 from gnr.core.gnrstring import templateReplace
 from gnr.core.gnrbag import Bag
 AUTH_FORBIDDEN = -1


### PR DESCRIPTION
## Summary
- Update import of `GnrSqlMissingTable` in `ep_table.py` from `gnr.sql.gnrsql` to `gnr.sql.gnrsql_exceptions`
- Fixes broken import after the gnrsql.py refactoring into a sub-package (#501)

## Test plan
- [x] Verified new import path resolves correctly
- [x] No behavioral changes — only import path updated
- [x] CI tests pass