### PR TITLE
fix(gnrwebpage): userLocalTags returns None in remoteBuilder context

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -1635,9 +1635,10 @@ class GnrWebPage(GnrBaseWebPage):
     
     @property
     def userLocalTags(self):
-        if not hasattr(self,'_rootenv'):
-             return
-        return self.rootenv['user_local_tags']
+        rootenv = self.rootenv
+        if not rootenv:
+            return
+        return rootenv['user_local_tags']
     
     @property
     def userMenu(self):


### PR DESCRIPTION
## Problem

`userLocalTags` always returned `None` during `remoteBuilder` calls (`.remote()` lazy-loaded sections), causing server-side `_tags` filtering to silently fail: widgets gated on a local tag (e.g. `TAGSEDE_NAZ`) were marked `__forbidden__` and excluded from the rendered output — even when the user legitimately held that tag.

## Root Cause

The old code:

```python
@property
def userLocalTags(self):
    if not hasattr(self, '_rootenv'):
        return
    return self.rootenv['user_local_tags']
```

In a **remoteBuilder call** the client sends `page_id`, which causes the server to initialize `_workdate` directly from `page_item['data']['rootenv.workdate']`, bypassing `_get_workdate` entirely. Since `_rootenv` is only set inside `_get_workdate` (or lazily via the `rootenv` property), it was never set. The guard `not hasattr(self, '_rootenv')` therefore always fired and returned `None`.

Result: `userTags` returned only `avatar.user_tags` (base tags), all local tags were stripped, and any widget with `_tags` requiring a local tag was incorrectly forbidden.

## Fix

```python
@property
def userLocalTags(self):
    rootenv = self.rootenv
    if not rootenv:
        return
    return rootenv['user_local_tags']
```

Going through the `rootenv` property directly always lazily loads from the correct `pageStore` (identified by `self.page_id`), regardless of whether `_get_workdate` ran.