### PR TITLE
fix: add missing H↔HZ type conversions to migration system

### DIFF
--- a/gnrpy/gnr/sql/adapters/_gnrbaseadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbaseadapter.py
@@ -149,6 +149,8 @@ class SqlDbAdapter(object):
         ('DH', 'DHZ'): None,
         ('DHZ', 'D'): None,
         ('DHZ', 'DH'): None,
+        ('H', 'HZ'): None,
+        ('HZ', 'H'): None,
     }
 
 


### PR DESCRIPTION
## Summary

- Add `('H', 'HZ'): None` and `('HZ', 'H'): None` to `TYPE_CONVERSIONS` in `_gnrbaseadapter.py`
- Mirrors the existing `('DH', 'DHZ')` / `('DHZ', 'DH')` entries which were already handled

## Problem

Migrating a non-empty column from `H` (time without time zone) to `HZ` (time with time zone) raises:

```
GnrSqlException: GNRSQL-001 : Incompatible data type change in a non-empty column. Column <table>.<column> H HZ.
```

## Fix

PostgreSQL handles `time without time zone` → `time with time zone` as a direct `ALTER COLUMN TYPE` cast — same as `DH→DHZ`. Setting the conversion value to `None` triggers a simple alter with no `USING` clause.

## Test plan

- [ ] Define a model column with `dtype='H'`
- [ ] Change to `dtype='HZ'`, run `gnr db migrate` on a non-empty table → should succeed
- [ ] Reverse: change back to `'H'`, run migrate → should succeed

Closes #750