### PR TITLE
fix: post-testing-day visual fixes for grid, tabs, menus, themes

### DIFF
--- a/gnrjs/gnr_d11/css/gnr_dojotheme/layout/TabContainer.css
+++ b/gnrjs/gnr_d11/css/gnr_dojotheme/layout/TabContainer.css
@@ -79,6 +79,13 @@
     background: var(--card-surface, #F2F2F7);
 }
 
+/* --- Top tab strip: flex wrap --- */
+.gnr_dojotheme .dijitAlignTop {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 0;
+}
+
 /* --- Left/Right alignment: vertical margin --- */
 .gnr_dojotheme .dijitAlignLeft .dijitTab,
 .gnr_dojotheme .dijitAlignRight .dijitTab {

--- a/gnrjs/gnr_d11/css/gnrbase_css/01_gnr_variables.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/01_gnr_variables.css
@@ -90,8 +90,8 @@
 
     /* --- Border radius --- */
     --radius-sm:   4px;    /* @theme @palette inputs, grid cells, buttons, small interactive elements */
-    --radius-md:   10px;    /* @theme @palette dialogs, menus, tooltips, dropdowns, medium containers */
-    --radius-lg:   14px;   /* @theme @palette layout sections, cards, search boxes, large wrappers */
+    --radius-md:   8px;    /* @theme @palette dialogs, menus, tooltips, dropdowns, medium containers */
+    --radius-lg:   12px;   /* @theme @palette layout sections, cards, search boxes, large wrappers */
     --radius-pill: 9999px; /* @theme @palette pill shapes: tags, badges, semaphores, mobile bars */
     --radius-full: 50%;    /* @theme @palette circles: status indicators */
 
@@ -129,10 +129,6 @@
     --grid-reporting-header-color: var(--text-on-dark);
     --grid-footer-item-bg: rgba(255, 227, 60, .2);
     --grid-footer-filter-bg: rgba(221, 150, 90, 0.20);
-    --grid-btn-bg: var(--gray-200);
-    --grid-btn-selected-bg: var(--text-secondary);
-    --grid-btn-selected-shadow: inset 1px 1px 2px #222;
-
     /* --- Drag & Drop --- */
     --drop-valid-bg: rgba(76, 175, 80, 0.15);    /* color-success #4CAF50 15% + transparent */
     --drop-invalid-bg: rgba(229, 57, 53, 0.15);  /* color-error #E53935 15% + transparent */
@@ -289,6 +285,10 @@
     --menutree-mobile-selected-color: var(--frameindex-tablist-color);
     --menutree-branch-selected-color: var(--primary-dark);
     --menutree-mobile-branch-selected-color: var(--frameindex-tablist-color);
+    --menutree-mobile-font-size: 1.15em;     /* @theme menu item font size */
+    --menutree-mobile-font-size-l1: 1.3em;   /* @theme level-1 (top) items */
+    --menutree-mobile-line-height: 2em;      /* @theme touch-friendly row height */
+    --menutree-mobile-margin: 0.6em;         /* @theme outer spacing */
 
     /* --- FieldsTree (relation explorer) --- */
     --fieldsTree-rm-color: #2E2E30; /* @theme — gray-800 #3A3A3C 80% + black */

--- a/gnrjs/gnr_d11/css/gnrbase_css/03_gnr_widgets_grid.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/03_gnr_widgets_grid.css
@@ -41,15 +41,13 @@
 
 div.cellContent{
     border-radius: var(--radius-sm);
-    margin:1px;
-    padding: 0 1px;
-    transition-duration:0;
+    margin: 1px;
+    padding: 2px 1px;
+    transition-duration: 0;
     display: flex;
     align-items: center;
-    height: 100%;
-    line-height: 1.1em;
-    min-height: 1.1em;
-    border:1px solid transparent;
+    line-height: normal;
+    border: 1px solid transparent;
 }
 
 .cell_editable .cellContent:hover{

--- a/gnrjs/gnr_d11/css/gnrbase_css/13_gnr_tree_treegrid.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/13_gnr_tree_treegrid.css
@@ -402,17 +402,15 @@
 }
 
 .mode_mobile .menutree {
-    margin: 10px;
+    margin: var(--menutree-mobile-margin);
 }
 .mode_mobile .menutree .menu_shape {
     border-radius: var(--radius-sm);
-    margin-left: 0px;
-    font-size: 16px;
-    padding-left: 12px;
+    margin-left: 0;
+    font-size: var(--menutree-mobile-font-size);
     background: none;
-    padding-top: 0;
-    padding-bottom: 0;
-    line-height: 30px;
+    padding: 0;
+    line-height: var(--menutree-mobile-line-height);
     color: var(--text-on-dark);
 }
 .plugin_mobile_footer {
@@ -420,26 +418,16 @@
 }
 
 .mode_mobile .menutree .menu_existing_page.menu_shape {
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding: 0.2em 0;
 }
 .mode_mobile .menutree .menu_shape.menu_level_1 {
-    font-size: 18px;
-    line-height: 35px;
-}
-.mode_mobile .menutree .opendir {
-    background: none;
-}
-.mode_mobile .menutree .closedir {
-    background: none;
-}
-.mode_mobile .menutree.menutree_branchiconright .opendir,
-.mode_mobile .menutree.menutree_branchiconright .closedir {
-    background-color: var(--menutree-chevron-color);
+    font-size: var(--menutree-mobile-font-size-l1);
+    line-height: var(--menutree-mobile-line-height);
 }
 
 /* @group mobile menutree branch icons — CSS triangles with currentColor */
-.mode_mobile .menutree .label_opendir {
+.mode_mobile .menutree .label_opendir,
+.mode_mobile .menutree .label_closedir {
     background: none;
     padding-left: 1em;
     position: relative;
@@ -455,11 +443,6 @@
     border-width: 0.35em 0.25em 0 0.25em;
     border-color: currentColor transparent transparent transparent;
 }
-.mode_mobile .menutree .label_closedir {
-    background: none;
-    padding-left: 1em;
-    position: relative;
-}
 .mode_mobile .menutree .label_closedir::before {
     content: '';
     display: block;
@@ -473,7 +456,6 @@
 }
 .mode_mobile .menutree.menutree_branchiconright .label_opendir,
 .mode_mobile .menutree.menutree_branchiconright .label_closedir {
-    background: none;
     padding-left: 0;
 }
 .mode_mobile .menutree.menutree_branchiconright .label_opendir::before,
@@ -487,13 +469,11 @@
 }
 .menutree .menu_existing_page.menu_shape {
     font-weight: bold;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding: 0.3em 0;
 }
 .mode_mobile .menutree .menu_existing_page.menu_shape {
     font-weight: normal;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0;
 }
 .menutree .menu_shape.menu_level_2.addTableItem {
     font-style: italic;

--- a/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
@@ -337,47 +337,25 @@
 
 .buttons_grid .cellContent{
     border-radius: var(--radius-sm);
-    margin-top:0;
-    margin-right:0px;
-    text-align:center;
-    padding-top:2px;
-    padding-bottom:1px;
-    line-height:16px;
-    font-size: 8pt;
-    font-variant:small-caps;
-    color:var(--text-muted);
-    background-color: var(--grid-btn-bg);
-    border: 1px solid var(--text-muted);
-    cursor:pointer;
-    margin-top:2px;
+    margin: 0.3em 0 0.3em 1em;
+    padding: 0.3em 0.5em;
+    justify-content: center;
+    line-height: normal;
+    font-size: 0.85em;
+    font-variant: small-caps;
+    color: var(--text-color);
+    background: transparent;
+    border: none;
+    cursor: pointer;
 }
 
 .buttons_grid .dojoxGrid-row-selected .cellContent{
-    background: var(--grid-btn-selected-bg);
-    color: var(--surface-bg);
-    box-shadow: var(--grid-btn-selected-shadow);
+    background: var(--gray-200);
 }
 
 .grouper_buttons.buttons_grid .cellContent{
-    border-radius: var(--radius-md);
-    margin-top:0;
-    margin-right:0px;
-    text-align:center;
-    padding-top:2px;
-    padding-bottom:1px;
-    line-height:16px;
     font-size: inherit;
-    font-variant:normal;
-    color:var(--text-muted);
-    background-color: var(--surface-bg);
-    border: 1px solid var(--border-color);
-    cursor:pointer;
-    margin-top:5px;
-}
-
-.grouper_buttons.buttons_grid .dojoxGrid-row-selected .cellContent{
-    background: var(--grid-btn-selected-bg);
-    color: var(--surface-bg);
+    font-variant: normal;
 }
 
 /* --- Grid rows/header (from theme_shared) --- */

--- a/gnrjs/gnr_d20/css/gnr_dojotheme/layout/TabContainer.css
+++ b/gnrjs/gnr_d20/css/gnr_dojotheme/layout/TabContainer.css
@@ -46,7 +46,7 @@
 .gnr_dojotheme .dijitTabChecked {
     background: var(--card-surface, #F2F2F7);
     color: var(--primary-color, #1E3055);
-    font-weight: 600;
+    font-weight: 400;
     border: 1px solid var(--border-strong, #aab4c4);
     border-bottom: none;
     border-radius: var(--radius-md) var(--radius-md) 0 0;
@@ -57,7 +57,7 @@
 .gnr_dojotheme .dijitAlignTop .dijitTabCloseButtonChecked {
     background: var(--card-surface, #F2F2F7);
     color: var(--primary-color, #1E3055);
-    font-weight: 600;
+    font-weight: 400;
     border: 1px solid var(--border-strong, #aab4c4);
     border-bottom: none;
     border-radius: var(--radius-md) var(--radius-md) 0 0;
@@ -75,8 +75,15 @@
 /* --- Tab pane wrapper --- */
 .gnr_dojotheme .dijitTabPaneWrapper {
     border: 1px solid var(--border-strong, #aab4c4);
-    border-radius: 0 var(--radius-md) var(--radius-md) var(--radius-md);
+    border-radius: 0 0 var(--radius-md) var(--radius-md);
     background: var(--card-surface, #F2F2F7);
+}
+
+/* --- Top tab strip: flex wrap --- */
+.gnr_dojotheme .dijitAlignTop {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 0;
 }
 
 /* --- Left/Right alignment: vertical margin --- */
@@ -150,7 +157,7 @@
     background: rgba(0, 122, 255, 0.10);
     background: color-mix(in srgb, var(--accent-color, #007AFF) 10%, transparent);
     color: var(--primary-dark, #3A3A3C);
-    font-weight: 600;
+    font-weight: 400;
     border-right-color: var(--accent-color, #007AFF);
 }
 
@@ -158,7 +165,7 @@
     background: rgba(0, 122, 255, 0.10);
     background: color-mix(in srgb, var(--accent-color, #007AFF) 10%, transparent);
     color: var(--primary-dark, #3A3A3C);
-    font-weight: 600;
+    font-weight: 400;
     border-left-color: var(--accent-color, #007AFF);
 }
 

--- a/gnrjs/gnr_d20/css/gnrbase_css/01_gnr_variables.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/01_gnr_variables.css
@@ -47,7 +47,7 @@
     /* --- Typography --- */
     --font-family: 'Inter', -apple-system, 'Helvetica Neue', 'Arial', sans-serif; /* @theme @palette */
     --font-size: 14px; /* @theme @palette */
-    --mainWindow-font-size: 0.8125rem;
+    --mainWindow-font-size: 0.81rem;
 
     /* --- Brand / Primary --- */
     --primary-color: var(--gray-600); /* @theme */
@@ -90,8 +90,8 @@
 
     /* --- Border radius --- */
     --radius-sm:   4px;    /* @theme @palette inputs, grid cells, buttons, small interactive elements */
-    --radius-md:   10px;    /* @theme @palette dialogs, menus, tooltips, dropdowns, medium containers */
-    --radius-lg:   14px;   /* @theme @palette layout sections, cards, search boxes, large wrappers */
+    --radius-md:   8px;    /* @theme @palette dialogs, menus, tooltips, dropdowns, medium containers */
+    --radius-lg:   12px;   /* @theme @palette layout sections, cards, search boxes, large wrappers */
     --radius-pill: 9999px; /* @theme @palette pill shapes: tags, badges, semaphores, mobile bars */
     --radius-full: 50%;    /* @theme @palette circles: status indicators */
 
@@ -129,10 +129,6 @@
     --grid-reporting-header-color: var(--text-on-dark);
     --grid-footer-item-bg: rgba(255, 227, 60, .2);
     --grid-footer-filter-bg: rgba(221, 150, 90, 0.20);
-    --grid-btn-bg: var(--gray-200);
-    --grid-btn-selected-bg: var(--text-secondary);
-    --grid-btn-selected-shadow: inset 1px 1px 2px #222;
-
     /* --- Drag & Drop --- */
     --drop-valid-bg: rgba(76, 175, 80, 0.15);    /* color-success #4CAF50 15% + transparent */
     --drop-invalid-bg: rgba(229, 57, 53, 0.15);  /* color-error #E53935 15% + transparent */
@@ -289,6 +285,10 @@
     --menutree-mobile-selected-color: var(--frameindex-tablist-color);
     --menutree-branch-selected-color: var(--primary-dark);
     --menutree-mobile-branch-selected-color: var(--frameindex-tablist-color);
+    --menutree-mobile-font-size: 1.15em;     /* @theme menu item font size */
+    --menutree-mobile-font-size-l1: 1.3em;   /* @theme level-1 (top) items */
+    --menutree-mobile-line-height: 2em;      /* @theme touch-friendly row height */
+    --menutree-mobile-margin: 0.6em;         /* @theme outer spacing */
 
     /* --- FieldsTree (relation explorer) --- */
     --fieldsTree-rm-color: #2E2E30; /* @theme — gray-800 #3A3A3C 80% + black */

--- a/gnrjs/gnr_d20/css/gnrbase_css/03_gnr_widgets_grid.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/03_gnr_widgets_grid.css
@@ -41,15 +41,13 @@
 
 div.cellContent{
     border-radius: var(--radius-sm);
-    margin:1px;
-    padding: 0 1px;
-    transition-duration:0;
+    margin: 1px;
+    padding: 2px 1px;
+    transition-duration: 0;
     display: flex;
     align-items: center;
-    height: 100%;
-    line-height: 1.1em;
-    min-height: 1.1em;
-    border:1px solid transparent;
+    line-height: normal;
+    border: 1px solid transparent;
 }
 
 .cell_editable .cellContent:hover{

--- a/gnrjs/gnr_d20/css/gnrbase_css/13_gnr_tree_treegrid.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/13_gnr_tree_treegrid.css
@@ -402,17 +402,15 @@
 }
 
 .mode_mobile .menutree {
-    margin: 10px;
+    margin: var(--menutree-mobile-margin);
 }
 .mode_mobile .menutree .menu_shape {
     border-radius: var(--radius-sm);
-    margin-left: 0px;
-    font-size: 16px;
-    padding-left: 12px;
+    margin-left: 0;
+    font-size: var(--menutree-mobile-font-size);
     background: none;
-    padding-top: 0;
-    padding-bottom: 0;
-    line-height: 30px;
+    padding: 0;
+    line-height: var(--menutree-mobile-line-height);
     color: var(--text-on-dark);
 }
 .plugin_mobile_footer {
@@ -420,26 +418,16 @@
 }
 
 .mode_mobile .menutree .menu_existing_page.menu_shape {
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding: 0.2em 0;
 }
 .mode_mobile .menutree .menu_shape.menu_level_1 {
-    font-size: 18px;
-    line-height: 35px;
-}
-.mode_mobile .menutree .opendir {
-    background: none;
-}
-.mode_mobile .menutree .closedir {
-    background: none;
-}
-.mode_mobile .menutree.menutree_branchiconright .opendir,
-.mode_mobile .menutree.menutree_branchiconright .closedir {
-    background-color: var(--menutree-chevron-color);
+    font-size: var(--menutree-mobile-font-size-l1);
+    line-height: var(--menutree-mobile-line-height);
 }
 
 /* @group mobile menutree branch icons — CSS triangles with currentColor */
-.mode_mobile .menutree .label_opendir {
+.mode_mobile .menutree .label_opendir,
+.mode_mobile .menutree .label_closedir {
     background: none;
     padding-left: 1em;
     position: relative;
@@ -455,11 +443,6 @@
     border-width: 0.35em 0.25em 0 0.25em;
     border-color: currentColor transparent transparent transparent;
 }
-.mode_mobile .menutree .label_closedir {
-    background: none;
-    padding-left: 1em;
-    position: relative;
-}
 .mode_mobile .menutree .label_closedir::before {
     content: '';
     display: block;
@@ -473,7 +456,6 @@
 }
 .mode_mobile .menutree.menutree_branchiconright .label_opendir,
 .mode_mobile .menutree.menutree_branchiconright .label_closedir {
-    background: none;
     padding-left: 0;
 }
 .mode_mobile .menutree.menutree_branchiconright .label_opendir::before,
@@ -487,13 +469,11 @@
 }
 .menutree .menu_existing_page.menu_shape {
     font-weight: bold;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding: 0.3em 0;
 }
 .mode_mobile .menutree .menu_existing_page.menu_shape {
     font-weight: normal;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0;
 }
 .menutree .menu_shape.menu_level_2.addTableItem {
     font-style: italic;

--- a/gnrjs/gnr_d20/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/15_gnr_grid_extended.css
@@ -337,47 +337,25 @@
 
 .buttons_grid .cellContent{
     border-radius: var(--radius-sm);
-    margin-top:0;
-    margin-right:0px;
-    text-align:center;
-    padding-top:2px;
-    padding-bottom:1px;
-    line-height:16px;
-    font-size: 8pt;
-    font-variant:small-caps;
-    color:var(--text-muted);
-    background-color: var(--grid-btn-bg);
-    border: 1px solid var(--text-muted);
-    cursor:pointer;
-    margin-top:2px;
+    margin: 0.3em 0 0.3em 1em;
+    padding: 0.3em 0.5em;
+    justify-content: center;
+    line-height: normal;
+    font-size: 0.85em;
+    font-variant: small-caps;
+    color: var(--text-color);
+    background: transparent;
+    border: none;
+    cursor: pointer;
 }
 
 .buttons_grid .dojoxGrid-row-selected .cellContent{
-    background: var(--grid-btn-selected-bg);
-    color: var(--surface-bg);
-    box-shadow: var(--grid-btn-selected-shadow);
+    background: var(--gray-200);
 }
 
 .grouper_buttons.buttons_grid .cellContent{
-    border-radius: var(--radius-md);
-    margin-top:0;
-    margin-right:0px;
-    text-align:center;
-    padding-top:2px;
-    padding-bottom:1px;
-    line-height:16px;
     font-size: inherit;
-    font-variant:normal;
-    color:var(--text-muted);
-    background-color: var(--surface-bg);
-    border: 1px solid var(--border-color);
-    cursor:pointer;
-    margin-top:5px;
-}
-
-.grouper_buttons.buttons_grid .dojoxGrid-row-selected .cellContent{
-    background: var(--grid-btn-selected-bg);
-    color: var(--surface-bg);
+    font-variant: normal;
 }
 
 /* --- Grid rows/header (from theme_shared) --- */

--- a/projects/gnrcore/packages/adm/resources/frameindex.css
+++ b/projects/gnrcore/packages/adm/resources/frameindex.css
@@ -71,6 +71,10 @@
 
 /* --- iframetab (M3 segmented button) --- */
 
+.iframetab_caption{
+    padding-left:2px;
+    padding-right: 2px;
+}
 .iframetab {
     position: relative;
     display: inline-flex;

--- a/resources/common/gnrcomponents/framegrid.py
+++ b/resources/common/gnrcomponents/framegrid.py
@@ -148,7 +148,7 @@ class FrameGridTools(BaseComponent):
                                 **kwargs)
     @struct_method
     def fgr_slotbar_gridsemaphore(self,pane,**kwargs):
-        return pane.div(_class='editGrid_semaphore',padding_left='4px')
+        return pane.div(width='1.5em').div(_class='editGrid_semaphore')
 
     @extract_kwargs(cb=True,lbl=dict(slice_prefix=False))
     @struct_method

--- a/resources/common/gnrcomponents/settingmanager/settingmanager.py
+++ b/resources/common/gnrcomponents/settingmanager/settingmanager.py
@@ -227,12 +227,12 @@ class SettingManager(BaseComponent):
             content = Bag()
             group_info['group'] = groupNode.label
             settings = Bag(groupNode.value)
+            settings.popNode('__pycache__')
+            if not settings:
+                continue
             info_node = settings.popNode('__info__')
             group_info = self._get_info_from_node(info_node,table=table)
             if group_info is False:
-                continue
-            settings.popNode('__pycache__')
-            if not settings:
                 continue
             result.addItem(groupNode.label, content, **group_info)
             for setting_node in settings:

--- a/resources/common/themes/joanna/base.css
+++ b/resources/common/themes/joanna/base.css
@@ -34,6 +34,7 @@
     --btn-filled-hover-bg: #6F1556;    /* #8b1a6b 80% + black */
     --btn-filled-pressed-bg: #5A1146;  /* 65% + black */
     --btn-filled-selected-bg: #5A1146;
+    --btn-filled-disabled-bg: #C58CB5;  /* #8b1a6b 50% + white */
     --btn-tonal-bg: #F1E4ED;           /* 12% + white */
     --btn-tonal-color: #8b1a6b;
     --btn-tonal-hover-bg: #E8D1E1;     /* 20% + white */
@@ -54,6 +55,11 @@
     --fieldsTree-rm-color: #6F1556;
     --grid-draft-color: #4E505F;
     --grid-lineno-color: #4E505F;
+    --grid-row-odd-bg: rgba(237, 247, 242, .5);
+    --grid-row-selected-bg: rgba(192, 222, 206, .8);
+    --grid-cell-hover-bg: #FFF5D9;
+    --grid-cell-hover-bg-lazy: #E0EEFF;
+    --grid-cell-hover-bg-disabled: #FFE0D0;
 }
 
 /* Ocean - blue depths */
@@ -82,6 +88,7 @@
     --btn-filled-hover-bg: #086ACC;    /* #0a84ff 80% + black */
     --btn-filled-pressed-bg: #0756A6;  /* 65% + black */
     --btn-filled-selected-bg: #0756A6;
+    --btn-filled-disabled-bg: #84C1FF;  /* #0a84ff 50% + white */
     --btn-tonal-bg: #E2F0FF;           /* 12% + white */
     --btn-tonal-color: #0a84ff;
     --btn-tonal-hover-bg: #CEE6FF;     /* 20% + white */
@@ -105,6 +112,11 @@
     --fieldsTree-rm-color: #183B66;
     --grid-draft-color: #1C71CF;
     --grid-lineno-color: #1C71CF;
+    --grid-row-odd-bg: rgba(237, 242, 250, .5);
+    --grid-row-selected-bg: rgba(196, 212, 232, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E0FFEE;
+    --grid-cell-hover-bg-disabled: #FFE7DD;
 }
 
 /* Ruby - warm red */
@@ -132,6 +144,7 @@
     --btn-filled-hover-bg: #BA2B3B;    /* #e8364a 80% + black */
     --btn-filled-pressed-bg: #972330;  /* 65% + black */
     --btn-filled-selected-bg: #972330;
+    --btn-filled-disabled-bg: #F39AA4;  /* #e8364a 50% + white */
     --btn-tonal-bg: #FCE7E9;           /* 12% + white */
     --btn-tonal-color: #e8364a;
     --btn-tonal-hover-bg: #FAD7DB;     /* 20% + white */
@@ -152,6 +165,11 @@
     --fieldsTree-rm-color: #7B1B28;
     --grid-draft-color: #D53344;
     --grid-lineno-color: #D53344;
+    --grid-row-odd-bg: rgba(251, 239, 241, .5);
+    --grid-row-selected-bg: rgba(232, 200, 204, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E6F9FF;
+    --grid-cell-hover-bg-disabled: #FFEDB8;
 }
 
 /* Sunset - orange top / plum frameindex */
@@ -179,6 +197,7 @@
     --btn-filled-hover-bg: #551A46;    /* #6a2058 80% + black */
     --btn-filled-pressed-bg: #451539;  /* 65% + black */
     --btn-filled-selected-bg: #451539;
+    --btn-filled-disabled-bg: #B48FAB;  /* #6a2058 50% + white */
     --btn-tonal-bg: #EDE4EB;           /* 12% + white */
     --btn-tonal-color: #6a2058;
     --btn-tonal-hover-bg: #E1D2DE;     /* 20% + white */
@@ -199,6 +218,11 @@
     --fieldsTree-rm-color: #551A46;
     --grid-draft-color: #A4462D;
     --grid-lineno-color: #A4462D;
+    --grid-row-odd-bg: rgba(250, 243, 247, .5);
+    --grid-row-selected-bg: rgba(232, 205, 219, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E6F9FF;
+    --grid-cell-hover-bg-disabled: #FFE7DD;
 }
 
 /* Hornette - vivid wasp yellow / black */
@@ -258,6 +282,11 @@
     --fieldsTree-rm-color: #151515;
     --grid-draft-color: #A86E3A;
     --grid-lineno-color: #A86E3A;
+    --grid-row-odd-bg: rgba(254, 249, 231, .5);
+    --grid-row-selected-bg: rgba(253, 230, 138, .8);
+    --grid-cell-hover-bg: #E6EEFF;
+    --grid-cell-hover-bg-lazy: #E0FFE8;
+    --grid-cell-hover-bg-disabled: #FFE0D0;
 }
 
 /* Business - corporate navy / charcoal */
@@ -286,6 +315,7 @@
     --btn-filled-hover-bg: #2A3A4B;    /* #34495e 80% + black */
     --btn-filled-pressed-bg: #222F3D;  /* 65% + black */
     --btn-filled-selected-bg: #222F3D;
+    --btn-filled-disabled-bg: #99A4AE;  /* #34495e 50% + white */
     --btn-tonal-bg: #E7E9EC;           /* 12% + white */
     --btn-tonal-color: #34495e;
     --btn-tonal-hover-bg: #D6DBDF;     /* 20% + white */
@@ -309,6 +339,11 @@
     --fieldsTree-rm-color: #151E26;
     --grid-draft-color: #304356;
     --grid-lineno-color: #304356;
+    --grid-row-odd-bg: rgba(236, 240, 241, .5);
+    --grid-row-selected-bg: rgba(189, 195, 199, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E0FFEE;
+    --grid-cell-hover-bg-disabled: #FFE7DD;
 }
 
 /* Terra - warm terracotta / dark walnut */
@@ -337,6 +372,7 @@
     --btn-filled-hover-bg: #AE5F05;    /* #d97706 80% + black */
     --btn-filled-pressed-bg: #8D4D04;  /* 65% + black */
     --btn-filled-selected-bg: #8D4D04;
+    --btn-filled-disabled-bg: #ECBB82;  /* #d97706 50% + white */
     --btn-tonal-bg: #FAEFE1;           /* 12% + white */
     --btn-tonal-color: #d97706;
     --btn-tonal-hover-bg: #F7E4CD;     /* 20% + white */
@@ -360,4 +396,9 @@
     --fieldsTree-rm-color: #321F1C;
     --grid-draft-color: #C56308;
     --grid-lineno-color: #C56308;
+    --grid-row-odd-bg: rgba(253, 246, 238, .5);
+    --grid-row-selected-bg: rgba(232, 201, 160, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E6F9FF;
+    --grid-cell-hover-bg-disabled: #FFEDB8;
 }

--- a/resources/common/themes/mimi/base.css
+++ b/resources/common/themes/mimi/base.css
@@ -39,6 +39,7 @@
     --btn-filled-hover-bg: #256449;    /* #2E7D5B 80% + black */
     --btn-filled-pressed-bg: #1E513B;  /* 65% + black */
     --btn-filled-selected-bg: #1E513B;
+    --btn-filled-disabled-bg: #96BEAD;  /* #2E7D5B 50% + white */
     --btn-tonal-bg: #E5EFEB;           /* 12% + white */
     --btn-tonal-color: #2E7D5B;
     --btn-tonal-hover-bg: #D5E5DE;     /* 20% + white */
@@ -63,6 +64,11 @@
     --fieldsTree-rm-color: #164B36;
     --grid-draft-color: #2E7D5B;
     --grid-lineno-color: #2E7D5B;
+    --grid-row-odd-bg: rgba(237, 245, 241, .5);
+    --grid-row-selected-bg: rgba(184, 216, 202, .8);
+    --grid-cell-hover-bg: #FFF5D9;
+    --grid-cell-hover-bg-lazy: #E0EEFF;
+    --grid-cell-hover-bg-disabled: #FFE0D0;
 }
 
 /* Blue - deep ocean */
@@ -95,6 +101,7 @@
     --btn-filled-hover-bg: #005AB6;    /* #0071E3 80% + black */
     --btn-filled-pressed-bg: #004994;  /* 65% + black */
     --btn-filled-selected-bg: #004994;
+    --btn-filled-disabled-bg: #7FB8F1;  /* #0071E3 50% + white */
     --btn-tonal-bg: #E0EEFC;           /* 12% + white */
     --btn-tonal-color: #0071E3;
     --btn-tonal-hover-bg: #CCE3F9;     /* 20% + white */
@@ -119,6 +126,11 @@
     --fieldsTree-rm-color: #163860;
     --grid-draft-color: #1769C3;
     --grid-lineno-color: #1769C3;
+    --grid-row-odd-bg: rgba(236, 241, 249, .5);
+    --grid-row-selected-bg: rgba(184, 204, 228, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E0FFEE;
+    --grid-cell-hover-bg-disabled: #FFE7DD;
 }
 
 /* Red - cherry lipstick / fuchsia fashion */
@@ -149,6 +161,7 @@
     --btn-filled-hover-bg: #9B1349;    /* #C2185B 80% + black */
     --btn-filled-pressed-bg: #7E103B;  /* 65% + black */
     --btn-filled-selected-bg: #7E103B;
+    --btn-filled-disabled-bg: #E08BAD;  /* #C2185B 50% + white */
     --btn-tonal-bg: #F8E3EB;           /* 12% + white */
     --btn-tonal-color: #C2185B;
     --btn-tonal-hover-bg: #F3D1DE;     /* 20% + white */
@@ -169,43 +182,49 @@
     --fieldsTree-rm-color: #6D0B3F;
     --grid-draft-color: #C2185B;
     --grid-lineno-color: #C2185B;
+    --grid-row-odd-bg: rgba(248, 240, 244, .5);
+    --grid-row-selected-bg: rgba(216, 184, 200, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E6F9FF;
+    --grid-cell-hover-bg-disabled: #FFEDB8;
 }
 
-/* Orange - Apple Watch Ultra / plum + international orange */
+/* Orange - warm terracotta / plum buttons */
 .color_variant_orange {
     --gray-900: #3A1830;
     --gray-800: #4A2040;
-    --gray-600: #FF6C00;
-    --accent-500: #FF5722;
+    --gray-600: #D97020;
+    --accent-500: #D4650A;
     --gray-300: #D8C0D0;
     --gray-200: #E0D8DE;
     --gray-100: #F6F0F4;
 
     --primary-color: #4A2040;
     --primary-dark: #3A1830;
-    --accent-color: #FF5722;
+    --accent-color: #4A2040;
     --primary-light: #D8C0D0;
     --primary-lighter: #F6F0F4;
-    --root-top-background: #FF6C00;
-    --dialogtitlebar-background: #FF6C00;
+    --root-top-background: #D97020;
+    --dialogtitlebar-background: #D97020;
     --frameindex-tablist-background: #3A1830;
     --card-surface: #FAF8F6;
     --roundedgroup-bar: #E0D8DE;
-    --menu-item-hover-bg: #FFE0CC;
+    --menu-item-hover-bg: #F5DFD0;
     --menu-item-hover-color: #3A1830;
 
     --field-disabled-border: #C4B0BC;
     --field-readonly-border: #C4B0BC;
 
-    --btn-filled-bg: #FF5722;
-    --btn-filled-hover-bg: #CC461B;    /* #FF5722 80% + black */
-    --btn-filled-pressed-bg: #A63916;  /* 65% + black */
-    --btn-filled-selected-bg: #A63916;
-    --btn-tonal-bg: #FFEBE4;           /* 12% + white */
-    --btn-tonal-color: #FF5722;
-    --btn-tonal-hover-bg: #FFDDD3;     /* 20% + white */
-    --btn-tonal-pressed-bg: #FFD0C1;   /* 28% + white */
-    --btn-tonal-selected-bg: #FFD0C1;
+    --btn-filled-bg: #4A2040;
+    --btn-filled-hover-bg: #3B1A33;    /* #4A2040 80% + black */
+    --btn-filled-pressed-bg: #301529;  /* 65% + black */
+    --btn-filled-selected-bg: #301529;
+    --btn-filled-disabled-bg: #A48F9F;  /* #4A2040 50% + white */
+    --btn-tonal-bg: #EDE4EB;           /* #4A2040 12% + white */
+    --btn-tonal-color: #4A2040;
+    --btn-tonal-hover-bg: #E1D1DD;     /* 20% + white */
+    --btn-tonal-pressed-bg: #D5BFD0;   /* 28% + white */
+    --btn-tonal-selected-bg: #D5BFD0;
 
     --gray-50: #FAF6F8;
     --gray-150: #F0ECEE;
@@ -215,16 +234,21 @@
     --gray-700: #654B5E;
     --gnrfieldlabel-color: var(--gray-700);
     --accordion-title-bg: #E9E2E7;
-    --frameindex-subtab-bg: #923E26;
-    --frameindex-subtab-selected-bg: #FFAE73;
-    --frameindex-closer-hover-bg: #9B4D3C;
+    --frameindex-subtab-bg: #5E2A4E;
+    --frameindex-subtab-selected-bg: #D9A070;
+    --frameindex-closer-hover-bg: #6B3858;
     --frameindex-tab-bg: #D8D1D6;
     --frameindex-tab-bg-hover: #7F6978;
     --grid-reporting-header-bg: #3F1B36;
     --treegrid-header-bg: #431D3A;
     --fieldsTree-rm-color: #3B1A33;
-    --grid-draft-color: #FF630F;
-    --grid-lineno-color: #FF630F;
+    --grid-draft-color: #C06010;
+    --grid-lineno-color: #C06010;
+    --grid-row-odd-bg: rgba(246, 240, 244, .5);
+    --grid-row-selected-bg: rgba(216, 192, 208, .8);
+    --grid-cell-hover-bg: #F8FFD9;
+    --grid-cell-hover-bg-lazy: #E6F9FF;
+    --grid-cell-hover-bg-disabled: #FFE7DD;
 }
 
 /* Yellow - gold on dark titanium */
@@ -256,6 +280,7 @@
     --btn-filled-hover-bg: #005AB6;    /* #0071E3 80% + black (accent-color same as blue variant) */
     --btn-filled-pressed-bg: #004994;
     --btn-filled-selected-bg: #004994;
+    --btn-filled-disabled-bg: #7FB8F1;  /* #0071E3 50% + white */
     --btn-tonal-bg: #E0EEFC;
     --btn-tonal-color: #0071E3;
     --btn-tonal-hover-bg: #CCE3F9;
@@ -277,4 +302,9 @@
     --fieldsTree-rm-color: #3A3A3D;
     --grid-draft-color: #8CA666;
     --grid-lineno-color: #8CA666;
+    --grid-row-odd-bg: rgba(255, 248, 214, .5);
+    --grid-row-selected-bg: rgba(255, 240, 184, .8);
+    --grid-cell-hover-bg: #E6EEFF;
+    --grid-cell-hover-bg-lazy: #E0FFE8;
+    --grid-cell-hover-bg-disabled: #FFE0D0;
 }


### PR DESCRIPTION
## Summary
- Fix grid cellContent vertical padding, line-height, and height issues introduced by dojo_js_css refactor
- Add flex-wrap for top tab strips, reduce tab font-weight, fix pane wrapper border-radius
- Restyle buttons_grid as vertical tab pattern, remove unused grid-btn CSS variables
- Convert mobile menutree to responsive em units with CSS custom properties, cleanup duplicate rules
- Add per-variant disabled button backgrounds and grid row/cell hover colors for all color variants (mimi + joanna themes)
- Redesign mimi orange variant with softer warm orange tones and dark plum buttons
- Fix semaphore and iframetab caption spacing
- Reorder settingmanager pycache pop before info check to avoid KeyError on empty groups
- Sync all d11 CSS fixes to d20 for consistency

## Test plan
- [x] Manual visual testing on all color variants
- [x] flake8 passes with zero errors on modified Python files
- [x] All 1368 tests pass (260 skipped)
- [x] d11 and d20 CSS files verified identical