### PR TITLE
fix(menu): improve badge styling for consistent shape on mobile

### DIFF
--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -75,6 +75,7 @@
     padding: 2px 5px;
     font-weight: bold;
     line-height: 1;
+    margin-left: 6px;
 }
 
 .menuline_icon{

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -72,9 +72,9 @@
     border-radius: 30px;
     font-size: 75%;
     color: #444;
-    padding-right: 5px;
-    padding-left: 5px;
+    padding: 2px 5px;
     font-weight: bold;
+    line-height: 1;
 }
 
 .menuline_icon{

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -69,13 +69,20 @@
 
 .menuline_badge{
     background: #e7fa32;
-    border-radius: 30px;
-    font-size: 75%;
     color: #444;
-    padding: 2px 5px;
+    font-size: 70%;
     font-weight: bold;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 1.8em;
+    min-width: 1.8em;
+    padding: 0 0.4em;
+    border-radius: 1em;
     line-height: 1;
+    box-sizing: border-box;
     margin-left: 6px;
+    vertical-align: middle;
 }
 
 .menuline_icon{
@@ -166,6 +173,10 @@
     flex: 1;
     display: inline-flex;
     align-items: center;
+}
+
+.menutree.menutree_branchiconright .menuline_badge{
+    align-self: baseline;
 }
 
 /* Leaf nodes: hide empty icon spacer */

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -75,13 +75,13 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    height: 1.8em;
-    min-width: 1.8em;
-    padding: 0 0.4em;
-    border-radius: 1em;
+    height: 1.5em;
+    min-width: 1.5em;
+    padding: 0 0.35em;
+    border-radius: 0.75em;
     line-height: 1;
     box-sizing: border-box;
-    margin-left: 6px;
+    border: 1px solid #d4c820;
     vertical-align: middle;
 }
 
@@ -172,11 +172,11 @@
     order: 1;
     flex: 1;
     display: inline-flex;
-    align-items: center;
+    align-items: baseline;
 }
 
 .menutree.menutree_branchiconright .menuline_badge{
-    align-self: baseline;
+    margin-left: 4px;
 }
 
 /* Leaf nodes: hide empty icon spacer */


### PR DESCRIPTION
## Summary
- Restyle menu badge CSS for a guaranteed circular/pill shape on mobile and desktop
- Use compact `1.5em` dimensions with `inline-flex` centering for consistent rendering
- Add subtle border for better visual definition
- Use baseline alignment in branchiconright layout mode

## Test plan
- [x] Verify badge shape on mobile (1 digit, 2 digits)
- [x] Verify badge alignment with label text in both normal and branchiconright mode
- [x] Verify no visual regression on desktop menu