### PR TITLE
fix(menu): preserve whitespace in tree search highlight (#643)

### DIFF
--- a/gnrjs/gnr_d11/js/genro_tree.js
+++ b/gnrjs/gnr_d11/js/genro_tree.js
@@ -474,10 +474,13 @@ dojo.declare("gnr.widgets.Tree", gnr.widgets.baseDojo, {
                             if(search && isHTML){
                                 label = label.replace(/(<[^>]+>)/g, '\x00$1\x00').split('\x00')
                                     .map(function(part){
-                                        return part.charAt(0)==='<' ? part : part.replace(filterRegExp,"<span class='search_highlight'>$1</span>");
+                                        if(part.charAt(0)==='<') return part;
+                                        if(!part) return part;
+                                        var highlighted = part.replace(filterRegExp,"<span class='search_highlight'>$1</span>");
+                                        return '<span>' + highlighted + '</span>';
                                     }).join('');
-                            }else{
-                                label = label.replace(filterRegExp,"<span class='search_highlight'>$1</span>");
+                            }else if(search){
+                                label = '<span>' + label.replace(filterRegExp,"<span class='search_highlight'>$1</span>") + '</span>';
                             }
                             tn.labelNode.innerHTML = label;
                         }


### PR DESCRIPTION
## Summary

- Fixes whitespace collapsing in menu tree search results when `menutree_branchiconright` mode is active
- In inline-flex layout, search highlight `<span>` elements cause bare text nodes to become anonymous flex items, where CSS collapses leading/trailing whitespace at their boundaries
- Wraps text segments in `<span>` elements during search so content stays within proper inline formatting context

## Test plan

- [x] Open an app using `menutree_branchiconright` (e.g. gnrdevelop)
- [x] Search for a term that matches in the middle of multi-word labels (e.g. "Piano deiconti" → search "dei")
- [x] Verify spaces between words are preserved in highlighted results
- [x] Clear search — verify labels restore correctly
- [x] Test with labels that have icons and badges
- [x] Test in a tree without `menutree_branchiconright` to verify no regression

Closes #643