### PR TITLE
fix(menu): use CSS-only spacing for badge label

### DIFF
--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -83,6 +83,7 @@
     box-sizing: border-box;
     border: 1px solid #d4c820;
     vertical-align: middle;
+    margin-left: 4px;
 }
 
 .menuline_icon{
@@ -173,10 +174,6 @@
     flex: 1;
     display: inline-flex;
     align-items: baseline;
-}
-
-.menutree.menutree_branchiconright .menuline_badge{
-    margin-left: 4px;
 }
 
 /* Leaf nodes: hide empty icon spacer */

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
@@ -84,7 +84,7 @@ class MenuIframes(BaseComponent):
                 useInnerHTML = true;
             }
             if(!isNullOrBlank(badgeContent)){
-                label = `${label} <span class="${badgeClass}">${badgeContent}</span>`;
+                label = `${label}<span class="${badgeClass}">${badgeContent}</span>`;
                 useInnerHTML = true;
             }
             if(useInnerHTML){


### PR DESCRIPTION
## Summary
- Remove literal space before badge span in JS label template to avoid anonymous flex item in inline-flex contexts
- Move `margin-left: 4px` to the base `.menuline_badge` rule for consistent spacing in all layout modes
- Remove the now-unnecessary branchiconright-specific margin override

## Test plan
- [x] Verify badge spacing on mobile (branchiconright mode)
- [x] Verify badge spacing on desktop (normal mode)
- [x] No double spacing between label text and badge