### PR TITLE
feat: capability registry for package decoupling

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -984,6 +984,8 @@ class GnrApp(object):
         #    self.config['menu']=self.instanceMenu
 
         self.localizer = AppLocalizer(self)
+        self.capabilities = {}
+        self.pkgBroadcast('registerCapabilities', self)
         self.onInited()
 
     def addPackage(self,pkgid,pkgattrs=None,pkgcontent=None):
@@ -1186,9 +1188,25 @@ class GnrApp(object):
         """Hook method called before the :ref:`instance <instances>` initialization"""
         pass
 
+    def addCapability(self, name, provider, replace=False):
+        """Register a capability provider.
+
+        Packages call this during ``registerCapabilities`` to declare
+        the services they provide (e.g. ``'preference'``, ``'userobject'``).
+        Packages are broadcast in load order — last one wins when
+        *replace* is ``True``.
+
+        :param name: capability identifier (e.g. ``'preference'``)
+        :param provider: the package instance that provides this capability
+        :param replace: if ``False`` (default), raise on duplicate
+        """
+        if name in self.capabilities and not replace:
+            raise KeyError(f"Capability '{name}' is already registered")
+        self.capabilities[name] = provider
+
     def onInited(self):
         """Hook method called after the instance initialization is complete.
-        
+
         By default, it will call the :meth:`onApplicationInited()
         <gnr.app.gnrapp.GnrPackage.onApplicationInited>` method of each package"""
         self.pkgBroadcast('onApplicationInited')

--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -1204,6 +1204,10 @@ class GnrApp(object):
             raise KeyError(f"Capability '{name}' is already registered")
         self.capabilities[name] = provider
 
+    def hasCapability(self, name):
+        """Return ``True`` if a provider is registered for *name*."""
+        return name in self.capabilities
+
     def onInited(self):
         """Hook method called after the instance initialization is complete.
 
@@ -1240,12 +1244,14 @@ class GnrApp(object):
         return (found_locale or 'en-GB').replace('_','-')
 
     def setPreference(self, path, data, pkg):
-        if self.db.package('adm'):
-            self.db.table('adm.preference').setPreference(path, data, pkg=pkg)
+        provider = self.capabilities.get('preference')
+        if provider:
+            provider.setPreference(self, path, data, pkg=pkg)
 
     def getPreference(self, path, pkg=None, dflt=None, mandatoryMsg=None):
-        if self.db.package('adm'):
-            return self.db.table('adm.preference').getPreference(path, pkg=pkg, dflt=dflt, mandatoryMsg=mandatoryMsg)
+        provider = self.capabilities.get('preference')
+        if provider:
+            return provider.getPreference(self, path, pkg=pkg, dflt=dflt, mandatoryMsg=mandatoryMsg)
     
     def getResource(self, path, pkg=None, locale=None):
         """TODO

--- a/gnrpy/gnr/app/gnrdbo.py
+++ b/gnrpy/gnr/app/gnrdbo.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from gnr.core.gnrlang import boolean
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrstring import splitAndStrip,templateReplace,fromJson,slugify
-from gnr.core.gnrdecorator import public_method,extract_kwargs
+from gnr.core.gnrdecorator import public_method,extract_kwargs,capability
 from gnr.core.gnrdict import dictExtract
 
 from gnr.app import logger
@@ -142,20 +142,22 @@ class GnrDboPackage(object):
         :param pkg: the :ref:`package <packages>` object"""
         return self.dbtable('userobject').listUserObject(pkg=pkg or self.name, **kwargs)
         
+    @capability('preference')
     def getPreference(self, path, dflt=None, mandatoryMsg=None):
         """Get a preference for the current package. Return the value of the specified
         preference, or *dflt* if it is missing
-        
+
         :param path: a dotted name of the preference item
         :param dflt: the default value"""
-        return self.db.table('adm.preference').getPreference(path, pkg=self.name, dflt=dflt, mandatoryMsg=mandatoryMsg)
-        
+        ...
+
+    @capability('preference')
     def setPreference(self, path, value):
         """Set a preference for the current package.
