### PR TITLE
fix: resolve required_columns for pyColumns in th_hiddencolumns

### DIFF
--- a/resources/common/th/th_view.py
+++ b/resources/common/th/th_view.py
@@ -1141,6 +1141,24 @@ class TableHandlerView(BaseComponent):
     def th_slotbar_pageHooksSelector(self,pane,**kwargs):
         pane.multiButton(items='^.viewPages',value='^.viewPage',identifier='pageName')
       
+    def _th_addRequiredColumns(self, tblobj, hiddencolumns):
+        if not hiddencolumns:
+            return hiddencolumns
+        columns = [c.strip() for c in hiddencolumns.split(',')]
+        for col in list(columns):
+            colname = col.lstrip('$')
+            colobj = tblobj.model.column(colname)
+            if colobj is None:
+                continue
+            req = colobj.attributes.get('required_columns')
+            if not req:
+                continue
+            for rc in req.split(','):
+                rc = rc.strip()
+                if rc and rc not in columns:
+                    columns.append(rc)
+        return ','.join(columns)
+
     @struct_method
     def th_gridPane(self, frame,table=None,th_pkey=None,
                         virtualStore=None,condition=None,unlinkdict=None,
@@ -1206,7 +1224,7 @@ class TableHandlerView(BaseComponent):
         gridattr.update(rowsPerPage=rowsPerPage,
                         dropTypes=None,dropTarget=True,
                         
-                        hiddencolumns=self._th_hook('hiddencolumns',mangler=th_root)(),
+                        hiddencolumns=self._th_addRequiredColumns(tblobj, self._th_hook('hiddencolumns',mangler=th_root)()),
                         dragClass='draggedItem',
                         selfsubscribe_runbtn="""
                             var currLinkedSelection = GET .#parent.linkedSelectionPars;


### PR DESCRIPTION
## Summary
- Added `_th_addRequiredColumns` method in `th_view.py` that inspects the model for each hidden column and appends any missing `required_columns` to the hiddencolumns string
- When a pyColumn with `required_columns` (e.g. `filepath_endpoint_url` requiring `$external_url,$filepath`) was listed in `th_hiddencolumns`, the required columns were not included in the query — causing errors. The JS `columnsFromStruct` already handles this for struct columns, but `hiddencolumns` are appended as a raw string bypassing that logic
- The fix resolves `required_columns` server-side before passing `hiddencolumns` to the grid

## Linked Issue
Closes #577

## Test plan
- [ ] Verify pyColumn with `required_columns` works in `th_hiddencolumns` (no error)
- [ ] Verify pyColumn with `required_columns` still works in `th_struct` via `fieldcell` (no regression)
- [ ] Verify `th_hiddencolumns` without `required_columns` still works unchanged
- [ ] All automated tests pass (1303 passed, 147 skipped)