### PR TITLE
fix: preserve unique constraint on columns in composite primary keys (closes #576)

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmigration/orm_extractor.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration/orm_extractor.py
@@ -209,10 +209,14 @@ class OrmExtractor:
         pkeys = table_json['attributes']['pkeys']
 
         # Primary key columns are automatically NOT NULL
-        # and don't need a separate index or UNIQUE constraint
+        # and don't need a separate index (PK already creates one).
+        # For single-column PKs, unique is also redundant (PK implies uniqueness).
+        # For composite PKs, individual columns may still need their own
+        # UNIQUE constraint (issue #576).
         if pkeys and (column_name in pkeys.split(',')):
             attributes['notnull'] = '_auto_'
-            attributes.pop('unique', None)
+            if ',' not in pkeys:
+                attributes.pop('unique', None)
             attributes.pop('indexed', None)
 
         column_entity = new_column_item(

--- a/gnrpy/tests/sql/test_gnrsqlmigration.py
+++ b/gnrpy/tests/sql/test_gnrsqlmigration.py
@@ -189,6 +189,26 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
         check_value = 'CREATE TABLE "alfa"."alfa_recipe_row" ("recipe_code" character varying(12) NOT NULL , "recipe_line" bigint NOT NULL , "description" text , "ingredient_id" bigint , PRIMARY KEY (recipe_code,recipe_line));'
         self.checkChanges(check_value)
 
+    def test_05c1_composite_pkey_with_unique_column(self):
+        """Columns in a composite PK should retain individual unique constraints (issue #576)."""
+        pkg = self.src.package('alfa')
+        tbl = pkg.table('test_composite_unique', pkey='composite_key')
+        tbl.compositeColumn('composite_key', columns='field_a,field_b')
+        tbl.column('field_a', size='5')
+        tbl.column('field_b', size='5', unique=True)
+        tbl.column('field_c', size='5', unique=True)
+        check_value = ('CREATE TABLE "alfa"."alfa_test_composite_unique"(\n'
+                       ' "field_a" character(5) NOT NULL,\n'
+                       ' "field_b" character(5) NOT NULL,\n'
+                       ' "field_c" character(5),\n'
+                       ' PRIMARY KEY (field_a,field_b)\n'
+                       ');\n'
+                       'ALTER TABLE "alfa"."alfa_test_composite_unique"\n'
+                       'ADD CONSTRAINT "cst_f65e94e4" UNIQUE ("field_b");\n'
+                       'ALTER TABLE "alfa"."alfa_test_composite_unique"\n'
+                       'ADD CONSTRAINT "cst_7db93e7e" UNIQUE ("field_c");')
+        self.checkChanges(check_value)
+
     def test_05d_create_table_with_pkey_explicit_unique(self):
         """Tests creating a table with a primary key column."""
         pkg = self.src.package('alfa')


### PR DESCRIPTION
## Summary
- Fix bug where `unique=True` on a column was silently ignored when the column was part of a `compositeColumn` used as the table's primary key
- The ORM extractor now only removes redundant `unique` for single-column PKs (where PK already implies uniqueness), preserving it for composite PK columns
- Added test verifying that a column in a composite PK retains its individual UNIQUE constraint

## Linked Issue
Closes #576

## Test plan
- [x] New test `test_05c1_composite_pkey_with_unique_column` verifies the fix end-to-end against a real PostgreSQL database
- [x] All 112 migration tests pass (both postgres adapters)
- [x] Full test suite passes (1305 passed, 147 skipped)
- [x] flake8 clean on modified files
- [x] Existing test `test_05d_create_table_with_pkey_explicit_unique` confirms single-column PK still correctly drops redundant unique