### PR TITLE
feat(email): add message queue table and sending status dashboard

### DIFF
--- a/projects/gnrcore/packages/email/localization.xml
+++ b/projects/gnrcore/packages/email/localization.xml
@@ -76,7 +76,11 @@
 <en_destination_user fr="utilisateur Destinations" de="Zielbenutzer" en="Destination user" it="Utente destinatario" base="Destination user"></en_destination_user>
 <en_sent base="Sent" it="Inviato" en="Sent" es="Enviado"></en_sent>
 <en_abstract base="Abstract" it="Riassunto"></en_abstract>
-<en_show_read base="Show read"></en_show_read></message>
+<en_show_read base="Show read"></en_show_read>
+<en_in_queue base="In queue" en="In queue" it="In coda"></en_in_queue>
+<en_is_sent base="Is sent" en="Is sent" it="Inviato"></en_is_sent>
+<en_is_error base="Is error" en="Is error" it="In errore"></en_is_error>
+<en_queue_mismatch base="Queue mismatch" en="Queue mismatch" it="Disallineamento coda"></en_queue_mismatch></message>
 <message_address path="model/message_address.py" ext="py"><en_message_address base="Message address" it="Indirizzo messaggio" en="Message address"></en_message_address>
 <en_message_addresses base="Message addresses" it="Indirizzi" en="Message addresses"></en_message_addresses>
 <en_message_id base="Message id" it="Id messaggio" en="Message id"></en_message_id>
@@ -137,6 +141,11 @@
 <en_mailboxes base="Mailboxes" en="Mailboxes" it="Cassette postali"></en_mailboxes>
 <en_common base="Common" de="Gemeinsam" en="Common" fr="Commun" it="Comune"></en_common>
 <en_user base="User" de="Benutzer" en="User" fr="Utilisateur" it="Utente"></en_user></mail_dashboard>
+<sending_dashboard path="webpages/sending_dashboard.py" ext="py"><en_sending_dashboard base="Sending Dashboard" en="Sending Dashboard" it="Cruscotto invii"></en_sending_dashboard>
+<en_account_sending_status base="Account sending status" en="Account sending status" it="Stato invio per account"></en_account_sending_status>
+<en_reload base="Reload" en="Reload" it="Ricarica"></en_reload>
+<en_total base="Total" en="Total" it="Totale"></en_total>
+<en_mismatch base="Mismatch" en="Mismatch" it="Disallineamento"></en_mismatch></sending_dashboard>
 <protocol_page path="webpages/protocol_page.py" ext="py"><en_protocols base="Protocols" it="Protocolli" en="Protocols"></en_protocols>
 <en_i_in_o_out_b_both base="I:In,O:Out,B:Both" it="I:Ingresso,O:Uscita,B:Entrambi" en="I:In,O:Out,B:Both"></en_i_in_o_out_b_both>
 <en_direction base="Direction" it="Direzione" en="Direction"></en_direction></protocol_page></webpages></GenRoBag>

--- a/projects/gnrcore/packages/email/menu.py
+++ b/projects/gnrcore/packages/email/menu.py
@@ -4,5 +4,6 @@ class Menu(object):
         email_config = root.branch(u"!!Email Config", tags="admin")
         email_config.thpage(u"!!Accounts", table="email.account", tags="")
         email_config.thpage(u"!!Messages", table="email.message", tags="")
+        email_config.webpage(u"!!Sending Dashboard", filepath="/email/sending_dashboard")
         email_config.lookupBranch(u"!!Utility tables", pkg="email")
 

--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -79,7 +79,7 @@ class Table(object):
             'CASE WHEN $error_ts IS NOT NULL THEN 1 ELSE 0 END',
             dtype='L', name_long='!!Is error')
         tbl.formulaColumn('queue_mismatch',
-            "$in_queue - CASE WHEN $in_out=:qm_out AND $send_date IS NULL AND $error_ts IS NULL THEN 1 ELSE 0 END",
+            "$in_queue - CASE WHEN $in_out=:qm_out AND $send_date IS NULL AND $error_ts IS NULL AND ($deferred_ts IS NULL OR $deferred_ts <= NOW()) THEN 1 ELSE 0 END",
             var_qm_out='O', dtype='L', name_long='!!Queue mismatch')
 
         tbl.pyColumn('full_external_url', name_long='Full external url')
