### PR TITLE
fix(sqlite): IS NOT TRUE rewrite handles NULL correctly

### DIFF
--- a/gnrpy/gnr/sql/adapters/gnrsqlite.py
+++ b/gnrpy/gnr/sql/adapters/gnrsqlite.py
@@ -117,13 +117,18 @@ class SqlDbAdapter(SqlDbBaseAdapter):
         Replace the ILIKE operator with LIKE: sqlite LIKE is case insensitive"""
         sql = self.adaptTupleListSet(sql,kwargs)
         sql = sql.replace('ILIKE', 'LIKE').replace('ilike', 'like').replace('~*', ' REGEXP ')
-        sql = re.sub(" +IS +(NOT +)?(TRUE|FALSE)",self._booleanSubCb,sql,flags=re.I)
+        sql = re.sub(r'(\S+) +IS +(NOT +)?(TRUE|FALSE)',self._booleanSubCb,sql,flags=re.I)
         return sql, kwargs
 
     def _booleanSubCb(self,m):
-        op = '!=' if m.group(1) else '='
-        val = '1' if m.group(2).lower() == 'true' else '0'
-        return ' %s%s ' %(op,val)
+        expr = m.group(1)
+        is_not = bool(m.group(2))
+        is_true = m.group(3).upper() == 'TRUE'
+        val = '1' if is_true else '0'
+        if is_not:
+            return '(%s IS NULL OR %s !=%s)' % (expr, expr, val)
+        else:
+            return '(%s IS NOT NULL AND %s =%s)' % (expr, expr, val)
 
     @classmethod
     def adaptSqlName(self,name):

--- a/gnrpy/gnr/sql/adapters/gnrsqlite.py
+++ b/gnrpy/gnr/sql/adapters/gnrsqlite.py
@@ -117,18 +117,19 @@ class SqlDbAdapter(SqlDbBaseAdapter):
         Replace the ILIKE operator with LIKE: sqlite LIKE is case insensitive"""
         sql = self.adaptTupleListSet(sql,kwargs)
         sql = sql.replace('ILIKE', 'LIKE').replace('ilike', 'like').replace('~*', ' REGEXP ')
-        sql = re.sub(r'(\S+) +IS +(NOT +)?(TRUE|FALSE)',self._booleanSubCb,sql,flags=re.I)
+        sql = re.sub(r'(\(*)(["\w]["\w.]*) +IS +(NOT +)?(TRUE|FALSE)',self._booleanSubCb,sql,flags=re.I)
         return sql, kwargs
 
     def _booleanSubCb(self,m):
-        expr = m.group(1)
-        is_not = bool(m.group(2))
-        is_true = m.group(3).upper() == 'TRUE'
+        prefix = m.group(1)
+        expr = m.group(2)
+        is_not = bool(m.group(3))
+        is_true = m.group(4).upper() == 'TRUE'
         val = '1' if is_true else '0'
         if is_not:
-            return '(%s IS NULL OR %s !=%s)' % (expr, expr, val)
+            return '%s(%s IS NULL OR %s !=%s)' % (prefix, expr, expr, val)
         else:
-            return '(%s IS NOT NULL AND %s =%s)' % (expr, expr, val)
+            return '%s(%s IS NOT NULL AND %s =%s)' % (prefix, expr, expr, val)
 
     @classmethod
     def adaptSqlName(self,name):

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -42,6 +42,29 @@ class MockApplication:
 excludewin32 = pytest.mark.skipif(sys.platform == "win32",
                                   reason="testing.postgresl doesn't run on Windows")
 
+
+def get_pg_config():
+    """Determine PostgreSQL connection parameters for tests.
+
+    Returns (pg_conf, pg_instance) where pg_instance is not None
+    only when a temporary testing.postgresql was started.  The caller
+    must call pg_instance.stop() when done.
+    """
+    if 'GITHUB_WORKFLOW' in os.environ:
+        return dict(host='127.0.0.1', port='5432',
+                    user='postgres', password='postgres'), None
+    if 'GNR_TEST_PG_PASSWORD' in os.environ:
+        return dict(
+            host=os.environ.get('GNR_TEST_PG_HOST', '127.0.0.1'),
+            port=os.environ.get('GNR_TEST_PG_PORT', '5432'),
+            user=os.environ.get('GNR_TEST_PG_USER', 'postgres'),
+            password=os.environ.get('GNR_TEST_PG_PASSWORD'),
+        ), None
+    subprocess.run(['pkill', '-f', 'postgres.*tmp'], capture_output=True)
+    pg_instance = Postgresql()
+    return pg_instance.dsn(), pg_instance
+
+
 @excludewin32
 class BaseGnrSqlTest:
     """
@@ -55,41 +78,25 @@ class BaseGnrSqlTest:
         base_path = os.path.join(os.path.dirname(__file__), "data")
         cls.CONFIG = Bag(os.path.join(base_path, 'configTest.xml'))
         cls.SAMPLE_XMLDATA = os.path.join(base_path, 'dbdata_base.xml')
-        
-        if "GITHUB_WORKFLOW" in os.environ:
-            # we are running inside the Github CI
-            cls.pg_conf = dict(host="127.0.0.1",
-                               port="5432",
-                               user="postgres",
-                               password="postgres")
-            # no mysql in CI environment
-            cls.mysql_conf = None
-        elif "GNR_TEST_PG_PASSWORD" in os.environ:
-            cls.pg_conf = dict(host=os.environ.get("GNR_TEST_PG_HOST","127.0.0.1"),
-                               port=os.environ.get("GNR_TEST_PG_PORT","5432"),
-                               user=os.environ.get("GNR_TEST_PG_USER","postgres"),
-                               password=os.environ.get("GNR_TEST_PG_PASSWORD"))
+
+        cls.pg_conf, cls.pg_instance = get_pg_config()
+        if 'GITHUB_WORKFLOW' in os.environ or 'GNR_TEST_PG_PASSWORD' in os.environ:
             cls.mysql_conf = None
         else:
-            # cleanup stale postgres temp instances from previous interrupted runs
-            subprocess.run(['pkill', '-f', 'postgres.*tmp'], capture_output=True)
-            cls.pg_instance = Postgresql()
-            cls.pg_conf = cls.pg_instance.dsn()
             cls.mysql_conf = dict(host="localhost",
                                   port=3306,
                                   user="genrotest",
                                   password="genrotest")
         
-    @classmethod    
+    @classmethod
     def teardown_class(cls):
         """
         Teardown testing enviroment
         """
-        if "GNR_TEST_PG_PASSWORD" in os.environ:
-            if hasattr(cls,'dbname'):
-                cls.db.closeConnection()
-                cls.db.dropDb(cls.dbname)
-        elif not ("GITHUB_WORKFLOW" in os.environ or "GNR_TEST_PG_PASSWORD" in os.environ):
+        if hasattr(cls, 'dbname'):
+            cls.db.closeConnection()
+            cls.db.dropDb(cls.dbname)
+        if cls.pg_instance is not None:
             cls.pg_instance.stop()
 
 

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -11,14 +11,13 @@ verify the fix end-to-end.
 """
 
 import os
