### PR TITLE
install liberarion sans narrow fonts in docker image

### DIFF
--- a/dockerfiles/genropy/Dockerfile
+++ b/dockerfiles/genropy/Dockerfile
@@ -5,7 +5,7 @@
 FROM python:3.11-slim
 LABEL org.opencontainers.image.description "Genropy web framework"
 
-RUN apt-get update && apt-get -y full-upgrade &&  apt install -y supervisor procps iproute2 python3-psycopg weasyprint && apt-get autoremove -y && apt clean
+RUN apt-get update && apt-get -y full-upgrade &&  apt install -y supervisor procps iproute2 python3-psycopg weasyprint fonts-liberation fonts-liberation-sans-narrow && apt-get autoremove -y && apt clean
 RUN pip install --upgrade pip
 RUN adduser --group --system --shell /bin/bash --home /home/genro genro
   

--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -1,3 +1,9 @@
+Release 26.03.24
+================
+
+This is a bugfix release to provide in docker image the needed
+fonts for default printing templates.
+
 Release 26.03.18
 ================
 

--- a/gnrpy/gnr/__init__.py
+++ b/gnrpy/gnr/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from gnr.core import gnrlog
 
-VERSION = "26.03.18"
+VERSION = "26.03.24"
 
 gnrlog.init_logging_system()
 logger = logging.getLogger("gnr")


### PR DESCRIPTION
install liberarion sans narrow fonts in docker image

version bump for hotfix release

close #727 