### PR TITLE
fix(decorator): preserve __name__ in @customizable via functools.wraps

### DIFF
--- a/gnrpy/gnr/core/gnrdecorator.py
+++ b/gnrpy/gnr/core/gnrdecorator.py
@@ -21,6 +21,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import warnings
+from functools import wraps
 from gnr.core.gnrdict import dictExtract
 
 def metadata(**kwargs):
@@ -179,6 +180,7 @@ def customizable(func):
             if result is False:
                 return result
 
+    @wraps(func)
     def wrapper(page,*args,**kwargs):
         oncalling_result = customize(page,'%s_oncalling_' %func.__name__,*args,**kwargs)
         if oncalling_result is False:


### PR DESCRIPTION
Fixes #614

## Root cause

The `@customizable` decorator in `gnrpy/gnr/core/gnrdecorator.py` wrapped the original function without preserving its metadata. As a result, `wrapper.__name__` was literally `'wrapper'` instead of the decorated function's name.

The GenroPy RPC dispatcher resolves public methods by `__name__`, so when `@public_method` and `@customizable` were stacked on the same method, the server could not match the incoming RPC call to the correct handler — causing failures when calling via `.remote()`.

## Fix

Added `@wraps(func)` (from `functools`) to the inner `wrapper` function inside `customizable`. This preserves `__name__`, `__doc__`, `__dict__` (including `is_rpc`) and `__wrapped__`, making the decorator fully transparent to the RPC system regardless of the stacking order of `@public_method` and `@customizable`.

The change is two lines:

```python
from functools import wraps   # added import

def customizable(func):
    ...
    @wraps(func)              # added decorator
    def wrapper(page, *args, **kwargs):
        ...
```

This approach is consistent with how `@deprecated` already handles metadata preservation in the same file.

## Testing

Tested locally on the scenario described in the issue (`@public_method` + `@customizable` stacked, called via `.remote()`): the RPC call now resolves correctly. Previously it failed with an unresolvable method name.

## Notes

- Zero risk of regression: `functools.wraps` is stdlib, the change is minimal, and the wrapper logic is untouched.
- Both decorator orderings (`@public_method` + `@customizable` and `@customizable` + `@public_method`) now work correctly because `__dict__` propagation includes `is_rpc`.