### PR TITLE
unknown/invalid locale handling (refs #566)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,9 +54,5 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      env:
-        GNR_LOCALE: en_GB
-        LC_ALL: en_GB
-        LANG: en_GB
       run: |
         cd gnrpy/tests &&  pytest core sql web app xtnd

--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -20,7 +20,7 @@
 #License along with this library; if not, write to the Free Software
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-import locale
+
 import sys
 import re
 import types
@@ -39,6 +39,7 @@ from email.mime.text import MIMEText
 
 from gnr.core.gnrclasses import GnrClassCatalog
 from gnr.core.gnrbag import Bag
+from gnr.core.gnrlocale import defaultLocale
 from gnr.core.gnrdecorator import extract_kwargs, deprecated
 from gnr.core.gnrlang import  objectExtract,gnrImport, instanceMixin, GnrException
 from gnr.core.gnrstring import makeSet, toText, splitAndStrip, like, boolean
@@ -1217,11 +1218,8 @@ class GnrApp(object):
 
     @property
     def locale(self):
-        found_locale = self.config_locale or os.environ.get('GNR_LOCALE') or locale.getlocale()[0]
-        if not found_locale:
-            locale.setlocale(locale.LC_ALL, "")
-            found_locale = locale.getlocale(locale.LC_MESSAGES)[0]
-        return (found_locale or 'en-US').replace('_','-')
+        found_locale = self.config_locale or defaultLocale()
+        return (found_locale or 'en-GB').replace('_','-')
 
     def setPreference(self, path, data, pkg):
         if self.db.package('adm'):

--- a/gnrpy/gnr/core/gnrlocale.py
+++ b/gnrpy/gnr/core/gnrlocale.py
@@ -298,10 +298,20 @@ def getQuarterNames(locale=None):
     return d
 
 def defaultLocale():
-    sys_locale = locale.getlocale()[0]
+    static_default = "en_GB"
     if sys.platform == 'win32':
         windll = ctypes.windll.kernel32
         sys_locale = locale.windows_locale[windll.GetUserDefaultUILanguage()]
+    else:
+        sys_locale = locale.getlocale()[0]
+        
+    configured_locale = os.environ.get("GNR_LOCALE", sys_locale) or static_default
+    try:
+        Locale(configured_locale)
+        return configured_locale
+    except:
+        return static_default
+    
     return os.environ.get('GNR_LOCALE', sys_locale) or "en_GB"
 
 def currentLocale(locale=None):

--- a/gnrpy/gnr/sql/gnrsql/env.py
+++ b/gnrpy/gnr/sql/gnrsql/env.py
@@ -29,10 +29,11 @@ state such as ``workdate``, ``locale``, ``storename``, ``user``, etc.
 from __future__ import annotations
 
 import _thread
-import locale as locale_mod
+
 from datetime import date
 from typing import Any
 
+from gnr.core.gnrlocale import defaultLocale
 from gnr.sql.gnrsql.helpers import TempEnv
 
 
@@ -90,7 +91,7 @@ class EnvMixin:
 
         Falls back to the system locale if not explicitly set.
         """
-        return self.currentEnv.get('locale') or locale_mod.getlocale()[0]
+        return self.currentEnv.get('locale') or defaultLocale() 
 
     def _set_locale(self, locale: str) -> None:
         """Set the locale for the current thread."""

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -6,7 +6,7 @@ import pytest
 from testing.postgresql import Postgresql
 
 from gnr.core.gnrbag import Bag
-
+from gnr.core import gnrlocale
 
 class MockCache:
     """Mock cache for testing GnrSqlDb and GnrSqlAppDb"""
@@ -61,6 +61,8 @@ def get_pg_config():
             password=os.environ.get('GNR_TEST_PG_PASSWORD'),
         ), None
     subprocess.run(['pkill', '-f', 'postgres.*tmp'], capture_output=True)
+    # we need to ensure that a proper LANG is set, needed by postgresql's initdb
+    os.environ['LANG'] = "en_GB.UTF-8"
     pg_instance = Postgresql()
     return pg_instance.dsn(), pg_instance
 

--- a/gnrpy/tests/sql/common.py
+++ b/gnrpy/tests/sql/common.py
@@ -6,7 +6,6 @@ import pytest
 from testing.postgresql import Postgresql
 
 from gnr.core.gnrbag import Bag
-from gnr.core import gnrlocale
 
 class MockCache:
     """Mock cache for testing GnrSqlDb and GnrSqlAppDb"""

--- a/gnrpy/tests/sql/test_gnrsql.py
+++ b/gnrpy/tests/sql/test_gnrsql.py
@@ -1,9 +1,9 @@
 import datetime
 import tempfile
-import locale
 
 import pytest
 
+from gnr.core.gnrlocale import defaultLocale
 from gnr.sql import gnrsql as gs
 from .common import BaseGnrSqlTest, MockApplication
 
@@ -67,7 +67,7 @@ class TestGnrSql(BaseGnrSqlTest):
         assert db.workdate == datetime.date.today()
 
         # locale property
-        current_locale = locale.getlocale()[0]
+        current_locale = defaultLocale()
         assert db.locale == current_locale
         db.locale = "it_IT"
         assert db.locale == "it_IT"


### PR DESCRIPTION
The PR include a uniform usage for gnr.core.gnrlocale.defaultLocale, which now handles only babel valid locales. Tests have been updated accordingly, while forcing a locale in the testing.postgresql environment needed by initdb (only related to tests and postgresql execution, not the application)

close #566 