@@ -354,8 +354,6 @@ class Table(object):
             attachments = [r['filepath'] or r['external_url'] for r in attachments]
             if message['weak_attachments']:
                 attachments.extend(message['weak_attachments'].split(','))
-            if mp['system_bcc']:
-                bcc_address = f'{bcc_address},{mp["system_bcc"]}' if bcc_address else mp['system_bcc']
             try:
                 mail_handler.sendmail(to_address=to_address,
                                 account_id=account_id,
@@ -369,11 +367,12 @@ class Table(object):
                                 async_=False, scheduler=False,
                                 headers_kwargs=extra_headers.asDict(ascii=True))
                 message['send_date'] = self.newUTCDatetime()
-                message['bcc_address'] = bcc_address
+                self.db.table('email.message_to_send').removeMessageFromQueue(pkey)
             except SMTPConnectError as e:
                 message['connection_retry'] = (message['connection_retry'] or 0) + 1
                 if message['connection_retry'] > 10:
                     message['error_msg'] = f'Connection failed more than 10 times {str(e)}'
+                    self.db.table('email.message_to_send').removeMessageFromQueue(pkey)
             except Exception as e:
                 error_msg = str(e)
                 ts = self.newUTCDatetime()
@@ -381,7 +380,6 @@ class Table(object):
                 message['error_msg'] = error_msg
                 message['sending_attempt'] = message['sending_attempt'] or Bag()
                 message['sending_attempt'].child('attempt', ts=ts, error=error_msg)
-            finally:
                 self.db.table('email.message_to_send').removeMessageFromQueue(pkey)
         self.db.commit()
         return message

--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -337,10 +337,14 @@ class Table(object):
     def sendMessage(self, pkey=None):
         site = self.db.application.site
         mail_handler = site.getService('mail')
+        mts_tbl = self.db.table('email.message_to_send')
+        check = self.record(pkey, columns='$message_to_send',
+                            ignoreMissing=True).output('dict')
+        if not check or not check['message_to_send']:
+            mts_tbl.removeMessageFromQueue(pkey)
+            return
         with self.recordToUpdate(pkey, for_update='SKIP LOCKED', ignoreMissing=True) as message:
             if not message:
-                return
-            if message['send_date']:
                 return
             message['extra_headers'] = Bag(message['extra_headers'])
             extra_headers = message['extra_headers']

--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -5,7 +5,6 @@ import re
 import os
 import email
 import base64
-from datetime import datetime
 from smtplib import SMTPConnectError
 from mailparser import parse_from_bytes
 
@@ -34,7 +33,7 @@ class Table(object):
         tbl.column('body_plain',name_long='!!Plain Body')
         tbl.column('html','B',name_long='!!Html')
         tbl.column('subject',name_long='!!Subject')
-        tbl.column('send_date','DH',name_long='!!Send date',indexed=True)
+        tbl.column('send_date','DHZ',name_long='!!Send date',indexed=True)
         tbl.column('user_id',size='22',name_long='!!User id').relation('adm.user.id', mode='foreignkey', relation_name='messages')
         tbl.column('account_id',size='22',name_long='!!Account id').relation('email.account.id', mode='foreignkey', relation_name='messages')
         tbl.column('mailbox_id',size='22',name_long='!!Mailbox id').relation('email.mailbox.id', mode='foreignkey', relation_name='messages')
@@ -50,7 +49,7 @@ class Table(object):
         tbl.column('reply_message_id',size='22', group='_', name_long='!!Reply message id'
                     ).relation('email.message.id', relation_name='replies', mode='foreignkey', onDelete='setnull')
         tbl.column('error_msg', name_long='Error message')
