### PR TITLE
fix: close leaked file descriptor in S3TemporaryFilename

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -1,3 +1,9 @@
+Release 26.04.01
+================
+
+Bugfix release: FDs leaking in S3 storage node, causing easily reach of
+upper limits for open files in batches. (#760)
+
 Release 26.03.24.1
 ==================
 

--- a/gnrpy/gnr/__init__.py
+++ b/gnrpy/gnr/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from gnr.core import gnrlog
 
-VERSION = "26.03.24.1"
+VERSION = "26.04.01"
 
 gnrlog.init_logging_system()
 logger = logging.getLogger("gnr")

--- a/gnrpy/tests/web/test_s3_temporary_filename.py
+++ b/gnrpy/tests/web/test_s3_temporary_filename.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 
+import botocore.exceptions
 import pytest
 
 # S3TemporaryFilename lives under projects/gnrcore/ which is not on the
@@ -40,7 +41,6 @@ class FakeS3Client:
 
     def download_file(self, bucket, key, dest):
         if self.fail_download:
-            import botocore.exceptions
             raise botocore.exceptions.ClientError(
                 {'Error': {'Code': '404', 'Message': 'Not Found'}},
                 'GetObject',

--- a/gnrpy/tests/web/test_s3_temporary_filename.py
+++ b/gnrpy/tests/web/test_s3_temporary_filename.py
@@ -1,0 +1,160 @@
+import importlib.util
+import os
+
+import pytest
+
+# S3TemporaryFilename lives under projects/gnrcore/ which is not on the
+# default test sys.path.  We load it directly from the file system so the
+# test can run without requiring a full GenroPy site setup.
+_s3_module_path = os.path.join(
+    os.path.dirname(__file__), os.pardir, os.pardir, os.pardir,
+    'projects', 'gnrcore', 'packages', 'sys', 'resources',
+    'services', 'storage', 'aws_s3.py',
+)
+_s3_module_path = os.path.normpath(_s3_module_path)
+
+
+def _get_s3_temporary_filename_class():
+    """Import S3TemporaryFilename from the aws_s3 module."""
+    spec = importlib.util.spec_from_file_location('aws_s3', _s3_module_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.S3TemporaryFilename
+
+
+S3TemporaryFilename = _get_s3_temporary_filename_class()
+
+
+class FakeS3Client:
+    """Minimal fake S3 client for testing S3TemporaryFilename.
+
+    Only the external dependency (boto3 S3 client) is faked.
+    S3TemporaryFilename itself runs with real temp files and real fd handling.
+    """
+
+    def __init__(self, content=b'hello', fail_download=False, fail_upload=False):
+        self.content = content
+        self.fail_download = fail_download
+        self.fail_upload = fail_upload
+        self.uploaded = {}
+
+    def download_file(self, bucket, key, dest):
+        if self.fail_download:
+            import botocore.exceptions
+            raise botocore.exceptions.ClientError(
+                {'Error': {'Code': '404', 'Message': 'Not Found'}},
+                'GetObject',
+            )
+        with open(dest, 'wb') as f:
+            f.write(self.content)
+
+    def upload_file(self, src, bucket, key):
+        if self.fail_upload:
+            raise OSError('upload failed')
+        with open(src, 'rb') as f:
+            self.uploaded[key] = f.read()
+
+
+def _make_ctx(s3_client, mode='r', keep=False, key='test/file.txt'):
+    """Create an S3TemporaryFilename context manager."""
+    return S3TemporaryFilename(
+        bucket='test-bucket',
+        key=key,
+        s3_client=s3_client,
+        mode=mode,
+        keep=keep,
+    )
+
+
+class TestS3TemporaryFilenameFdLeak:
+    """Regression tests for issue #759: tempfile.mkstemp() returns an open fd
+    that was never closed in __exit__, causing EMFILE errors when processing
+    thousands of S3 files (e.g. in zipFiles)."""
+
+    def test_fd_closed_after_normal_exit(self):
+        """fd must be closed after a normal with-block exit."""
+        client = FakeS3Client(content=b'test data')
+        ctx = _make_ctx(client)
+
+        with ctx as local_path:
+            fd = ctx.fd
+            assert os.path.exists(local_path)
+            os.fstat(fd)  # fd is still open during the block
+
+        # After exiting, fd must be closed
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+    def test_fd_closed_after_exception_in_block(self):
+        """fd must be closed even if an exception occurs inside the with-block."""
+        client = FakeS3Client(content=b'test data')
+        ctx = _make_ctx(client)
+
+        with pytest.raises(ValueError):
+            with ctx as local_path:
+                fd = ctx.fd
+                raise ValueError('simulated error')
+
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+    def test_fd_closed_when_upload_fails(self):
+        """fd must be closed even if upload_file raises during __exit__."""
+        client = FakeS3Client(content=b'original', fail_upload=True)
+        ctx = _make_ctx(client, mode='w')
+
+        with pytest.raises(OSError, match='upload failed'):
+            with ctx as local_path:
+                fd = ctx.fd
+                with open(local_path, 'wb') as f:
+                    f.write(b'modified')
+
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+    def test_temp_file_removed_when_keep_false(self):
+        """Temp file must be removed when keep=False (default)."""
+        client = FakeS3Client(content=b'data')
+        ctx = _make_ctx(client, keep=False)
+
+        with ctx as local_path:
+            assert os.path.exists(local_path)
+
+        assert not os.path.exists(local_path)
+
+    def test_temp_file_kept_when_keep_true(self):
+        """Temp file must survive when keep=True."""
+        client = FakeS3Client(content=b'data')
+        ctx = _make_ctx(client, keep=True)
+
+        with ctx as local_path:
+            pass
+
+        assert os.path.exists(local_path)
+        os.unlink(local_path)
+
+    def test_no_fd_leak_over_many_iterations(self):
+        """Simulates the zipFiles loop: many sequential context managers
+        must not accumulate open file descriptors."""
+        client = FakeS3Client(content=b'x' * 100)
+        fds = []
+
+        for i in range(200):
+            ctx = _make_ctx(client, key=f'test/file_{i}.txt')
+            with ctx as local_path:
+                fds.append(ctx.fd)
+
+        for fd in fds:
+            with pytest.raises(OSError):
+                os.fstat(fd)
+
+    def test_download_failure_still_closes_fd(self):
+        """When S3 download fails (ClientError), fd must still be closed on exit."""
+        client = FakeS3Client(fail_download=True)
+        ctx = _make_ctx(client)
+
+        with ctx as local_path:
+            fd = ctx.fd
+
+        with pytest.raises(OSError):
+            os.fstat(fd)

--- a/gnrpy/tests/web/test_s3_temporary_filename.py
+++ b/gnrpy/tests/web/test_s3_temporary_filename.py
@@ -108,6 +108,10 @@ class TestS3TemporaryFilenameFdLeak:
                 fd = ctx.fd
                 with open(local_path, 'wb') as f:
                     f.write(b'modified')
+                # Force mtime change so __exit__ triggers upload_file,
+                # even on filesystems with 1-second mtime resolution.
+                future_mtime = ctx.enter_mtime + 2
+                os.utime(local_path, (future_mtime, future_mtime))
 
         with pytest.raises(OSError):
             os.fstat(fd)

--- a/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
+++ b/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
@@ -94,10 +94,13 @@ class S3TemporaryFilename(object):
         return self.name
 
     def __exit__(self, exc, value, tb):
-        if os.stat(self.name).st_mtime != self.enter_mtime:
-            self.s3.upload_file(self.name, self.bucket,self.key)
-        if not self.keep:
-            os.unlink(self.name)
+        try:
+            if os.stat(self.name).st_mtime != self.enter_mtime:
+                self.s3.upload_file(self.name, self.bucket, self.key)
+        finally:
+            os.close(self.fd)
+            if not self.keep:
+                os.unlink(self.name)
 
 class Service(StorageService):
 


### PR DESCRIPTION
## Summary

- `S3TemporaryFilename.__exit__()` never called `os.close(self.fd)` on the file descriptor returned by `tempfile.mkstemp()`. When processing thousands of S3 files (e.g. expense reports with attachments via `zipFiles()`), the leaked fds accumulate and cause EMFILE ("too many open files") errors.
- Added `os.close(self.fd)` inside a `try/finally` block so the fd is always released, even if `upload_file()` fails.

## Test plan

- [x] 7 new regression tests in `gnrpy/tests/web/test_s3_temporary_filename.py`
  - fd closed after normal exit
  - fd closed after exception in with-block
  - fd closed when upload fails
  - temp file removed (keep=False) / kept (keep=True)
  - no fd leak over 200 iterations (simulates zipFiles loop)
  - fd closed on S3 download failure
- [x] Full test suite passes (1516 passed, pre-existing failures unchanged)
- [x] flake8 clean

Refs #759