### PR TITLE
feat: auto min-width enforcement for flex grid columns

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
@@ -306,7 +306,13 @@
 }
 
 ._common_d11 .gr_wrap_footers .dojoxGrid-scrollbox{
-    overflow-x:hidden !important;
+    overflow-x:auto !important;
+    -ms-overflow-style:none;
+    scrollbar-width:none;
+}
+._common_d11 .gr_wrap_footers .dojoxGrid-scrollbox::-webkit-scrollbar:horizontal{
+    height:0;
+    display:none;
 }
 .gr_noFooter .gr_footer.gr_scrollbox .gr_itemcontainer{
     background: transparent;

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -494,6 +494,14 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
                     sourceNode._columnsetsNode._value.getNode('scrollbox').domNode.scrollLeft = e.target.scrollLeft;
                 }
             });
+            var footerScrollDom = scrollbox.domNode;
+            var mainScrollbox = that.views.views[0].scrollboxNode;
+            genro.dom.setEventListener(mainScrollbox,'scroll',function(e){
+                footerScrollDom.scrollLeft = mainScrollbox.scrollLeft;
+                if(sourceNode._columnsetsNode){
+                    sourceNode._columnsetsNode._value.getNode('scrollbox').domNode.scrollLeft = mainScrollbox.scrollLeft;
+                }
+            });
         }else{
             genro.dom.setEventListener(sourceNode.widget.domNode,'scroll',function(e){
                 if(e.target===that.views.views[0].scrollboxNode){
@@ -535,9 +543,13 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
             return;
         }
 
+        /* Use the wider of header table and content node to cover
+           the full scrollable area when adaptFlexMinWidths enforces
+           a content width wider than the viewport */
+        const contentWidth = this.views.views[0].contentNode.offsetWidth;
+        const totalWidth = Math.max(vn.clientWidth, contentWidth) - 1;
         filler.style.height = delta+'px';
-        /* -1 prevents filler table from triggering horizontal scrollbar */
-        const totalWidth = vn.clientWidth-1;
+        filler.style.width = totalWidth+'px';
         const tdlist = [];
         const colinfo = this.getColumnInfo();
         dojo.query('th',this.viewsHeaderNode).forEach(function(n,idx){
@@ -554,6 +566,50 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
             return tdlist.push('<td style="'+style+'"></td>');
         });
         filler.innerHTML = '<table class="grid_filler" style="width:'+totalWidth+'px;"><tbody><tr>'+tdlist.join('')+'</tr></tbody></table>';
+    },
+
+    mixin__emPixels:function(){
+        if(!this._emPixelsCache){
+            var probe = document.createElement('div');
+            probe.style.cssText = 'width:1em;position:absolute;visibility:hidden;';
+            this.domNode.appendChild(probe);
+            this._emPixelsCache = probe.offsetWidth || 14;
+            this.domNode.removeChild(probe);
+        }
+        return this._emPixelsCache;
+    },
+
+    mixin_adaptFlexMinWidths:function(){
+        var view = this.views.views[0];
+        if(!view || !view.flexCells){
+            return;
+        }
+        var cells = view.structure.rows[0];
+        var emPx = this._emPixels();
+        var fixedTotal = 0;
+        var flexMinTotal = 0;
+        for(var i = 0; i < cells.length; i++){
+            var cell = cells[i];
+            if(cell.isFlex()){
+                flexMinTotal += (cell._minWidthEm || 10) * emPx;
+            }else{
+                var th = dojo.query('th', this.viewsHeaderNode)[cell.index];
+                if(th){
+                    fixedTotal += th.offsetWidth;
+                }
+            }
+        }
+        if(!flexMinTotal){
+            return;
+        }
+        var contentWidth = parseInt(view.contentWidth) || 0;
+        var availableFlex = contentWidth - fixedTotal;
+        if(availableFlex < flexMinTotal){
+            var enforced = fixedTotal + flexMinTotal + 'px';
+            view.contentWidth = enforced;
+            view.headerContentNode.firstChild.style.width = enforced;
+            view.contentNode.style.width = enforced;
+        }
     },
 
     mixin_setDraggable_row:function(draggable, view) {
@@ -921,6 +977,13 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
                 });
             }
         }