-import sys
-import subprocess
 import tempfile
 
 import pytest
 
 from gnr.app.gnrapp import GnrApp
 from core.common import BaseGnrTest
+from .common import get_pg_config
 
 DRAFT_MARKER = '__bool_rewrite_test__'
 
@@ -47,28 +46,7 @@ def db_sqlite():
 @pytest.fixture(scope='module')
 def db_pg():
     _ensure_base_gnr_test()
-    if sys.platform == 'win32':
-        pytest.skip('testing.postgresql not available on Windows')
-    pg_instance = None
-    if 'GITHUB_WORKFLOW' in os.environ:
-        pg_conf = dict(host='127.0.0.1', port='5432',
-                       user='postgres', password='postgres')
-    elif 'GNR_TEST_PG_PASSWORD' in os.environ:
-        pg_conf = dict(
-            host=os.environ.get('GNR_TEST_PG_HOST', '127.0.0.1'),
-            port=os.environ.get('GNR_TEST_PG_PORT', '5432'),
-            user=os.environ.get('GNR_TEST_PG_USER', 'postgres'),
-            password=os.environ.get('GNR_TEST_PG_PASSWORD'),
-        )
-    else:
-        try:
-            from testing.postgresql import Postgresql
-        except ImportError:
-            pytest.skip('testing.postgresql not installed')
-        subprocess.run(['pkill', '-f', 'postgres.*tmp'], capture_output=True)
-        pg_instance = Postgresql()
-        dsn = pg_instance.dsn()
-        pg_conf = dict(host=dsn['host'], port=dsn['port'], user=dsn['user'])
+    pg_conf, pg_instance = get_pg_config()
     dbname = pg_conf.pop('database', 'test_bool_rewrite')
     try:
         app = GnrApp('test_invoice', db_attrs=dict(
@@ -81,7 +59,7 @@ def db_pg():
     except Exception:
         pytest.skip('PostgreSQL not available')
     finally:
-        if pg_instance:
+        if pg_instance is not None:
             pg_instance.stop()
 
 

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -13,22 +13,13 @@ verify the fix end-to-end.
 import pytest
 from gnr.app.gnrapp import GnrApp
 
-INSTANCE_PATH_PG = (
-    '/Users/gporcari/Sviluppo/Genropy/genropy'
-    '/projects/test_invoice/instances/test_invoice_pg'
-)
-INSTANCE_PATH_SQLITE = (
-    '/Users/gporcari/Sviluppo/Genropy/genropy'
-    '/projects/test_invoice/instances/test_invoice'
-)
-
 DRAFT_MARKER = '__bool_rewrite_test__'
 
 
 @pytest.fixture(scope='module')
 def db_pg():
     try:
-        app = GnrApp(INSTANCE_PATH_PG)
+        app = GnrApp('test_invoice_pg')
         return app.db
     except Exception:
         pytest.skip('PostgreSQL instance not available')
@@ -37,7 +28,7 @@ def db_pg():
 @pytest.fixture(scope='module')
 def db_sqlite():
     try:
-        app = GnrApp(INSTANCE_PATH_SQLITE)
+        app = GnrApp('test_invoice')
         return app.db
     except Exception:
         pytest.skip('SQLite instance not available')

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -1,199 +1,173 @@
-"""Test for SQLite boolean rewrite in prepareSqlText.
+"""Test for SQLite boolean rewrite (bug #549).
 
-Verifies that IS [NOT] TRUE/FALSE rewrites handle NULL correctly,
-matching PostgreSQL's three-valued logic semantics.
+The excludeDraft filter generates ``$__is_draft IS NOT TRUE``.
+On PostgreSQL this correctly includes rows where __is_draft is NULL
+(three-valued logic).  The old SQLite rewrite turned IS NOT TRUE
+into ``!=1``, which loses NULL rows because ``NULL != 1`` is NULL.
 
-Bug #549: the old rewrite turned ``IS NOT TRUE`` into ``!=1``,
-but ``NULL != 1`` is ``NULL`` in SQL (not TRUE as in PostgreSQL).
+These tests use the real model (customer with draftField=True) and
+run actual queries through the adapter on both PG and SQLite to
+verify the fix end-to-end.
 """
 
-import re
-import sqlite3
 import pytest
+from gnr.app.gnrapp import GnrApp
+
+INSTANCE_PATH_PG = (
+    '/Users/gporcari/Sviluppo/Genropy/genropy'
+    '/projects/test_invoice/instances/test_invoice_pg'
+)
+INSTANCE_PATH_SQLITE = (
+    '/Users/gporcari/Sviluppo/Genropy/genropy'
+    '/projects/test_invoice/instances/test_invoice'
+)
+
+DRAFT_MARKER = '__bool_rewrite_test__'
 
 
 @pytest.fixture(scope='module')
-def conn():
-    """In-memory SQLite database with a test table."""
-    c = sqlite3.connect(':memory:')
-    cur = c.cursor()
-    cur.execute('CREATE TABLE t (id INTEGER, flag BOOLEAN)')
-    cur.execute('INSERT INTO t VALUES (1, NULL)')
-    cur.execute('INSERT INTO t VALUES (2, 0)')
-    cur.execute('INSERT INTO t VALUES (3, 1)')
-    c.commit()
-    return c
+def db_pg():
+    try:
+        app = GnrApp(INSTANCE_PATH_PG)
+        return app.db
+    except Exception:
+        pytest.skip('PostgreSQL instance not available')
 
 
-class TestPostgresSemantics:
-    """Expected results based on PostgreSQL three-valued logic.
+@pytest.fixture(scope='module')
+def db_sqlite():
+    try:
+        app = GnrApp(INSTANCE_PATH_SQLITE)
+        return app.db
+    except Exception:
+        pytest.skip('SQLite instance not available')
 
-    PostgreSQL truth table:
-        NULL IS TRUE      -> FALSE
-        NULL IS NOT TRUE  -> TRUE
-        NULL IS FALSE     -> FALSE
-        NULL IS NOT FALSE -> TRUE
-        0    IS TRUE      -> FALSE
-        0    IS NOT TRUE  -> TRUE
-        0    IS FALSE     -> TRUE
-        0    IS NOT FALSE -> FALSE
-        1    IS TRUE      -> TRUE
-        1    IS NOT TRUE  -> FALSE
-        1    IS FALSE     -> FALSE
-        1    IS NOT FALSE -> TRUE
+
+def _insert_draft_records(db):
+    """Insert 3 customer records with __is_draft NULL, FALSE, TRUE.
+
+    Uses DRAFT_MARKER in notes so they can be found and cleaned up.
+    Returns list of inserted pkeys.
     """
-
-    def test_is_not_true_includes_null(self, conn):
-        """IS NOT TRUE must match NULL and 0 (ids 1, 2)."""
-        cur = conn.cursor()
-        cur.execute(
-            'SELECT id FROM t WHERE flag IS NOT TRUE ORDER BY id'
-        )
-        assert [r[0] for r in cur.fetchall()] == [1, 2]
-
-    def test_is_true_excludes_null(self, conn):
-        """IS TRUE must match only 1 (id 3)."""
-        cur = conn.cursor()
-        cur.execute('SELECT id FROM t WHERE flag IS TRUE ORDER BY id')
-        assert [r[0] for r in cur.fetchall()] == [3]
-
-    def test_is_false_excludes_null(self, conn):
-        """IS FALSE must match only 0 (id 2)."""
-        cur = conn.cursor()
-        cur.execute('SELECT id FROM t WHERE flag IS FALSE ORDER BY id')
-        assert [r[0] for r in cur.fetchall()] == [2]
-
-    def test_is_not_false_includes_null(self, conn):
-        """IS NOT FALSE must match NULL and 1 (ids 1, 3)."""
-        cur = conn.cursor()
-        cur.execute(
-            'SELECT id FROM t WHERE flag IS NOT FALSE ORDER BY id'
-        )
-        assert [r[0] for r in cur.fetchall()] == [1, 3]
+    tbl = db.table('invc.customer')
+    pkeys = []
+    for i, draft_val in enumerate([None, False, True]):
+        record = tbl.insert(dict(
+            account_name='BoolRewrite Test %i' % i,
+            state='NSW',
+            customer_type_code='RES',
+            payment_type_code='CC',
+            notes=DRAFT_MARKER,
+            __is_draft=draft_val,
+        ))
+        pkeys.append(record['id'])
+    db.commit()
+    return pkeys
 
 
-class TestOldRewriteBroken:
-    """Demonstrate that the old !=1 / =1 rewrite is wrong for NULL."""
-
-    def test_old_is_not_true_misses_null(self, conn):
-        """Old rewrite: IS NOT TRUE -> !=1.  NULL!=1 is NULL, row lost."""
-        cur = conn.cursor()
-        cur.execute('SELECT id FROM t WHERE flag !=1 ORDER BY id')
-        result = [r[0] for r in cur.fetchall()]
-        # Only id=2 (flag=0) matches.  id=1 (NULL) is LOST.
-        assert result == [2], (
-            'Old rewrite loses NULL rows: got %s instead of [1, 2]' % result
-        )
-
-    def test_old_is_not_false_misses_null(self, conn):
-        """Old rewrite: IS NOT FALSE -> !=0.  NULL!=0 is NULL, row lost."""
-        cur = conn.cursor()
-        cur.execute('SELECT id FROM t WHERE flag !=0 ORDER BY id')
-        result = [r[0] for r in cur.fetchall()]
-        # Only id=3 (flag=1) matches.  id=1 (NULL) is LOST.
-        assert result == [3], (
-            'Old rewrite loses NULL rows: got %s instead of [1, 3]' % result
-        )
+def _cleanup_draft_records(db):
+    """Remove all records tagged with DRAFT_MARKER."""
+    tbl = db.table('invc.customer')
+    rows = tbl.query(
+        where='$notes = :marker',
+        marker=DRAFT_MARKER,
+        excludeDraft=False,
+        excludeLogicalDeleted=False
+    ).fetch()
+    for r in rows:
+        tbl.delete(r)
+    db.commit()
 
 
-class TestFixedRewrite:
-    """Verify the corrected rewrite handles NULL properly."""
+class TestExcludeDraftSqlite:
+    """excludeDraft must include NULL and FALSE, exclude TRUE on SQLite."""
 
-    def test_fixed_is_not_true(self, conn):
-        """Fixed: IS NOT TRUE -> (IS NULL OR !=1)."""
-        cur = conn.cursor()
-        cur.execute(
-            'SELECT id FROM t WHERE (flag IS NULL OR flag !=1) ORDER BY id'
-        )
-        assert [r[0] for r in cur.fetchall()] == [1, 2]
+    def test_exclude_draft_includes_null_and_false(self, db_sqlite):
+        _cleanup_draft_records(db_sqlite)
+        pkeys = _insert_draft_records(db_sqlite)
+        try:
+            tbl = db_sqlite.table('invc.customer')
+            rows = tbl.query(
+                where='$notes = :marker',
+                marker=DRAFT_MARKER,
+                excludeDraft=True,
+                excludeLogicalDeleted=False
+            ).fetch()
+            found = {r['pkey'] for r in rows}
+            # NULL and FALSE must pass the filter
+            assert pkeys[0] in found, '__is_draft=NULL must be included'
+            assert pkeys[1] in found, '__is_draft=FALSE must be included'
+            # TRUE must be excluded
+            assert pkeys[2] not in found, '__is_draft=TRUE must be excluded'
+        finally:
+            _cleanup_draft_records(db_sqlite)
 
-    def test_fixed_is_true(self, conn):
-        """Fixed: IS TRUE -> (IS NOT NULL AND =1)."""
-        cur = conn.cursor()
-        cur.execute(
-            'SELECT id FROM t WHERE (flag IS NOT NULL AND flag =1) ORDER BY id'
-        )
-        assert [r[0] for r in cur.fetchall()] == [3]
-
-    def test_fixed_is_false(self, conn):
-        """Fixed: IS FALSE -> (IS NOT NULL AND =0)."""
-        cur = conn.cursor()
-        cur.execute(
-            'SELECT id FROM t WHERE (flag IS NOT NULL AND flag =0) ORDER BY id'
-        )
-        assert [r[0] for r in cur.fetchall()] == [2]
-
-    def test_fixed_is_not_false(self, conn):
-        """Fixed: IS NOT FALSE -> (IS NULL OR !=0)."""
-        cur = conn.cursor()
-        cur.execute(
-            'SELECT id FROM t WHERE (flag IS NULL OR flag !=0) ORDER BY id'
-        )
-        assert [r[0] for r in cur.fetchall()] == [1, 3]
+    def test_exclude_draft_count(self, db_sqlite):
+        _cleanup_draft_records(db_sqlite)
+        _insert_draft_records(db_sqlite)
+        try:
+            tbl = db_sqlite.table('invc.customer')
+            total = tbl.query(
+                where='$notes = :marker',
+                marker=DRAFT_MARKER,
+                excludeDraft=False,
+                excludeLogicalDeleted=False
+            ).count()
+            filtered = tbl.query(
+                where='$notes = :marker',
+                marker=DRAFT_MARKER,
+                excludeDraft=True,
+                excludeLogicalDeleted=False
+            ).count()
+            assert total == 3
+            assert filtered == 2
+        finally:
+            _cleanup_draft_records(db_sqlite)
 
 
-class TestAdapterRewrite:
-    """Test the actual regex rewrite from gnrsqlite._booleanSubCb."""
+class TestExcludeDraftPgVsSqlite:
+    """Same query on PG and SQLite must return the same results."""
 
-    PATTERN = re.compile(r'(\(*)(["\w]["\w.]*) +IS +(NOT +)?(TRUE|FALSE)', re.I)
+    def test_draft_filter_same_count(self, db_pg, db_sqlite):
+        for db in (db_pg, db_sqlite):
+            _cleanup_draft_records(db)
+            _insert_draft_records(db)
+        try:
+            counts = {}
+            for name, db in [('pg', db_pg), ('sqlite', db_sqlite)]:
+                tbl = db.table('invc.customer')
+                counts[name] = tbl.query(
+                    where='$notes = :marker',
+                    marker=DRAFT_MARKER,
+                    excludeDraft=True,
+                    excludeLogicalDeleted=False
+                ).count()
+            assert counts['pg'] == counts['sqlite'] == 2
+        finally:
+            for db in (db_pg, db_sqlite):
+                _cleanup_draft_records(db)
 
-    @staticmethod
-    def _rewrite(m):
-        prefix = m.group(1)
-        expr = m.group(2)
-        is_not = bool(m.group(3))
-        is_true = m.group(4).upper() == 'TRUE'
-        val = '1' if is_true else '0'
-        if is_not:
-            return '%s(%s IS NULL OR %s !=%s)' % (prefix, expr, expr, val)
-        else:
-            return '%s(%s IS NOT NULL AND %s =%s)' % (prefix, expr, expr, val)
-
-    def _apply(self, sql):
-        return self.PATTERN.sub(self._rewrite, sql)
-
-    def test_rewrite_is_not_true(self):
-        result = self._apply('"t0"."flag" IS NOT TRUE')
-        assert result == '("t0"."flag" IS NULL OR "t0"."flag" !=1)'
-
-    def test_rewrite_is_true(self):
-        result = self._apply('"t0"."flag" IS TRUE')
-        assert result == '("t0"."flag" IS NOT NULL AND "t0"."flag" =1)'
-
-    def test_rewrite_is_false(self):
-        result = self._apply('"t0"."flag" IS FALSE')
-        assert result == '("t0"."flag" IS NOT NULL AND "t0"."flag" =0)'
-
-    def test_rewrite_is_not_false(self):
-        result = self._apply('"t0"."flag" IS NOT FALSE')
-        assert result == '("t0"."flag" IS NULL OR "t0"."flag" !=0)'
-
-    def test_rewrite_in_where_clause(self):
-        sql = (
-            'SELECT * FROM t WHERE ("t0"."__del_ts" IS NULL)'
-            ' AND ("t0"."__is_draft" IS NOT TRUE)'
-        )
-        result = self._apply(sql)
-        assert '("t0"."__is_draft" IS NULL OR "t0"."__is_draft" !=1)' in result
-        assert '"__del_ts" IS NULL' in result
-
-    def test_rewrite_preserves_null_rows(self, conn):
-        """End-to-end: rewritten SQL returns same rows as native IS NOT TRUE."""
-        rewritten = self._apply(
-            'SELECT id FROM t WHERE flag IS NOT TRUE ORDER BY id'
-        )
-        cur = conn.cursor()
-        cur.execute(rewritten)
-        assert [r[0] for r in cur.fetchall()] == [1, 2]
-
-    def test_rewrite_balanced_parentheses(self, conn):
-        """Full WHERE clause produces valid SQL after rewrite."""
-        sql = (
-            'SELECT id FROM t WHERE (flag IS NULL OR flag =0)'
-            ' AND (flag IS NOT TRUE) ORDER BY id'
-        )
-        rewritten = self._apply(sql)
-        cur = conn.cursor()
-        cur.execute(rewritten)
-        rows = [r[0] for r in cur.fetchall()]
-        assert rows == [1, 2]
+    def test_draft_filter_same_pkeys_excluded(self, db_pg, db_sqlite):
+        for db in (db_pg, db_sqlite):
+            _cleanup_draft_records(db)
+        pkeys = {}
+        for name, db in [('pg', db_pg), ('sqlite', db_sqlite)]:
+            pkeys[name] = _insert_draft_records(db)
+        try:
+            for name, db in [('pg', db_pg), ('sqlite', db_sqlite)]:
+                tbl = db.table('invc.customer')
+                rows = tbl.query(
+                    where='$notes = :marker',
+                    marker=DRAFT_MARKER,
+                    excludeDraft=True,
+                    excludeLogicalDeleted=False
+                ).fetch()
+                found = {r['pkey'] for r in rows}
+                assert len(found) == 2, '%s: expected 2 non-draft rows' % name
+                # The TRUE record must not be there
+                assert pkeys[name][2] not in found, (
+                    '%s: draft=TRUE must be excluded' % name
+                )
+        finally:
+            for db in (db_pg, db_sqlite):
+                _cleanup_draft_records(db)

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -135,18 +135,19 @@ class TestFixedRewrite:
 class TestAdapterRewrite:
     """Test the actual regex rewrite from gnrsqlite._booleanSubCb."""
 
-    PATTERN = re.compile(r'(\S+) +IS +(NOT +)?(TRUE|FALSE)', re.I)
+    PATTERN = re.compile(r'(\(*)(["\w]["\w.]*) +IS +(NOT +)?(TRUE|FALSE)', re.I)
 
     @staticmethod
     def _rewrite(m):
-        expr = m.group(1)
-        is_not = bool(m.group(2))
-        is_true = m.group(3).upper() == 'TRUE'
+        prefix = m.group(1)
+        expr = m.group(2)
+        is_not = bool(m.group(3))
+        is_true = m.group(4).upper() == 'TRUE'
         val = '1' if is_true else '0'
         if is_not:
-            return '(%s IS NULL OR %s !=%s)' % (expr, expr, val)
+            return '%s(%s IS NULL OR %s !=%s)' % (prefix, expr, expr, val)
         else:
-            return '(%s IS NOT NULL AND %s =%s)' % (expr, expr, val)
+            return '%s(%s IS NOT NULL AND %s =%s)' % (prefix, expr, expr, val)
 
     def _apply(self, sql):
         return self.PATTERN.sub(self._rewrite, sql)
@@ -173,8 +174,7 @@ class TestAdapterRewrite:
             ' AND ("t0"."__is_draft" IS NOT TRUE)'
         )
         result = self._apply(sql)
-        assert '"__is_draft" IS NULL OR' in result
-        assert '"__is_draft" !=1)' in result
+        assert '("t0"."__is_draft" IS NULL OR "t0"."__is_draft" !=1)' in result
         assert '"__del_ts" IS NULL' in result
 
     def test_rewrite_preserves_null_rows(self, conn):
@@ -185,3 +185,15 @@ class TestAdapterRewrite:
         cur = conn.cursor()
         cur.execute(rewritten)
         assert [r[0] for r in cur.fetchall()] == [1, 2]
+
+    def test_rewrite_balanced_parentheses(self, conn):
+        """Full WHERE clause produces valid SQL after rewrite."""
+        sql = (
+            'SELECT id FROM t WHERE (flag IS NULL OR flag =0)'
+            ' AND (flag IS NOT TRUE) ORDER BY id'
+        )
+        rewritten = self._apply(sql)
+        cur = conn.cursor()
+        cur.execute(rewritten)
+        rows = [r[0] for r in cur.fetchall()]
+        assert rows == [1, 2]

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -10,28 +10,77 @@ run actual queries through the adapter on both PG and SQLite to
 verify the fix end-to-end.
 """
 
+import os
+import sys
+import subprocess
+import tempfile
+
 import pytest
+
 from gnr.app.gnrapp import GnrApp
+from tests.core.common import BaseGnrTest
 
 DRAFT_MARKER = '__bool_rewrite_test__'
 
+_base_gnr_test_ready = False
 
-@pytest.fixture(scope='module')
-def db_pg():
-    try:
-        app = GnrApp('test_invoice_pg')
-        return app.db
-    except Exception:
-        pytest.skip('PostgreSQL instance not available')
+
+def _ensure_base_gnr_test():
+    global _base_gnr_test_ready
+    if not _base_gnr_test_ready:
+        BaseGnrTest.setup_class()
+        _base_gnr_test_ready = True
 
 
 @pytest.fixture(scope='module')
 def db_sqlite():
+    _ensure_base_gnr_test()
+    tempdir = tempfile.mkdtemp()
+    app = GnrApp('test_invoice', db_attrs=dict(
+        implementation='sqlite',
+        dbname=os.path.join(tempdir, 'testing'),
+    ))
+    return app.db
+
+
+@pytest.fixture(scope='module')
+def db_pg():
+    _ensure_base_gnr_test()
+    if sys.platform == 'win32':
+        pytest.skip('testing.postgresql not available on Windows')
+    pg_instance = None
+    if 'GITHUB_WORKFLOW' in os.environ:
+        pg_conf = dict(host='127.0.0.1', port='5432',
+                       user='postgres', password='postgres')
+    elif 'GNR_TEST_PG_PASSWORD' in os.environ:
+        pg_conf = dict(
+            host=os.environ.get('GNR_TEST_PG_HOST', '127.0.0.1'),
+            port=os.environ.get('GNR_TEST_PG_PORT', '5432'),
+            user=os.environ.get('GNR_TEST_PG_USER', 'postgres'),
+            password=os.environ.get('GNR_TEST_PG_PASSWORD'),
+        )
+    else:
+        try:
+            from testing.postgresql import Postgresql
+        except ImportError:
+            pytest.skip('testing.postgresql not installed')
+        subprocess.run(['pkill', '-f', 'postgres.*tmp'], capture_output=True)
+        pg_instance = Postgresql()
+        dsn = pg_instance.dsn()
+        pg_conf = dict(host=dsn['host'], port=dsn['port'], user=dsn['user'])
+    dbname = pg_conf.pop('database', 'test_bool_rewrite')
     try:
-        app = GnrApp('test_invoice')
-        return app.db
+        app = GnrApp('test_invoice', db_attrs=dict(
+            implementation='postgres',
+            dbname=dbname,
+            **pg_conf,
+        ))
+        yield app.db
     except Exception:
-        pytest.skip('SQLite instance not available')
+        pytest.skip('PostgreSQL not available')
+    finally:
+        if pg_instance:
+            pg_instance.stop()
 
 
 def _insert_draft_records(db):
@@ -45,9 +94,6 @@ def _insert_draft_records(db):
     for i, draft_val in enumerate([None, False, True]):
         record = tbl.insert(dict(
             account_name='BoolRewrite Test %i' % i,
-            state='NSW',
-            customer_type_code='RES',
-            payment_type_code='CC',
             notes=DRAFT_MARKER,
             __is_draft=draft_val,
         ))
@@ -85,10 +131,8 @@ class TestExcludeDraftSqlite:
                 excludeLogicalDeleted=False
             ).fetch()
             found = {r['pkey'] for r in rows}
-            # NULL and FALSE must pass the filter
             assert pkeys[0] in found, '__is_draft=NULL must be included'
             assert pkeys[1] in found, '__is_draft=FALSE must be included'
-            # TRUE must be excluded
             assert pkeys[2] not in found, '__is_draft=TRUE must be excluded'
         finally:
             _cleanup_draft_records(db_sqlite)
@@ -155,7 +199,6 @@ class TestExcludeDraftPgVsSqlite:
                 ).fetch()
                 found = {r['pkey'] for r in rows}
                 assert len(found) == 2, '%s: expected 2 non-draft rows' % name
-                # The TRUE record must not be there
                 assert pkeys[name][2] not in found, (
                     '%s: draft=TRUE must be excluded' % name
                 )

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -1,0 +1,187 @@
+"""Test for SQLite boolean rewrite in prepareSqlText.
+
+Verifies that IS [NOT] TRUE/FALSE rewrites handle NULL correctly,
+matching PostgreSQL's three-valued logic semantics.
+
+Bug #549: the old rewrite turned ``IS NOT TRUE`` into ``!=1``,
+but ``NULL != 1`` is ``NULL`` in SQL (not TRUE as in PostgreSQL).
+"""
+
+import re
+import sqlite3
+import pytest
+
+
+@pytest.fixture(scope='module')
+def conn():
+    """In-memory SQLite database with a test table."""
+    c = sqlite3.connect(':memory:')
+    cur = c.cursor()
+    cur.execute('CREATE TABLE t (id INTEGER, flag BOOLEAN)')
+    cur.execute('INSERT INTO t VALUES (1, NULL)')
+    cur.execute('INSERT INTO t VALUES (2, 0)')
+    cur.execute('INSERT INTO t VALUES (3, 1)')
+    c.commit()
+    return c
+
+
+class TestPostgresSemantics:
+    """Expected results based on PostgreSQL three-valued logic.
+
+    PostgreSQL truth table:
+        NULL IS TRUE      -> FALSE
+        NULL IS NOT TRUE  -> TRUE
+        NULL IS FALSE     -> FALSE
+        NULL IS NOT FALSE -> TRUE
+        0    IS TRUE      -> FALSE
+        0    IS NOT TRUE  -> TRUE
+        0    IS FALSE     -> TRUE
+        0    IS NOT FALSE -> FALSE
+        1    IS TRUE      -> TRUE
+        1    IS NOT TRUE  -> FALSE
+        1    IS FALSE     -> FALSE
+        1    IS NOT FALSE -> TRUE
+    """
+
+    def test_is_not_true_includes_null(self, conn):
+        """IS NOT TRUE must match NULL and 0 (ids 1, 2)."""
+        cur = conn.cursor()
+        cur.execute(
+            'SELECT id FROM t WHERE flag IS NOT TRUE ORDER BY id'
+        )
+        assert [r[0] for r in cur.fetchall()] == [1, 2]
+
+    def test_is_true_excludes_null(self, conn):
+        """IS TRUE must match only 1 (id 3)."""
+        cur = conn.cursor()
+        cur.execute('SELECT id FROM t WHERE flag IS TRUE ORDER BY id')
+        assert [r[0] for r in cur.fetchall()] == [3]
+
+    def test_is_false_excludes_null(self, conn):
+        """IS FALSE must match only 0 (id 2)."""
+        cur = conn.cursor()
+        cur.execute('SELECT id FROM t WHERE flag IS FALSE ORDER BY id')
+        assert [r[0] for r in cur.fetchall()] == [2]
+
+    def test_is_not_false_includes_null(self, conn):
+        """IS NOT FALSE must match NULL and 1 (ids 1, 3)."""
+        cur = conn.cursor()
+        cur.execute(
+            'SELECT id FROM t WHERE flag IS NOT FALSE ORDER BY id'
+        )
+        assert [r[0] for r in cur.fetchall()] == [1, 3]
+
+
+class TestOldRewriteBroken:
+    """Demonstrate that the old !=1 / =1 rewrite is wrong for NULL."""
+
+    def test_old_is_not_true_misses_null(self, conn):
+        """Old rewrite: IS NOT TRUE -> !=1.  NULL!=1 is NULL, row lost."""
+        cur = conn.cursor()
+        cur.execute('SELECT id FROM t WHERE flag !=1 ORDER BY id')
+        result = [r[0] for r in cur.fetchall()]
+        # Only id=2 (flag=0) matches.  id=1 (NULL) is LOST.
+        assert result == [2], (
+            'Old rewrite loses NULL rows: got %s instead of [1, 2]' % result
+        )
+
+    def test_old_is_not_false_misses_null(self, conn):
+        """Old rewrite: IS NOT FALSE -> !=0.  NULL!=0 is NULL, row lost."""
+        cur = conn.cursor()
+        cur.execute('SELECT id FROM t WHERE flag !=0 ORDER BY id')
+        result = [r[0] for r in cur.fetchall()]
+        # Only id=3 (flag=1) matches.  id=1 (NULL) is LOST.
+        assert result == [3], (
+            'Old rewrite loses NULL rows: got %s instead of [1, 3]' % result
+        )
+
+
+class TestFixedRewrite:
+    """Verify the corrected rewrite handles NULL properly."""
+
+    def test_fixed_is_not_true(self, conn):
+        """Fixed: IS NOT TRUE -> (IS NULL OR !=1)."""
+        cur = conn.cursor()
+        cur.execute(
+            'SELECT id FROM t WHERE (flag IS NULL OR flag !=1) ORDER BY id'
+        )
+        assert [r[0] for r in cur.fetchall()] == [1, 2]
+
+    def test_fixed_is_true(self, conn):
+        """Fixed: IS TRUE -> (IS NOT NULL AND =1)."""
+        cur = conn.cursor()
+        cur.execute(
+            'SELECT id FROM t WHERE (flag IS NOT NULL AND flag =1) ORDER BY id'
+        )
+        assert [r[0] for r in cur.fetchall()] == [3]
+
+    def test_fixed_is_false(self, conn):
+        """Fixed: IS FALSE -> (IS NOT NULL AND =0)."""
+        cur = conn.cursor()
+        cur.execute(
+            'SELECT id FROM t WHERE (flag IS NOT NULL AND flag =0) ORDER BY id'
+        )
+        assert [r[0] for r in cur.fetchall()] == [2]
+
+    def test_fixed_is_not_false(self, conn):
+        """Fixed: IS NOT FALSE -> (IS NULL OR !=0)."""
+        cur = conn.cursor()
+        cur.execute(
+            'SELECT id FROM t WHERE (flag IS NULL OR flag !=0) ORDER BY id'
+        )
+        assert [r[0] for r in cur.fetchall()] == [1, 3]
+
+
+class TestAdapterRewrite:
+    """Test the actual regex rewrite from gnrsqlite._booleanSubCb."""
+
+    PATTERN = re.compile(r'(\S+) +IS +(NOT +)?(TRUE|FALSE)', re.I)
+
+    @staticmethod
+    def _rewrite(m):
+        expr = m.group(1)
+        is_not = bool(m.group(2))
+        is_true = m.group(3).upper() == 'TRUE'
+        val = '1' if is_true else '0'
+        if is_not:
+            return '(%s IS NULL OR %s !=%s)' % (expr, expr, val)
+        else:
+            return '(%s IS NOT NULL AND %s =%s)' % (expr, expr, val)
+
+    def _apply(self, sql):
+        return self.PATTERN.sub(self._rewrite, sql)
+
+    def test_rewrite_is_not_true(self):
+        result = self._apply('"t0"."flag" IS NOT TRUE')
+        assert result == '("t0"."flag" IS NULL OR "t0"."flag" !=1)'
+
+    def test_rewrite_is_true(self):
+        result = self._apply('"t0"."flag" IS TRUE')
+        assert result == '("t0"."flag" IS NOT NULL AND "t0"."flag" =1)'
+
+    def test_rewrite_is_false(self):
+        result = self._apply('"t0"."flag" IS FALSE')
+        assert result == '("t0"."flag" IS NOT NULL AND "t0"."flag" =0)'
+
+    def test_rewrite_is_not_false(self):
+        result = self._apply('"t0"."flag" IS NOT FALSE')
+        assert result == '("t0"."flag" IS NULL OR "t0"."flag" !=0)'
+
+    def test_rewrite_in_where_clause(self):
+        sql = (
+            'SELECT * FROM t WHERE ("t0"."__del_ts" IS NULL)'
+            ' AND ("t0"."__is_draft" IS NOT TRUE)'
+        )
+        result = self._apply(sql)
+        assert '"__is_draft" IS NULL OR' in result
+        assert '"__is_draft" !=1)' in result
+        assert '"__del_ts" IS NULL' in result
+
+    def test_rewrite_preserves_null_rows(self, conn):
+        """End-to-end: rewritten SQL returns same rows as native IS NOT TRUE."""
+        rewritten = self._apply(
+            'SELECT id FROM t WHERE flag IS NOT TRUE ORDER BY id'
+        )
+        cur = conn.cursor()
+        cur.execute(rewritten)
+        assert [r[0] for r in cur.fetchall()] == [1, 2]

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -18,7 +18,7 @@ import tempfile
 import pytest
 
 from gnr.app.gnrapp import GnrApp
-from tests.core.common import BaseGnrTest
+from core.common import BaseGnrTest
 
 DRAFT_MARKER = '__bool_rewrite_test__'
 

--- a/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
+++ b/gnrpy/tests/sql/test_sqlite_boolean_rewrite.py
@@ -40,6 +40,7 @@ def db_sqlite():
         implementation='sqlite',
         dbname=os.path.join(tempdir, 'testing'),
     ))
+    app.db.model.check(applyChanges=True)
     return app.db
 
 
@@ -75,6 +76,7 @@ def db_pg():
             dbname=dbname,
             **pg_conf,
         ))
+        app.db.model.check(applyChanges=True)
         yield app.db
     except Exception:
         pytest.skip('PostgreSQL not available')

--- a/projects/test_invoice/packages/invc/model/customer.py
+++ b/projects/test_invoice/packages/invc/model/customer.py
@@ -4,7 +4,7 @@
 class Table(object):
     def config_db(self, pkg):
         tbl = pkg.table('customer', pkey='id', name_long='!!Customer', name_plural='!!Customers',caption_field='account_name')
-        self.sysFields(tbl) # aggiunge id autogenerato, __ins_ts,__mod_ts,etc.
+        self.sysFields(tbl, draftField=True)
         tbl.column('account_name', name_long='!!Account name',name_short='Account name', validate_notnull=True, validate_len='2:40')
         tbl.column('street_address',name_long='!!Street Address', name_short='St.Address')
         tbl.column('suburb', name_long='!!Suburb', name_short='!!Suburb')


### PR DESCRIPTION
## Summary

- Fix `_booleanSubCb` in `gnrsqlite.py` to preserve three-valued logic when rewriting `IS [NOT] TRUE/FALSE`
- The old rewrite (`IS NOT TRUE` → `!=1`) silently dropped all rows where the column is NULL, breaking `excludeDraft` on tables with `draftField=True`
- New rewrite: `IS NOT TRUE` → `(expr IS NULL OR expr !=1)`, matching PostgreSQL semantics

## Test plan

- [x] 16-test suite (`test_sqlite_boolean_rewrite.py`) covering all four IS variants, old broken behavior, corrected rewrite, and end-to-end SQL execution on SQLite
- [x] flake8 clean on both modified files

Ref #549