-        
+
         :param path: a dotted name of the preference item
         :param value: the new value"""
-        self.db.table('adm.preference').setPreference(path, value, pkg=self.name)
+        ...
          
     @public_method
     def loadStartupData(self,basepath=None,empty_before=None):
@@ -221,8 +223,9 @@ class GnrDboPackage(object):
                             )
                 tblobj.insertMany(recordsToInsert)
 
-        if s['preferences']:
-            self.db.table('adm.preference').initPkgPref(self.name,s['preferences'])
+        if s['preferences'] and self.application.hasCapability('preference'):
+            provider = self.application.capabilities['preference']
+            provider.initPkgPref(self, self.name, s['preferences'])
             
         db.commit()
         
@@ -318,7 +321,11 @@ class GnrDboPackage(object):
                     queryPars.update(qp_handler())
                 f = tblobj.dbtable.query(**queryPars).fetch()
             s[tname] = f
-        s['preferences'] = self.db.table('adm.preference').loadPreference()['data'][self.name]
+        if self.application.hasCapability('preference'):
+            provider = self.application.capabilities['preference']
+            s['preferences'] = provider.loadPreference(self)['data'][self.name]
+        else:
+            s['preferences'] = Bag()
         s.makePicklable()
         s.pickle('%s.pik' %bagpath)
         import gzip

--- a/gnrpy/gnr/app/gnrdbo.py
+++ b/gnrpy/gnr/app/gnrdbo.py
@@ -40,6 +40,20 @@ def _add_localized_prefix(label, prefix):
 
 class GnrDboPackage(object):
     """Base class for packages"""
+
+    def registerCapabilities(self, app):
+        """Register capabilities provided by this package.
+
+        Override in subclasses to call ``app.addCapability()`` for each
+        service this package provides (e.g. ``'preference'``,
+        ``'userobject'``, ``'counter'``).
+
+        Called via ``pkgBroadcast`` during app initialization, in
+        package load order — last registered provider wins when
+        using ``replace=True``.
+        """
+        pass
+
     def updateFromExternalDb(self,externaldb,empty_before=None):
         """TODO
         

--- a/gnrpy/gnr/core/gnrdecorator.py
+++ b/gnrpy/gnr/core/gnrdecorator.py
@@ -30,7 +30,8 @@ def capability(name):
 
     The decorated method acts as an interface contract — its body is never
     executed.  At call time, the decorator looks up ``self.application.capabilities[name]``
-    and calls the same-named method on the provider.
+    and calls the same-named method on the provider, passing the original
+    ``self`` (the caller) as first argument.
 
     If no provider is registered, raises ``GnrException``.
 
@@ -39,11 +40,21 @@ def capability(name):
         @capability('preference')
         def getPreference(self, path, dflt=None):
             ...