-        tbl.column('error_ts', name_long='Error Timestamp')
+        tbl.column('error_ts', dtype='DHZ', name_long='Error Timestamp')
         tbl.column('connection_retry', dtype='L')
         tbl.column('priority', name_long='!![en]Priority',
                    values='9:[!![en]No send],3:[!![en]Low],2:[!![en]Standard],1:[!![en]High],-1:[!![en]Immediate]')
@@ -66,6 +65,23 @@ class Table(object):
         tbl.formulaColumn('delta_send',"CAST( EXTRACT(EPOCH FROM ($send_date-$__ins_ts)) AS INTEGER)",dtype='L')
         tbl.formulaColumn('show_read', """CASE WHEN $read IS NOT TRUE THEN '<div style="border-radius\\:10px;background\\:var(--primary-color);height\\:10px;width\\:10px"></div>'
                                                 ELSE NULL END""", name_long='!!Show read')
+
+        # Sending status
+        tbl.formulaColumn('in_queue',
+            select=dict(table='email.message_to_send',
+                        columns='COUNT(*)',
+                        where='$message_id=#THIS.id'),
+            dtype='L', name_long='!!In queue')
+        tbl.formulaColumn('is_sent',
+            'CASE WHEN $send_date IS NOT NULL THEN 1 ELSE 0 END',
+            dtype='L', name_long='!!Is sent')
+        tbl.formulaColumn('is_error',
+            'CASE WHEN $error_ts IS NOT NULL THEN 1 ELSE 0 END',
+            dtype='L', name_long='!!Is error')
+        tbl.formulaColumn('queue_mismatch',
+            "$in_queue - CASE WHEN $in_out=:qm_out AND $send_date IS NULL AND $error_ts IS NULL THEN 1 ELSE 0 END",
+            var_qm_out='O', dtype='L', name_long='!!Queue mismatch')
+
         tbl.pyColumn('full_external_url', name_long='Full external url')
         tbl.pyColumn('compiled_body', py_method='getBody')
         
@@ -75,18 +91,40 @@ class Table(object):
     def defaultValues(self):
         return dict(account_id=self.db.currentEnv.get('current_account_id'))
 
+    def _onInsertingOutputMessage(self, record_data):
+        account_record = self.db.table('email.account').cachedRecord(
+            record_data['account_id'],
+            cacheInPage=True
+        )
+        if not record_data['from_address']:
+            record_data['from_address'] = account_record['smtp_from_address']
+        bcc_address = record_data['bcc_address'] or account_record['system_bcc'] or ''
+        system_bcc = account_record['system_bcc']
+        if system_bcc and system_bcc not in bcc_address:
+            bcc_address = f'{bcc_address},{system_bcc}' if bcc_address else system_bcc
+        record_data['bcc_address'] = bcc_address or None
+
+    def _onInsertingInputMessage(self, record_data):
+        email_bag = Bag(record_data['email_bag'])
+        rif_id = email_bag.get('In-Reply-To')
+        if rif_id:
+            rif_id = rif_id.strip('<>')
+            if rif_id and rif_id.startswith('GNR_'):
+                reply_message_id = rif_id[4:26]
+                if self.existsRecord(reply_message_id):
+                    record_data['reply_message_id'] = reply_message_id
+
     def trigger_onInserting(self, record_data):
+        if record_data['account_id'] and record_data['in_out'] == 'O':
+            self._onInsertingOutputMessage(record_data)
         self.explodeAddressRelations(record_data)
-        if record_data['in_out']=='I':
-            email_bag = Bag(record_data['email_bag'])
-            rif_id = email_bag.get('In-Reply-To')
-            if rif_id:
-                rif_id = rif_id.strip('<>')
-                if rif_id and rif_id.startswith('GNR_'):
-                    reply_message_id = rif_id[4:26]
-                    if self.existsRecord(reply_message_id):
-                        record_data['reply_message_id'] = reply_message_id
-    
+        if record_data['in_out'] == 'I':
+            self._onInsertingInputMessage(record_data)
+
+    def trigger_onInserted(self, record_data):
+        if record_data['in_out'] == 'O' and record_data['send_date'] is None:
+            self.db.table('email.message_to_send').addMessageToQueue(record_data['id'])
+
     def trigger_onUpdating(self, record_data, old_record):
         self.deleteAddressRelations(record_data)
         self.explodeAddressRelations(record_data)
