### PR TITLE
fix(dbo): remove hardcoded table in hierarchical update trigger

### DIFF
--- a/gnrpy/gnr/app/gnrdbo.py
+++ b/gnrpy/gnr/app/gnrdbo.py
@@ -600,7 +600,7 @@ class TableBase(object):
         record[fldname] = root_record['id']
 
     def trigger_updateLinkedHierarchicalRoot(self,record,fldname,old_record=None,**kwargs):
-        htbl = self.column(fldname).relatedTable()
+        htbl = self.column(fldname).relatedTable().dbtable
         hierarchical = htbl.attributes.get('hierarchical')
         updater = {}
         if hierarchical is not True:
@@ -608,8 +608,7 @@ class TableBase(object):
                 if record.get(k) is not None:
                     updater[k] = record.get(k)
         if self.fieldsChanged(','.join(updater.keys()),record,old_record):
-            with self.db.table('srvy.question'
-                ).recordToUpdate(record[fldname]) as rec:
+            with htbl.recordToUpdate(record[fldname]) as rec:
                 rec.update(updater)
         
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `self.db.table('srvy.question')` reference in `trigger_updateLinkedHierarchicalRoot`
- Use dynamically resolved `htbl` via `self.column(fldname).relatedTable().dbtable`, consistent with the sibling `trigger_insertLinkedHierarchicalRoot` method
- The hardcoded reference was introduced in the original commit (0cdfa6b2a) and made the update trigger only work for `srvy.question` instead of being generic

## Test plan
- [x] All 1040 tests pass
- [ ] Manual verification with a table using `hierarchical_linked_to`