### PR TITLE
Add Sourcerer integration as a GenroPy service

### DIFF
--- a/projects/gnrcore/packages/sys/lib/services/sourcerer.py
+++ b/projects/gnrcore/packages/sys/lib/services/sourcerer.py
@@ -1,3 +1,4 @@
+import os
 import urllib.request
 import urllib.error
 import json
@@ -11,7 +12,7 @@ class SourcererClient:
     """HTTP client for Sourcerer API communication."""
 
     def __init__(self, url=None, sourcerer_token=None):
-        self.url = (url or DEFAULT_SOURCERER_URL).rstrip('/')
+        self.url = (url or os.environ.get('GNR_SOURCERER_URL', DEFAULT_SOURCERER_URL)).rstrip('/')
         self.sourcerer_token = sourcerer_token
 
     def _request(self, endpoint, payload=None, method='POST',

--- a/projects/gnrcore/packages/sys/lib/services/sourcerer.py
+++ b/projects/gnrcore/packages/sys/lib/services/sourcerer.py
@@ -1,0 +1,63 @@
+import urllib.request
+import urllib.error
+import json
+
+import secrets
+
+DEFAULT_SOURCERER_URL = 'https://sourcerer.genropy.net'
+
+
+class SourcererClient:
+    """HTTP client for Sourcerer API communication."""
+
+    def __init__(self, url=None, sourcerer_token=None):
+        self.url = (url or DEFAULT_SOURCERER_URL).rstrip('/')
+        self.sourcerer_token = sourcerer_token
+
+    def _request(self, endpoint, payload=None, method='POST',
+                 authenticated=True, timeout=10):
+        headers = {}
+        if authenticated and self.sourcerer_token:
+            headers['Authorization'] = f'Bearer {self.sourcerer_token}'
+        if payload:
+            headers['Content-Type'] = 'application/json'
+        data = json.dumps(payload).encode('utf-8') if payload else None
+        req = urllib.request.Request(
+            f'{self.url}/api/{endpoint}',
+            data=data,
+            headers=headers,
+            method=method
+        )
+        try:
+            resp = urllib.request.urlopen(req, timeout=timeout)
+        except urllib.error.HTTPError as e:
+            raise Exception(f'Sourcerer API error {e.code}: {e.reason}') from e
+        return json.loads(resp.read().decode('utf-8'))
+
+    def request_registration(self, host, name, callback_url):
+        callback_token = secrets.token_urlsafe()
+        data = self._request('srv/request_server_registration',
+                             payload={'host': host, 'name': name,
+                                      'callback_url': callback_url,
+                                      'callback_token': callback_token},
+                             authenticated=False)
+        return {
+            'token': callback_token,
+            'sourcerer_token': data.get('token', '')
+        }
+
+    def check_status(self):
+        if not self.sourcerer_token:
+            return 'idle'
+        try:
+            self._request('srv/status', method='GET', timeout=5)
+            return 'enabled'
+        except urllib.error.HTTPError as e:
+            if e.code == 403:
+                return 'pending'
+            return 'idle'
+        except Exception:
+            return 'idle'
+
+    def api_request(self, endpoint, payload=None, method='POST'):
+        return self._request(endpoint, payload=payload, method=method)

--- a/projects/gnrcore/packages/sys/resources/services/sourcerer/sourcerer.py
+++ b/projects/gnrcore/packages/sys/resources/services/sourcerer/sourcerer.py
@@ -1,0 +1,51 @@
+from gnr.core.gnrbag import Bag
+from gnr.lib.services import GnrBaseService
+from gnr.core.gnrdecorator import public_method
+from gnr.web.gnrbaseclasses import BaseComponent
+from gnrpkg.sys.services.sourcerer import SourcererClient
+
+
+class Service(GnrBaseService):
+
+    def __init__(self, parent=None, url=None, token=None,
+                 sourcerer_token=None, **kwargs):
+        self.parent = parent
+        self.token = token
+        self.sourcerer_token = sourcerer_token
+        self.client = SourcererClient(url=url, sourcerer_token=sourcerer_token)
+
+    def request_registration(self, host, name, callback_url):
+        return self.client.request_registration(host, name, callback_url)
+
+    def check_status(self):
+        return self.client.check_status()
+
+    def api_request(self, endpoint, payload=None, method='POST'):
+        return self.client.api_request(endpoint, payload, method)
+
+
+class ServiceParameters(BaseComponent):
+
+    def service_parameters(self, pane, datapath=None, **kwargs):
+        fb = pane.formbuilder(datapath=datapath, cols=1, border_spacing='4px')
+        fb.textbox(value='^.url', lbl='!!Sourcerer URL',
+                   placeholder='https://sourcerer.genropy.net',
+                   width='30em')
+        fb.textbox(value='^.token', lbl='!!Callback Token',
+                   readOnly=True, width='30em')
+        fb.textbox(value='^.sourcerer_token', lbl='!!Sourcerer Token',
+                   readOnly=True, width='30em')
+        fb.button('!![en]Connect to Sourcerer',
+                  hidden='^.token').dataRpc(self.rpc_connectToSourcerer,
+                   _onResult="""SET .token = result.getItem('token');
+                                SET .sourcerer_token = result.getItem('sourcerer_token');
+                                this.form.save();""")
+
+    @public_method
+    def rpc_connectToSourcerer(self):
+        service = self.getService('sourcerer')
+        host = self.site.external_host
+        callback_url = self.site.externalUrl('/sys/ep_sourcerer')
+        site_name = self.site.site_name or host
+        result = service.request_registration(host, site_name, callback_url)
+        return Bag(result)

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from gnr.core.gnrdecorator import public_method
+from gnr.core.gnrbag import Bag
+from gnr.web.verifiers import AuthorizationBearerVerifier
+
+
+class SourcererBearerVerifier(AuthorizationBearerVerifier):
+    def get_token_to_verify(self):
+        service = self.page.getService('sourcerer')
+        if service:
+            return service.token
+
+
+class GnrCustomWebPage(object):
+    py_requires = 'gnrcomponents/externalcall:BaseRpc'
+
+    @public_method(verifier=SourcererBearerVerifier)
+    def rpc_health(self, **kwargs):
+        return Bag(dict(result='ok'))


### PR DESCRIPTION
## Summary
- Add `SourcererClient` HTTP client for Sourcerer API communication (registration, status check, generic requests)
- Add Sourcerer as a GenroPy service (`Service` + `ServiceParameters` UI component) with registration flow
- Add `ep_sourcerer` endpoint with Bearer token verification for Sourcerer health callbacks

## Test plan
- [ ] Manual tests: register a GenroPy instance with Sourcerer via the service parameters UI
- [ ] Verify health endpoint responds correctly with valid Bearer token
- [ ] Verify health endpoint rejects requests with invalid/missing Bearer token
- [ ] Automated tests pass (1368 passed, 260 skipped)