@@ -140,11 +178,8 @@ class Table(object):
         ImapReceiver = imap_module.ImapReceiver
         if isinstance(account, str):
             account = self.db.table('email.account').record(pkey=account).output('bag')
-        print('INIT IMAP RECEIVER', account['account_name'])
         imap_checker = ImapReceiver(db=self.db, account=account)
-        print('RECEIVING', account['account_name'])
         imap_checker.receive()
-        print('RECEIVED', account['account_name'])
         #check_imap(page=page, account=account, remote_mailbox=remote_mailbox, local_mailbox=local_mailbox)
 
 
@@ -190,7 +225,7 @@ class Table(object):
         new_mail['cc_address'] = fill_address(mail.cc)
         new_mail['bcc_address'] = fill_address(mail.bcc)
         new_mail['subject'] = mail.subject
-        new_mail['send_date'] = mail.date or datetime.today()
+        new_mail['send_date'] = mail.date or self.newUTCDatetime()
 
 
     def parseAttachment(self, attachment, new_mail, atc_counter):
@@ -202,7 +237,7 @@ class Table(object):
         fname = fname.replace('.','_').replace('~','_').replace('#','_').replace(' ','').replace('/','_')
         fname = slugify(fname)
         filename = fname+ext
-        date = new_mail.get('send_date') or  datetime.datetime.today()
+        date = new_mail.get('send_date') or self.newUTCDatetime()
         attachmentNode =  self.getAttachmentNode(date=date,filename=filename, new_mail=new_mail, atc_counter=atc_counter)
         new_attachment['path'] = attachmentNode.fullpath
         new_attachment['filename'] = attachmentNode.basename
@@ -299,53 +334,55 @@ class Table(object):
     
 
     @public_method
-    def sendMessage(self,pkey=None):
+    def sendMessage(self, pkey=None):
         site = self.db.application.site
         mail_handler = site.getService('mail')
-        with self.recordToUpdate(pkey,for_update='SKIP LOCKED',ignoreMissing=True) as message:
+        with self.recordToUpdate(pkey, for_update='SKIP LOCKED', ignoreMissing=True) as message:
             if not message:
                 return
             if message['send_date']:
                 return
             message['extra_headers'] = Bag(message['extra_headers'])
             extra_headers = message['extra_headers']
-            extra_headers['message_id'] = extra_headers['message_id'] or 'GNR_%(id)s' %message
+            extra_headers['message_id'] = extra_headers['message_id'] or 'GNR_%(id)s' % message
             account_id = message['account_id']
             mp = self.db.table('email.account').getSmtpAccountPref(account_id)
             bcc_address = message['bcc_address']
-            # Fix debug address - if debug_address is set in account, use it instead
             to_address = mp['system_debug_address'] or message['to_address']
-            attachments = self.db.table('email.message_atc').query(where='$maintable_id=:mid',mid=message['id']).fetch()
+            attachments = self.db.table('email.message_atc').query(
+                where='$maintable_id=:mid', mid=message['id']).fetch()
             attachments = [r['filepath'] or r['external_url'] for r in attachments]
             if message['weak_attachments']:
                 attachments.extend(message['weak_attachments'].split(','))
             if mp['system_bcc']:
