### PR TITLE
fix: include required_columns in print resource grid queries

### DIFF
--- a/gnrpy/gnr/web/gnrbaseclasses.py
+++ b/gnrpy/gnr/web/gnrbaseclasses.py
@@ -535,6 +535,7 @@ class TableScriptToHtml(BagToHtmlWeb):
                         subtotal_order_by=attr.get('subtotal_order_by'),
                         style=attr.get('style'), content_class = content_class, lbl_class=lbl_class,
                         sqlcolumn=attr.get('sqlcolumn'),dtype=attr.get('dtype'),
+                        required_columns=attr.get('required_columns'),
                         columnset=attr.get('columnset'),sheet=attr.get('sheet','*'),
                         totalize=attr.get('totalize'),formula=attr.get('formula'),
                         background=attr.get('background'),color=attr.get('color'),
@@ -707,7 +708,16 @@ class TableScriptToHtml(BagToHtmlWeb):
 
     @property
     def grid_sqlcolumns(self):
-        return ','.join(set([c['sqlcolumn'] for c in self.gridColumnsInfo()['columns'] if c.get('sqlcolumn')]))
+        columns_info = self.gridColumnsInfo()['columns']
+        sqlcolumns = set([c['sqlcolumn'] for c in columns_info if c.get('sqlcolumn')])
+        for c in columns_info:
+            required_columns = c.get('required_columns')
+            if required_columns:
+                for rc in required_columns.split(','):
+                    rc = rc.strip()
+                    if rc:
+                        sqlcolumns.add(rc)
+        return ','.join(sqlcolumns)
 
     @property
     def grid_subtotal_order_by(self):


### PR DESCRIPTION
## Summary
- Print resources using `fieldcell` for pyColumns with `required_columns` were missing those columns in the SQL query, causing errors or empty values in printed output
- `gridColumnsFromStruct()` now extracts the `required_columns` attribute from struct cells
- `grid_sqlcolumns` property now collects and includes `required_columns` in the SQL column set, matching the behavior of JS grids (`columnsFromStruct()` in `genro_grid.js`)

## Test plan
- [ ] Use a print resource with a `fieldcell` referencing a pyColumn that has `required_columns`
- [ ] Verify the printed output includes correct computed values
- [ ] Verify JS grids continue to work normally