### PR TITLE
fix: resolve rootNode scoping issue in quickDialog close_action

### DIFF
--- a/gnrjs/gnr_d11/js/genro_dlg.js
+++ b/gnrjs/gnr_d11/js/genro_dlg.js
@@ -468,9 +468,9 @@ dojo.declare("gnr.GnrDlgHandler", null, {
     _resolveDialogRoot:function(rootNode, label){
         if(!rootNode){
             genro.src.getNode()._('div',label);
-            return genro.src.getNode(label).clearValue();
+            return genro.src.getNode();
         }
-        const skipTags = new Set(['dataformula', 'datascript', 'datacontroller', 
+        const skipTags = new Set(['dataformula', 'datascript', 'datacontroller',
                                 'datarpc', 'button', 'slotbutton', 'lightbutton']);
         let roottag = rootNode.attr.tag.toLowerCase();
         while(skipTags.has(roottag)){
@@ -478,7 +478,7 @@ dojo.declare("gnr.GnrDlgHandler", null, {
             roottag = rootNode.attr.tag.toLowerCase();
         }
         rootNode._('div',label,{_attachTo:'mainWindow',parentForm:false});
-        return rootNode.getValue().getNode(label).clearValue();
+        return rootNode;
     },
 
     _groupletForm:function(name, kw,rootNode){
@@ -505,7 +505,8 @@ dojo.declare("gnr.GnrDlgHandler", null, {
             dlgKw.autoSize = false;
             dlgKw.closable = dlgKw.closable !== undefined ? dlgKw.closable : true;
             dlgKw.animateResize = dlgKw.animateResize !== undefined ? dlgKw.animateResize : true;
-            const node = this._resolveDialogRoot(rootNode, 'root_'+dlgId);
+            rootNode = this._resolveDialogRoot(rootNode, 'root_'+dlgId);
+            const node = rootNode.getValue().getNode('root_'+dlgId).clearValue();
             const dlg = node._('dialog', dlgId,dlgKw);
             const loadChunk = pkey ? `genro.formById("${formId}").goToRecord("${pkey}")` : `genro.formById("${formId}").load()`;
             kw.grouplet__onRemote = `setTimeout(() => {genro.nodeById('${dlgId}').widget.adjustDialogSize();${loadChunk};}, 1);`;
@@ -869,7 +870,8 @@ dojo.declare("gnr.GnrDlgHandler", null, {
     quickDialog: function(title,kw,rootNode) {
         kw = objectUpdate({_class:'dlg_prompt'},kw);
         var quickRoot = '_dlg_quick_'+genro.getCounter();
-        var node = this._resolveDialogRoot(rootNode, quickRoot);
+        rootNode = this._resolveDialogRoot(rootNode, quickRoot);
+        var node = rootNode.getValue().getNode(quickRoot).clearValue();
         node.freeze();
         let kwdimension = objectExtract(kw,'height,width,background,padding');
         let bottom_position_kw = {}


### PR DESCRIPTION
## Summary

- Fix regression in `quickDialog` `close_action` that throws `TypeError: Cannot read properties of null (reading 'popNode')` when closing dialogs opened from button/slotbutton nodes
- Root cause: the `_resolveDialogRoot` refactoring moved the rootNode walk-up logic into a separate method, but the caller's `rootNode` parameter was no longer reassigned — the `close_action` closure captured the original (unwalkable) node instead of the resolved parent
- `_resolveDialogRoot` now returns the resolved root node; both callers (`quickDialog` and `_groupletForm`) reassign `rootNode` and extract the child node themselves

## Details

When `quickDialog` is called with a `rootNode` that is a `button`, `slotbutton`, or similar skipTag node, `_resolveDialogRoot` walks up the tree to find a suitable parent and creates the dialog div there. Before the refactoring, this walk happened inline in `quickDialog`, so the local `rootNode` variable (captured by the `close_action` closure) pointed to the correct parent. After the extraction into `_resolveDialogRoot`, the walk only modified a local parameter inside that method — the caller's `rootNode` remained unchanged, pointing to the original button node whose `getValue()` returns `null`.

## Test plan

- [x] Open a page that triggers `quickDialog` from a button/slotbutton node
- [x] Open and close the dialog — no `popNode` TypeError
- [x] Verify grouplet dialogs (`_groupletForm` path) still open and close correctly
- [x] Check browser console for JavaScript errors during dialog lifecycle