### PR TITLE
fix(migrate): clear error on unreachable DB server (#654)

### DIFF
--- a/gnrpy/gnr/sql/adapters/gnrpostgres.py
+++ b/gnrpy/gnr/sql/adapters/gnrpostgres.py
@@ -43,7 +43,7 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT, ISOLATION_LEVEL_READ
 
 from gnr.sql.adapters._gnrbasepostgresadapter import PostgresSqlDbBaseAdapter
 from gnr.sql.adapters._gnrbaseadapter import GnrDictRow
-from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException
+from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException, GnrSqlConnectionException
 
 
 RE_SQL_PARAMS = re.compile(r"(?<!:):(?!:)(\S\w*)(\W|$)")
@@ -136,8 +136,10 @@ class SqlDbAdapter(PostgresSqlDbBaseAdapter):
             conn = psycopg2.connect(**kwargs)
             if autoCommit:
                 conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-        except psycopg2.OperationalError:
-            raise GnrNonExistingDbException(self.dbroot.dbname)
+        except psycopg2.OperationalError as e:
+            if 'does not exist' in str(e).lower():
+                raise GnrNonExistingDbException(self.dbroot.dbname)
+            raise GnrSqlConnectionException(self.dbroot.dbname, original_error=e)
         finally:
             self._lock.release()
         return conn

--- a/gnrpy/gnr/sql/adapters/gnrpostgres3.py
+++ b/gnrpy/gnr/sql/adapters/gnrpostgres3.py
@@ -32,7 +32,7 @@ from psycopg import sql
 
 from gnr.core.gnrlist import GnrNamedList
 from gnr.sql.adapters._gnrbasepostgresadapter import PostgresSqlDbBaseAdapter
-from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException
+from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException, GnrSqlConnectionException
 
 RE_SQL_PARAMS = re.compile(r"(?<!:):(?!:)(\S\w*)(\W|$)")
 
@@ -55,8 +55,10 @@ class SqlDbAdapter(PostgresSqlDbBaseAdapter):
         
         try:
             conn = psycopg.connect(**kwargs)
-        except psycopg.OperationalError:
-            raise GnrNonExistingDbException(self.dbroot.dbname)
+        except psycopg.OperationalError as e:
+            if 'does not exist' in str(e).lower():
+                raise GnrNonExistingDbException(self.dbroot.dbname)
+            raise GnrSqlConnectionException(self.dbroot.dbname, original_error=e)
         conn.cursor_factory = GnrDictCursor
         return conn
 

--- a/gnrpy/gnr/sql/gnrsql_exceptions.py
+++ b/gnrpy/gnr/sql/gnrsql_exceptions.py
@@ -36,6 +36,17 @@ class GnrSqlException(GnrException):
 class GnrNonExistingDbException(GnrSqlException):
     def __init__(self, dbname):
         self.dbname = dbname
+
+class GnrSqlConnectionException(GnrSqlException):
+    """Raised when the database server is unreachable or the connection fails
+    for reasons other than a non-existing database (e.g. wrong host, port,
+    network timeout)."""
+    def __init__(self, dbname, original_error=None):
+        self.dbname = dbname
+        self.original_error = original_error
+
+    def __str__(self):
+        return f"Cannot connect to database '{self.dbname}': {self.original_error}"
         
 class NotMatchingModelError(GnrSqlException):
     pass

--- a/gnrpy/gnr/sql/gnrsqlmigration/db_extractor.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration/db_extractor.py
@@ -77,7 +77,7 @@ produce commands for the complete database creation.
 """
 
 from gnr.dev.decorator import time_measure
-from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException
+from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException, GnrSqlConnectionException
 
 from .structures import (
     COL_JSON_KEYS,
@@ -201,6 +201,8 @@ class DbExtractor(object):  # REVIEW: old-style (object) base class — unnecess
                 result['event_triggers'] = adapter.struct_get_event_triggers()
         except GnrNonExistingDbException:
             result = False
+        except GnrSqlConnectionException:
+            raise
         finally:
             self.close_connection()
         return result

--- a/gnrpy/gnr/sql/gnrsqlmigration/migrator.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration/migrator.py
@@ -100,7 +100,7 @@ Typical usage example::
 """
 
 from gnr.core.gnrbag import Bag
-from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException
+from gnr.sql.gnrsql_exceptions import GnrNonExistingDbException, GnrSqlConnectionException
 
 from .structures import nested_defaultdict, json_to_tree
 from .orm_extractor import OrmExtractor
@@ -176,7 +176,13 @@ class SqlMigrator(DiffMixin, CommandBuilderMixin, ExecutorMixin):
         'removed' events are skipped if ``removeDisabled`` is True.
         Entities in readOnly schemas are ignored.
         """
-        self.prepareStructures()
+        try:
+            self.prepareStructures()
+        except GnrSqlConnectionException as e:
+            raise SystemExit(
+                f'ERROR: {e}\n'
+                'Migration aborted. Please check your database connection settings.'
+            ) from e
         self.commands = nested_defaultdict()
         for evt, kw in self.dictDifferChanges():
             if evt == 'removed' and self.removeDisabled:

--- a/gnrpy/tests/sql/test_connection_error.py
+++ b/gnrpy/tests/sql/test_connection_error.py
@@ -23,6 +23,7 @@ from gnr.sql.gnrsql_exceptions import (
     GnrNonExistingDbException,
     GnrSqlConnectionException,
 )
+from gnr.sql.gnrsqlmigration.migrator import SqlMigrator
 
 
 class TestPsycopg2ConnectionError:
@@ -123,3 +124,22 @@ class TestPsycopg3ConnectionError:
                 SqlDbAdapter.connect(adapter)
             assert exc_info.value.dbname == 'test_db'
             assert exc_info.value.original_error is error
+
+
+class TestMigratorConnectionError:
+    """Test that the migrator catches GnrSqlConnectionException and exits cleanly."""
+
+    def test_migrator_exits_on_connection_error(self):
+        """prepareMigrationCommands should raise SystemExit with a clear message
+        when the DB server is unreachable."""
+        migrator = MagicMock(spec=SqlMigrator)
+        migrator.prepareMigrationCommands = SqlMigrator.prepareMigrationCommands.__get__(migrator)
+        conn_error = GnrSqlConnectionException('mydb', original_error=Exception('No route to host'))
+        migrator.prepareStructures.side_effect = conn_error
+
+        with pytest.raises(SystemExit) as exc_info:
+            migrator.prepareMigrationCommands()
+        msg = str(exc_info.value)
+        assert 'mydb' in msg
+        assert 'No route to host' in msg
+        assert 'Migration aborted' in msg

--- a/gnrpy/tests/sql/test_connection_error.py
+++ b/gnrpy/tests/sql/test_connection_error.py
@@ -1,0 +1,125 @@
+"""Tests for issue #654: unreachable DB server should produce a clear error.
+
+When 'gnr db migrate' is run against an unreachable database server,
+the system should raise GnrSqlConnectionException with a clear message
+instead of a misleading TypeError deep in diff_engine.py.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+try:
+    import psycopg2
+    HAS_PSYCOPG2 = True
+except ImportError:
+    HAS_PSYCOPG2 = False
+
+try:
+    import psycopg
+    HAS_PSYCOPG3 = True
+except ImportError:
+    HAS_PSYCOPG3 = False
+
+from gnr.sql.gnrsql_exceptions import (
+    GnrNonExistingDbException,
+    GnrSqlConnectionException,
+)
+
+
+class TestPsycopg2ConnectionError:
+    """Test that psycopg2 adapter distinguishes connection errors from non-existing DB."""
+
+    @pytest.mark.skipif(not HAS_PSYCOPG2, reason="psycopg2 not installed")
+    def test_nonexisting_db_raises_nonexisting_exception(self):
+        """OperationalError with 'does not exist' should raise GnrNonExistingDbException."""
+        from gnr.sql.adapters.gnrpostgres import SqlDbAdapter
+
+        adapter = MagicMock(spec=SqlDbAdapter)
+        adapter.dbroot = MagicMock()
+        adapter.dbroot.dbname = 'test_db'
+        adapter._lock = MagicMock()
+        adapter.get_connection_params = MagicMock(return_value={
+            'host': 'localhost', 'dbname': 'nonexistent_db',
+        })
+
+        error = psycopg2.OperationalError('FATAL:  database "nonexistent_db" does not exist')
+        with patch('psycopg2.connect', side_effect=error):
+            with pytest.raises(GnrNonExistingDbException):
+                SqlDbAdapter.connect(adapter)
+
+    @pytest.mark.skipif(not HAS_PSYCOPG2, reason="psycopg2 not installed")
+    def test_unreachable_server_raises_connection_exception(self):
+        """OperationalError with connection refused should raise GnrSqlConnectionException."""
+        from gnr.sql.adapters.gnrpostgres import SqlDbAdapter
+
+        adapter = MagicMock(spec=SqlDbAdapter)
+        adapter.dbroot = MagicMock()
+        adapter.dbroot.dbname = 'test_db'
+        adapter._lock = MagicMock()
+        adapter.get_connection_params = MagicMock(return_value={
+            'host': 'nonexistent-host.invalid', 'dbname': 'test_db',
+        })
+
+        error = psycopg2.OperationalError(
+            'could not connect to server: Connection refused\n'
+            '\tIs the server running on host "nonexistent-host.invalid" '
+            'and accepting TCP/IP connections on port 5432?'
+        )
+        with patch('psycopg2.connect', side_effect=error):
+            with pytest.raises(GnrSqlConnectionException) as exc_info:
+                SqlDbAdapter.connect(adapter)
+            assert exc_info.value.dbname == 'test_db'
+            assert exc_info.value.original_error is error
+
+    @pytest.mark.skipif(not HAS_PSYCOPG2, reason="psycopg2 not installed")
+    def test_connection_exception_has_clear_message(self):
+        """GnrSqlConnectionException.__str__ should produce a human-readable message."""
+        exc = GnrSqlConnectionException(
+            'mydb',
+            original_error=Exception('Connection refused'),
+        )
+        msg = str(exc)
+        assert 'mydb' in msg
+        assert 'Connection refused' in msg
+
+
+class TestPsycopg3ConnectionError:
+    """Test that psycopg (v3) adapter distinguishes connection errors from non-existing DB."""
+
+    @pytest.mark.skipif(not HAS_PSYCOPG3, reason="psycopg not installed")
+    def test_nonexisting_db_raises_nonexisting_exception(self):
+        """OperationalError with 'does not exist' should raise GnrNonExistingDbException."""
+        from gnr.sql.adapters.gnrpostgres3 import SqlDbAdapter
+
+        adapter = MagicMock(spec=SqlDbAdapter)
+        adapter.dbroot = MagicMock()
+        adapter.dbroot.dbname = 'test_db'
+        adapter.get_connection_params = MagicMock(return_value={
+            'host': 'localhost', 'database': 'nonexistent_db',
+        })
+
+        error = psycopg.OperationalError('FATAL:  database "nonexistent_db" does not exist')
+        with patch('psycopg.connect', side_effect=error):
+            with pytest.raises(GnrNonExistingDbException):
+                SqlDbAdapter.connect(adapter)
+
+    @pytest.mark.skipif(not HAS_PSYCOPG3, reason="psycopg not installed")
+    def test_unreachable_server_raises_connection_exception(self):
+        """OperationalError with connection refused should raise GnrSqlConnectionException."""
+        from gnr.sql.adapters.gnrpostgres3 import SqlDbAdapter
+
+        adapter = MagicMock(spec=SqlDbAdapter)
+        adapter.dbroot = MagicMock()
+        adapter.dbroot.dbname = 'test_db'
+        adapter.get_connection_params = MagicMock(return_value={
+            'host': 'nonexistent-host.invalid', 'database': 'test_db',
+        })
+
+        error = psycopg.OperationalError(
+            'connection to server at "nonexistent-host.invalid", port 5432 failed: '
+            'Connection refused'
+        )
+        with patch('psycopg.connect', side_effect=error):
+            with pytest.raises(GnrSqlConnectionException) as exc_info:
+                SqlDbAdapter.connect(adapter)
+            assert exc_info.value.dbname == 'test_db'
+            assert exc_info.value.original_error is error


### PR DESCRIPTION
## Summary

- Distinguish "database does not exist" from "server unreachable" in both psycopg2 and psycopg3 adapters
- New `GnrSqlConnectionException` for connection failures (wrong host, port, network timeout)
- Migrator catches connection errors and exits with a clean, user-friendly message instead of a misleading `TypeError` deep in `diff_engine.py`

## Changes

- `gnrsql_exceptions.py`: add `GnrSqlConnectionException`
- `gnrpostgres.py` / `gnrpostgres3.py`: check error message to distinguish "does not exist" from connection errors
- `db_extractor.py`: re-raise `GnrSqlConnectionException` (don't swallow it)
- `migrator.py`: catch `GnrSqlConnectionException` in `prepareMigrationCommands()` and raise `SystemExit` with clear message

## Before

```
TypeError: string indices must be integers, not 'str'
  File "diff_engine.py", line 166
```

## After

```
ERROR: Cannot connect to database 'mydb': connection to server at "192.168.84.133", port 5432 failed: No route to host
Migration aborted. Please check your database connection settings.
```

## Test plan

- [x] 6 unit tests in `test_connection_error.py` (adapter-level + migrator-level)
- [x] CI green on Python 3.11, 3.12, 3.13, 3.14
- [x] Verified by @cgabriel on his environment (see issue #654 comments)

Ref #654