+
+        dojo.connect(widget,'adaptWidth',function(){
+            this.adaptFlexMinWidths();
+            if(this.sourceNode.attr.fillDown){
+                this.drawFiller();
+            }
+        });
 
         dojo.connect(widget,'onKeyEvent',function(e){
             if(e.type=='keydown' && !widget.gnrediting){
@@ -1809,8 +1872,19 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
                 cell.cellClasses = (cell.cellClasses || '') + ' cell_' + dtype;
             }                       
             var zoomAttr = objectExtract(cell,'zoom_*',true,true);
-            cell.cellStyles = objectAsStyle(objectUpdate(objectFromStyle(cell.cellStyles),
-                                            genro.dom.getStyleDict(cell, [ 'width'])));
+            var cellStyleDict = objectUpdate(objectFromStyle(cell.cellStyles),
+                                            genro.dom.getStyleDict(cell, [ 'width']));
+            var cellWidth = cell.width;
+            if(!cellWidth || cellWidth == 'auto' || (typeof cellWidth == 'string' && cellWidth.endsWith('%'))){
+                if(cellStyleDict['min-width']){
+                    cell._minWidthEm = parseFloat(cellStyleDict['min-width']) || 5;
+                }else{
+                    var headerLen = (cell_name || '').length;
+                    cell._minWidthEm = Math.min(15, Math.max(10, Math.ceil(headerLen * 0.7)));
+                }
+                delete cellStyleDict['min-width'];
+            }
+            cell.cellStyles = objectAsStyle(cellStyleDict);
             var formats = objectExtract(cell, 'format_*');
             var format = objectPop(cell, 'format');
             format = sourceNode.currentFromDatasource(format);
@@ -1991,6 +2065,19 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
                             cellsort.push(`${field_sorter}:${cell.sort}`);
                         }
                     },'static');
