### PR TITLE
fix(email): use virtual_columns for message_to_send in sendMessage

### DIFF
--- a/projects/gnrcore/packages/email/model/message.py
+++ b/projects/gnrcore/packages/email/model/message.py
@@ -343,7 +343,7 @@ class Table(object):
         site = self.db.application.site
         mail_handler = site.getService('mail')
         mts_tbl = self.db.table('email.message_to_send')
-        check = self.record(pkey, columns='$message_to_send',
+        check = self.record(pkey, virtual_columns='$message_to_send',
                             ignoreMissing=True).output('dict')
         if not check or not check['message_to_send']:
             mts_tbl.removeMessageFromQueue(pkey)


### PR DESCRIPTION
## Summary

- Fix `KeyError: 'message_to_send'` in `sendMessage` caused by using `columns=` instead of `virtual_columns=` for a formulaColumn

## Root cause

`message_to_send` is a `formulaColumn` (SQL-computed virtual column). `self.record(pkey, columns='$message_to_send')` only fetches physical columns, so the formula was never evaluated and the key was missing from the resulting dict.

## Fix

Changed `columns='$message_to_send'` to `virtual_columns='$message_to_send'` in `self.record()` call.

## Test plan

- [ ] Queue an outgoing email and verify `sendMessage` completes without KeyError
- [ ] Verify emails are sent correctly through the sending dashboard

Fixes #767