### PR TITLE
fix(adm): hide email formlet from user preferences

### DIFF
--- a/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/general/email.py
+++ b/projects/gnrcore/packages/adm/resources/tables/user_setting/formlet/general/email.py
@@ -4,7 +4,8 @@ info = {
     "code":'email',
     "caption":"!![en]Email",
     "priority":1,
-    "editing_path":"adm"
+    "editing_path":"adm",
+    "tags":"NOBODY"
 }
 
 class Formlet(BaseComponent):


### PR DESCRIPTION
## Summary
- Add `"tags":"NOBODY"` to the email formlet `info` dict so it is never displayed in user preferences
- The SMTP credentials panel (host, username, password, port, TLS/SSL) was visible to all users, including on mobile
- This is a conservative fix that hides the formlet entirely until proper admin-only permission handling is implemented

## Linked Issue
Closes #539

## Test plan
- [x] Verify the email formlet no longer appears in user preferences for any user
- [x] Verify other user preference formlets (fonts, shortcuts, etc.) are unaffected
- [x] All 1040 automated tests pass