### PR TITLE
fix(preferences): GroupletForm datapath separation and error-only indicator

### DIFF
--- a/gnrjs/gnr_d11/js/genro_components.js
+++ b/gnrjs/gnr_d11/js/genro_components.js
@@ -959,7 +959,10 @@ dojo.declare("gnr.widgets.GroupletForm",gnr.widgets.gnrwdg,{
         let resource = objectPop(kw,'resource');
         let value = objectPop(kw,'value');
         let dynamicLocationPath = objectPop(kw,'dynamicLocationPath');
-        let datapath = objectPop(kw,'datapath') || 'gnr.grouplet_'+genro.time36Id();
+        let formId = kw.formId;
+        let datapath = objectPop(grouplets_pars,'datapath') || objectPop(kw,'datapath') || 'gnr.grouplet_'+(formId || genro.time36Id());
+        let formDatapath = objectPop(grouplets_pars,'formDatapath') || objectPop(kw,'formDatapath');
+        let formControllerPath = objectPop(grouplets_pars,'formControllerPath') || objectPop(kw,'formControllerPath');
         let loadOnBuilt = objectPop(kw,'loadOnBuilt');
         let startKey = objectPop(kw,'startKey');
         let rootTag = objectPop(kw,'rootTag');
@@ -1007,6 +1010,9 @@ dojo.declare("gnr.widgets.GroupletForm",gnr.widgets.gnrwdg,{
         kw.store_handler = kw.store_handler || 'memory';
         kw.store_table = table;
         kw.storeType = kw.storeType || 'Item';
+        kw.datapath = datapath;
+        kw.formDatapath = formDatapath;
+        kw.controllerPath = formControllerPath;
         let formdiv = sourceNode._('BoxForm',kw);
         return formdiv._('grouplet',grouplets_pars);
     }

--- a/gnrjs/gnr_d11/js/genro_components.js
+++ b/gnrjs/gnr_d11/js/genro_components.js
@@ -998,7 +998,6 @@ dojo.declare("gnr.widgets.GroupletForm",gnr.widgets.gnrwdg,{
                 grouplets_pars._onRemote = "this.form.load();";
             }
         }
-        kw.datapath = datapath;
         grouplets_pars.table = grouplets_pars.table || table;
         grouplets_pars.handler = grouplets_pars.handler || handler;
         grouplets_pars.resource = grouplets_pars.resource || resource;

--- a/projects/gnrcore/packages/adm/resources/prefhandler/prefhandler.py
+++ b/projects/gnrcore/packages/adm/resources/prefhandler/prefhandler.py
@@ -97,7 +97,7 @@ class AppPrefHandler(BasePreferenceTabs):
             menuCallback=self._ph_preferenceMenu,
             grouplet_datapath='.app_grouplet_form',
             grouplet_formDatapath='.record',
-            grouplet_formControllerPath = '.controller'
+            grouplet_formControllerPath='.controller'
         )
         bar = form.bottom.slotBar('5,cancel,*,revertbtn,10,savebtn,saveAndClose,5',
                                    margin_bottom='2px', _class='slotbar_dialog_footer')

--- a/projects/gnrcore/packages/adm/resources/prefhandler/prefhandler.py
+++ b/projects/gnrcore/packages/adm/resources/prefhandler/prefhandler.py
@@ -94,11 +94,15 @@ class AppPrefHandler(BasePreferenceTabs):
             grouplets_root='app_preferences',
             value='^#FORM.record.data',
             frameCode='app_pref_grplt',
-            menuCallback=self._ph_preferenceMenu
+            menuCallback=self._ph_preferenceMenu,
+            grouplet_datapath='.app_grouplet_form',
+            grouplet_formDatapath='.record',
+            grouplet_formControllerPath = '.controller'
         )
         bar = form.bottom.slotBar('5,cancel,*,revertbtn,10,savebtn,saveAndClose,5',
                                    margin_bottom='2px', _class='slotbar_dialog_footer')
-        bar.savebtn.button('!!Apply', action='this.form.publish("save")')
+        bar.savebtn.button('!!Save', action='this.form.publish("save")',
+                           iconClass='fh_semaphore')
         return form
 
     def _ph_preferenceMenu(self, **kwargs):

--- a/projects/gnrcore/packages/adm/webpages/app_preference.py
+++ b/projects/gnrcore/packages/adm/webpages/app_preference.py
@@ -25,4 +25,4 @@ class GnrCustomWebPage(object):
                             formsubscribe_onDismissed=True)
         bar = form.bottom.bar
         bar.cancel.button('!!Cancel',action='this.form.abort();')
