### PR TITLE
fix(sql): remove premature macro registry-to-expander copy

### DIFF
--- a/gnrpy/gnr/sql/gnrsqldata/compiler.py
+++ b/gnrpy/gnr/sql/gnrsqldata/compiler.py
@@ -236,8 +236,6 @@ class SqlQueryCompiler(object):
         self.aliasPrefix = aliasPrefix or 't'
         self.locale = locale
         self.macro_expander = self.db.adapter.macroExpander(self)
-        for name, (regex, callback) in self.db._macro_registry.items():
-            self.macro_expander.register(name, regex, callback)
 
     def aliasCode(self, n):
         """Return the table alias for index *n*.


### PR DESCRIPTION
## Summary

- Remove two lines in `compiler.py` that copied all registered macros (including those with `callback=None`) from `db._macro_registry` into `MacroExpander._registered_macros`
- These lines were introduced in PR #650 but belong to the usage phase, not the preparation phase
- Since registered macros take precedence over class-level ones in `replace()`, macros with `None` callback (PREF, THIS, BAG, BAGCOLS, TSQUERY, TSRANK, etc.) caused `TypeError` when invoked

## Test plan

- [x] All 666 SQL tests pass (1 pre-existing failure on develop unrelated to this change)
- [ ] Verify that adapter macros (TSQUERY, TSRANK, TSHEADLINE) expand correctly on Postgres queries
- [ ] Verify that app-level macros (PREF, THIS, BAG, BAGCOLS) expand correctly

Ref #617