### PR TITLE
fix(sql): restore guessPkey lost in gnrsqltable split

### DIFF
--- a/gnrpy/gnr/sql/gnrsqltable/record.py
+++ b/gnrpy/gnr/sql/gnrsqltable/record.py
@@ -270,6 +270,37 @@ class RecordMixin:
             data, in_cache = cb(cache=localcache, **kwargs)
         return data
 
+    def guessPkey(self, identifier, tolerant=False):
+        if identifier is None:
+            return
+        def cb(cache=None, identifier=None, **kwargs):
+            if identifier in cache:
+                return cache[identifier], True
+            codeField = None
+            result = None
+            if ':' in identifier:
+                wherelist = []
+                wherekwargs = dict()
+
+                for cond in identifier.split(','):
+                    cond = cond.strip()
+                    codeField, codeVal = cond.split(':')
+                    if codeVal is None or codeVal == '':
+                        continue
+                    cf = '${}'.format(codeField) if not (codeField.startswith('$') or codeField.startswith('@')) else codeField
+                    vf = codeField.replace('@', '_').replace('.', '_').replace('$', '')
+                    wherelist.append('%s ILIKE :v_%s' % (cf, vf) if tolerant else '%s = :v_%s' % (cf, vf))
+                    wherekwargs['v_%s' % vf] = codeVal
+                result = self.readColumns(columns='$%s' % self.pkey, where=' AND '.join(wherelist),
+                                        subtable='*', **wherekwargs)
+            elif hasattr(self, 'sysRecord_%s' % identifier):
+                result = self.sysRecord(identifier)[self.pkey]
+            elif self.pkey != 'id' or not codeField:
+                result = identifier
+            cache[identifier] = result
+            return result, False
+        return self.tableCachedData('guessedPkey', cb, identifier=identifier)
+
     # ------------------------------------------------------------------
     #  Record retrieval
     # ------------------------------------------------------------------


### PR DESCRIPTION
## URGENT

`guessPkey` was lost during the `gnrsqltable.py` → `gnrsqltable/` sub-package split (PR #506).

The method is still called by `serialization.py:120` (`importFromXmlDump`) — any XML import with FK values using `:` syntax (field-based lookup) raises `AttributeError`.

## Fix

Restored `guessPkey` in `gnrsqltable/record.py` (next to `tableCachedData` which it calls).

## Verification

Full AST comparison between old `gnrsqltable.py` and current sub-package: **192/192 methods match** (signatures, decorators, defaults, class attributes all identical).

Ref #506