### PR TITLE
feat(menu): add iconClass support and improve tree arrows

### DIFF
--- a/gnrjs/gnr_d11/js/genro_tree.js
+++ b/gnrjs/gnr_d11/js/genro_tree.js
@@ -467,10 +467,19 @@ dojo.declare("gnr.widgets.Tree", gnr.widgets.baseDojo, {
                     if(!searchColumn){
                         var label = that.getLabel(item);
                         if(label){
-                            if(label.startsWith('innerHTML:')){
+                            var isHTML = label.startsWith('innerHTML:');
+                            if(isHTML){
                                 label = label.replace('innerHTML:','');
                             }
-                            tn.labelNode.innerHTML = label.replace(filterRegExp,"<span class='search_highlight'>$1</span>");
+                            if(search && isHTML){
+                                label = label.replace(/(<[^>]+>)/g, '\x00$1\x00').split('\x00')
+                                    .map(function(part){
+                                        return part.charAt(0)==='<' ? part : part.replace(filterRegExp,"<span class='search_highlight'>$1</span>");
+                                    }).join('');
+                            }else{
+                                label = label.replace(filterRegExp,"<span class='search_highlight'>$1</span>");
+                            }
+                            tn.labelNode.innerHTML = label;
                         }
                     }
                     while(parent&&dojo.hasClass(parent.domNode,'hidden')){

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -100,6 +100,12 @@
     --menutree-chevron-color: #bbb;
 }
 
+.mode_mobile .menutree.menutree_branchiconright{
+    --menutree-node-background: rgba(255, 255, 255, 0.08);
+    --menutree-node-hover-background: rgba(255, 255, 255, 0.15);
+    --menutree-chevron-color: rgba(255, 255, 255, 0.5);
+}
+
 /* Kill tundra tree-line background images on nodes */
 .menutree.menutree_branchiconright .dijitTreeNode,
 .menutree.menutree_branchiconright .dijitTreeIsLast{

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -1,20 +1,46 @@
+/* Menutree layout */
+.menutree{
+    padding-left: 4px;
+}
+
+.menutree .dijitTreeContent{
+    display: flex;
+    align-items: center;
+}
+
+/* CSS triangles replacing pixelated PNG arrows */
+.menutree .dijitTreeIcon{
+    flex-shrink: 0;
+    width: 10px;
+}
+
+.menutree .closedir,
 .menutree .opendir{
-    width: 12px;
-    background: url(/_gnr/11/css/icons/base10/tinyOpenBranch.png) no-repeat center center;
-
-}
-.menutree .closedir{
-    width: 12px;
-    background: url(/_gnr/11/css/icons/base10/tinyCloseBranch.png) no-repeat center center;
-
+    background: none;
+    text-align: center;
+    padding-top: 2px;
 }
 
-.tundra .menutree .dijitTreeIcon{
-    height: 20px;
+.menutree .closedir::after,
+.menutree .opendir::after{
+    content: '';
+    display: inline-block;
+}
+
+.menutree .closedir::after{
+    border-style: solid;
+    border-width: 4px 0 4px 5px;
+    border-color: transparent transparent transparent #666;
+}
+
+.menutree .opendir::after{
+    border-style: solid;
+    border-width: 5px 4px 0 4px;
+    border-color: #666 transparent transparent transparent;
 }
 
 .menutree .treeNoIcon{
-    width: 12px;
+    /* same width as arrows inherited from .dijitTreeIcon */
 }
 .mode_mobile .menutree .treeNoIcon{
     display: none;
@@ -49,4 +75,15 @@
     padding-right: 5px;
     padding-left: 5px;
     font-weight: bold;
+}
+
+.menuline_icon{
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center center;
+    flex-shrink: 0;
 }

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -82,8 +82,110 @@
     width: 16px;
     height: 16px;
     margin-right: 4px;
+    vertical-align: middle;
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center center;
     flex-shrink: 0;
+}
+
+/* ==========================================================================
+   Branch-icon-right layout mode
+   Activated by adding 'menutree_branchiconright' class alongside 'menutree'
+   ========================================================================== */
+
+.menutree.menutree_branchiconright{
+    --menutree-node-background: rgba(0, 0, 0, 0.03);
+    --menutree-node-hover-background: rgba(0, 0, 0, 0.07);
+    --menutree-chevron-color: #bbb;
+}
+
+/* Kill tundra tree-line background images on nodes */
+.menutree.menutree_branchiconright .dijitTreeNode,
+.menutree.menutree_branchiconright .dijitTreeIsLast{
+    background-image: none !important;
+    background: none !important;
+}
+
+/* Content: tinted background, smooth hover */
+._common_d11 .menutree.menutree_branchiconright .dijitTreeContent{
+    border-radius: 4px;
+    margin: 3px 4px;
+    padding: 4px 8px;
+    background: var(--menutree-node-background);
+    transition: background 0.15s ease;
+}
+
+/* Content hover */
+._common_d11 .menutree.menutree_branchiconright .dijitTreeContent:hover{
+    background: var(--menutree-node-hover-background);
+}
+
+/* Chevron rotation transition */
+.menutree.menutree_branchiconright .closedir,
+.menutree.menutree_branchiconright .opendir{
+    transition: transform 0.2s ease;
+}
+
+/* Hide the default Dijit expando (+/- button) */
+.menutree.menutree_branchiconright .dijitTreeExpando,
+.menutree.menutree_branchiconright .dijitExpandoText{
+    display: none;
+}
+
+/* Content takes all available space */
+.menutree.menutree_branchiconright .dijitTreeContent{
+    flex: 1;
+}
+
+/* Branch icon moves to the right, padding keeps it from panel edge */
+.menutree.menutree_branchiconright .dijitTreeIcon{
+    order: 2;
+    margin-left: auto;
+    margin-right: 8px;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+}
+
+/* Label stays on the left, fills space */
+.menutree.menutree_branchiconright .dijitTreeLabel{
+    order: 1;
+    flex: 1;
+}
+
+/* Leaf nodes: hide empty icon spacer */
+.menutree.menutree_branchiconright .treeNoIcon{
+    display: none;
+}
+
+/* Hide CSS triangle pseudo-elements in this mode */
+.menutree.menutree_branchiconright .closedir::after,
+.menutree.menutree_branchiconright .opendir::after{
+    display: none;
+}
+
+/* Shared chevron SVG mask */
+.menutree.menutree_branchiconright .closedir,
+.menutree.menutree_branchiconright .opendir{
+    background: none;
+    -webkit-mask-image: url(/_rsrc/common/css_icons/svg/16/mobile_right_in_small.svg);
+    mask-image: url(/_rsrc/common/css_icons/svg/16/mobile_right_in_small.svg);
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    background-color: var(--menutree-chevron-color);
+}
+
+/* Closed dir: chevron pointing right */
+.menutree.menutree_branchiconright .closedir{
+    transform: rotate(0deg);
+}
+
+/* Open dir: chevron rotated down */
+.menutree.menutree_branchiconright .opendir{
+    transform: rotate(90deg);
 }

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -101,8 +101,8 @@
 }
 
 .mode_mobile .menutree.menutree_branchiconright{
-    --menutree-node-background: rgba(255, 255, 255, 0.08);
-    --menutree-node-hover-background: rgba(255, 255, 255, 0.15);
+    --menutree-node-background: none;
+    --menutree-node-hover-background: none;
     --menutree-chevron-color: rgba(255, 255, 255, 0.5);
 }
 
@@ -152,6 +152,10 @@
     width: 16px;
     height: 16px;
     flex-shrink: 0;
+}
+.mode_mobile .menutree.menutree_branchiconright .dijitTreeIcon{
+    width: 22px;
+    height: 22px;
 }
 
 /* Label stays on the left, fills space */

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -127,6 +127,7 @@
     background: var(--menutree-node-hover-background);
 }
 
+
 /* Chevron rotation transition */
 .menutree.menutree_branchiconright .closedir,
 .menutree.menutree_branchiconright .opendir{
@@ -158,10 +159,12 @@
     height: 22px;
 }
 
-/* Label stays on the left, fills space */
+/* Label stays on the left, fills space, aligns icon and text */
 .menutree.menutree_branchiconright .dijitTreeLabel{
     order: 1;
     flex: 1;
+    display: inline-flex;
+    align-items: center;
 }
 
 /* Leaf nodes: hide empty icon spacer */

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
@@ -48,12 +48,12 @@ class MenuIframes(BaseComponent):
 
                  
     def _menutree_getIconClass(self):
-        if self.device_mode=='std':
+        if self.device_mode=='std' or self.iframemenu_brancharrow_right:
             return """function(item,opened){
                         if(!item.attr.isDir){
                             return "treeNoIcon";
                         }
-                        return opened? 'opendir':'closedir';                        
+                        return opened? 'opendir':'closedir';
                     }"""
         return  "return 'treeNoIcon';"
     

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
@@ -28,6 +28,7 @@ from gnr.web.gnrbaseclasses import BaseComponent
 
 class MenuIframes(BaseComponent):
     css_requires='frameplugin_menu/frameplugin_menu'
+    iframemenu_brancharrow_right = True
 
     def mainLeft_iframemenu_plugin(self, tc):
         frame = tc.framePane(title="Menu", pageName='menu_plugin')
@@ -98,7 +99,7 @@ class MenuIframes(BaseComponent):
         tree = pane.tree(id="_gnr_main_menu_tree", storepath='gnr.appmenu.root', selected_file='gnr.filepath',
                   labelAttribute='label',
                   hideValues=True,
-                  _class='menutree',
+                  _class='menutree menutree_branchiconright' if self.iframemenu_brancharrow_right else 'menutree',
                   persist='site',
                   inspect='AltShift',
                   identifier='#p',

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
@@ -74,10 +74,20 @@ class MenuIframes(BaseComponent):
     def _menutree_getLabel(self):
         return """
             let label = node.attr.label;
-            let badgeContent =  node.attr.badgeContent;
+            let iconClass = node.attr.iconClass;
+            let badgeContent = node.attr.badgeContent;
             let badgeClass = node.attr.badgeClass || 'menuline_badge';
+            let useInnerHTML = false;
+            if(iconClass){
+                label = `<span class="menuline_icon ${iconClass}"></span>${label}`;
+                useInnerHTML = true;
+            }
             if(!isNullOrBlank(badgeContent)){
-                label = `innerHTML:${label} <span class="${badgeClass}">${badgeContent}</span>`
+                label = `${label} <span class="${badgeClass}">${badgeContent}</span>`;
+                useInnerHTML = true;
+            }
+            if(useInnerHTML){
+                label = `innerHTML:${label}`;
             }
             return label;
         """

--- a/resources/common/themes/mimi.css
+++ b/resources/common/themes/mimi.css
@@ -2,6 +2,10 @@
 
 body {
     --primary-color: #1E3055;
+    --mainWindow-background: white;
+    --frameindexroot-background: white;
+    --frameindexcenter-background: white;
+    --frameindexroot-mobile-background: #4b525b;
 }
 
 body.tundra.mimi {
@@ -10,13 +14,13 @@ body.tundra.mimi {
 }
 
 .frameindexroot{
-    background:linear-gradient(to right, #ffffff, #bacbdf);    
+    background: var(--frameindexroot-background);
 }
 .frameindexcenter{
-    background:linear-gradient(to top, #f6f8fa, #ffffff);    
+    background: var(--frameindexcenter-background);
 }
 .mode_mobile .frameindexroot{
-    background:#4b525b;    
+    background: var(--frameindexroot-mobile-background);
 }
 
 
@@ -707,8 +711,7 @@ body.tundra.mimi {
 
 .menutree {
     margin-top: 5px;
-    margin-right:3px; /*font-weight: bold;*/
-    background-position: left;
+    margin-right:3px;
 }
 
 .menutree .dijitTreeContent {
@@ -733,7 +736,6 @@ body.tundra.mimi {
     margin-top: 0px;
     color: #444;
     padding-bottom: 4px;
-    background: linear-gradient(45deg, #1f345d26, transparent);
 }
 .menutree .menu_shape.branchPage{
     font-style: italic;

--- a/resources/common/themes/mimi.css
+++ b/resources/common/themes/mimi.css
@@ -782,6 +782,10 @@ body.tundra.mimi {
 .mode_mobile .menutree .closedir{
     background: none;
 }
+.mode_mobile .menutree.menutree_branchiconright .opendir,
+.mode_mobile .menutree.menutree_branchiconright .closedir{
+    background-color: var(--menutree-chevron-color);
+}
 .menutree .label_emptydir{
     opacity: .5;
 }
@@ -791,6 +795,10 @@ body.tundra.mimi {
 }
 ._common_d11.mimi.mode_mobile .menutree .label_closedir{
     background: url(/_gnr/11/css/icons/base10/tinyCloseBranch_white.png) no-repeat 4px center;
+}
+._common_d11.mimi.mode_mobile .menutree.menutree_branchiconright .label_opendir,
+._common_d11.mimi.mode_mobile .menutree.menutree_branchiconright .label_closedir{
+    background: none;
 }
 
 .menutree .menu_current_page {


### PR DESCRIPTION
## Summary
- Add `iconClass` parameter to menu items (MenuStruct) for rendering icons left of the label text, using the existing `innerHTML:` mechanism alongside `badgeContent`
- Replace pixelated PNG arrows (opendir/closedir) with crisp CSS triangles for retina displays
- Use flexbox on `.dijitTreeContent` for consistent vertical alignment of arrows, icons, labels and badges

## Test plan
- [x] Verify `iconClass` renders icon left of label text
- [x] Verify `badgeContent` and `iconClass` work together
- [x] Verify tree search still works with innerHTML labels
- [x] Verify menu items without `iconClass` are unaffected
- [x] Verify open/close arrows render correctly at all tree levels