### PR TITLE
add werkzeug's middleware ProxyFix 

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -18,6 +18,7 @@ from werkzeug.utils import redirect
 from werkzeug.exceptions import (HTTPException, InternalServerError,
                                   NotFound, Forbidden, PreconditionFailed,
                                   BadRequest, Unauthorized)
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from gnr.core.gnrbag import Bag
 from gnr.core import gnrstring
@@ -1570,6 +1571,14 @@ class GnrWsgiSite(object):
                 wsgiapp = SentryWsgiMiddleware(wsgiapp)
             except Exception as e:
                 logger.error(f"Sentry support has been disabled due to configuration errors: {e}")
+
+        # when the application is executed being a reverse proxy / ssl terminator,
+        # werkzeug needs this middleware to compute the correct external host
+        # which is used by externalUrl in the Site object when the value is
+        # computed using the request data.
+        # Limited to Kubernetes environment for initial staging testing
+        if os.environ.get("KUBERNETES_SERVICE_HOST", None):
+            wsgiapp = ProxyFix(wsgiapp, x_for=1, x_proto=1, x_host=1)
         return wsgiapp
 
     def build_gnrapp(self, options=None):


### PR DESCRIPTION
Added werkzeug's middleware ProxyFix (initially, only under K8S execution) to correctly use x-forwarder-for, x-forwarded-proto etc header, in order to correctly compute the external url.

Since 'external_host' must be removed from instanceconfig configuration file (to be able to use an instance on different hostname, the name depends on how the application is deployed), the correct external computation is a must when behing a reverse proxy / ssl terminator. Otherwise links will be generated using 'http://' (schema used between reverse proxy and application backend). This is usually not noticed by the user, because we have a direct from http to https, but if sensitive information are in the QUERY_INDEX (like tokens, keys etc) they are transferred via http.
