### PR TITLE
fix: allow multiple ext_ handlers on the same column

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmodel/model.py
+++ b/gnrpy/gnr/sql/gnrsqlmodel/model.py
@@ -940,7 +940,6 @@ class DbModelSrc(GnrStructData):
                 if handler:
                     extKwargs = extKwargs if isinstance(extKwargs, dict) else {pkgExt: extKwargs}
                     handler(tblsrc, colname=name, colattr=result.attributes, **extKwargs)
-                    return result
 
         if localized:
             currpkgobj = self.root._dbmodel.db.application.packages[tblsrc.attributes['pkg']]


### PR DESCRIPTION
## Summary
- The `ext_kwargs` loop in `DbModelSrc.column()` exited with `return result` after processing the first `ext_` handler, preventing subsequent handlers from running
- A column with both `ext_ltx` and `ext_emb` (e.g. `tbl.column('docstring', ext_ltx='*', ext_emb=True)`) would only get the first extension configured
- Fix: remove the premature `return result` so all ext_ handlers are executed

## Test plan
- [ ] Verify a column with two `ext_*` attributes gets both extensions configured
- [ ] Verify existing single-ext columns are unaffected