### PR TITLE
fix(css): hiderMessage not vertically centered in nested hiderLayer (#765)

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase_css/10_gnr_toolbars_formhandler.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/10_gnr_toolbars_formhandler.css
@@ -268,6 +268,18 @@
     opacity: 1;
 }
 
+.emptyRecordMessage {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 2em;
+    font-weight: 600;
+    color: var(--gray-500, #555);
+}
+
 .draggingElement{
     /*chrome 106 bug it will be fixed in 108 */
     transform: translate(0, 0);

--- a/gnrjs/gnr_d20/css/gnrbase_css/10_gnr_toolbars_formhandler.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/10_gnr_toolbars_formhandler.css
@@ -268,6 +268,18 @@
     opacity: 1;
 }
 
+.emptyRecordMessage {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 2em;
+    font-weight: 600;
+    color: var(--gray-500, #555);
+}
+
 .draggingElement{
     /*chrome 106 bug it will be fixed in 108 */
     transform: translate(0, 0);

--- a/resources/common/th/th.py
+++ b/resources/common/th/th.py
@@ -662,7 +662,7 @@ class MultiButtonForm(BaseComponent):
                 """)
             sc = frame.center.stackContainer(selectedPage='^.selectedForm')
             emptyPageMessage = emptyPageMessage or '!!No Record Selected'
-            sc.contentPane(pageName='emptypage').div(emptyPageMessage,_class='hiderMessage',height='50px',position='absolute',top='25%',left=0,right=0,text_align='center')
+            sc.contentPane(pageName='emptypage').div(emptyPageMessage, _class='emptyRecordMessage')
             columnslist.append('$%s' %switch)
             switchdict = dict()
             for formId,pars in list(formhandler_kwargs.items()):
@@ -761,7 +761,7 @@ class MultiButtonForm(BaseComponent):
                     if(hasRows){
                         frameWidget.setHiderLayer(false);
                     }else{
-                        frameWidget.setHiderLayer(true,{message:emptyMessage,_class:'hiderMessage',text_align:'center',top:'25%',left:0,right:0});
+                        frameWidget.setHiderLayer(true,{message:emptyMessage});
                     }
                 }
             """,store='^.store',frm=form.js_form,frameWidget=frame,emptyMessage=emptyPageMessage)


### PR DESCRIPTION
## Summary

- **Root cause identified**: in `th_multiButtonForm`, the `setHiderLayer` call at line 764 passed `_class:'hiderMessage'` in the kw argument. In `makeHiderLayer` (`genro_dom.js`), `objectUpdate(default_kw, kw)` overwrites the default `_class:'hiderLayer'` with `_class:'hiderMessage'`, removing the flex container (`display:flex` + `align-items:center` + `justify-content:center`) entirely. The `top:'25%'` and other inline styles were workarounds for the broken centering.
- **Line 764 fix**: removed the `_class` override and inline positioning from the `setHiderLayer` call, letting `makeHiderLayer` use its correct defaults — `hiderLayer` (flex container) on the outer div and `hiderMessage` (text styling) on the inner message div.
- **Line 665 fix**: the static empty page in the `formhandler_kwargs` path also misused `hiderMessage` with hardcoded absolute positioning. Replaced with a new dedicated CSS class `emptyRecordMessage` that uses proper flex centering.
- **New CSS class** `emptyRecordMessage` added to both d11 and d20 formhandler stylesheets — uses `position:absolute` + `inset:0` + `display:flex` centering, without background or z-index (it's a page content, not an overlay).

## Linked Issue

Closes #765

## Test plan

- [x] Open a multi-button form page (formhandler_kwargs path) — "No Record Selected" message should be vertically and horizontally centered
- [x] Open a single-form tablehandler with an empty store — the hider overlay message should be centered (not stuck at top)
- [x] Verify the hider overlay retains its semi-transparent white background (single-form path only)
- [x] Verify Shift+double-click on the hider overlay still dismisses it (developer escape hatch)