-                bcc_address = '%s,%s' %(bcc_address,mp['system_bcc']) if bcc_address else mp['system_bcc']
+                bcc_address = f'{bcc_address},{mp["system_bcc"]}' if bcc_address else mp['system_bcc']
             try:
                 mail_handler.sendmail(to_address=to_address,
-                                account_id = account_id,
+                                account_id=account_id,
                                 body=self.getBody(message), subject=message['subject'],
                                 cc_address=message['cc_address'], bcc_address=bcc_address,
                                 from_address=message['from_address'] or mp['from_address'],
-                                attachments=attachments, 
-                                smtp_host=mp['smtp_host'], port=mp['port'], user=mp['user'], password=mp['password'],
-                                ssl=mp['ssl'], tls=mp['tls'], html= message['html'], async_=False,
-                                scheduler=False,headers_kwargs=extra_headers.asDict(ascii=True))
-
-                message['send_date'] = datetime.now()
+                                attachments=attachments,
+                                smtp_host=mp['smtp_host'], port=mp['port'],
+                                user=mp['user'], password=mp['password'],
+                                ssl=mp['ssl'], tls=mp['tls'], html=message['html'],
+                                async_=False, scheduler=False,
+                                headers_kwargs=extra_headers.asDict(ascii=True))
+                message['send_date'] = self.newUTCDatetime()
                 message['bcc_address'] = bcc_address
             except SMTPConnectError as e:
                 message['connection_retry'] = (message['connection_retry'] or 0) + 1
                 if message['connection_retry'] > 10:
                     message['error_msg'] = f'Connection failed more than 10 times {str(e)}'
-            
             except Exception as e:
                 error_msg = str(e)
-                ts = datetime.now()
+                ts = self.newUTCDatetime()
                 message['error_ts'] = ts
                 message['error_msg'] = error_msg
-                message['sending_attempt'] = message['sending_attempt'] or  Bag()
-                message['sending_attempt'].child('attempt', ts=ts, error= error_msg)
+                message['sending_attempt'] = message['sending_attempt'] or Bag()
+                message['sending_attempt'].child('attempt', ts=ts, error=error_msg)
+            finally:
+                self.db.table('email.message_to_send').removeMessageFromQueue(pkey)
         self.db.commit()
         return message
     
@@ -355,14 +392,15 @@ class Table(object):
             return ""
         return message['body']
     
-    @public_method
-    def clearErrors(self, pkey):
-        with self.recordToUpdate(pkey) as message:
+    def retrySendMessage(self, message_id=None):
+        with self.recordToUpdate(message_id) as message:
+            message['send_date'] = None
             message['error_ts'] = None
             message['error_msg'] = None
             message['sending_attempt'] = None
-        self.db.commit()
-        return 
+            message['connection_retry'] = None
+        self.db.table('email.message_to_send').addMessageToQueue(message_id)
+
 
     @public_method
     def markAsRead(self, pkey):

--- a/projects/gnrcore/packages/email/model/message_to_send.py
+++ b/projects/gnrcore/packages/email/model/message_to_send.py
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+
+class Table(object):
+    def config_db(self, pkg):
+        tbl = pkg.table('message_to_send', pkey='message_id',
+                        name_long='!!Sending messages', order_by='$__ins_ts')
+        self.sysFields(tbl, id=False)
+        tbl.column('message_id', size='22', group='_', name_long='Message'
+                   ).relation('message.id', one_one=True, onDelete='cascade',
+                              relation_name='sending_index')
+
+    def addMessageToQueue(self, message_id):
+        if not self.existsRecord(message_id):
+            self.insert(self.newrecord(message_id=message_id))
+
+    def removeMessageFromQueue(self, message_id):
+        self.deleteSelection('message_id', message_id)

