### PR TITLE
feat(#630): redirect gnrdbsetup to gnr db migrate for Postgres

### DIFF
--- a/gnrpy/gnr/app/cli/gnrdbsetup.py
+++ b/gnrpy/gnr/app/cli/gnrdbsetup.py
@@ -184,6 +184,11 @@ def main():
 
     
     app, storename = get_app(options)
+    if app.db.implementation in ('postgres', 'postgres3'):
+        logger.warning('gnrdbsetup is deprecated for Postgres. Redirecting to gnr db migrate.')
+        from gnr.db.cli.gnrmigrate import main as migrate_main
+        migrate_main()
+        return
     errordb = []
     if storename == '*':
         stores = [None] + sorted(app.db.dbstores.keys())


### PR DESCRIPTION
## Summary

- When `gnrdbsetup` detects a Postgres database, it prints a deprecation warning and delegates to `gnr db migrate`
- SQLite path remains unchanged
- This makes the old `SqlModelChecker` bugs (like #626) irrelevant for Postgres users

## Test plan

- [x] flake8: zero errors
- [ ] Manual: `gnrdbsetup <postgres_instance>` should print warning and run migrate
- [ ] Manual: `gnrdbsetup <sqlite_instance>` should work as before

Ref #630