### PR TITLE
fix: _th_mixinResource safeMode and multidomain error URLs

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1016,7 +1016,8 @@ class GnrWsgiSite(object):
                 kwargs['request_uri'] = request.url
                 kwargs['request_host'] = request.host_url
 
-        kwargs.setdefault('current_domain', self.currentDomain)
+        if self.multidomain:
+            kwargs.setdefault('current_domain', self.currentDomain)
         error_id = self.gnrapp.errorHandler(exception=exception, **kwargs)
         if error_id and page:
             notify_user = kwargs.get('notify_user')

--- a/projects/gnrcore/packages/sys/model/error.py
+++ b/projects/gnrcore/packages/sys/model/error.py
@@ -23,8 +23,13 @@ class Table(object):
         tbl.column('error_type',name_long='!!Error type')
         tbl.column('error_code',name_long='!!Error code',indexed=True)
         tbl.formulaColumn('detail_url',
-                          """(CASE WHEN $request_host IS NULL THEN '/sys/ep_error?error_id=' || $id
-                                ELSE $request_host || '/sys/ep_error?error_id=' || $id
+                          """(CASE WHEN $request_host IS NULL
+                                THEN CASE WHEN $current_domain IS NOT NULL
+                                    THEN '/_main_/sys/ep_error?error_id=' || $id
+                                    ELSE '/sys/ep_error?error_id=' || $id END
+                                ELSE $request_host || CASE WHEN $current_domain IS NOT NULL
+                                    THEN '/_main_/sys/ep_error?error_id=' || $id
+                                    ELSE '/sys/ep_error?error_id=' || $id END
                              END)
                             """,
                           name_long='!!Detail')

--- a/resources/common/th/th_form.py
+++ b/resources/common/th/th_form.py
@@ -20,7 +20,7 @@ class TableHandlerForm(BaseComponent):
     def th_tableEditor(self,pane,frameCode=None,table=None,th_pkey=None,formResource=None,
                         formInIframe=False,dfltoption_kwargs=None,**kwargs):
         table = table or pane.attributes.get('table')
-        resourcePath = self._th_mixinResource(frameCode,table=table,resourceName=formResource,defaultClass='Form',pane=pane)
+        resourcePath = self._th_mixinResource(frameCode,table=table,resourceName=formResource,defaultClass='Form',pane=pane,safeMode=True)
         if not resourcePath:
             return
         options = dfltoption_kwargs
@@ -133,7 +133,7 @@ class TableHandlerForm(BaseComponent):
                         store='recordCluster',handlerType=None,tree_kwargs=None,**kwargs):
         tableCode = table.replace('.','_')
         formId = formId or tableCode
-        resourcePath = self._th_mixinResource(formId,table=table,resourceName=formResource,defaultClass='Form',pane=pane)
+        resourcePath = self._th_mixinResource(formId,table=table,resourceName=formResource,defaultClass='Form',pane=pane,safeMode=True)
         if not resourcePath:
             return
         resource_options = self._th_getOptions(formId)

--- a/resources/common/th/th_lib.py
+++ b/resources/common/th/th_lib.py
@@ -109,7 +109,7 @@ class TableHandlerCommon(BaseComponent):
         rootCode = rootCode or table.replace('.','_')
         self._th_mixinResource(rootCode=rootCode,table=table,resourceName=resourceName)
 
-    def _th_mixinResource(self,rootCode=None,table=None,resourceName=None,defaultClass=None,pane=None):
+    def _th_mixinResource(self,rootCode=None,table=None,resourceName=None,defaultClass=None,pane=None,safeMode=False):
         pkg,tablename = table.split('.')
         defaultModule = 'th_%s' %tablename
         resourcePath = self._th_getResourceName(resourceName,defaultModule,defaultClass)
@@ -131,6 +131,8 @@ class TableHandlerCommon(BaseComponent):
                 found = self.mixinComponent('tables','_packages',pkg,tablename,resourcePath,pkg=refpkg,mangling_th=rootCode, pkgOnly=True,safeMode=True) or found
         found = self.mixinComponent('tables','_packages',pkg,tablename,resourcePath,pkg=self.package.name,mangling_th=rootCode, pkgOnly=True,safeMode=True) or found
         if not found:
+            if safeMode:
+                return resourcePath
             exc = GnrMixinNotFound("Missing resource '%s' for table '%s'" % (defaultClass or '?', table))
             if pane is not None:
                 self._th_missingResource(pane, exc)
@@ -149,7 +151,7 @@ class TableHandlerCommon(BaseComponent):
                 self._th_missingResource(pane, e)
                 return None
             raise
-            
+
     def _th_getOptions(self,mangler=None):
         if isinstance(mangler,Bag):
             inattr = mangler.getInheritedAttributes()

--- a/resources/common/th/th_view.py
+++ b/resources/common/th/th_view.py
@@ -33,7 +33,7 @@ class TableHandlerView(BaseComponent):
                        virtualStore=None,condition=None,condition_kwargs=None,
                        structure_field=None,structure_field_kwargs=None,sections_kwargs=None,
                        store_kwargs=None,extendedQuery=None,**kwargs):
-        if not self._th_mixinResource(frameCode,table=table,resourceName=viewResource,defaultClass='View',pane=pane):
+        if not self._th_mixinResource(frameCode,table=table,resourceName=viewResource,defaultClass='View',pane=pane,safeMode=True):
             return
         options = self._th_getOptions(frameCode)
         if extendedQuery is None:


### PR DESCRIPTION
## Summary
- Add `safeMode` parameter to `_th_mixinResource` so that tolerant callers (`th_tableViewer`, `th_tableEditor`, `th_thFormHandler`) can proceed with framework defaults when no table-specific `th_*.py` mixin is found. This fixes a regression from `2222f99db` where lookup tables without explicit th_ files failed with `GnrMixinNotFound`.
- Fix error detail URLs in multidomain apps: `current_domain` is now saved only when multidomain is active, and the `detail_url` formula uses `/_main_/` prefix since errors are centralized in the primary database.

## Test plan
- [ ] Verify lookup table picker works without explicit `th_*.py` (e.g. `dialogTableHandler` with picker on a lookup table)
- [ ] Verify error detail URL in multidomain app includes `/_main_/` prefix
- [ ] Verify error detail URL in single-domain app remains unchanged
- [ ] All automated tests pass (1368 passed, 260 skipped)