+                    var flexMinTotal = 0;
+                    var flexAutoRow = [];
+                    for(var fi = 0; fi < row.length; fi++){
+                        if(row[fi]._minWidthEm && row[fi].width === 'auto'){
+                            flexMinTotal += row[fi]._minWidthEm;
+                            flexAutoRow.push(row[fi]);
+                        }
+                    }
+                    if(flexAutoRow.length){
+                        for(var fj = 0; fj < flexAutoRow.length; fj++){
+                            flexAutoRow[fj].width = (flexAutoRow[fj]._minWidthEm / flexMinTotal * 100).toFixed(2) + '%';
+                        }
+                    }
                     rows.push(row);
                 }
                 if(sourceNode.attr.sortedBy && cellsort.length){

--- a/projects/gnrcore/packages/test/webpages/components/Grid/test_flex_minwidth.py
+++ b/projects/gnrcore/packages/test/webpages/components/Grid/test_flex_minwidth.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+"""Test page for flex column min-width enforcement in grids"""
+
+from gnr.core.gnrbag import Bag
+
+class GnrCustomWebPage(object):
+    py_requires = "gnrcomponents/testhandler:TestHandlerFull,gnrcomponents/framegrid:frameGrid"
+
+    def getSampleData(self):
+        result = Bag()
+        rows = [
+            dict(code='PROD-001', description='High performance widget with extended warranty',
+                 category='Electronics', quantity=150, unit_price=29.99,
+                 supplier='Acme Corp International', notes='Best seller this quarter'),
+            dict(code='PROD-002', description='Compact storage solution',
+                 category='Hardware', quantity=75, unit_price=49.50,
+                 supplier='GlobalTech', notes='New arrival'),
+            dict(code='PROD-003', description='Professional development toolkit for enterprise use',
+                 category='Software', quantity=200, unit_price=199.00,
+                 supplier='DevTools Inc', notes='Volume discount available'),
+            dict(code='PROD-004', description='Ergonomic desk accessory',
+                 category='Furniture', quantity=30, unit_price=89.90,
+                 supplier='Office Solutions Ltd', notes='Limited stock'),
+            dict(code='PROD-005', description='Network security appliance',
+                 category='Networking', quantity=12, unit_price=599.00,
+                 supplier='SecureNet Global Partners', notes='Requires installation'),
+        ]
+        for i, row in enumerate(rows):
+            result.setItem('r_%i' % i, Bag(row))
+        return result
+
+    def test_0_mixed_fixed_flex(self, pane):
+        """Mixed fixed and flex columns with fillDown and footer. Resize the splitter to squeeze flex columns
+        and verify they stop shrinking at min-width. Test trackpad horizontal scroll over grid body."""
+        bc = pane.borderContainer(height='500px')
+        bc.contentPane(region='right', width='200px', splitter=True,
+                       background='#f0f0f0').div('Drag the splitter left to squeeze the grid',
+                                                  padding='10px')
+        center = bc.contentPane(region='center')
+
+        def struct(struct):
+            r = struct.view().rows()
+            r.cell('code', width='8em', name='Code')
+            r.cell('description', width='auto', name='Description', edit=True)
+            r.cell('category', width='auto', name='Category')
+            r.cell('quantity', width='6em', dtype='L', name='Qty',
+                    totalize=True)
+            r.cell('unit_price', width='7em', dtype='N', name='Unit Price',
+                    format='#,###.00', totalize=True)
+            r.cell('supplier', width='auto', name='Supplier')
+            r.cell('notes', width='auto', name='Notes')
+
+        center.data('.sample_data', self.getSampleData())
+        center.dataFormula('.grid.store','sample_data', sample_data='=.sample_data',_onStart=True)
+
+        center.bagGrid(frameCode='mixed', datapath='.grid',
+                               struct=struct, storepath='.store',
+                               height='100%', fillDown=True)
+
+    def test_1_flex_with_columnsets(self, pane):
+        """Flex columns organized in columnsets. Resize to verify columnset headers
+        and footer widths stay in sync when min-width enforcement kicks in."""
+        bc = pane.borderContainer(height='500px')
+        bc.contentPane(region='right', width='200px', splitter=True,
+                       background='#f0f0f0').div('Drag the splitter left to squeeze the grid',
+                                                  padding='10px')
+        center = bc.contentPane(region='center')
+
+        def struct(struct):
+            r = struct.view().rows()
+            r.cell('code', width='8em', name='Product Code')
+            r.cell('description', width='auto', name='Description',
+                    columnset='product')
+            r.cell('category', width='auto', name='Category',
+                    columnset='product')
+            r.cell('quantity', width='6em', dtype='L', name='Quantity',
+                    columnset='numbers')
+            r.cell('unit_price', width='7em', dtype='N', name='Unit Price',
+                    format='#,###.00', columnset='numbers')
+            r.cell('supplier', width='auto', name='Supplier',
+                    columnset='supply')
+            r.cell('notes', width='auto', name='Notes',
+                    columnset='supply')
+
+        center.data('.sample_data', self.getSampleData())
+        center.dataFormula('.grid_1.store_1', 'sample_data', sample_data='=.sample_data', _onStart=True)
+
+        center.bagGrid(frameCode='colsets', datapath='.grid_1',
+                               struct=struct, storepath='.store_1',
+                               height='100%', fillDown=True,
+                               grid_footer='Totals',
+                               columnset_product='Product Info',
+                               columnset_numbers='Quantities',
+                               columnset_supply='Supply Chain')
+
+    def test_2_explicit_min_width(self, pane):
+        """Explicit min_width override on flex columns. The 'Description' column has min_width='15em'.
+        Verify this overrides the auto-calculated value when resizing."""
+        bc = pane.borderContainer(height='500px')
+        bc.contentPane(region='right', width='200px', splitter=True,
+                       background='#f0f0f0').div('Drag the splitter left to squeeze the grid',
+                                                  padding='10px')
+        center = bc.contentPane(region='center')
+
+        def struct(struct):
+            r = struct.view().rows()
+            r.cell('code', width='8em', name='Code')
+            r.cell('description', width='auto', name='Description',
+                    min_width='15em')
+            r.cell('category', width='auto', name='Category')
+            r.cell('quantity', width='6em', dtype='L', name='Qty')
+            r.cell('supplier', width='auto', name='Supplier')
+
+        center.data('.sample_data', self.getSampleData())
+        center.dataFormula('.grid_2.store_2', 'sample_data', sample_data='=.sample_data', _onStart=True)
+
+        center.bagGrid(frameCode='minwidth', datapath='.grid_2',
+                               struct=struct, storepath='.store_2',
+                               height='100%', fillDown=True)


### PR DESCRIPTION
## Summary
- Flex columns (`width='auto'` or `%`) in dojox grids were squeezed to near-zero when the container shrank, because fixed-width columns don't compress and `table-layout: fixed` ignores CSS `min-width`
- Added JS-based min-width enforcement: auto-computed from header name length (10-15em range), with user override via `min_width` attribute. At structure build time, `auto` columns are converted to proportional percentages; at runtime, `adaptFlexMinWidths()` enforces minimum total flex width, triggering horizontal scroll when space is insufficient
- Fixed trackpad horizontal scroll on grids with footers: changed `overflow-x: hidden` to invisible `overflow-x: auto` with bidirectional scroll sync between grid body, footer, and columnsets
- Fixed filler div width to cover the full scrollable area when content overflows the viewport

## Changed files
- `gnrjs/gnr_d11/js/genro_grid.js` — min-width computation, JS enforcement mixins, scroll sync, filler fix
- `gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css` — hidden scrollbar for footer scrollbox
- `projects/gnrcore/packages/test/webpages/components/Grid/test_flex_minwidth.py` — test page with 3 scenarios

## Test plan
- [x] Manual tests executed (3 scenarios: mixed fixed+flex, columnsets with footer, explicit min_width)
- [x] Automated tests pass (1368 passed, 260 skipped)
- [x] Non-flex grids verified unaffected (early returns, scoped CSS selectors)
- [x] Flake8 passes with zero errors