### PR TITLE
fix(#686): restore custom rpcmethod in document store load

### DIFF
--- a/gnrjs/gnr_d11/js/genro_frm.js
+++ b/gnrjs/gnr_d11/js/genro_frm.js
@@ -2759,7 +2759,7 @@ dojo.declare("gnr.formstores.Base", null, {
         const that = this;
         const form = this.form;
         kw = kw || {};
-        kw.rpcmethod = kw.rpcmethod || 'getSiteDocument';
+        kw.rpcmethod = kw.rpcmethod || this.handlers.load.rpcmethod || 'getSiteDocument';
         kw.path = form.getCurrentPkey();
 
         const onResult = function(result){

--- a/gnrjs/gnr_d20/js/genro_frm.js
+++ b/gnrjs/gnr_d20/js/genro_frm.js
@@ -2759,7 +2759,7 @@ dojo.declare("gnr.formstores.Base", null, {
         const that = this;
         const form = this.form;
         kw = kw || {};
-        kw.rpcmethod = kw.rpcmethod || 'getSiteDocument';
+        kw.rpcmethod = kw.rpcmethod || this.handlers.load.rpcmethod || 'getSiteDocument';
         kw.path = form.getCurrentPkey();
 
         const onResult = function(result){


### PR DESCRIPTION
## Summary

Fixes #686 — `IsADirectoryError` when opening the Localization Editor.

## Root cause

The grouplets refactoring (PR #560, commit `d98a4cf56f`) rewrote `load_document` in `genro_frm.js` and hardcoded `'getSiteDocument'` as the RPC method:

```javascript
// NEW (broken) — ignores custom handler
kw.rpcmethod = kw.rpcmethod || 'getSiteDocument';
```

The **original** code respected the custom `rpcmethod` set via `form.store.handler('load', rpcmethod=...)`:

```javascript
// OLD (working) — custom handler first, default as fallback
this.handlers.load.rpcmethod = loader.rpcmethod || 'getSiteDocument';
```

The Localization Editor uses `store='document'` with a custom handler (`loadLocalizationFile`) that knows how to handle directory paths (it does `os.path.join(path, 'localization.xml')`). After the regression, `getSiteDocument` was called instead, which tried to `open()` a directory path — crash.

## Fix

Restore the original priority chain in `load_document`:

```javascript
kw.rpcmethod = kw.rpcmethod || this.handlers.load.rpcmethod || 'getSiteDocument';
```

Also reverts the symptomatic `snode.isdir` guard on `getSiteDocument` (commit `aed62de316`) which masked the real cause without fixing it.

## Files changed

- `gnrjs/gnr_d11/js/genro_frm.js` — restore handler rpcmethod priority
- `gnrjs/gnr_d20/js/genro_frm.js` — same fix for dojo_20
- `gnrpy/gnr/web/gnrwebpage.py` — revert isdir workaround

## Test plan

- [ ] Open a Genropy app with localization (e.g. any app with `adm` package)
- [ ] Navigate to **System → Localization Editor**
- [ ] Select the **core** block — should load without error
- [ ] Select package blocks — should also load correctly
- [ ] Verify that other `store='document'` forms still work (e.g. doc_handler)

@dgpaci please test on the environment where the bug was originally reported.