### PR TITLE
feat(sql): VECQUERY/VECRANK macros for pgvector similarity

### DIFF
--- a/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
@@ -31,6 +31,15 @@ class MacroExpander(BaseMacroExpander):
                 r"(?P<textfield>[\$\@][\w\.\@]+)\s*"  # Primo parametro: colonna con il testo
                 r"(?:,\s*'(?P<config>[^']+)')?\s*"  # Config opzionale tra apici singoli
                 r"\)"
+        ),
+        'VECQUERY': re.compile(
+                r"#VECQUERY(?:_(?P<querycode>\w+))?\s*\(\s*"
+                r"(?P<veccol>[\$\@][\w\.\@]+)\s*,\s*"
+                r"(?P<target>[:\$\@][\w\.\@]+)\s*"
+                r"\)"
+        ),
+        'VECRANK': re.compile(
+                r"#VECRANK(?:_(?P<code>\w+))?"
         )
     }
 
@@ -74,6 +83,29 @@ class MacroExpander(BaseMacroExpander):
         config = m.group("config") or "StartSel=<mark>, StopSel=</mark>, MaxWords=20, MinWords=5, MaxFragments=99, FragmentDelimiter=<hr/>"
         return f"ts_headline(CAST({language_param} AS regconfig), {text_field}, websearch_to_tsquery(CAST({language_param} AS regconfig), {query_param}), '{config}')"
 
+    def _expand_VECQUERY(self, m):
+        """Expands the #VECQUERY macro into a vector similarity filter condition.
+
+        Usage: #VECQUERY($table.embedding_col, :param_name)
+        Stores vector params in sqlparams and returns a NOT NULL check as filter."""
+        veccol = m.group("veccol").strip()
+        target = m.group("target")
+        channel_code = m.group('querycode') or 'current'
+        sqlparams = self.querycompiler.sqlparams
+        sqlparams[f'vecquery_{channel_code}'] = {'veccol': veccol, 'target': target}
+        return f"{veccol} IS NOT NULL"
+
+    def _expand_VECRANK(self, m):
+        """Expands the #VECRANK macro into a cosine similarity score.
+
+        Returns (1 - cosine_distance) so higher values = more similar.
+        Requires a prior #VECQUERY in the same query (same channel code)."""
+        channel_code = m.group('code') or 'current'
+        sqlparams = self.querycompiler.sqlparams
+        vecquery_params = sqlparams.get(f'vecquery_{channel_code}', {})
+        veccol = vecquery_params['veccol']
+        target = vecquery_params['target']
+        return f"(1 - ({veccol} <=> CAST({target} AS vector)))"
 
 
 class PostgresSqlDbBaseAdapter(SqlDbBaseAdapter):

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -417,7 +417,7 @@ class SqlQueryCompiler(object):
                         sql_text = self.db.queryCompile(table=sq_table,where=sq_where,aliasPrefix=aliasPrefix,addPkeyColumn=False,ignoreTableOrderBy=True,**sq_pars)
                         sql_formula = re.sub('#%s\\b' %susbselect, tpl %sql_text,sql_formula)
                 subreldict = {}
-                sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE')
+                sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE,VECRANK')
                 sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
                 sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
                 sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
@@ -972,7 +972,7 @@ class SqlQueryCompiler(object):
         if where:
             where = BETWEENFINDER.sub(self.expandBetween, where)
             where = PERIODFINDER.sub(self.expandPeriod, where)
-            where = self.macro_expander.replace(where,'TSQUERY')
+            where = self.macro_expander.replace(where,'TSQUERY,VECQUERY')
 
         env_conditions = dictExtract(currentEnv,'env_%s_condition_' %self.tblobj.fullname.replace('.','_'))
         wherelist = [where]
@@ -1095,11 +1095,11 @@ class SqlQueryCompiler(object):
 
         # --- Store all compiled fragments into the SqlCompiledQuery ---
         self.cpl.distinct = distinct
-        self.cpl.columns = self.macro_expander.replace(columns,'TSRANK,TSHEADLINE')
+        self.cpl.columns = self.macro_expander.replace(columns,'TSRANK,TSHEADLINE,VECRANK')
         self.cpl.where = where
         self.cpl.group_by = group_by
         self.cpl.having = having
-        self.cpl.order_by = self.macro_expander.replace(order_by,'TSRANK')
+        self.cpl.order_by = self.macro_expander.replace(order_by,'TSRANK,VECRANK')
         self.cpl.limit = limit
         self.cpl.offset = offset
         self.cpl.for_update = for_update

