### PR TITLE
improved CLI arg validation for IP address (interface) where to

### DIFF
--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -2,6 +2,8 @@ import sys
 import os
 import atexit
 import webbrowser
+import ipaddress
+import argparse
 
 from werkzeug.serving import make_server, is_running_from_reloader
 from werkzeug._reloader import run_with_reloader
@@ -127,6 +129,16 @@ class GnrDebuggedApplication(DebuggedApplication):
 class ServerException(Exception):
     pass
 
+def ip_address(value):
+    """
+    Type validator for command line
+    """
+    try:
+        ipaddress.ip_address(value)
+        return value
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid IP address: {value}")
+    
 class Server(object):
     description = "This command serves a genropy web application."
 
@@ -154,19 +166,16 @@ class Server(object):
                             dest='open_browser',
                             action='store_true',
                             help="Automatically open the browser to this application")
-        
         parser.add_argument('-c', '--config',
                             dest='config_path',
                             help="gnrserve directory path")
-
         parser.add_argument('-p', '--port',
                             dest='port',
                             help="Sets server listening port (Default: 8080)")
-
         parser.add_argument('-H', '--host',
                             dest='host',
+                            type=ip_address,
                             help="Sets server listening address (Default: 0.0.0.0)")
-
         parser.add_argument('--restore',
                             dest='restore',
                             help="Restore from path")
@@ -314,8 +323,9 @@ class Server(object):
 
     @property
     def app_url(self):
-        return f'{self.app_scheme}://{self.app_host}:{self.app_port}'
-    
+        connect_host = '127.0.0.1' if self.app_host == '0.0.0.0' else self.app_host
+        return f'{self.app_scheme}://{connect_host}:{self.app_port}'
+        
     def serve(self):
         self.app_port = int(self.options.port)
         self.app_host = self.options.host
@@ -370,8 +380,9 @@ class Server(object):
                     app_scheme = 'https'
                     self.app_host = self.options.ssl_cert.split('/')[-1].split('.pem')[0]
                     
-                logger.info(f"Starting server - listening on {self.app_url}\t%s", ",".join(extra_info))
-
+                logger.info(f"Started server on {self.app_host}:{self.app_port}\t%s", ",".join(extra_info))
+                logger.info(f"Connect at {self.app_url}")
+                
             if self.options.open_browser and not os.environ.get("WERKZEUG_RUN_MAIN", None):
                 logger.info(f'Opening browser to application on {self.app_url}')
                 webbrowser.open(self.app_url)

--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -2,8 +2,7 @@ import sys
 import os
 import atexit
 import webbrowser
-import ipaddress
-import argparse
+import socket
 
 from werkzeug.serving import make_server, is_running_from_reloader
 from werkzeug._reloader import run_with_reloader
@@ -129,15 +128,15 @@ class GnrDebuggedApplication(DebuggedApplication):
 class ServerException(Exception):
     pass
 
-def ip_address(value):
+def host_binding_address(host):
     """
     Type validator for command line
     """
     try:
-        ipaddress.ip_address(value)
-        return value
-    except ValueError:
-        raise argparse.ArgumentTypeError(f"Invalid IP address: {value}")
+        socket.getaddrinfo(host, 1)
+        return host
+    except:
+        raise ValueError(f"Invalid address: {host}")
     
 class Server(object):
     description = "This command serves a genropy web application."
@@ -174,7 +173,7 @@ class Server(object):
                             help="Sets server listening port (Default: 8080)")
         parser.add_argument('-H', '--host',
                             dest='host',
-                            type=ip_address,
+                            type=host_binding_address,
                             help="Sets server listening address (Default: 0.0.0.0)")
         parser.add_argument('--restore',
                             dest='restore',


### PR DESCRIPTION
improved CLI arg validation for IP address (interface) where tobind the server to.

Update server startup log to display the current binding and provide a valid URL where to connect to, avoiding issues on widely used and distributed operating systems.