### PR TITLE
feat: extend badge system to TabContainer tabs (tabBadge)

### DIFF
--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -214,6 +214,7 @@ dojo.declare("gnr.widgets.baseHtml", null, {
     },
     setControllerTitle:function(attributes, sourceNode) {
         var iconClass = objectPop(attributes, 'iconClass');
+        var tabBadgeContent = attributes['tabBadgeContent'];
         var title = attributes['title'];
         if (iconClass) {
             if (attributes['title']) {
@@ -229,6 +230,9 @@ dojo.declare("gnr.widgets.baseHtml", null, {
         if (attributes.title) {
             var tip = objectPop(attributes, 'tip') || title || '';
             attributes.title = '<span title="' + tip + '">' + attributes.title + '</span>';
+        }
+        if (tabBadgeContent) {
+            attributes.title = (attributes.title || '') + tabBadgeContent;
         }
     },
     setDraggable:function(domNode, value) {
@@ -376,6 +380,23 @@ dojo.declare("gnr.widgets.baseHtml", null, {
                     }
                     parentNode.publish('onChangedChildTitle',{title:title,child:this})
                 });
+                if (savedAttrs.tabBadge) {
+                    var _tabBadgeKW = objectExtract(sourceNode.attr, 'tabBadge_*', false);
+                    _tabBadgeKW.handler = savedAttrs.tabBadge;
+                    _tabBadgeKW.table = _tabBadgeKW.table || savedAttrs.table;
+                    var _tabBaseTitle = savedAttrs._tabBaseTitle || '';
+                    var _tabTipTitle = '<span title="' + _tabBaseTitle + '">' + _tabBaseTitle + '</span>';
+                    var _tabWidget = newobj;
+                    if (_tabBadgeKW.table) {
+                        var _refreshTabBadge = function() {
+                            genro.serverCall('badge.getBadgeHandler', _tabBadgeKW, function(result) {
+                                _tabWidget.setTitle(_tabTipTitle + (result || ''));
+                            });
+                        };
+                        _refreshTabBadge();
+                        dojo.subscribe(_tabBadgeKW.table.replace('.', '_'), _refreshTabBadge);
+                    }
+                }
             }
             else if (parentTagLower == 'accordioncontainer') {
                 objectFuncReplace(newobj, 'setTitle', function(title) {
@@ -2904,7 +2925,13 @@ dojo.declare("gnr.widgets.ContentPane", gnr.widgets.baseDojo, {
     },
     creating:function(attributes, sourceNode) {
         attributes.isLoaded = true;
+        var savedAttrs = {};
+        if (attributes.tabBadge) {
+            savedAttrs.tabBadge = attributes.tabBadge;
+            savedAttrs._tabBaseTitle = attributes.title || '';
+        }
         this.setControllerTitle(attributes, sourceNode);
+        return savedAttrs;
     },
     created: function(widget, savedAttrs, sourceNode) {
         dojo.connect(widget, 'startup', dojo.hitch(this, 'afterStartup', widget));

--- a/gnrjs/gnr_d20/js/genro_widgets.js
+++ b/gnrjs/gnr_d20/js/genro_widgets.js
@@ -214,6 +214,7 @@ dojo.declare("gnr.widgets.baseHtml", null, {
     },
     setControllerTitle:function(attributes, sourceNode) {
         var iconClass = objectPop(attributes, 'iconClass');
+        var tabBadgeContent = attributes['tabBadgeContent'];
         var title = attributes['title'];
         if (iconClass) {
             if (attributes['title']) {
@@ -229,6 +230,9 @@ dojo.declare("gnr.widgets.baseHtml", null, {
         if (attributes.title) {
             var tip = objectPop(attributes, 'tip') || title || '';
             attributes.title = '<span title="' + tip + '">' + attributes.title + '</span>';
+        }
+        if (tabBadgeContent) {
+            attributes.title = (attributes.title || '') + tabBadgeContent;
         }
     },
     setDraggable:function(domNode, value) {
@@ -376,6 +380,23 @@ dojo.declare("gnr.widgets.baseHtml", null, {
                     }
                     parentNode.publish('onChangedChildTitle',{title:title,child:this})
                 });
+                if (savedAttrs.tabBadge) {
+                    var _tabBadgeKW = objectExtract(sourceNode.attr, 'tabBadge_*', false);
+                    _tabBadgeKW.handler = savedAttrs.tabBadge;
+                    _tabBadgeKW.table = _tabBadgeKW.table || savedAttrs.table;
+                    var _tabBaseTitle = savedAttrs._tabBaseTitle || '';
+                    var _tabTipTitle = '<span title="' + _tabBaseTitle + '">' + _tabBaseTitle + '</span>';
+                    var _tabWidget = newobj;
+                    if (_tabBadgeKW.table) {
+                        var _refreshTabBadge = function() {
+                            genro.serverCall('badge.getBadgeHandler', _tabBadgeKW, function(result) {
+                                _tabWidget.setTitle(_tabTipTitle + (result || ''));
+                            });
+                        };
+                        _refreshTabBadge();
+                        dojo.subscribe(_tabBadgeKW.table.replace('.', '_'), _refreshTabBadge);
+                    }
+                }
             }
             else if (parentTagLower == 'accordioncontainer') {
                 objectFuncReplace(newobj, 'setTitle', function(title) {
@@ -2904,7 +2925,13 @@ dojo.declare("gnr.widgets.ContentPane", gnr.widgets.baseDojo, {
     },
     creating:function(attributes, sourceNode) {
         attributes.isLoaded = true;
+        var savedAttrs = {};
+        if (attributes.tabBadge) {
+            savedAttrs.tabBadge = attributes.tabBadge;
+            savedAttrs._tabBaseTitle = attributes.title || '';
+        }
         this.setControllerTitle(attributes, sourceNode);
+        return savedAttrs;
     },
     created: function(widget, savedAttrs, sourceNode) {
         dojo.connect(widget, 'startup', dojo.hitch(this, 'afterStartup', widget));

--- a/gnrpy/gnr/web/gnrmenu.py
+++ b/gnrpy/gnr/web/gnrmenu.py
@@ -328,7 +328,7 @@ class MenuResolver(BagResolver):
                     menuLineBadge_attr['table'] = attributes.get('table') or menuLineBadge_attr.get('table')
                 if menuLineBadge_attr.get('table'):
                     self._page.subscribeTable(menuLineBadge_attr.get('table'), True, subscribeMode=True)
-                    attributes['badgeContent'] = self._page.menu.getMenuLineBadge(**menuLineBadge_attr)
+                    attributes['badgeContent'] = self._page.badge.getBadgeHandler(**menuLineBadge_attr)
             
             result.setItem(node.label, value, attributes)
         return result

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -50,6 +50,7 @@ from gnr.web._gnrbasewebpage import GnrBaseWebPage
 from gnr.web.gnrwebreqresp import GnrWebRequest, GnrWebResponse
 from gnr.web.gnrwebpage_proxy.gnrbaseproxy import GnrBaseProxy
 from gnr.web.gnrwebpage_proxy.menuproxy import GnrMenuProxy
+from gnr.web.gnrwebpage_proxy.badgeproxy import GnrBadgeProxy
 from gnr.web.gnrwebpage_proxy.apphandler import GnrWebAppHandler
 from gnr.web.gnrwebpage_proxy.connection import GnrWebConnection
 from gnr.web.gnrwebpage_proxy.serverbatch import GnrWebBatch
@@ -1616,6 +1617,12 @@ class GnrWebPage(GnrBaseWebPage):
         if not hasattr(self, '_menu'):
             self._menu = GnrMenuProxy(self)
         return self._menu
+
+    @property
+    def badge(self):
+        if not hasattr(self, '_badge'):
+            self._badge = GnrBadgeProxy(self)
+        return self._badge
 
     @property
     def btc(self):

--- a/gnrpy/gnr/web/gnrwebpage_proxy/badgeproxy.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/badgeproxy.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from gnr.core.gnrdecorator import public_method
+from gnr.web.gnrwebpage_proxy.gnrbaseproxy import GnrBaseProxy
+from gnr.web import logger
+
+
+class GnrBadgeProxy(GnrBaseProxy):
+
+    @public_method
+    def getBadgeHandler(self, table=None, handler=None, condition=None, **kwargs):
+        """Generic badge content resolver shared by menuLineBadge and tabBadge.
+
+        Args:
+            table: the table to query
+            handler: determines the badge computation method:
+                - 'methodName': calls the specified RPC method on the table
+                - '#': returns total record count for the table
+                - '#:fieldpath': returns count where field has a "positive" value
+                - '#:!fieldpath': returns count where field has a "negative" value
+                  fieldpath can be prefixed with $ (column) or @ (relation), defaults to $
+            condition: deprecated, use handler with '#' syntax instead
+
+        The filter condition depends on the column dtype:
+            - Boolean (B): IS TRUE / IS NOT TRUE
+            - Numeric (N,L,I,R): IS NOT NULL AND !=0 / IS NULL OR =0
+            - Other (text, date, etc.): IS NOT NULL / IS NULL
+        """
+        if condition:
+            logger.warning("getBadgeHandler 'condition' parameter is deprecated. "
+                           "Use '#' or '#:columnName' handler syntax instead")
+            return self.page.db.table(table).query(where=condition, **kwargs).count()
+        if not handler:
+            return
+        if not handler.startswith('#'):
+            return self.getPublicMethod('rpc', f'_table.{table}.{handler}')(**kwargs)
+
+        where = None
+        tblobj = self.page.db.table(table)
+        if ':' in handler:
+            fieldpath = handler.split(':')[1]
+            positiveCondition = True
+            if fieldpath.startswith('!'):
+                fieldpath = fieldpath[1:]
+                positiveCondition = False
+            if fieldpath[0] not in ('$', '@'):
+                fieldpath = f'${fieldpath}'
+            column = tblobj.column(fieldpath)
+            if column is None:
+                raise ValueError(f"Column {fieldpath} not found in table {table}")
+            dtype = column.attributes.get('dtype')
+            if dtype == 'B':
+                where = f'{fieldpath} IS TRUE' if positiveCondition else f'{fieldpath} IS NOT TRUE'
+            elif dtype in ('N', 'L', 'I', 'R'):
+                if positiveCondition:
+                    where = f'{fieldpath} IS NOT NULL AND {fieldpath}!=0'
+                else:
+                    where = f'{fieldpath} IS NULL OR {fieldpath}=0'
+            else:
+                where = f'{fieldpath} IS NOT NULL' if positiveCondition else f'{fieldpath} IS NULL'
+        return tblobj.query(where=where, **kwargs).count() or None

--- a/gnrpy/gnr/web/gnrwebpage_proxy/menuproxy.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/menuproxy.py
@@ -1,87 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from gnr.core.gnrbag import Bag
-from gnr.core.gnrdecorator import public_method
 from gnr.web.gnrwebpage_proxy.gnrbaseproxy import GnrBaseProxy
 from gnr.web.gnrmenu import MenuResolver
-from gnr.web import logger
 
 
 class GnrMenuProxy(GnrBaseProxy):
 
-    @public_method
-    def getMenuLineBadge(self, table=None, handler=None, condition=None, **kwargs):
-        """Get badge content for menu line.
-
-        Args:
-            table: the table to query
-            handler: determines the badge computation method:
-                - 'methodName': calls the specified RPC method on the table
-                - '#': returns total record count for the table
-                - '#:fieldpath': returns count where field has a "positive" value
-                - '#:!fieldpath': returns count where field has a "negative" value
-                  fieldpath can be prefixed with $ (column) or @ (relation), defaults to $
-            condition: deprecated, use handler with '#' syntax instead
-
-        The filter condition depends on the column dtype:
-            - Boolean (B): IS TRUE / IS NOT TRUE
-            - Numeric (N,L,I,R): IS NOT NULL AND !=0 / IS NULL OR =0
-            - Other (text, date, etc.): IS NOT NULL / IS NULL
-        """
-        if condition:
-            logger.warning("getMenuLineBadge 'condition' parameter is deprecated. "
-                           "Use menuLineBadge='#' for count or '#:columnName' for filtered count")
-            return self.page.db.table(table).query(where=condition, **kwargs).count()
-        if not handler:
-            return
-        # handler is a table method name - call it via RPC
-        if not handler.startswith('#'):
-            return self.getPublicMethod('rpc', f'_table.{table}.{handler}')(**kwargs)
-
-        # handler starts with '#': use record count
-        where = None
-        tblobj = self.page.db.table(table)
-        if ':' in handler:
-            # extract fieldpath after ':'
-            fieldpath = handler.split(':')[1]
-
-            # check for negation prefix '!'
-            positiveCondition = True
-            if fieldpath.startswith('!'):
-                fieldpath = fieldpath[1:]
-                positiveCondition = False
-
-            # auto-prepend $ if no prefix specified
-            if fieldpath[0] not in ('$', '@'):
-                fieldpath = f'${fieldpath}'
-
-            # build WHERE clause based on column dtype
-            column = tblobj.column(fieldpath)
-            if column is None:
-                raise ValueError(f"Column {fieldpath} not found in table {table}")
-            dtype = column.attributes.get('dtype')
-            if dtype == 'B':
-                # boolean: check for TRUE/NOT TRUE
-                where = f'{fieldpath} IS TRUE' if positiveCondition else f'{fieldpath} IS NOT TRUE'
-            elif dtype in ('N', 'L', 'I', 'R'):
-                # numeric: check for non-null and non-zero
-                if positiveCondition:
-                    where = f'{fieldpath} IS NOT NULL AND {fieldpath}!=0'
-                else:
-                    where = f'{fieldpath} IS NULL OR {fieldpath}=0'
-            else:
-                # text, date, etc.: check for non-null
-                where = f'{fieldpath} IS NOT NULL' if positiveCondition else f'{fieldpath} IS NULL'
-        return tblobj.query(where=where, **kwargs).count() or None
-            
-
-    def getRoot(self,pkg=None,indexPagePkg=None,**kwargs):
+    def getRoot(self, pkg=None, indexPagePkg=None, **kwargs):
         result = Bag()
         result['root'] = MenuResolver(pagepath=self.page.pagepath,
                                         _page=self.page,
-                                        pkg=pkg,**kwargs)
+                                        pkg=pkg, **kwargs)
         return result
-    
-
-
-    

--- a/gnrpy/gnr/web/gnrwebstruct.py
+++ b/gnrpy/gnr/web/gnrwebstruct.py
@@ -390,6 +390,14 @@ class GnrDomSrc(GnrStructData):
                 kwargs[k]=v.js_sourceNode()
         if kwargs.get('nodeId'):
             self.checkNodeId(kwargs['nodeId'])
+        tabBadge = kwargs.get('tabBadge')
+        if tabBadge and tag.lower() == 'contentpane':
+            tabBadge_kw = dictExtract(kwargs, 'tabBadge_', pop=False)
+            tabBadge_kw['handler'] = tabBadge
+            tabBadge_kw['table'] = tabBadge_kw.get('table') or kwargs.get('table')
+            if tabBadge_kw.get('table'):
+                self.page.subscribeTable(tabBadge_kw['table'], True, subscribeMode=True)
+            kwargs['tabBadgeContent'] = self.page.badge.getBadgeHandler(**tabBadge_kw)
         sourceNodeValueAttr = dictExtract(kwargs,'attr_')
         serverpath = sourceNodeValueAttr.get('serverpath')
        # dbenv = sourceNodeValueAttr.get('dbenv')

--- a/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
+++ b/projects/gnrcore/packages/adm/resources/frameplugin_menu/frameplugin_menu.py
@@ -175,7 +175,7 @@ class MenuIframes(BaseComponent):
                                     }
                                     if(objectNotEmpty(menuLineBadgeKW)){
                                         menuLineBadgeKW.table = menuLineBadgeKW.table || n.attr.table;
-                                        genro.serverCall('menu.getMenuLineBadge',menuLineBadgeKW,
+                                        genro.serverCall('badge.getBadgeHandler',menuLineBadgeKW,
                                                             function(result){
                                                                 n.updAttributes({badgeContent:result});
                                                             })


### PR DESCRIPTION
## Summary

- Introduce `GnrBadgeProxy` (`badgeproxy.py`) — a generic badge resolver that replaces `GnrMenuProxy.getMenuLineBadge` and also serves the new `tabBadge` use case
- Add `tabBadge` support for `ContentPane` widgets inside a `TabContainer`, resolved server-side and refreshed client-side via `dojo.subscribe`

## Changes

- **`badgeproxy.py`** (new): `getBadgeHandler` `@public_method` — supports `'methodName'`, `'#'`, `'#:fieldpath'` handler syntax
- **`gnrwebpage.py`**: `badge` property exposing `GnrBadgeProxy`
- **`menuproxy.py`**: removed `getMenuLineBadge` (moved to badgeproxy)
- **`gnrmenu.py`** + **`frameplugin_menu.py`**: updated callers to `badge.getBadgeHandler`
- **`gnrwebstruct.py`**: `tabBadge` resolution in `child()` for ContentPane tags
- **`genro_widgets.js` (d11 + d20)**: `setControllerTitle` appends badge HTML; `ContentPane.creating` saves tabBadge to savedAttrs; `_created` calls immediately + `dojo.subscribe` for reactive refresh

## Usage

```python
tc.contentPane(title='Webex', tabBadge='getWebexBadge', tabBadge_table='el_org.sede')
```

## Breaking Change

`menu.getMenuLineBadge` RPC is removed → use `badge.getBadgeHandler`.

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)