### PR TITLE
refactor: eliminate circular deps from gnrlang

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -43,7 +43,7 @@ from gnr.core.gnrbag import Bag
 from gnr.core.gnrlocale import defaultLocale
 from gnr.core.gnrdecorator import extract_kwargs, deprecated
 from gnr.core.gnrlang import  objectExtract,gnrImport, instanceMixin, GnrException
-from gnr.core.gnrlog import tracebackBag
+from gnr.core.gnrerror import tracebackBag
 from gnr.core.gnrstring import makeSet, toText, splitAndStrip, like, boolean
 from gnr.core.gnrsys import expandpath
 from gnr.core.gnrconfig import getGnrConfig

--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -42,7 +42,8 @@ from gnr.core.gnrclasses import GnrClassCatalog
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrlocale import defaultLocale
 from gnr.core.gnrdecorator import extract_kwargs, deprecated
-from gnr.core.gnrlang import  objectExtract,gnrImport, instanceMixin, GnrException, tracebackBag
+from gnr.core.gnrlang import  objectExtract,gnrImport, instanceMixin, GnrException
+from gnr.core.gnrlog import tracebackBag
 from gnr.core.gnrstring import makeSet, toText, splitAndStrip, like, boolean
 from gnr.core.gnrsys import expandpath
 from gnr.core.gnrconfig import getGnrConfig

--- a/gnrpy/gnr/core/gnrerror.py
+++ b/gnrpy/gnr/core/gnrerror.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import hashlib
+import linecache
+import json
+
+from gnr.core.gnrstructures import GnrStructData
+from gnr.core.gnrbag import Bag
+
+
+def _is_library_frame(filename):
+    if filename.startswith('<'):
+        return True
+    _library_markers = (
+        os.sep + 'site-packages' + os.sep,
+        os.sep + 'lib' + os.sep + 'python',
+        os.sep + 'Lib' + os.sep,
+    )
+    for marker in _library_markers:
+        if marker in filename:
+            return True
+    return False
+
+def tracebackBag(limit=None, full_stack=False):
+    result = Bag()
+    if limit is None:
+        if hasattr(sys, 'tracebacklimit'):
+            limit = sys.tracebacklimit
+    n = 0
+    hash_cache = {}
+    tb = sys.exc_info()[2]
+    frames = []
+    last_own_idx = 0
+    while tb is not None and (limit is None or n < limit):
+        tb_bag = Bag()
+        f = tb.tb_frame
+        lineno = tb.tb_lineno
+        co = f.f_code
+        filename = co.co_filename
+        name = co.co_name
+        linecache.checkcache(filename)
+        line = linecache.getline(filename, lineno)
+        if line: line = line.strip()
+        else: line = None
+        if filename not in hash_cache:
+            try:
+                with open(filename, 'rb') as fh:
+                    hash_cache[filename] = hashlib.sha256(fh.read()).hexdigest()[:12]
+            except Exception:
+                hash_cache[filename] = None
+        tb_bag['module'] = os.path.basename(os.path.splitext(filename)[0])
+        tb_bag['filename'] = filename
+        tb_bag['file_hash'] = hash_cache[filename]
+        tb_bag['lineno'] = lineno
+        tb_bag['name'] = name
+        tb_bag['line'] = line
+        loc = Bag()
+        for k,v in list(f.f_locals.items()):
+            try:
+                if isinstance(v,GnrStructData):
+                    v = '*STRUCTURE*'
+                elif isinstance(v,Bag):
+                    v = '*BAG*'
+                elif isinstance(v,(dict,list,tuple)):
+
+                    json.dumps(v)
+                loc[k] = v
+            except Exception:
+                loc[k] = '*UNSERIALIZABLE* %s' %v.__class__
+        tb_bag['locals'] = loc
+        label = '%s method %s line %s' % (tb_bag['module'], name, lineno)
+        frames.append((label, tb_bag, filename))
+        if not _is_library_frame(filename):
+            last_own_idx = n
+        tb = tb.tb_next
+        n = n + 1
+    if not full_stack:
+        frames = frames[:last_own_idx + 1]
+    for label, tb_bag, _filename in frames:
+        result[label] = tb_bag
+    return Bag(root=result)

