### PR TITLE
fix(menu): use center alignment for branch-icon-right label

### DIFF
--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.css
@@ -173,7 +173,7 @@
     order: 1;
     flex: 1;
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
 }
 
 /* Leaf nodes: hide empty icon spacer */


### PR DESCRIPTION
## Summary
- Revert `align-items` on `.menutree_branchiconright .dijitTreeLabel` from `baseline` back to `center`
- `baseline` broke vertical alignment of `iconClass` icons (background-image on empty spans have no text baseline)
- `center` correctly aligns icons, text and badges together

## Test plan
- [x] Verify menu icons (iconClass) are vertically centered with label text
- [x] Verify badge alignment next to label text
- [x] Check both desktop and mobile views