--- a/gnrpy/tests/sql/test_vecquery_macro.py
+++ b/gnrpy/tests/sql/test_vecquery_macro.py
@@ -1,0 +1,125 @@
+"""Tests for VECQUERY/VECRANK macros in the PostgreSQL MacroExpander.
+
+Verifies regex matching, parameter storage in sqlparams, and SQL expansion
+for vector similarity search macros. Also includes regression tests to
+ensure existing TSQUERY/TSRANK/TSHEADLINE macros are not broken.
+
+Ref #583
+"""
+
+import pytest
+from gnr.sql.adapters._gnrbasepostgresadapter import MacroExpander
+
+
+class FakeQueryCompiler:
+    """Minimal stand-in for SqlQueryCompiler — only needs sqlparams."""
+
+    def __init__(self):
+        self.sqlparams = {}
+
+
+@pytest.fixture
+def expander():
+    return MacroExpander(FakeQueryCompiler())
+
+
+# --- VECQUERY ---
+
+class TestVecquery:
+
+    def test_basic_expansion(self, expander):
+        sql = "#VECQUERY($embedding, :target_vec)"
+        result = expander.replace(sql, 'VECQUERY')
+        assert result == "$embedding IS NOT NULL"
+
+    def test_stores_params(self, expander):
+        expander.replace("#VECQUERY($embedding, :target_vec)", 'VECQUERY')
+        params = expander.querycompiler.sqlparams
+        assert 'vecquery_current' in params
+        assert params['vecquery_current']['veccol'] == '$embedding'
+        assert params['vecquery_current']['target'] == ':target_vec'
+
+    def test_channel_code(self, expander):
+        sql = "#VECQUERY_secondary($other_emb, :other_vec)"
+        result = expander.replace(sql, 'VECQUERY')
+        assert result == "$other_emb IS NOT NULL"
+        assert 'vecquery_secondary' in expander.querycompiler.sqlparams
+
+    def test_dotted_column(self, expander):
+        sql = "#VECQUERY($rel.@table.embedding, :vec)"
+        result = expander.replace(sql, 'VECQUERY')
+        assert result == "$rel.@table.embedding IS NOT NULL"
+
+    def test_dollar_target(self, expander):
+        sql = "#VECQUERY($embedding, $other_embedding)"
+        result = expander.replace(sql, 'VECQUERY')
+        assert result == "$embedding IS NOT NULL"
+        assert expander.querycompiler.sqlparams['vecquery_current']['target'] == '$other_embedding'
+
+
+# --- VECRANK ---
+
+class TestVecrank:
+
+    def test_basic_expansion(self, expander):
+        expander.replace("#VECQUERY($embedding, :target_vec)", 'VECQUERY')
+        result = expander.replace("#VECRANK", 'VECRANK')
+        assert result == "(1 - ($embedding <=> CAST(:target_vec AS vector)))"
+
+    def test_channel_code(self, expander):
+        expander.replace("#VECQUERY_alt($emb, :v)", 'VECQUERY')
+        result = expander.replace("#VECRANK_alt", 'VECRANK')
+        assert result == "(1 - ($emb <=> CAST(:v AS vector)))"
+
+    def test_missing_vecquery_raises(self, expander):
+        with pytest.raises(KeyError):
+            expander.replace("#VECRANK", 'VECRANK')
+
+
+# --- Combined expansion (simulates compiler pipeline) ---
+
+class TestCombined:
+
+    def test_where_columns_orderby(self, expander):
+        where = "#VECQUERY($embedding, :target_vec) AND $kind = 'function'"
+        columns = "$name, $kind, #VECRANK AS similarity"
+        order_by = "#VECRANK DESC"
+
+        where_out = expander.replace(where, 'TSQUERY,VECQUERY')
+        cols_out = expander.replace(columns, 'TSRANK,TSHEADLINE,VECRANK')
+        order_out = expander.replace(order_by, 'TSRANK,VECRANK')
+
+        assert where_out == "$embedding IS NOT NULL AND $kind = 'function'"
+        assert cols_out == "$name, $kind, (1 - ($embedding <=> CAST(:target_vec AS vector))) AS similarity"
+        assert order_out == "(1 - ($embedding <=> CAST(:target_vec AS vector))) DESC"
+
+    def test_two_channels(self, expander):
+        where = "#VECQUERY($emb_a, :vec_a) AND #VECQUERY_b($emb_b, :vec_b)"
+        columns = "#VECRANK AS sim_a, #VECRANK_b AS sim_b"
+
+        expander.replace(where, 'VECQUERY')
+        cols_out = expander.replace(columns, 'VECRANK')
+
+        assert "(1 - ($emb_a <=> CAST(:vec_a AS vector))) AS sim_a" in cols_out
+        assert "(1 - ($emb_b <=> CAST(:vec_b AS vector))) AS sim_b" in cols_out
+
+
+# --- Regression: TSQUERY/TSRANK still work ---
+
+class TestTsRegressions:
+
+    def test_tsquery_still_works(self, expander):
+        sql = "#TSQUERY($tsv, :search_text)"
+        result = expander.replace(sql, 'TSQUERY')
+        assert "websearch_to_tsquery" in result
+        assert "@@ websearch_to_tsquery" in result
+
+    def test_tsrank_still_works(self, expander):
+        expander.replace("#TSQUERY($tsv, :q)", 'TSQUERY')
+        result = expander.replace("#TSRANK", 'TSRANK')
+        assert "ts_rank" in result
+
+    def test_tsheadline_still_works(self, expander):
+        expander.replace("#TSQUERY($tsv, :q)", 'TSQUERY')
+        result = expander.replace("#TSHEADLINE($content)", 'TSHEADLINE')
+        assert "ts_headline" in result


### PR DESCRIPTION
## Summary

- Add `#VECQUERY` and `#VECRANK` macros to the PostgreSQL `MacroExpander`, enabling declarative vector similarity queries through the standard `db.table().query()` API
- Follow the same pattern as existing `#TSQUERY`/`#TSRANK` (channel codes, sqlparams storage, compiler hook points)
- Register macros at all 4 expansion points in the compiler (WHERE, columns, order_by, formulaColumn)

## Motivation

pgvector's `<=>` operator requires `::vector` casts which conflict with GenroPy's parameter preprocessing (`prepareSqlText` matches `:vector` as a named parameter). Without these macros, vector queries must bypass the entire query infrastructure via raw cursor access, losing relations, access filters, and automatic joins.

## Usage

```python
db.table('sourcerer.symbol').query(
    where='#VECQUERY($embedding, :target_vec)',
    columns='$name, $kind, #VECRANK AS similarity',
    order_by='#VECRANK DESC',
    target_vec=embedding_list
).fetch()
```

## Test plan

- [x] 13 unit tests covering VECQUERY, VECRANK, channel codes, combined expansion, and TS macro regression
- [ ] Integration test with real pgvector column on Sourcerer DB

Ref #583