### PR TITLE
Fix/k8s docker gunicorn loader

### DIFF
--- a/docs/development/envvars.py
+++ b/docs/development/envvars.py
@@ -33,6 +33,7 @@ variables = {
         "GNR_LOCALE": "The default locale (en_US, it_IT, etc)",
         "GNR_LOGLEVEL": "The default logging level (debug, info, warning, error)",
         "GNR_CURRENT_SITE": "TBD",
+        "GNR_CUSTOM_GUNICORN_CONF": "Gunicorn's custom configuration file (python)",
         "GNR_WSGI_OPT_": "Prefix for options to be passed to the wsgi server",
         "GNR_GUNICORN_": "Prefix for options to be passed to the gunicorn based application server",
         "GNR_WORKER_ID": "Used by taskworker, the worker ID",

--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -1,3 +1,10 @@
+Release 26.03.24.1
+==================
+
+Backport release for handling reverse-proxy/ssl termination correctly
+in a K8S enviroment, and to provide an easy way (with default path or
+env-var provided path) custom configuration for gunicorn backend.
+
 Release 26.03.24
 ================
 

--- a/gnrpy/gnr/__init__.py
+++ b/gnrpy/gnr/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from gnr.core import gnrlog
 
-VERSION = "26.03.24"
+VERSION = "26.03.24.1"
 
 gnrlog.init_logging_system()
 logger = logging.getLogger("gnr")

--- a/gnrpy/gnr/web/cli/gnrserveprod.py
+++ b/gnrpy/gnr/web/cli/gnrserveprod.py
@@ -2,11 +2,16 @@
 # encoding: utf-8
 
 import os
-    
+import os.path
+
 from gunicorn.app.base import BaseApplication
 from gunicorn.config import Config as GunicornConfig
 
 from gnr.web.gnrwsgisite import GnrWsgiSite
+
+# this is the default path for gunicorn configuration
+# created in the base genropy docker image
+DEFAULT_DOCKER_GUNICORN_CONF_PATH = "/home/genro/gunicorn.py"
 
 description = """Start production server for site"""
 
@@ -124,8 +129,18 @@ def main():
     app = get_gnr_wsgi_application(cli_config.get("instance_name"), cli_config)
 
     file_config = {}
+    # always load the default docker image when running in k8s
+    if os.environ.get("KUBERNETES_SERVICE_HOST", None):
+        if os.path.exists(DEFAULT_DOCKER_GUNICORN_CONF_PATH):
+            file_config.update(load_config_file(DEFAULT_DOCKER_GUNICORN_CONF_PATH))
+            
     if "config" in cli_config:
-        file_config = load_config_file(cli_config["config"])
+        if os.path.exists(cli_config["config"]):
+            file_config.update(load_config_file(cli_config["config"]))
+
+    if custom_conf_file := os.environ.get("GNR_CUSTOM_GUNICORN_CONF", None):
+        if os.path.exists(custom_conf_file):
+            file_config.update(load_config_file(custom_conf_file))
     
     # precedence order: command line options, environment, configuration file
     combined_config = {**file_config, **env_config, **cli_config}        

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -18,6 +18,7 @@ from werkzeug.utils import redirect
 from werkzeug.exceptions import (HTTPException, InternalServerError,
                                   NotFound, Forbidden, PreconditionFailed,
                                   BadRequest, Unauthorized)
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from gnr.core.gnrbag import Bag
 from gnr.core import gnrstring
@@ -1537,6 +1538,15 @@ class GnrWsgiSite(object):
                 wsgiapp = SentryWsgiMiddleware(wsgiapp)
             except Exception as e:
                 logger.error(f"Sentry support has been disabled due to configuration errors: {e}")
+
+        # when the application is executed being a reverse proxy / ssl terminator,
+        # werkzeug needs this middleware to compute the correct external host
+        # which is used by externalUrl in the Site object when the value is
+        # computed using the request data.
+        # Limited to Kubernetes environment for initial staging testing
+        if os.environ.get("KUBERNETES_SERVICE_HOST", None):
+            wsgiapp = ProxyFix(wsgiapp, x_for=1, x_proto=1, x_host=1)
+
         return wsgiapp
 
     def build_gnrapp(self, options=None):


### PR DESCRIPTION
serveprod (gunicorn wrapper) now loads from a k8s predefined configuration
    file, and to use a python configuration file from env var provided path.
    
Documented the new env var.

Backport for ProxyFix from #721 