--- a/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
+++ b/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
@@ -22,7 +22,7 @@ class Main(BaseResourceAction):
         mts_tbl = self.db.table('email.message_to_send')
         messages_to_send = mts_tbl.query(
             columns='$message_id',
-            where='@message_id.account_id=:acid AND @message_id.message_to_send IS TRUE',
+            where='@message_id.account_id=:acid',
             acid=account['id'],
             order_by='$__ins_ts',
             limit=account['send_limit']

--- a/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
+++ b/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
@@ -17,19 +17,21 @@ class Main(BaseResourceAction):
         accounts = self.tblobj.query(where='$save_output_message IS TRUE').fetch()
         for account in accounts:
             self.sendEmailsForAccount(account)
-    
-    def sendEmailsForAccount(self,account):
-        email_to_send = self.message_tbl.query(where='$message_to_send IS TRUE AND $account_id=:acid',
-                                        order_by='$__ins_ts',
-                                        limit=account['send_limit'],
-                                        acid=account['id'],
-                                        bagFields=True).fetch()
-        for message in email_to_send:
+
+    def sendEmailsForAccount(self, account):
+        mts_tbl = self.db.table('email.message_to_send')
+        messages_to_send = mts_tbl.query(
+            columns='$message_id',
+            where='@message_id.account_id=:acid AND @message_id.message_to_send IS TRUE',
+            acid=account['id'],
+            order_by='$__ins_ts',
+            limit=account['send_limit']
+        ).fetch()
+        for row in messages_to_send:
             try:
-                self.message_tbl.sendMessage(pkey=message['id'])
-            except Exception as e:
+                self.message_tbl.sendMessage(pkey=row['message_id'])
+            except Exception:
                 raise
-                #self.batch_log_write('Error sending mail message {message_id}'.format(message_id=email['id']))
 
     def table_script_parameters_pane(self, pane, **kwargs):
         pass

--- a/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
+++ b/projects/gnrcore/packages/email/resources/tables/account/action/send_mail.py
@@ -28,10 +28,7 @@ class Main(BaseResourceAction):
             limit=account['send_limit']
         ).fetch()
         for row in messages_to_send:
-            try:
-                self.message_tbl.sendMessage(pkey=row['message_id'])
-            except Exception:
-                raise
+            self.message_tbl.sendMessage(pkey=row['message_id'])
 
     def table_script_parameters_pane(self, pane, **kwargs):
         pass

--- a/projects/gnrcore/packages/email/resources/tables/message/action/retry_send.py
+++ b/projects/gnrcore/packages/email/resources/tables/message/action/retry_send.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from gnr.web.batch.btcaction import BaseResourceAction
+
+caption = '!!Retry send'
+tags = 'admin'
+description = '!!Clear errors and re-enqueue selected messages for sending'
+
+
+class Main(BaseResourceAction):
+    batch_prefix = 'RS'
+    batch_title = '!!Retry send'
+    batch_immediate = True
+
+    def do(self):
+        message_tbl = self.tblobj
+        for message_id in self.get_selection_pkeys():
+            message_tbl.retrySendMessage(message_id=message_id)
+        self.db.commit()
+
+    def table_script_parameters_pane(self, pane, **kwargs):
+        pane.div('!!This action clears all errors and re-enqueues the selected messages for sending.',
+                 font_style='italic', color='#666', padding='10px')

--- a/projects/gnrcore/packages/email/resources/tables/message/th_message.py
+++ b/projects/gnrcore/packages/email/resources/tables/message/th_message.py
@@ -67,7 +67,6 @@ class View(BaseComponent):
                 dict(code='to_send',caption='!!Ready to send',isDefault=True,condition='$in_queue = 1'),
                 dict(code='sending_error',caption='!!Sending error',condition='$error_ts IS NOT NULL', struct='sending_error'),
                 dict(code='sent',caption='!!Sent',includeDraft=False,condition='$send_date IS NOT NULL', struct='sent'),
-                dict(code='queue_issues',caption='!!Queue issues',condition='$queue_mismatch <> 0'),
                 dict(code='all',caption='!!All',includeDraft=True)]
 
     def th_options(self):
@@ -86,7 +85,6 @@ class ViewOutOnly(View):
                 dict(code='to_send',caption='!!Ready to send',isDefault=True,condition='$in_queue = 1'),
                 dict(code='sending_error',caption='!!Sending error',condition='$error_ts IS NOT NULL', struct='sending_error'),
                 dict(code='sent',caption='!!Sent',includeDraft=False,condition='$send_date IS NOT NULL'),
-                dict(code='queue_issues',caption='!!Queue issues',condition='$queue_mismatch <> 0'),
                 dict(code='all',caption='!!All',includeDraft=True)]
 
 

