### PR TITLE
fix: restore onResult callback contract in uploadMultipart_oneFile

### DIFF
--- a/gnrjs/gnr_d11/js/genro_rpc.js
+++ b/gnrjs/gnr_d11/js/genro_rpc.js
@@ -1113,7 +1113,7 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                 try {
                     envelope.fromXmlDoc(responseXML, genro.clsdict);
                 } catch(e) {
-                    if (onResult) onResult(sender);
+                    if (onResult) onResult.call(sender, {currentTarget: sender, target: sender});
                     return;
                 }
                 var error = envelope.getItem('error');
@@ -1124,7 +1124,7 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                     return;
                 }
             }
-            if (onResult) onResult(sender);
+            if (onResult) onResult.call(sender, {currentTarget: sender, target: sender});
         };
         sender.send(content);
         return sender;

--- a/gnrjs/gnr_d20/js/genro_rpc.js
+++ b/gnrjs/gnr_d20/js/genro_rpc.js
@@ -1113,7 +1113,7 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                 try {
                     envelope.fromXmlDoc(responseXML, genro.clsdict);
                 } catch(e) {
-                    if (onResult) onResult(sender);
+                    if (onResult) onResult.call(sender, {currentTarget: sender, target: sender});
                     return;
                 }
                 var error = envelope.getItem('error');
@@ -1124,7 +1124,7 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                     return;
                 }
             }
-            if (onResult) onResult(sender);
+            if (onResult) onResult.call(sender, {currentTarget: sender, target: sender});
         };
         sender.send(content);
         return sender;


### PR DESCRIPTION
## Summary

- PR #724 (f77dddcf7) replaced `dojo.connect(sender, 'onload', onResult)` with a direct `onResult(sender)` call in `uploadMultipart_oneFile`, breaking the callback contract
- All upload consumers that use `evt.currentTarget.responseText`, `evt.target.responseText`, or `this.responseText` fail with `TypeError: Cannot read properties of undefined`
- Fix: use `onResult.call(sender, {currentTarget: sender, target: sender})` to restore `this` binding and event-like argument

## Affected consumers (at least 12 occurrences)

| Pattern | Files |
|---------|-------|
| `evt.currentTarget.responseText` | genro_components.js, genro_dlg.js |
| `evt.target.responseText` | genro_extra.js (TinyMCE) |
| `this.responseText` | genro_widgets.js, genro_dom.js |

## Files modified
- `gnrjs/gnr_d20/js/genro_rpc.js` — lines 1116, 1127
- `gnrjs/gnr_d11/js/genro_rpc.js` — lines 1116, 1127

## Test plan
- [ ] Upload XLS (modalità non-alfa) — nessun TypeError, import funzionante
- [ ] Upload file duplicato — messaggio "file già importato"
- [ ] TableImporter (drop CSV) — parseResponseText e onImportCheck
- [ ] Upload/paste immagine — this.responseText restituisce URL
- [ ] Upload con errore server — toast handleRpcError ancora funzionante

> Da riportare su `develop` dopo il merge.