### PR TITLE
execute the daemon without a site in docker image

### DIFF
--- a/gnrpy/gnr/app/cli/gnrdockerize.py
+++ b/gnrpy/gnr/app/cli/gnrdockerize.py
@@ -221,6 +221,8 @@ stderr_logfile_maxbytes=0
             build_command = ['docker', 'build', '--platform', self.options.architecture,
                              '-t', f'{self.image_name}:{version_tag}',
                              self.build_context_dir]
+            if self.options.no_pull:
+                build_command.insert(2, '--pull=false')
             subprocess.run(build_command, check=True)
             logger.info("Docker image built successfully.")
             os.chdir(entry_dir)
@@ -358,6 +360,10 @@ def main():
                         action="store_true",
                         dest="keep_temp",
                         help="Keep intermediate data for debugging the image build")
+    parser.add_argument('--no-pull',
+                        action="store_true",
+                        dest="no_pull",
+                        help="Avoid pulling remote image, useful for local development")
     parser.add_argument('--router',
                         dest='router',
                         type=str,

--- a/gnrpy/gnr/web/cli/gnrstack.py
+++ b/gnrpy/gnr/web/cli/gnrstack.py
@@ -25,8 +25,7 @@ processes = {}
 
 def start_process(cmd_name, command_path, site, args):
     if cmd_name == "daemon":
-        # unfortunately, this is needed for the current daemon
-        cmd = [sys.executable] + command_path.split() + ['-n', site, site]
+        cmd = [sys.executable] + command_path.split()
     else:
         cmd = [sys.executable] + command_path.split() + [site]
     if args:


### PR DESCRIPTION
execute the daemon without a site, which causes the subprocess not to be started.

added a '--no-pull' option to dockerize, useful to build local images using a local image of the framework

close #642