### PR TITLE
refactor(sql): rename #BETWEEN macro to #IN_RANGE

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -317,9 +317,9 @@ Enhancements
   * The `GNR_GLOBAL_DEBUG` flag was removed, and `gnr db migrate` now defaults to **INFO** log level instead of DEBUG.
   * Improved `checkRelationIndex()` to log more descriptive errors when an invalid relation is encountered.
   * Improved handling of deferred relations and indexing for tenant schemas.
-  * **New `#BETWEEN` syntax** added for SQL queries, supporting range
-    filtering (e.g., dates, integers), which include the **upper
-    bound** by default.
+  * **`#BETWEEN` renamed to `#IN_RANGE`** for SQL queries — the old name
+    caused confusion with the SQL ``BETWEEN`` operator (which is inclusive on
+    both ends, while this macro handles NULLs).  ``#BETWEEN`` has been removed.
   * Excluded unique constraints that overlap with primary keys.
   * Added support for PostgreSQL extensions in migrations, including:
     * Commands to create extensions.
@@ -430,7 +430,7 @@ Bug Fixes
 
 * **SQL Query Fixes**
   * Fixed incorrect **column width calculations** in `ThResourceMaker`. :contentReference[oaicite:33]{index=33}
-  * Ensured `#BETWEEN` syntax correctly handles **blank values**. :contentReference[oaicite:34]{index=34}
+  * Ensured `#IN_RANGE` (formerly ``#BETWEEN``) syntax correctly handles **blank values**. :contentReference[oaicite:34]{index=34}
   * SQL **range comparisons** now consistently include the **upper bound**. :contentReference[oaicite:35]{index=35}
 
 
@@ -447,7 +447,7 @@ Upgrade Instructions
 
 * Recommended for every upgrade, to reinstall the framework using the original installation method in order to
   have dependencies working correctly.
-* **Update your SQL queries** to properly utilize **`#BETWEEN`** syntax changes.
+* **Update your SQL queries**: replace **`#BETWEEN`** with **`#IN_RANGE`** — the old macro has been removed.
 - **Review migration logs**, as error handling for relations has changed.
 - **Reconfigure handbook settings**, as redundant preferences were removed.
 

--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -317,9 +317,9 @@ Enhancements
   * The `GNR_GLOBAL_DEBUG` flag was removed, and `gnr db migrate` now defaults to **INFO** log level instead of DEBUG.
   * Improved `checkRelationIndex()` to log more descriptive errors when an invalid relation is encountered.
   * Improved handling of deferred relations and indexing for tenant schemas.
-  * **`#BETWEEN` renamed to `#IN_RANGE`** for SQL queries — the old name
-    caused confusion with the SQL ``BETWEEN`` operator (which is inclusive on
-    both ends, while this macro handles NULLs).  ``#BETWEEN`` has been removed.
+  * **New `#BETWEEN` syntax** added for SQL queries, supporting range
+    filtering (e.g., dates, integers), which include the **upper
+    bound** by default.
   * Excluded unique constraints that overlap with primary keys.
   * Added support for PostgreSQL extensions in migrations, including:
     * Commands to create extensions.
@@ -430,7 +430,7 @@ Bug Fixes
 
 * **SQL Query Fixes**
   * Fixed incorrect **column width calculations** in `ThResourceMaker`. :contentReference[oaicite:33]{index=33}
-  * Ensured `#IN_RANGE` (formerly ``#BETWEEN``) syntax correctly handles **blank values**. :contentReference[oaicite:34]{index=34}
+  * Ensured `#BETWEEN` syntax correctly handles **blank values**. :contentReference[oaicite:34]{index=34}
   * SQL **range comparisons** now consistently include the **upper bound**. :contentReference[oaicite:35]{index=35}
 
 
@@ -447,7 +447,7 @@ Upgrade Instructions
 
 * Recommended for every upgrade, to reinstall the framework using the original installation method in order to
   have dependencies working correctly.
-* **Update your SQL queries**: replace **`#BETWEEN`** with **`#IN_RANGE`** — the old macro has been removed.
+* **Update your SQL queries** to properly utilize **`#BETWEEN`** syntax changes.
 - **Review migration logs**, as error handling for relations has changed.
 - **Reconfigure handbook settings**, as redundant preferences were removed.
 

--- a/gnrpy/gnr/sql/gnrsqldata/README.md
+++ b/gnrpy/gnr/sql/gnrsqldata/README.md
@@ -28,7 +28,7 @@ Contains two classes:
 
 - **`SqlQueryCompiler`**: the actual compiler.  Receives a `tblobj`
   (table model), resolves relational paths (`@rel.column`), generates
-  JOIN clauses, expands macros (#BETWEEN, #PERIOD, #BAG, #ENV, #PREF,
+  JOIN clauses, expands macros (#IN_RANGE, #PERIOD, #BAG, #ENV, #PREF,
   #THIS), handles virtual columns (sql_formula, py_method, select/exists),
   and produces a `SqlCompiledQuery` instance.
 
@@ -37,7 +37,7 @@ Contains two classes:
   - `compiledRecordQuery()` for single-record loading
 
 Module-level regex constants:
-`COLFINDER`, `RELFINDER`, `COLRELFINDER`, `BETWEENFINDER`,
+`COLFINDER`, `RELFINDER`, `COLRELFINDER`, `IN_RANGEFINDER`,
 `PERIODFINDER`, `BAGEXPFINDER`, `BAGCOLSEXPFINDER`, `ENVFINDER`,
 `PREFFINDER`, `THISFINDER`.
 
@@ -139,7 +139,7 @@ Detailed notes are also appended at the end of each module.
 | 5 | `compiledQuery` — comment "It is the right behaviour ????" on distinct/count + exploding | Design |
 | 6 | `_handle_virtual_columns` — `else` branch with only `pass`, variables unassigned | Potential bug |
 | 7 | `_handle_virtual_columns` — commented-out Python 2 debug print | Dead code |
-| 8 | `expandBetween` vs legacy between — inconsistency `<=` vs `<` | Inconsistency |
+| 8 | `expandInRange` vs legacy between — inconsistency `<=` vs `<` | Inconsistency |
 | 9 | `expandPeriod` — native SQL BETWEEN, consider deprecating in favor of range | Deprecation |
 | 10 | `compiledRecordQuery` — duplicated `virtual_columns = ... or []` line | Copy-paste |
 | 11 | `_getRelationAlias` — `target_sqlcolumn` potentially `None` | Potential bug |

--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -31,7 +31,7 @@ Classes:
         SQL SELECT statement (columns, joins, where, group_by, etc.).
     SqlQueryCompiler: Stateful compiler that walks the relation tree of a
         table, resolves ``$column`` and ``@relation.column`` references,
-        builds JOIN clauses, expands macros (#BETWEEN, #PERIOD, #ENV, ...),
+        builds JOIN clauses, expands macros (#IN_RANGE, #PERIOD, #ENV, ...),
         and produces a fully populated ``SqlCompiledQuery``.
 
 The compiler is used internally by ``SqlQuery`` (selections) and
@@ -41,8 +41,8 @@ directly by application code.
 Module-level constants:
     COLFINDER, RELFINDER, COLRELFINDER: Regular expressions for detecting
         ``$column`` and ``@relation.column`` references in SQL fragments.
-    BETWEENFINDER, PERIODFINDER: Regular expressions for the ``#BETWEEN``
-        and ``#PERIOD`` macro syntax.
+    IN_RANGEFINDER: Regular expression for the ``#IN_RANGE`` macro syntax.
+    PERIODFINDER: Regular expression for the ``#PERIOD`` macro syntax.
     BAGEXPFINDER, BAGCOLSEXPFINDER: Regular expressions for the ``#BAG``
         and ``#BAGCOLS`` macro syntax.
     ENVFINDER, PREFFINDER, THISFINDER: Regular expressions for the
@@ -63,7 +63,7 @@ COLFINDER = re.compile(r"(\W|^)\$(\w+)")
 RELFINDER = re.compile(r"([^A-Za-z0-9_]|^)(\@(\w[\w.@:]+))")
 COLRELFINDER = re.compile(r"([@$]\w+(?:\.\w+)*)")
 
-BETWEENFINDER = re.compile(r"#BETWEEN\s*\(\s*((?:\$|@|\:)?[\w\.\@]+)\s*,\s*((?:\$|@|\:)?[\w\.\@]+)\s*,\s*((?:\$|@|\:)?[\w\.\@]+)\s*\)\s*",re.MULTILINE)
+IN_RANGEFINDER = re.compile(r"#IN_RANGE\s*\(\s*((?:\$|@|\:)?[\w\.\@]+)\s*,\s*((?:\$|@|\:)?[\w\.\@]+)\s*,\s*((?:\$|@|\:)?[\w\.\@]+)\s*\)\s*",re.MULTILINE)
 PERIODFINDER = re.compile(r"#PERIOD\s*\(\s*((?:\$|@)?[\w\.\@]+)\s*,\s*:?(\w+)\)")
 
 BAGEXPFINDER = re.compile(r"#BAG\s*\(\s*((?:\$|@)?[\w\.\@]+)\s*\)(\s*AS\s*(\w*))?")
@@ -175,7 +175,7 @@ class SqlQueryCompiler(object):
     ``SqlQueryCompiler`` is used internally by ``SqlQuery`` (for selections)
     and ``SqlRecord`` (for single-record fetches).  It walks the relation
     tree of a table, resolves ``$column`` / ``@relation.column`` references,
-    builds LEFT JOIN clauses, expands macros (``#BETWEEN``, ``#PERIOD``,
+    builds LEFT JOIN clauses, expands macros (``#IN_RANGE``, ``#PERIOD``,
     ``#ENV``, ``#PREF``, ``#THIS``, ``#BAG``, ``#BAGCOLS``), and fills a
     ``SqlCompiledQuery`` instance with all the SQL fragments.
 
@@ -419,7 +419,7 @@ class SqlQueryCompiler(object):
                 subreldict = {}
                 sql_formula = self.macro_expander.replace(sql_formula,'TSRANK,TSHEADLINE,VECRANK')
                 sql_formula = self.updateFieldDict(sql_formula, reldict=subreldict)
-                sql_formula = BETWEENFINDER.sub(self.expandBetween, sql_formula)
+                sql_formula = IN_RANGEFINDER.sub(self.expandInRange, sql_formula)
                 sql_formula = ENVFINDER.sub(expandEnv, sql_formula)
                 sql_formula = PREFFINDER.sub(expandPref, sql_formula)
                 sql_formula = THISFINDER.sub(expandThis,sql_formula)
@@ -532,7 +532,7 @@ class SqlQueryCompiler(object):
         - Case-insensitive joins.
         - Virtual joins (``joiner['virtual']``).
         - Custom ``cnd`` / ``join_on`` expressions.
-        - ``between`` range joins (deprecated in favour of ``#BETWEEN``).
+        - ``between`` range joins (deprecated in favour of ``#IN_RANGE``).
 
         Args:
             relNode: The relation resolver node carrying the ``joiner``
@@ -622,11 +622,11 @@ class SqlQueryCompiler(object):
         if joiner.get('cnd'):
             # Branch: explicit condition expression
             cnd = joiner.get('cnd')
-            cnd = BETWEENFINDER.sub(self.expandBetween, cnd)
+            cnd = IN_RANGEFINDER.sub(self.expandInRange, cnd)
             #cnd = self.updateFieldDict(joiner['cnd'], reldict=joindict)
         elif joiner.get('between'):
             # Branch: legacy ``between`` syntax
-            # REVIEW: TODO deprecate -- use #BETWEEN macro instead
+            # REVIEW: TODO deprecate -- use #IN_RANGE macro instead
             value_field,low_field,high_field = joiner.get('between').split(';')
             cnd = f"""
                 ({low_field} IS NULL AND {high_field} IS NOT NULL AND {value_field}<{high_field}) OR
@@ -857,7 +857,7 @@ class SqlQueryCompiler(object):
 
         1. Normalise and expand the *columns* specification (``*`` globs,
            ``#BAG`` / ``#BAGCOLS`` macros).
-        2. Expand macros in the *where* clause (``#BETWEEN``, ``#PERIOD``,
+        2. Expand macros in the *where* clause (``#IN_RANGE``, ``#PERIOD``,
            ``#TSQUERY``).
         3. Assemble additional WHERE predicates (env conditions, partition,
            subtable, logical deletion, draft exclusion).
@@ -970,7 +970,7 @@ class SqlQueryCompiler(object):
             subtable = context_subtables
         subtable = subtable or self.tblobj.attributes.get('default_subtable')
         if where:
-            where = BETWEENFINDER.sub(self.expandBetween, where)
+            where = IN_RANGEFINDER.sub(self.expandInRange, where)
             where = PERIODFINDER.sub(self.expandPeriod, where)
             where = self.macro_expander.replace(where,'TSQUERY,VECQUERY')
 
@@ -1298,8 +1298,8 @@ class SqlQueryCompiler(object):
         self.cpl.evaluateBagColumns.append(((asfld or fld).replace('$',''),True))
         return fld if not asfld else '{} AS {}'.format(fld, asfld)
 
-    def expandBetween(self, m):
-        """Regex callback: expand ``#BETWEEN(value, low, high)`` into SQL.
+    def expandInRange(self, m):
+        """Regex callback: expand ``#IN_RANGE(value, low, high)`` into SQL.
 
         Generates a four-branch OR expression that handles NULLs on either
         bound:
@@ -1316,7 +1316,7 @@ class SqlQueryCompiler(object):
         Returns:
             str: SQL fragment implementing the inclusive range check.
         """
-        # Example: #BETWEEN($dataLavoro,$dataInizioValidita,$dataFineValidita)
+        # Example: #IN_RANGE($dataLavoro,$dataInizioValidita,$dataFineValidita)
         value_field = m.group(1)
         low_field = m.group(2)
         high_field = m.group(3)
@@ -1328,10 +1328,6 @@ class SqlQueryCompiler(object):
                     {value_field} >= {low_field} AND {value_field} <= {high_field}) OR
                 ({low_field} IS NULL AND {high_field} IS NULL))
             """
-        # REVIEW: TODO -- verify whether the upper bound should be inclusive
-        # (<=) or exclusive (<). Currently inclusive, but the legacy between
-        # in _getRelationAlias uses < for the upper bound.
-        # Inconsistent behaviour between the two.
         return result
 
     def expandPeriod(self, m):
@@ -1483,8 +1479,8 @@ class SqlQueryCompiler(object):
 #    - ``#print 'not existing col:%s' % col_name`` is Python 2 syntax.
 #    - If a warning is needed, use logging.warning.
 #
-# 8. expandBetween -- interval inclusivity inconsistency
-#    - expandBetween uses ``<=`` (inclusive) on the upper bound.
+# 8. expandInRange -- interval inclusivity inconsistency
+#    - expandInRange uses ``<=`` (inclusive) on the upper bound.
 #    - The legacy between in _getRelationAlias uses ``<`` (exclusive).
 #    - Inconsistent behaviour: unify.
 #

--- a/gnrpy/tests/sql/e_query_test.py
+++ b/gnrpy/tests/sql/e_query_test.py
@@ -138,18 +138,19 @@ class BaseSql(BaseGnrSqlTest):
         result = query.selection().output('list')
         assert result[0][0] == datetime.date(2005, 4, 7)
 
-    def test_between_syntax(self):
+    def test_in_range_syntax(self):
+        """Test #IN_RANGE macro (renamed from #BETWEEN, issue #622)."""
         # test blank handling
         query = self.db.query('video.location',
                               order_by="$rating",
                               columns='$id',
-                              where='#BETWEEN(  $rating  ,:lower, :upper     )',
+                              where='#IN_RANGE(  $rating  ,:lower, :upper     )',
                               sqlparams={'lower': -1, 'upper': 0})
         result = query.selection().output('list')
         assert result[0][0] == 2
         assert len(result) == 2
 
-        # test between using int
+        # test in_range using int
         lower = -6
         upper = 5
         params_cases = [
@@ -178,7 +179,7 @@ class BaseSql(BaseGnrSqlTest):
             query = self.db.query('video.location',
                                   order_by="$rating",
                                   columns='$rating',
-                                  where='#BETWEEN($rating, :lower, :upper)',
+                                  where='#IN_RANGE($rating, :lower, :upper)',
                                   sqlparams=params.get("params"))
             result = query.selection().output('list')
             print('PARAMS', params.get("params"))
@@ -186,7 +187,7 @@ class BaseSql(BaseGnrSqlTest):
             assert result[0][0] == params.get("expected")
             assert len(result) == params.get("n_records")
 
-        # test between using dates
+        # test in_range using dates
         lower = datetime.date(2005,4,1)
         upper = datetime.date(2005,4,30)
         params_cases = [
@@ -220,12 +221,11 @@ class BaseSql(BaseGnrSqlTest):
             query = self.db.query('video.dvd',
                                   order_by="$purchasedate",
                                   columns='$purchasedate',
-                                  where='#BETWEEN($purchasedate, :lower, :upper)',
+                                  where='#IN_RANGE($purchasedate, :lower, :upper)',
                                   sqlparams=params.get("params"))
             result = query.selection().output('list')
             assert result[0][0] == params.get("expected")
             assert len(result) == params.get("n_records")
-
 
     def test_joinSimple(self):
         tbl = self.db.table('video.dvd')

--- a/gnrpy/tests/sql/h_query_surface_test.py
+++ b/gnrpy/tests/sql/h_query_surface_test.py
@@ -278,11 +278,12 @@ class BaseQuerySurface(BaseGnrSqlTest):
         cols = sel.allColumns
         assert '_movie_id_title' in cols
 
-    # --- BETWEEN in where ---
+    # --- IN_RANGE in where (renamed from BETWEEN, issue #622) ---
 
-    def test_between_in_where(self):
+    def test_in_range_in_where(self):
+        """Test #IN_RANGE macro in where clause."""
         q = self.db.query('video.movie', columns='$id,$title,$year',
-                          where='#BETWEEN($year,:y_low,:y_high)',
+                          where='#IN_RANGE($year,:y_low,:y_high)',
                           sqlparams={'y_low': 2004, 'y_high': 2006})
         sel = q.selection()
         assert len(sel) > 0


### PR DESCRIPTION
## Summary

- Renamed the `#BETWEEN` SQL macro to `#IN_RANGE` to avoid confusion with the SQL `BETWEEN` operator (which has different NULL semantics)
- Removed `#BETWEEN` entirely (no deprecated alias) since all real-world usages are in edodevel (internal project, 5 occurrences) and will be updated separately
- Renamed `expandBetween` method to `expandInRange`, `BETWEENFINDER` regex to `IN_RANGEFINDER`
- Updated all tests, docstrings, README and RELEASE_NOTES

### Current `#BETWEEN` usages in projects (to be updated separately)

| Project | File | Usage |
|---------|------|-------|
| edodevel | `model/rate.py:64` | `#BETWEEN(:env_workdate, $valid_from, $valid_to)` in formulaColumn |
| edodevel | `model/studio_allocation.py:62` | `#BETWEEN($date, @rate_id.valid_from, @rate_id.valid_to)` in cnd |
| edodevel | `model/tb_timesheet.py:91` | `#BETWEEN($date, @applicable_rate_id.valid_from, ...)` in cnd |
| edodevel | `model/worker_allocation.py:79` | `#BETWEEN($date, @specific_rate_id.valid_from, ...)` in cnd |
| edodevel | `model/worker_allocation.py:86` | `#BETWEEN($date, @specific_rate_id.valid_from, ...)` in cnd |

## Test plan

- [x] flake8 zero errors on modified files
- [x] Full SQL test suite: 1007 passed, 10 skipped, 0 failed
- [x] `test_in_range_syntax` passes on sqlite and postgres (3 implementations)
- [x] `test_in_range_in_where` passes on sqlite and postgres
- [ ] Update edodevel usages after merge

Ref #622