### PR TITLE
fix(menu): prevent tableBranch badge fallthrough to RPC on dbchanges

### DIFF
--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
@@ -148,15 +148,17 @@ class MenuIframes(BaseComponent):
                                     if(titleCounter){
                                         console.warn('titleCounter is deprecated. Use menuLineBadge instead of it')
                                     }
-                                    if(n.attr.tag == "tableBranch" && n.attr.table.replace('.','_') == flat_tblname){
-                                        n.refresh(true)
-                                        let content = n.getValue();
-                                        let child_count = (content instanceof gnr.GnrBag)?content.len():0;
-                                        let updater = {child_count:child_count};
-                                        if(titleCounter === true || menuLineBadge == '#'){
-                                            updater.badgeContent = child_count || null;
+                                    if(n.attr.tag == "tableBranch"){
+                                        if(n.attr.table.replace('.','_') == flat_tblname){
+                                            n.refresh(true);
+                                            let content = n.getValue();
+                                            let child_count = (content instanceof gnr.GnrBag)?content.len():0;
+                                            let updater = {child_count:child_count};
+                                            if(titleCounter === true || menuLineBadge == '#'){
+                                                updater.badgeContent = child_count || null;
+                                            }
+                                            n.updAttributes(updater);
                                         }
-                                        n.updAttributes(updater);
                                         return;
                                     }
    


### PR DESCRIPTION
## Summary
- Fix bug where `menuLineBadge='#'` on `tableBranch` nodes showed total table record count instead of child count
- When a `dbchanges` event fired for table X, `tableBranch` nodes for other tables (Y) failed the combined condition check and fell through to the generic RPC path, which called `getMenuLineBadge(handler='#')` counting ALL records without filtering
- Split the `if` condition so `tableBranch` nodes always `return` early from the walk callback, regardless of table match — mirroring the server-side guard at `gnrmenu.py:318`

## Test plan
- [x] Open a page with multiple subscribed tables and tableBranch menu items with `menuLineBadge='#'`
- [x] Modify a record in table X and verify that tableBranch badges for table Y are NOT overwritten
- [x] Verify that tableBranch badges for table X still refresh correctly with the proper child count