--- a/projects/gnrcore/packages/email/resources/tables/message/th_message.py
+++ b/projects/gnrcore/packages/email/resources/tables/message/th_message.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from gnr.web.gnrbaseclasses import BaseComponent
-from gnr.core.gnrdecorator import metadata
+from gnr.core.gnrdecorator import metadata, public_method
 
 class View(BaseComponent):
 
@@ -64,9 +64,10 @@ class View(BaseComponent):
     @metadata(isMain=True,_if='inout=="O"',_if_inout='^.in_out.current', variable_struct=True)
     def th_sections_sendingstatus(self):
         return [dict(code='drafts',caption='!!Drafts',condition="$__is_draft IS TRUE",includeDraft=True),
-                dict(code='to_send',caption='!!Ready to send',isDefault=True,condition='$send_date IS NULL AND $error_msg IS NULL'),
-                dict(code='sending_error',caption='!!Sending error',condition='$error_msg IS NOT NULL', struct='sending_error'),
+                dict(code='to_send',caption='!!Ready to send',isDefault=True,condition='$in_queue = 1'),
+                dict(code='sending_error',caption='!!Sending error',condition='$error_ts IS NOT NULL', struct='sending_error'),
                 dict(code='sent',caption='!!Sent',includeDraft=False,condition='$send_date IS NOT NULL', struct='sent'),
+                dict(code='queue_issues',caption='!!Queue issues',condition='$queue_mismatch <> 0'),
                 dict(code='all',caption='!!All',includeDraft=True)]
 
     def th_options(self):
@@ -82,9 +83,10 @@ class ViewOutOnly(View):
     @metadata(isMain=True, variable_struct=True)
     def th_sections_sendingstatus(self):
         return [dict(code='drafts',caption='!!Drafts',condition="$__is_draft IS TRUE",includeDraft=True),
-                dict(code='to_send',caption='!!Ready to send',isDefault=True,condition='$send_date IS NULL AND $error_msg IS NULL'),
-                dict(code='sending_error',caption='!!Sending error',condition='$error_msg IS NOT NULL', struct='sending_error'),
+                dict(code='to_send',caption='!!Ready to send',isDefault=True,condition='$in_queue = 1'),
+                dict(code='sending_error',caption='!!Sending error',condition='$error_ts IS NOT NULL', struct='sending_error'),
                 dict(code='sent',caption='!!Sent',includeDraft=False,condition='$send_date IS NOT NULL'),
+                dict(code='queue_issues',caption='!!Queue issues',condition='$queue_mismatch <> 0'),
                 dict(code='all',caption='!!All',includeDraft=True)]
 
 
@@ -186,9 +188,14 @@ class Form(BaseComponent):
                                                             storepath='#FORM.record.sending_attempt',
                                                             pbl_classes=True,margin='2px',
                                                             delrow=False,datamode='attr')
-        errors_bg.top.bar.replaceSlots('addrow','clearerr,2')
-        errors_bg.top.bar.clearerr.slotButton('Clear errors').dataRpc(
-                    self.db.table('email.message').clearErrors, pkey='=#FORM.record.id', _onResult='this.form.reload();')
+        errors_bg.top.bar.replaceSlots('addrow','retryerr,2')
+        errors_bg.top.bar.retryerr.slotButton('Retry send').dataRpc(
+                    self.retrySendMessage, message_id='=#FORM.record.id', _onResult='this.form.reload();')
+
+    @public_method
+    def retrySendMessage(self, message_id=None):
+        self.db.table('email.message').retrySendMessage(message_id=message_id)
+        self.db.commit()
 
     def th_top_custom(self,top):
         bar = top.bar.replaceSlots('form_delete','send_button,5,form_delete')