-        bar.saveAndClose.button('!!Confirm',action='this.form.publish("save",{destPkey:"*dismiss*"})')
+        bar.saveAndClose.button('!!Save and Close',action='this.form.publish("save",{destPkey:"*dismiss*"})')

--- a/resources/common/app_preferences/legacy_pref.py
+++ b/resources/common/app_preferences/legacy_pref.py
@@ -9,4 +9,4 @@ class Grouplet(object):
             return
         panecb = getattr(self, f'prefpane_{locationpath}', None)
         if panecb:
-            panecb(pane, nodeId=locationpath, _anchor=True)
+            panecb(pane, nodeId=locationpath, datapath='.record',_anchor=True)

--- a/resources/common/gnrcomponents/grouplet/grouplet.css
+++ b/resources/common/gnrcomponents/grouplet/grouplet.css
@@ -219,31 +219,9 @@
     border-bottom: none;
 }
 
-/* Panel semaphore (tree variant) */
-.grouplet_panel_semaphore {
-    height: 12px;
-    width: 12px;
-    border-radius: 50%;
-    margin-left: 8px;
-    display: none;
-    vertical-align: middle;
-    background-color: #9e9e9e;
-    transition: background-color 0.2s;
-}
-
-.grouplet_panel_semaphore.semaphore_ok {
-    display: inline-block;
-    background-color: #4caf50;
-}
-
-.grouplet_panel_semaphore.semaphore_error {
-    display: inline-block;
-    background-color: #f44336;
-}
-
-.grouplet_panel_semaphore.semaphore_changed {
-    display: inline-block;
-    background-color: #ff9800;
+/* Tree panel: error state on title label */
+.grouplet_panel_title.grplt_status_error {
+    color: #f44336;
 }
 
 /* Topic panel: status color on selected multiButton */

--- a/resources/common/gnrcomponents/grouplet/grouplet.py
+++ b/resources/common/gnrcomponents/grouplet/grouplet.py
@@ -301,24 +301,21 @@ class GroupletHandler(BaseComponent):
         right = bc.borderContainer(region='center')
         top = right.contentPane(region='top',
                                 _class='grouplet_panel_title_bar')
+        title_id = f'{frameCode}_title'
         top.div('^.selected_caption',
-                _class='grouplet_panel_title')
+                _class='grouplet_panel_title',
+                nodeId=title_id)
         center = right.contentPane(region='center', overflow='auto')
         if useForm:
-            semaphore_id = f'{frameCode}_semaphore'
             bc.dataController("""
-                var semNode = genro.nodeById(semId);
-                if(semNode){
-                    ['ok','changed','error'].forEach(function(s){
-                        genro.dom.setClass(semNode, 'semaphore_' + s,
-                            selectedResource && s == status);
-                    });
+                var titleNode = genro.nodeById(titleId);
+                if(titleNode){
+                    genro.dom.setClass(titleNode, 'grplt_status_error',
+                        selectedResource && status == 'error');
                 }
-            """, semId=semaphore_id,
+            """, titleId=title_id,
                 selectedResource='=.selected_resource',
                 **{f'subscribe_form_{formId}_onStatusChange': True})
-            top.div(_class='grouplet_panel_semaphore',
-                    nodeId=semaphore_id)
             right.dataController("genro.formById(innerFormId).reload()",
                                  innerFormId=formId,
                                  formsubscribe_onLoaded=True)


### PR DESCRIPTION
## Summary
- Enable explicit `datapath`/`formDatapath`/`controllerPath` on GroupletForm via `grouplet_*` kwargs, allowing proper data isolation when grouplets contain structured data with grids and controls
- Replace the three-state semaphore indicator (ok/changed/error) in tree-variant grouplet panels with an error-only red title label — autosave makes ok/changed states meaningless
- Update preference buttons labels (Save, Save and Close) and add semaphore icon to Save button
- Pass `datapath='.record'` to legacy preference panes for correct data path separation

## Test plan
- [x] Open Application Preferences, verify all preference panes load correctly
- [x] Change a preference value, verify autosave works
- [x] Introduce a validation error, verify title turns red
- [x] Verify legacy preference panes (tabContainer-based) still function
- [x] Verify grouplet panels used outside preferences are not affected (default behavior unchanged)