--- a/gnrpy/gnr/core/gnrlang.py
+++ b/gnrpy/gnr/core/gnrlang.py
@@ -21,22 +21,18 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 
-import sys, traceback, datetime
+import sys
 import importlib
 import os.path
 import _thread
 import uuid
 import base64
-import hashlib
-import linecache
-import json
 import inspect
 from types import MethodType
 from io import IOBase
 from functools import total_ordering
 from chardet.universaldetector import UniversalDetector
 
-from gnr.core import logger
 from gnr.core.gnrdecorator import extract_kwargs # keep for compatibility
 
 try:

--- a/gnrpy/gnr/core/gnrlang.py
+++ b/gnrpy/gnr/core/gnrlang.py
@@ -62,79 +62,6 @@ def getmixincount():
     _mixincount+=1
     return '%015i' %_mixincount
 
-def _is_library_frame(filename):
-    if filename.startswith('<'):
-        return True
-    _library_markers = (
-        os.sep + 'site-packages' + os.sep,
-        os.sep + 'lib' + os.sep + 'python',
-        os.sep + 'Lib' + os.sep,
-    )
-    for marker in _library_markers:
-        if marker in filename:
-            return True
-    return False
-
-def tracebackBag(limit=None, full_stack=False):
-    from gnr.core.gnrstructures import GnrStructData
-    from gnr.core.gnrbag import Bag
-    result = Bag()
-    if limit is None:
-        if hasattr(sys, 'tracebacklimit'):
-            limit = sys.tracebacklimit
-    n = 0
-    hash_cache = {}
-    tb = sys.exc_info()[2]
-    frames = []
-    last_own_idx = 0
-    while tb is not None and (limit is None or n < limit):
-        tb_bag = Bag()
-        f = tb.tb_frame
-        lineno = tb.tb_lineno
-        co = f.f_code
-        filename = co.co_filename
-        name = co.co_name
-        linecache.checkcache(filename)
-        line = linecache.getline(filename, lineno)
-        if line: line = line.strip()
-        else: line = None
-        if filename not in hash_cache:
-            try:
-                with open(filename, 'rb') as fh:
-                    hash_cache[filename] = hashlib.sha256(fh.read()).hexdigest()[:12]
-            except Exception:
-                hash_cache[filename] = None
-        tb_bag['module'] = os.path.basename(os.path.splitext(filename)[0])
-        tb_bag['filename'] = filename
-        tb_bag['file_hash'] = hash_cache[filename]
-        tb_bag['lineno'] = lineno
-        tb_bag['name'] = name
-        tb_bag['line'] = line
-        loc = Bag()
-        for k,v in list(f.f_locals.items()):
-            try:
-                if isinstance(v,GnrStructData):
-                    v = '*STRUCTURE*'
-                elif isinstance(v,Bag):
-                    v = '*BAG*'
-                elif isinstance(v,(dict,list,tuple)):
-
-                    json.dumps(v)
-                loc[k] = v
-            except Exception:
-                loc[k] = '*UNSERIALIZABLE* %s' %v.__class__
-        tb_bag['locals'] = loc
-        label = '%s method %s line %s' % (tb_bag['module'], name, lineno)
-        frames.append((label, tb_bag, filename))
-        if not _is_library_frame(filename):
-            last_own_idx = n
-        tb = tb.tb_next
-        n = n + 1
-    if not full_stack:
-        frames = frames[:last_own_idx + 1]
-    for label, tb_bag, _filename in frames:
-        result[label] = tb_bag
-    return Bag(root=result)
 
 
 def get_caller_info():
@@ -708,55 +635,6 @@ def instanceOf(obj, *args, **kwargs):
     else:
         return obj
 
