### PR TITLE
fix: cache raw request body before parsing parameters

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1054,6 +1054,7 @@ class GnrWsgiSite(object):
         """TODO
 
         :param params: TODO"""
+        request.get_data(cache=True)
         out_dict = dict()
         for source in (request.values, request.files):
             for name,value in source.lists():


### PR DESCRIPTION
## Summary

- `parse_request_params` accesses `request.values` which consumes the WSGI input stream
- After that, `request.data` returns empty bytes `b''`
- Webhook endpoints need the raw body for HMAC signature verification
- Adding `request.get_data(cache=True)` before `request.values` preserves the raw body in Werkzeug's internal cache
- One line change, fully backward compatible

## Context

This was discovered while implementing GitHub webhook endpoints in gnrgh. The HMAC verification requires the exact raw bytes sent by GitHub, but `request.data` was always empty because `request.values` had already consumed the stream.

## Test plan

- [x] Verified on production server (sourcerer.genropy.net): webhook HMAC verification passes after this fix
- [x] No impact on existing form/file uploads (they continue to work via `request.values`)