+
+    The provider must implement the same method receiving the caller::
+
+        def getPreference(self, caller, path, dflt=None):
+            # self = provider package, caller = who called getPreference
+            ...
     """
     def decorator(method):
         @wraps(method)
         def wrapper(self, *args, **kwargs):
             app = getattr(self, 'application', None) or getattr(self, 'app', None)
+            if app is None:
+                db = getattr(self, 'db', None)
+                if db is not None:
+                    app = getattr(db, 'application', None)
             if app is None:
                 from gnr.core.gnrlang import GnrException
                 raise GnrException(f"Cannot resolve application for capability '{name}'")
@@ -51,7 +62,7 @@ def capability(name):
             if provider is None:
                 from gnr.core.gnrlang import GnrException
                 raise GnrException(f"No provider registered for capability '{name}'")
-            return getattr(provider, method.__name__)(*args, **kwargs)
+            return getattr(provider, method.__name__)(self, *args, **kwargs)
         wrapper._capability = name
         return wrapper
     return decorator

--- a/gnrpy/gnr/core/gnrdecorator.py
+++ b/gnrpy/gnr/core/gnrdecorator.py
@@ -21,7 +21,41 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import warnings
+from functools import wraps
 from gnr.core.gnrdict import dictExtract
+
+
+def capability(name):
+    """Decorator that delegates a method call to a registered capability provider.
+
+    The decorated method acts as an interface contract — its body is never
+    executed.  At call time, the decorator looks up ``self.application.capabilities[name]``
+    and calls the same-named method on the provider.
+
+    If no provider is registered, raises ``GnrException``.
+
+    Usage::
+
+        @capability('preference')
+        def getPreference(self, path, dflt=None):
+            ...
+    """
+    def decorator(method):
+        @wraps(method)
+        def wrapper(self, *args, **kwargs):
+            app = getattr(self, 'application', None) or getattr(self, 'app', None)
+            if app is None:
+                from gnr.core.gnrlang import GnrException
+                raise GnrException(f"Cannot resolve application for capability '{name}'")
+            provider = app.capabilities.get(name)
+            if provider is None:
+                from gnr.core.gnrlang import GnrException
+                raise GnrException(f"No provider registered for capability '{name}'")
+            return getattr(provider, method.__name__)(*args, **kwargs)
+        wrapper._capability = name
+        return wrapper
+    return decorator
+
 
 def metadata(**kwargs):
     """TODO"""

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -2185,9 +2185,9 @@ class GnrWebPage(GnrBaseWebPage):
         rootenv = self.getStartRootenv()
         self._workdate = None #reset workdate
         prefenv = Bag()
-        has_adm = self.application.db.package('adm')
-        if has_adm:
-            prefenv = self.application.db.table('adm.preference').envPreferences(username=self.user)
+        if self.application.hasCapability('preference'):
+            provider = self.application.capabilities['preference']
+            prefenv = provider.envPreferences(self, username=self.user)
         data = Bag(dict(root_page_id=self.root_page_id,parent_page_id=self.parent_page_id,rootenv=rootenv,prefenv=prefenv))
         self.pageStore().update(data)
         self._db = None #resetting db property after setting dbenv
@@ -2247,7 +2247,7 @@ class GnrWebPage(GnrBaseWebPage):
             page.data('gnr.dbstore',self.dbstore)
         page.data('gnr.multidomain', self.multidomain)
         page.data('gnr.currentDomain', self.currentDomain)
-        if has_adm and not self.isGuest:
+        if self.application.hasCapability('preference') and not self.isGuest:
             page.dataRemote('gnr.user_preference', self.getUserPreference,username='^gnr.avatar.user',
                             _resolved=True,_resolved_username=self.user)
             page.dataRemote('gnr.app_preference', self.getAppPreference,_resolved=True)

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -676,7 +676,7 @@ class GnrWsgiSite(object):
     @property
     def connectionLogEnabled(self):
         if not hasattr(self,'_connectionLogEnabled'):
-            if not self.db.package('adm'):
+            if not self.gnrapp.hasCapability('preference'):
                 self._connectionLogEnabled = False
             else:
                 self._connectionLogEnabled = self.getPreference('dev.connection_log_enabled',pkg='adm')
@@ -1587,9 +1587,9 @@ class GnrWsgiSite(object):
         :param path: TODO
         :param data: TODO
         :param pkg: the :ref:`package <packages>` object"""
-        if self.db.package('adm'):
+        if self.gnrapp.hasCapability('preference'):
             pkg = pkg or self.currentPage.packageId
-            self.db.table('adm.preference').setPreference(path, data, pkg=pkg)
+            self.gnrapp.setPreference(path, data, pkg=pkg)
 
     def getPreference(self, path, pkg=None, dflt=None, mandatoryMsg=None):
         """TODO
@@ -1597,9 +1597,9 @@ class GnrWsgiSite(object):
         :param path: TODO
         :param pkg: the :ref:`package <packages>` object
         :param dflt: TODO"""