-def errorTxt():
-    """TODO"""
-    el = sys.exc_info()
-    tb_text = traceback.format_exc()
-    e = el[2]
-    while e.tb_next:
-        e = e.tb_next
-
-    locals_list = []
-    for k, v in list(e.tb_frame.f_locals.items()):
-        try:
-            from gnr.core.gnrstring import toText
-            strvalue = toText(v)
-        except:
-            strvalue = 'unicode error'
-        locals_list.append('%s: %s' % (k, strvalue))
-    return u'%s\n\nLOCALS:\n\n%s' % (tb_text, '\n'.join(locals_list))
-
-def errorLog(proc_name, host=None, from_address='', to_address=None, user=None, password=''):
-    """Report the error log
-
-    :param proc_name: the name of the wrong process
-    :param host: the database server host
-    :param from_address: the email sender
-    :param to_address: the email receiver
-    :param user: the username
-    :param password: the username's password"""
-    from gnr.utils.gnrmail import sendmail
-
-    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S: ')
-    title = '%s - Error in %s' % (ts, proc_name)
-    logger.error(title)
-    tb_text = errorTxt()
-    logger.error(tb_text.encode('ascii', 'ignore'))
-
-    if (host and to_address):
-        try:
-            sendmail(host=host,
-                     from_address=from_address,
-                     to_address=to_address,
-                     subject=title,
-                     body=tb_text,
-                     user=user,
-                     password=password
-                     )
-        except:
-            logger.exception("While sending errroLog email")
-            
-    return tb_text
 
 
 

--- a/gnrpy/gnr/core/gnrlog.py
+++ b/gnrpy/gnr/core/gnrlog.py
@@ -4,9 +4,18 @@ import logging
 import logging.handlers
 import inspect
 import importlib
+import traceback
+import datetime
+import hashlib
+import linecache
+import json
 from collections import defaultdict
 
 from gnr.core.gnrconfig import getGnrConfig
+from gnr.core.gnrstructures import GnrStructData
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrstring import toText
+from gnr.utils.gnrmail import sendmail
 
 # other loggers, hardcoded for the moment
 werkzeug_logger = logging.getLogger("werkzeug")
@@ -252,3 +261,115 @@ class AuditLogger(object):
 
     def log(self, statement, *args, **kwargs):
         self.loggers.get(statement).log(self.DEFAULT_LEVEL, *args, **kwargs)
+
+
+def _is_library_frame(filename):
+    if filename.startswith('<'):
+        return True
+    _library_markers = (
+        os.sep + 'site-packages' + os.sep,
+        os.sep + 'lib' + os.sep + 'python',
+        os.sep + 'Lib' + os.sep,
+    )
+    for marker in _library_markers:
+        if marker in filename:
+            return True
+    return False
+
+def tracebackBag(limit=None, full_stack=False):
+    result = Bag()
+    if limit is None:
+        if hasattr(sys, 'tracebacklimit'):
+            limit = sys.tracebacklimit
+    n = 0
+    hash_cache = {}
+    tb = sys.exc_info()[2]
+    frames = []
+    last_own_idx = 0
+    while tb is not None and (limit is None or n < limit):
+        tb_bag = Bag()
+        f = tb.tb_frame
+        lineno = tb.tb_lineno
+        co = f.f_code
+        filename = co.co_filename
+        name = co.co_name
+        linecache.checkcache(filename)
+        line = linecache.getline(filename, lineno)
+        if line: line = line.strip()
+        else: line = None
+        if filename not in hash_cache:
+            try:
+                with open(filename, 'rb') as fh:
+                    hash_cache[filename] = hashlib.sha256(fh.read()).hexdigest()[:12]
+            except Exception:
+                hash_cache[filename] = None
+        tb_bag['module'] = os.path.basename(os.path.splitext(filename)[0])
+        tb_bag['filename'] = filename
+        tb_bag['file_hash'] = hash_cache[filename]
+        tb_bag['lineno'] = lineno
+        tb_bag['name'] = name
+        tb_bag['line'] = line
+        loc = Bag()
+        for k,v in list(f.f_locals.items()):
+            try:
+                if isinstance(v,GnrStructData):
+                    v = '*STRUCTURE*'
+                elif isinstance(v,Bag):
+                    v = '*BAG*'
+                elif isinstance(v,(dict,list,tuple)):
+
+                    json.dumps(v)
+                loc[k] = v
+            except Exception:
+                loc[k] = '*UNSERIALIZABLE* %s' %v.__class__
+        tb_bag['locals'] = loc
+        label = '%s method %s line %s' % (tb_bag['module'], name, lineno)
+        frames.append((label, tb_bag, filename))
+        if not _is_library_frame(filename):
+            last_own_idx = n
+        tb = tb.tb_next
+        n = n + 1
+    if not full_stack:
+        frames = frames[:last_own_idx + 1]
+    for label, tb_bag, _filename in frames:
+        result[label] = tb_bag
+    return Bag(root=result)
+
+def errorTxt():
+    el = sys.exc_info()
+    tb_text = traceback.format_exc()
+    e = el[2]
+    while e.tb_next:
+        e = e.tb_next
+
+    locals_list = []
+    for k, v in list(e.tb_frame.f_locals.items()):
+        try:
+            strvalue = toText(v)
+        except:
+            strvalue = 'unicode error'
+        locals_list.append('%s: %s' % (k, strvalue))
+    return u'%s\n\nLOCALS:\n\n%s' % (tb_text, '\n'.join(locals_list))
+
+def errorLog(proc_name, host=None, from_address='', to_address=None, user=None, password=''):
+    gnr_logger = logging.getLogger('gnr')
+    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S: ')
+    title = '%s - Error in %s' % (ts, proc_name)
+    gnr_logger.error(title)
+    tb_text = errorTxt()
+    gnr_logger.error(tb_text.encode('ascii', 'ignore'))
+
+    if (host and to_address):
+        try:
+            sendmail(host=host,
+                     from_address=from_address,
+                     to_address=to_address,
+                     subject=title,
+                     body=tb_text,
+                     user=user,
+                     password=password
+                     )
+        except:
+            gnr_logger.exception("While sending errorLog email")
+
+    return tb_text