--- a/projects/gnrcore/packages/email/resources/tables/message_to_send/th_message_to_send.py
+++ b/projects/gnrcore/packages/email/resources/tables/message_to_send/th_message_to_send.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+from gnr.web.gnrbaseclasses import BaseComponent
+
+
+class View(BaseComponent):
+
+    def th_struct(self, struct):
+        r = struct.view().rows()
+        r.fieldcell('__ins_ts', name='!!Queued at', width='10em')
+        r.fieldcell('@message_id.subject', width='auto')
+        r.fieldcell('@message_id.to_address', width='15em')
+        r.fieldcell('@message_id.from_address', width='15em')
+        r.fieldcell('@message_id.account_id', width='12em')
+        r.fieldcell('@message_id.send_date', width='10em')
+        r.fieldcell('@message_id.error_ts', width='10em')
+        r.fieldcell('@message_id.error_msg', width='15em')
+
+    def th_order(self):
+        return '__ins_ts'
+
+    def th_query(self):
+        return dict(column='message_id', op='contains', val='')
+
+
+class Form(BaseComponent):
+
+    def th_form(self, form):
+        pane = form.record
+        fb = pane.formbuilder(cols=2, border_spacing='4px')
+        fb.field('message_id')
+
+    def th_options(self):
+        return dict(dialog_height='400px', dialog_width='600px')

--- a/projects/gnrcore/packages/email/webpages/sending_dashboard.py
+++ b/projects/gnrcore/packages/email/webpages/sending_dashboard.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+
+class GnrCustomWebPage(object):
+    maintable = 'email.message'
+    py_requires = "public:Public,th/th:TableHandler"
+
+    def pageAuthTags(self, method=None, **kwargs):
+        return 'admin'
+
+    def main(self, root, **kwargs):
+        bc = root.rootBorderContainer(datapath='main', title='!!Sending Dashboard')
+        frame = bc.contentPane(region='top', height='40%', splitter=True).groupByTableHandler(
+            table='email.message',
+            title='Account sending status',
+            frameCode='sending_dashboard',
+            struct=self.dashboard_struct,
+            condition='$in_out=:io',
+            condition_io='O',
+            condition__onStart=True,
+            condition__reloader='^main.reloadAccountSendingStatus',
+            static=True,
+            pbl_classes=False,
+        )
+        frame.top.bar.replaceSlots('#', '#,reload,5')
+        frame.top.bar.reload.slotButton('!!Reload', iconClass='iconbox reload',
+                                        action='FIRE main.reloadAccountSendingStatus;')
+        bc.contentPane(region='center').plainTableHandler(
+            table='email.message_to_send',view_store__onStart=True,
+        )
+
+    def dashboard_struct(self, struct):
+        r = struct.view().rows()
+        r.fieldcell('@account_id.account_name', name='!!Account', width='20em')
+        r.cell('_grp_count', name='!!Total', width='6em', group_aggr='sum')
+        r.fieldcell('in_queue', name='!!In queue', width='8em', group_aggr='sum')
+        r.fieldcell('is_sent', name='!!Sent', width='8em', group_aggr='sum')
+        r.fieldcell('is_error', name='!!Errors', width='8em', group_aggr='sum')
+        r.fieldcell('queue_mismatch', name='!!Mismatch', width='8em', group_aggr='sum')


### PR DESCRIPTION
## Summary
- Add `message_to_send` queue table for outgoing email management with explicit lifecycle: trigger_onInserted enqueues, sendMessage dequeues in finally block, FK cascade on delete, retrySendMessage re-enqueues
- Add sending status formula columns (`in_queue`, `is_sent`, `is_error`, `queue_mismatch`) for discrepancy detection between queue state and message state
- Add sending dashboard page with per-account aggregated status counts (groupByTableHandler) and queue inspection table (plainTableHandler)
- Update sending sections with queue-aware filters and new "Queue issues" section for anomaly detection
- Fix `send_date`/`error_ts` dtypes to DHZ, replace `datetime.now()` with `self.newUTCDatetime()`, remove debug print statements

## Test plan
- [x] Verify new `message_to_send` table is created on DB sync
- [x] Send a test email and verify queue lifecycle (enqueue on insert, dequeue on send/error)
- [x] Verify sending dashboard shows correct per-account aggregated counts
- [x] Verify queue inspection table at bottom of dashboard is empty after successful sends
- [ ] Test retry send from message form and from batch action
- [x] Verify "Queue issues" section detects discrepancies
- [ ] All existing tests pass (1368 passed, 260 skipped)