### PR TITLE
fix(#626): auto-GIN index for TSV columns

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmigration.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration.py
@@ -27,6 +27,10 @@ COL_JSON_KEYS = ("dtype","notnull","sqldefault","size","unique","extra_sql","gen
 
 GNR_DTYPE_CONVERTER = {'X':'T', 'Z':'T', 'P':'T'}
 
+DTYPE_INDEX_CONFIG = {
+    'TSV': dict(method='gin', required=True),
+}
+
 def new_structure_root(dbname):
     return {'root':{
             'entity':'db',
@@ -262,6 +266,9 @@ class OrmExtractor:
         colattr = colobj.attributes
         joiner =  colobj.relatedColumnJoiner()
         indexed = colattr.get('indexed') or colattr.get('unique')
+        dtype_index_config = DTYPE_INDEX_CONFIG.get(colattr.get('dtype'))
+        if not indexed and dtype_index_config and dtype_index_config.get('required'):
+            indexed = True
         table_name = colobj.table.sqlname
         schema_name = tenant_schema or colobj.table.pkg.sqlname
         table_json = self.schemas[schema_name]['tables'][table_name]
@@ -337,7 +344,10 @@ class OrmExtractor:
         
     
     def fill_json_column_index(self,colobj,indexed=None,tenant_schema=None):
-        indexed =  {} if indexed is True else dict(indexed) 
+        indexed =  {} if indexed is True else dict(indexed)
+        dtype_index_config = DTYPE_INDEX_CONFIG.get(colobj.attributes.get('dtype'))
+        if dtype_index_config:
+            indexed.setdefault('method', dtype_index_config.get('method'))
         if colobj.attributes.get('unique'):
             #if there is an unique constraint the db add an automatic index
             return

--- a/gnrpy/tests/sql/test_gnrsqlmigration.py
+++ b/gnrpy/tests/sql/test_gnrsqlmigration.py
@@ -157,6 +157,31 @@ class BaseGnrSqlMigration(BaseGnrSqlTest):
         check_value = 'ALTER TABLE "alfa"."alfa_recipe"\nADD COLUMN "testuniquecol" character varying(10);\nALTER TABLE "alfa"."alfa_recipe"\nADD CONSTRAINT "cst_f797d32c" UNIQUE ("testuniquecol");'
         self.checkChanges(check_value)
 
+    def test_04e_add_column_with_gin_index(self):
+        """Tests that indexed=dict(method='gin') generates USING gin.
+
+        Ref: https://github.com/genropy/genropy/issues/626
+        """
+        pkg = self.src.package('alfa')
+        tbl = pkg.table('recipe')
+        tbl.column('search_tsv', dtype='TSV', indexed=dict(method='gin'))
+        check_value = 'ALTER TABLE "alfa"."alfa_recipe" \n ADD COLUMN "search_tsv" tsvector ;\nCREATE INDEX idx_1a420e6d ON "alfa"."alfa_recipe" USING gin ("search_tsv") ;'
+        self.checkChanges(check_value)
+
+    def test_04f_tsv_indexed_true_auto_gin(self):
+        """Tests that dtype='TSV' with indexed=True auto-generates GIN index.
+
+        A btree index on tsvector is never useful and fails on large documents.
+        The migration system should automatically use GIN for TSV columns.
+
+        Ref: https://github.com/genropy/genropy/issues/626
+        """
+        pkg = self.src.package('alfa')
+        tbl = pkg.table('recipe')
+        tbl.column('content_tsv', dtype='TSV', indexed=True)
+        check_value = 'ALTER TABLE "alfa"."alfa_recipe" \n ADD COLUMN "content_tsv" tsvector ;\nCREATE INDEX idx_0ae87617 ON "alfa"."alfa_recipe" USING gin ("content_tsv") ;'
+        self.checkChanges(check_value)
+
 
     def test_05a_create_table_withpkey(self):
         """Tests creating a table with a primary key column."""


### PR DESCRIPTION
## Summary

- Add `DTYPE_INDEX_CONFIG` dict that maps dtype to index configuration (method, required)
- For `TSV`: `method='gin'` and `required=True` — GIN indexes are always created, btree is never used
- The config acts via `setdefault`, so explicit `indexed=dict(method=...)` from the model always wins
- Two new tests: `test_04e` (explicit GIN) and `test_04f` (auto-GIN for TSV)

## Problem

A `dtype='TSV'` column with `indexed=True` generated a btree index, which is useless for tsvector and fails on large documents with `index row requires 8560 bytes, maximum size is 8191`.

## Test plan

- [x] `test_04e_add_column_with_gin_index` — `indexed=dict(method='gin')` generates `USING gin`
- [x] `test_04f_tsv_indexed_true_auto_gin` — `indexed=True` on TSV auto-generates GIN
- [x] Full SQL test suite: 297 passed, 0 failed
- [x] flake8: zero errors on modified files

Ref #626