### PR TITLE
fix(#569): increase default page_max_age from 120s to 600s

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -38,7 +38,7 @@ from gnr.web.gnrwsgisite_proxy.gnrresourceloader import ResourceLoader
 from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import LegacyStorageHandler
 from gnr.web.gnrwsgisite_proxy.gnrstatichandler import StaticHandlerManager
 from gnr.web.gnrwsgisite_proxy.gnrpwahandler import PWAHandler
-from gnr.web.gnrwsgisite_proxy.gnrsiteregister import SiteRegisterClient
+from gnr.web.gnrwsgisite_proxy.gnrsiteregister import SiteRegisterClient, DEFAULT_PAGE_MAX_AGE
 from gnr.web.gnrwsgisite_proxy.gnrwebsockethandler import WsgiWebSocketHandler
 
 try:
@@ -514,7 +514,7 @@ class GnrWsgiSite(object):
 
         cleanup = self.custom_config.getAttr('cleanup') or dict()
         self.cleanup_interval = int(cleanup.get('interval') or 120)
-        self.page_max_age = int(cleanup.get('page_max_age') or 120)
+        self.page_max_age = int(cleanup.get('page_max_age') or DEFAULT_PAGE_MAX_AGE)
         self.connection_max_age = int(cleanup.get('connection_max_age')or 600)
 
         self.db.closeConnection()

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrsiteregister.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrsiteregister.py
@@ -41,6 +41,7 @@ if hasattr(Pyro4.config, 'REQUIRE_EXPOSE'):
 
 OLD_HMAC_MODE = hasattr(Pyro4.config,'HMAC_KEY')
 DAEMON_TIMEOUT_START = 5
+DEFAULT_PAGE_MAX_AGE = 600
 PROCESS_SELFDESTROY_TIMEOUT = 600
 
 class GnrDaemonException(Exception):
@@ -641,7 +642,7 @@ class SiteRegister(BaseRemoteObject):
     def setConfiguration(self,cleanup=None):
         cleanup = cleanup or dict()
         self.cleanup_interval = int(cleanup.get('interval') or 120)
-        self.page_max_age = int(cleanup.get('page_max_age') or 120)
+        self.page_max_age = int(cleanup.get('page_max_age') or DEFAULT_PAGE_MAX_AGE)
         self.guest_connection_max_age = int(cleanup.get('guest_connection_max_age') or 40)
         self.connection_max_age = int(cleanup.get('connection_max_age')or 600)
 


### PR DESCRIPTION
## Summary

- Introduce `DEFAULT_PAGE_MAX_AGE = 600` constant in `gnrsiteregister.py`
- Replace hardcoded `120` with the constant in both `gnrsiteregister.py` and `gnrwsgisite.py`
- Prevents page cleanup during long-running batch operations

## Test plan

- [x] Verify that pages are not dropped during batch operations lasting up to 10 minutes
- [x] Verify that custom `page_max_age` in site config still overrides the default

Ref #569