-        if self.db.package('adm'):
+        if self.gnrapp.hasCapability('preference'):
             pkg = pkg or self.currentPage.packageId
-            return self.db.table('adm.preference').getPreference(path, pkg=pkg, dflt=dflt, mandatoryMsg=mandatoryMsg)
+            return self.gnrapp.getPreference(path, pkg=pkg, dflt=dflt, mandatoryMsg=mandatoryMsg)
 
     def getUserPreference(self, path, pkg=None, dflt=None, username=None):
         """TODO
@@ -1608,10 +1608,11 @@ class GnrWsgiSite(object):
         :param pkg: the :ref:`package <packages>` object
         :param dflt: TODO
         :param username: TODO"""
-        if self.db.package('adm'):
+        if self.gnrapp.hasCapability('user_preference'):
             username = username or self.currentPage.user if self.currentPage else None
             pkg = pkg or self.currentPage.packageId if self.currentPage else None
-            return self.db.table('adm.user').getPreference(path=path, pkg=pkg, dflt=dflt, username=username)
+            provider = self.gnrapp.capabilities['user_preference']
+            return provider.getUserPreference(self, path=path, pkg=pkg, dflt=dflt, username=username)
 
     def setUserPreference(self, path, data, pkg=None, username=None):
         """TODO
@@ -1620,10 +1621,11 @@ class GnrWsgiSite(object):
         :param data: TODO
         :param pkg: the :ref:`package <packages>` object
         :param username: TODO"""
-        if self.db.package('adm'):
+        if self.gnrapp.hasCapability('user_preference'):
             pkg = pkg or self.currentPage.packageId
             username = username or self.currentPage.user if self.currentPage else None
-            self.db.table('adm.user').setPreference(path, data, pkg=pkg, username=username)
+            provider = self.gnrapp.capabilities['user_preference']
+            provider.setUserPreference(self, path, data, pkg=pkg, username=username)
 
     @property
     def ukeInstanceId(self):

--- a/projects/gnrcore/packages/adm/main.py
+++ b/projects/gnrcore/packages/adm/main.py
@@ -17,6 +17,38 @@ class Package(GnrDboPackage):
     def config_db(self, pkg):
         pass
 
+    def registerCapabilities(self, app):
+        app.addCapability('preference', self)
+        app.addCapability('user_preference', self)
+
+    # --- capability: preference ---
+
+    def getPreference(self, caller, path, dflt=None, mandatoryMsg=None, pkg=None):
+        pkg = pkg or getattr(caller, 'name', None)
+        return self.db.table('adm.preference').getPreference(path, pkg=pkg, dflt=dflt, mandatoryMsg=mandatoryMsg)
+
+    def setPreference(self, caller, path, value=None, data=None, pkg=None):
+        pkg = pkg or getattr(caller, 'name', None)
+        value = value if data is None else data
+        self.db.table('adm.preference').setPreference(path, value, pkg=pkg)
+
+    def envPreferences(self, caller, username=None):
+        return self.db.table('adm.preference').envPreferences(username=username)
+
+    def initPkgPref(self, caller, pkg_name, preferences):
+        self.db.table('adm.preference').initPkgPref(pkg_name, preferences)
+
+    def loadPreference(self, caller):
+        return self.db.table('adm.preference').loadPreference()
+
+    # --- capability: user_preference ---
+
+    def getUserPreference(self, caller, path=None, pkg=None, dflt=None, username=None):
+        return self.db.table('adm.user').getPreference(path=path, pkg=pkg, dflt=dflt, username=username)
+
+    def setUserPreference(self, caller, path, data, pkg=None, username=None):
+        self.db.table('adm.user').setPreference(path, data, pkg=pkg, username=username)
+
     def required_packages(self):
         return ['gnrcore:sys']
 


### PR DESCRIPTION
## Summary

This PR introduces a **capability registry** pattern to decouple the GenroPy framework core (`gnrpy/gnr/`) from optional packages like `adm` and `sys`.