--- a/gnrpy/gnr/core/gnrlog.py
+++ b/gnrpy/gnr/core/gnrlog.py
@@ -4,18 +4,9 @@ import logging
 import logging.handlers
 import inspect
 import importlib
-import traceback
-import datetime
-import hashlib
-import linecache
-import json
 from collections import defaultdict
 
 from gnr.core.gnrconfig import getGnrConfig
-from gnr.core.gnrstructures import GnrStructData
-from gnr.core.gnrbag import Bag
-from gnr.core.gnrstring import toText
-from gnr.utils.gnrmail import sendmail
 
 # other loggers, hardcoded for the moment
 werkzeug_logger = logging.getLogger("werkzeug")
@@ -263,113 +254,3 @@ class AuditLogger(object):
         self.loggers.get(statement).log(self.DEFAULT_LEVEL, *args, **kwargs)
 
 
-def _is_library_frame(filename):
-    if filename.startswith('<'):
-        return True
-    _library_markers = (
-        os.sep + 'site-packages' + os.sep,
-        os.sep + 'lib' + os.sep + 'python',
-        os.sep + 'Lib' + os.sep,
-    )
-    for marker in _library_markers:
-        if marker in filename:
-            return True
-    return False
-
-def tracebackBag(limit=None, full_stack=False):
-    result = Bag()
-    if limit is None:
-        if hasattr(sys, 'tracebacklimit'):
-            limit = sys.tracebacklimit
-    n = 0
-    hash_cache = {}
-    tb = sys.exc_info()[2]
-    frames = []
-    last_own_idx = 0
-    while tb is not None and (limit is None or n < limit):
-        tb_bag = Bag()
-        f = tb.tb_frame
-        lineno = tb.tb_lineno
-        co = f.f_code
-        filename = co.co_filename
-        name = co.co_name
-        linecache.checkcache(filename)
-        line = linecache.getline(filename, lineno)
-        if line: line = line.strip()
-        else: line = None
-        if filename not in hash_cache:
-            try:
-                with open(filename, 'rb') as fh:
-                    hash_cache[filename] = hashlib.sha256(fh.read()).hexdigest()[:12]
-            except Exception:
-                hash_cache[filename] = None
-        tb_bag['module'] = os.path.basename(os.path.splitext(filename)[0])
-        tb_bag['filename'] = filename
-        tb_bag['file_hash'] = hash_cache[filename]
-        tb_bag['lineno'] = lineno
-        tb_bag['name'] = name
-        tb_bag['line'] = line
-        loc = Bag()
-        for k,v in list(f.f_locals.items()):
-            try:
-                if isinstance(v,GnrStructData):
-                    v = '*STRUCTURE*'
-                elif isinstance(v,Bag):
-                    v = '*BAG*'
-                elif isinstance(v,(dict,list,tuple)):
-
-                    json.dumps(v)
-                loc[k] = v
-            except Exception:
-                loc[k] = '*UNSERIALIZABLE* %s' %v.__class__
-        tb_bag['locals'] = loc
-        label = '%s method %s line %s' % (tb_bag['module'], name, lineno)
-        frames.append((label, tb_bag, filename))
-        if not _is_library_frame(filename):
-            last_own_idx = n
-        tb = tb.tb_next
-        n = n + 1
-    if not full_stack:
-        frames = frames[:last_own_idx + 1]
-    for label, tb_bag, _filename in frames:
-        result[label] = tb_bag
-    return Bag(root=result)
-
-def errorTxt():
-    el = sys.exc_info()
-    tb_text = traceback.format_exc()
-    e = el[2]
-    while e.tb_next:
-        e = e.tb_next
-
-    locals_list = []
-    for k, v in list(e.tb_frame.f_locals.items()):
-        try:
-            strvalue = toText(v)
-        except:
-            strvalue = 'unicode error'
-        locals_list.append('%s: %s' % (k, strvalue))
-    return u'%s\n\nLOCALS:\n\n%s' % (tb_text, '\n'.join(locals_list))
-
-def errorLog(proc_name, host=None, from_address='', to_address=None, user=None, password=''):
-    gnr_logger = logging.getLogger('gnr')
-    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S: ')
-    title = '%s - Error in %s' % (ts, proc_name)
-    gnr_logger.error(title)
-    tb_text = errorTxt()
-    gnr_logger.error(tb_text.encode('ascii', 'ignore'))
-
-    if (host and to_address):
-        try:
-            sendmail(host=host,
-                     from_address=from_address,
-                     to_address=to_address,
-                     subject=title,
-                     body=tb_text,
-                     user=user,
-                     password=password
-                     )
-        except:
-            gnr_logger.exception("While sending errorLog email")
-
-    return tb_text

