### PR TITLE
sped up the initial loading

### DIFF
--- a/gnrjs/gnr_d11/tpl/gnr_header.tpl
+++ b/gnrjs/gnr_d11/tpl/gnr_header.tpl
@@ -67,7 +67,7 @@
 % endfor
 
 % for jsname in js_requires:
-        <script type="text/javascript" src="${jsname}"></script>
+        <script type="text/javascript" src="${jsname}" defer></script>
 % endfor
         % if logo_url:
             <style type="text/css">
@@ -76,31 +76,24 @@
                 }
             </style>
         % endif
-        <style type="text/css">
-            % for cssname in css_dojo:
-            @import url("${cssname}");  
-            % endfor
-        </style>
-            
-        % for cssmedia, cssnames  in css_genro.items():
-        <style type="text/css" media="${cssmedia}">
-                % for cssname in cssnames:
-            @import url("${cssname}");
-                % endfor
-        </style>
+        % for cssname in css_dojo:
+        <link rel="stylesheet" href="${cssname}">
         % endfor
-        <style type="text/css">    
-            % for cssname in css_requires:
-            @import url("${cssname}");
+
+        % for cssmedia, cssnames in css_genro.items():
+            % for cssname in cssnames:
+        <link rel="stylesheet" media="${cssmedia}" href="${cssname}">
             % endfor
-        </style>
-        
-        % for cssmedia, cssnames  in css_media_requires.items():
-        <style type="text/css" media="${cssmedia}">
-                % for cssname in cssnames:
-            @import url("${cssname}");
-                % endfor
-        </style>
+        % endfor
+
+        % for cssname in css_requires:
+        <link rel="stylesheet" href="${cssname}">
+        % endfor
+
+        % for cssmedia, cssnames in css_media_requires.items():
+            % for cssname in cssnames:
+        <link rel="stylesheet" media="${cssmedia}" href="${cssname}">
+            % endfor
         % endfor
         
         <script type="text/javascript">


### PR DESCRIPTION
I’m trying to speed up the initial loading.

I replaced all ```<style>@import url(...);</style>``` blocks with direct ```<link rel="stylesheet">``` tags. Now the browser can download all CSS in parallel instead of discovering them one by one during the parsing of ```@import```.

For CSS with media queries (e.g. print, mobile), I moved the media attribute directly onto the ```<link media="...">``` tag.

I added defer only to the scripts in js_requires. Not to dojo.js, dijitImport, or genroJsImport, because many scripts depend on others being loaded; by working only on js_requires I’m reasonably confident I won’t introduce issues.

For now I don’t have a speed test comparing before and after applying the patch. From a quick impression, the initial loading speed doesn’t seem to have changed much—likely because I’m testing on pages with few CSS files or very small ones.