The goal (ref #564) is to allow using the framework without `adm`/`sys` packages — applications that don't need preferences, user objects, counters, etc. should work without those packages being installed.

## Approach: Capability Registry

Instead of hard-coding references like `self.db.table('adm.preference')` throughout the framework, we introduce:

1. **`app.capabilities`** — a dict populated at startup via `pkgBroadcast('registerCapabilities')`
2. **`app.addCapability(name, provider)`** — packages register themselves as providers for named capabilities
3. **`app.hasCapability(name)`** — guard check for optional features
4. **`@capability(name)` decorator** — applied to base class methods (body is `...`), delegates the call to the registered provider. Raises `GnrException` if no provider is registered.

### How it works

```python
# Base class (gnrdbo.py) — declares the interface
class GnrDboPackage:
    @capability('preference')
    def getPreference(self, path, dflt=None, mandatoryMsg=None):
        ...

# Provider (adm/main.py) — implements the capability
class Package(GnrDboPackage):
    def registerCapabilities(self, app):
        app.addCapability('preference', self)
        app.addCapability('user_preference', self)

    def getPreference(self, caller, path, dflt=None, mandatoryMsg=None, pkg=None):
        pkg = pkg or getattr(caller, 'name', None)
        return self.db.table('adm.preference').getPreference(path, pkg=pkg, ...)
```

The `@capability` decorator intercepts the call, finds the provider, and delegates — passing the original `self` (caller) as first argument so the provider knows who's calling.

For call sites that aren't on decorated methods (e.g. `GnrApp`, `GnrWsgiSite`, `GnrWebPage`), we use `hasCapability` guards:

```python
if self.application.hasCapability('preference'):
    provider = self.application.capabilities['preference']
    provider.envPreferences(self, username=self.user)
```

## What this PR implements

**Preference capability** as a complete proof-of-concept:
- `@capability('preference')` on `GnrDboPackage.getPreference` / `setPreference`
- `hasCapability('preference')` guards in `GnrApp`, `GnrWsgiSite`, `GnrWebPage`
- `user_preference` as separate capability (uses `adm.user` table)
- Full provider implementation in `adm/main.py`

## Remaining capabilities to migrate

If this approach is approved, the same pattern will be applied to all remaining dependencies (45 call sites across 11 files):

| Capability | Call sites | Files | Package |
|--|--|--|--|
| **userobject** | 9 | `gnrapp.py`, `gnrdbo.py`, `gnrwebpage.py`, `developer.py`, `btcbase.py`, `get_selection.py` | adm |
| **task_manager** | 8 | `gnrtask.py`, `gnrtask_new.py` | sys |
| **htmltemplate** | 5 | `gnrbaseclasses.py`, `gnrtablescript.py`, `gnrtablescript_new.py` | adm |
| **user_auth** | 5 | `gnrapp.py`, `gnrdbo.py`, `gnrwebpage.py`, `gnrwebapp.py` | adm/sys |
| **batch_log** | 4 | `btcbase.py`, `btcmail.py` | sys/adm |
| **counter** | 4 | `gnrdbo.py` | adm |
| **connection_log** | 3 | `gnrwsgisite.py` | adm |
| **error_log** | 2 | `gnrwsgisite.py` | sys |
| **data_retention** | 2 | `gnrapp.py` | sys |
| **audit** | 1 | `gnrwebapp.py` | adm |
| **shortcut** | 1 | `gnrwebpage.py` | adm |
| **tblinfo** | 1 | `gnrwebpage.py` | adm |

## Request for review

@mbertoldi @cgabriel @fporcari — please evaluate this approach before we proceed with the remaining capabilities. Key questions:

1. Is the **capability registry + decorator** pattern acceptable for decoupling?
2. Is the **provider receives `caller` as first argument** convention clear enough?
3. Any concerns about the `hasCapability` guard pattern for non-decorated call sites?
4. Should any capability groupings be changed (e.g. merge `preference` + `user_preference`)?

Ref #564