### PR TITLE
fix(#556): resolve USER-DEFINED type mapping in migrator

### DIFF
--- a/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
@@ -646,7 +646,7 @@ class PostgresSqlDbBaseAdapter(SqlDbBaseAdapter):
                 s.schema_name,
                 t.table_name,
                 c.column_name,
-                c.data_type,
+                CASE WHEN c.data_type = 'USER-DEFINED' THEN c.udt_name ELSE c.data_type END AS data_type,
                 c.character_maximum_length,
                 c.is_nullable,
                 c.column_default,


### PR DESCRIPTION
## Summary

- When PostgreSQL reports `data_type = 'USER-DEFINED'` in `information_schema.columns` (for enum, composite types, etc.), the migrator now uses `udt_name` instead of the generic string `USER-DEFINED`
- This allows `model.check()` to correctly identify the real column type and avoid false migration diffs

## Test plan

- [ ] Run `model.check()` on a database with enum/composite columns and verify no spurious changes are reported
- [ ] Verify existing migration tests still pass

Ref #556