--- a/gnrpy/tests/core/gnrlang_test.py
+++ b/gnrpy/tests/core/gnrlang_test.py
@@ -2,6 +2,7 @@ import pytest
 import os
 from gnr.core import gnrlang as gl
 from gnr.core.gnrbag import Bag
+from gnr.core.gnrerror import tracebackBag
 
 class TestGnrLang():
     def test_getUuid(self):
@@ -126,7 +127,7 @@ class TestGnrLang():
         assert e.main == 1
 
     def test_tracebackBag(self):
-        r = gl.tracebackBag()
+        r = tracebackBag()
         #FIXME: how to test this properly?
 
     def test_thlocal(self):

--- a/projects/gnrcore/packages/lgcy/model/transaction.py
+++ b/projects/gnrcore/packages/lgcy/model/transaction.py
@@ -1,7 +1,8 @@
 # encoding: utf-8
 
 from datetime import datetime
-from gnr.core.gnrlang import GnrException,tracebackBag
+from gnr.core.gnrlang import GnrException
+from gnr.core.gnrerror import tracebackBag
 
 
 class Table(object):


### PR DESCRIPTION
## Summary

- Remove circular dependencies from `gnr.core.gnrlang` (Ref #710)
- Create new `gnr.core.gnrerror` module for `tracebackBag` — not a Bag flavour, but a utility that transforms a Python traceback into a Bag for easier handling. The module can host other error-related functions in the future
- Drop `errorTxt` and `errorLog` (confirmed unused across the entire codebase)
- Clean all orphan imports from `gnrlog.py` (`GnrStructData`, `toText`, `sendmail`, `Bag`, `traceback`, `datetime`, `hashlib`, `linecache`, `json`)
- Update all call sites: `gnrapp.py`, `lgcy/transaction.py`, `gnrlang_test.py`

After this change, `gnrlang.py` has zero imports from `gnr.core` (only stdlib + `gnr.core.gnrdecorator`).

## Test plan

- [x] flake8 clean on all modified files
- [x] All 1557 tests pass (22 pre-existing failures in gnrdate/gnrlocale/compiler unrelated to this change)
- [x] CI green on Python 3.11, 3.12, 3.13, 3.14

closes #710