### PR TITLE
ensure a menu is displayed

### DIFF
--- a/gnrpy/gnr/web/gnrmenu.py
+++ b/gnrpy/gnr/web/gnrmenu.py
@@ -249,10 +249,15 @@ class MenuResolver(BagResolver):
         instanceMenu = self.getInstanceMenu()
         if instanceMenu:
             return instanceMenu
-        pkgMenus = self.app.config['menu?package']
-        if pkgMenus:
-            return self.legacyMenuFromPkgList(pkgMenus)
-        return self.mainPackageMenu(self._page.package.name)
+
+        pkgMenus = self.app.config.get('menu?package')
+        if pkgMenus is None:
+            # Try mainPackage first, fallback to all packages
+            mainPkgMenu = self.mainPackageMenu(self._page.package.name)
+            if mainPkgMenu and len(mainPkgMenu) > 0:
+                return mainPkgMenu
+            pkgMenus = '*'
+        return self.legacyMenuFromPkgList(pkgMenus)
     
     def mainPackageMenu(self,pkg):
         result = self.pkgMenu(pkg,className=getattr(self._page,'menuClass',None))


### PR DESCRIPTION
check if the main package has a menu, and if not, fallback to using '*' as menu?package, which will show the menu arrange by package list from the instance.

This maintains compatibility with <menu package=..> usage in instanconfig.xml, the menu (if present) from the main package is used, but at least it will show a menu if the main package doesn't have one and <menu> is not configured.

Otherwise, no menu will be shown. Useful for new main packages for an application which doesn't have a menu yet.

close #430