### PR TITLE
feat(grouplets): improvements after real-world grouplet usage

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase.css
+++ b/gnrjs/gnr_d11/css/gnrbase.css
@@ -6072,6 +6072,13 @@ div[disabled='true'], div[disabled='disabled']{
     background-color:lightyellow;
 }
 
+.grouplet_chunk_box{
+    border: 1px solid silver;
+    border-radius: 4px;
+    padding: 4px 8px;
+    min-height: 14px;
+}
+
 .theme_variant_green .theme_background{
     background-color: #306227;
     color: white;

--- a/gnrjs/gnr_d11/js/genro_dlg.js
+++ b/gnrjs/gnr_d11/js/genro_dlg.js
@@ -470,8 +470,10 @@ dojo.declare("gnr.GnrDlgHandler", null, {
             genro.src.getNode()._('div',label);
             return genro.src.getNode(label).clearValue();
         }
+        const skipTags = new Set(['dataformula', 'datascript', 'datacontroller', 
+                                'datarpc', 'button', 'slotbutton', 'lightbutton']);
         let roottag = rootNode.attr.tag.toLowerCase();
-        while(roottag == 'dataformula' || roottag == 'datascript' || roottag == 'datacontroller' || roottag == 'datarpc' || roottag == 'button' || roottag == 'slotbutton'){
+        while(skipTags.has(roottag)){
             rootNode = rootNode.getParentNode();
             roottag = rootNode.attr.tag.toLowerCase();
         }

--- a/projects/gnrcore/packages/test/webpages/gnrwdg/grouplet_chunk_test.py
+++ b/projects/gnrcore/packages/test/webpages/gnrwdg/grouplet_chunk_test.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+"""Test page for groupletChunk struct_method - real DB record editing"""
+
+from gnr.core.gnrdecorator import public_method
+
+
+class GnrCustomWebPage(object):
+    py_requires = """gnrcomponents/testhandler:TestHandlerFull,
+                     gnrcomponents/formhandler:FormHandler,
+                     gnrcomponents/grouplet:GroupletHandler"""
+
+    def _comune_form(self, pane, frameCode, datapath):
+        """Shared form setup: frameForm + formStore + dbselect selector"""
+        form = pane.frameForm(frameCode=frameCode,
+                             height='500px', width='700px',
+                             datapath=datapath,
+                             border='1px solid silver',
+                             pkeyPath='.comune_pkey',
+                             _anchor=True)
+        form.formStore(table='glbl.comune', storeType='Item',
+                      handler='recordCluster', startKey='*norecord*')
+        bar = form.top.slotToolbar('5,selector,*,semaphore,locker,5')
+        fb = bar.selector.formbuilder(cols=1, border_spacing='1px')
+        fb.dbselect(value='^.comune_pkey', table='glbl.comune',
+                   parentForm=False,
+                   validate_onAccept="""if(userChange){
+                       this.getParentNode().form.publish('load',{destPkey:value})
+                   }""",
+                   lbl='Comune')
+        return form
+
+    def test_1_chunk_with_handler(self, pane):
+        """Editable fields + groupletChunk with handler for extra data"""
+        form = self._comune_form(pane, 'chunk_handler', '.handler_form')
+        center = form.center.contentPane(padding='10px', datapath='.record')
+        fb = center.formlet(cols=2, border_spacing='3px',
+                               table='glbl.comune')
+        fb.field('denominazione', colspan=2, width='100%')
+        fb.field('sigla_provincia')
+        fb.field('codice_comune')
+        fb.field('capoluogo')
+        chunk_pane = fb.div(colspan=2, width='100%', lbl='Territorio',
+                           height='60px')
+        chunk_pane.groupletChunk(
+            value='^.record',
+            template="""
+            <div style="color:#555;">
+                ${<span>Zona altimetrica: $zona_altimetrica</span>}
+                ${<span style="margin-left:8px;">Alt. $altitudine m</span>}
+            </div>
+            ${<div style="color:#555;">Comune montano: $comune_montano</div>}
+            """,
+            name='edit_territorio',
+            handler=self.grp_territorio,
+            title='Edit Territorio')
+
+    def test_2_chunk_with_resource(self, pane):
+        """Editable fields + groupletChunk with resource grouplet"""
+        form = self._comune_form(pane, 'chunk_resource', '.resource_form')
+        center = form.center.contentPane(padding='10px', datapath='.record')
+        fb = center.formlet(cols=2, border_spacing='3px',
+                               table='glbl.comune')
+        fb.field('zona_altimetrica')
+        fb.field('altitudine')
+        fb.field('comune_montano')
+        chunk_pane = fb.div(colspan=2, width='100%', lbl='Anagrafica',
+                           height='50px')
+        chunk_pane.groupletChunk(
+            value='^.record',
+            template="""
+            <div style="font-weight:bold;">$denominazione</div>
+            <div style="color:#555;">$sigla_provincia - $codice_comune</div>
+            """,
+            name='edit_anagrafica_res',
+            resource='anagrafica',
+            table='glbl.comune',
+            title='Edit Anagrafica')
+
+    def test_3_chunk_with_box_kwargs(self, pane):
+        """Editable fields + groupletChunk with box_ kwargs and virtual_columns"""
+        form = self._comune_form(pane, 'chunk_box', '.box_form')
+        center = form.center.contentPane(padding='10px', datapath='.record')
+        fb = center.formlet(cols=2, border_spacing='3px',
+                               table='glbl.comune')
+        fb.field('denominazione', colspan=2, width='100%')
+        fb.field('capoluogo')
+        fb.field('comune_montano')
+        chunk_pane = fb.div(colspan=2, width='100%', lbl='Dettagli',
+                           height='70px')
+        chunk_pane.groupletChunk(
+            value='^.record',
+            template="""
+            <div>$sigla_provincia - $codice_comune</div>
+            <div style="color:#555;">
+                ${<span>Altitudine: $altitudine m</span>}
+                ${<span style="margin-left:8px;">Zona: $zona_altimetrica</span>}
+            </div>
+            """,
+            name='edit_dettagli',
+            handler=self.grp_dettagli,
+            title='Edit Dettagli',
+            virtual_columns='zona_altimetrica,altitudine',
+            box_padding='5px',
+            box_background='#f9f9f9',
+            box_border_radius='4px')
+
+    @public_method
+    def grp_territorio(self, pane, **kwargs):
+        fb = pane.formlet(cols=2, border_spacing='3px',
+                             table='glbl.comune')
+        fb.field('zona_altimetrica')
+        fb.field('altitudine')
+        fb.field('comune_montano')
+
+    @public_method
+    def grp_dettagli(self, pane, **kwargs):
+        fb = pane.formlet(cols=2, border_spacing='3px',
+                             table='glbl.comune')
+        fb.field('sigla_provincia')
+        fb.field('codice_comune')
+        fb.field('zona_altimetrica')
+        fb.field('altitudine')

--- a/resources/common/gnrcomponents/grouplet.py
+++ b/resources/common/gnrcomponents/grouplet.py
@@ -1,7 +1,8 @@
-from gnr.core.gnrdecorator import public_method
+from gnr.core.gnrdecorator import extract_kwargs, public_method
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrlang import gnrImport
 from gnr.web.gnrbaseclasses import BaseComponent
+from gnr.web.gnrwebstruct import struct_method
 
 
 class GroupletHandler(BaseComponent):
@@ -10,7 +11,11 @@ class GroupletHandler(BaseComponent):
     def gr_loadGrouplet(self, pane, resource=None, table=None,
                         handlername=None, valuepath=None, **kwargs):
         grouplet_module = None
-        if resource:
+        if not resource:
+            if not handlername:
+                raise self.exception('generic', msg='Missing resource or method for handling grouplet')
+            handler = self.getPublicMethod('remote', handlername)
+        else:
             handlername = handlername or 'grouplet_main'
             if ':' not in resource:
                 resource = f'{resource}:Grouplet'
@@ -19,10 +24,47 @@ class GroupletHandler(BaseComponent):
             else:
                 mixinedClass = self.mixinComponent(resource)
             grouplet_module = getattr(mixinedClass, '__top_mixined_module', None)
-        if not handlername:
-            raise self.exception('generic', msg='Missing resource or method for handling grouplet')
+            handler = getattr(self, handlername)
         box = pane.contentPane(datapath=valuepath, grouplet_module=grouplet_module)
-        return getattr(self, handlername)(box, **kwargs)
+        return handler(box, **kwargs)
+
+    @extract_kwargs(grouplet=True,template=True,btn=True)
+    @struct_method
+    def gr_groupletChunk(self, pane, value=None, template=None, name=None,
+                         handler=None, resource=None, table=None,
+                         title=None,
+                         virtual_columns=None,
+                         grouplet_kwargs=None,template_kwargs=None,
+                         btn_kwargs=None, **kwargs):
+        root_kw = {}
+        if virtual_columns:
+            root_kw['_virtual_columns'] = virtual_columns
+        btn_kwargs.setdefault('_class','iconbox pencil')
+        btn_kwargs.setdefault('height','14px')
+        btn_kwargs.setdefault('position','absolute')
+        btn_kwargs.setdefault('bottom','2px')
+        btn_kwargs.setdefault('right','2px')
+        kwargs.setdefault('_class', 'grouplet_chunk_box')
+
+        root = pane.div(position='relative',**kwargs)
+        template_kwargs['template'] = template
+        template_kwargs['datasource'] = value
+        root.div(**template_kwargs) #templatechunk
+        btn = root.lightButton(**btn_kwargs)
+        grouplet_kwargs['value'] = value.replace('^','')
+        if resource:
+            grouplet_kwargs['resource'] = resource
+        if table:
+            grouplet_kwargs['table'] = table
+        if title:
+            grouplet_kwargs['title'] = title
+        if handler:
+            grouplet_kwargs['handler'] = handler
+        btn.dataController("""
+            let editor_kw = {..._kwargs};
+            genro.dlg.memoryDataEditor(name,editor_kw,this);
+        """,name=name, **grouplet_kwargs)
+        return root
 
     @public_method
     def gr_getGroupletMenu(self, table=None, **kwargs):


### PR DESCRIPTION
## Summary
- Use `getPublicMethod` for RPC handler resolution in `gr_loadGrouplet` instead of bare `getattr`, ensuring only decorated public methods are callable
- Add `groupletChunk` struct_method: reusable pattern for template display with inline pencil edit button and `memoryDataEditor` dialog, supporting `handler`, `resource`, `table`, `virtual_columns`, and `extract_kwargs` prefixes (`grouplet_*`, `template_*`, `btn_*`)
- Add `lightbutton` to skipTags in `_resolveDialogRoot` (genro_dlg.js) and refactor the `||` chain to a `Set` for readability
- Add `.grouplet_chunk_box` CSS class for bordered chunk styling with min-height
- Add `grouplet_chunk_test.py` test page with 3 scenarios using real `glbl.comune` DB records

## Test plan
- [x] All 1304 existing tests pass (verified locally)
- [x] flake8 passes with zero errors on modified files
- [x] Manual test: load `grouplet_chunk_test.py`, select a comune, verify template display and pencil edit dialog