### PR TITLE
fix(dom): guard against undefined headers in scrollableTable

### DIFF
--- a/gnrjs/gnr_d11/js/genro_dom.js
+++ b/gnrjs/gnr_d11/js/genro_dom.js
@@ -1502,7 +1502,7 @@ dojo.declare("gnr.GnrDomHandler", null, {
             });
         }
         var tblclass = kw.tblclass;
-        let noHeader = headers.length==1 && headers[0]=='*'
+        let noHeader = headers && headers.length==1 && headers[0]=='*'
         let thead_style = noHeader? 'style="display:none;"':'';
         var thead = `<thead ${thead_style} onmouseup="dojo.stopEvent(event)"><tr>`;
         var autoWidth = true;


### PR DESCRIPTION
## Summary

- Fix regression from commit `43f3a48a` ("template auxColumns") that crashes `scrollableTable` when called with `kw.struct` instead of `kw.headers`
- When `headers` is `undefined`, `headers.length` throws `TypeError: Cannot read properties of undefined (reading 'length')`
- Added a guard check (`headers &&`) before accessing `.length`, so struct-based callers (like `mastrini.js`) work correctly

## Test plan

- [ ] Open erpy, navigate to operazioni, click "Mastrini" → palette opens without JS errors
- [ ] Verify that `auxColumns_template` lookups (headers-based path in `genro_patch.js`) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)