### PR TITLE
fix: localize filteringSelect values and ask dialog title

### DIFF
--- a/gnrjs/gnr_d11/js/genro_dlg.js
+++ b/gnrjs/gnr_d11/js/genro_dlg.js
@@ -664,7 +664,7 @@ dojo.declare("gnr.GnrDlgHandler", null, {
             }
             funcApply(cb, parameters, sourceNode,argnames,argvalues);
         }
-        genro.dlg.prompt(objectPop(promptkw,'title','Parameters'),promptkw,sourceNode);
+        genro.dlg.prompt(_T(objectPop(promptkw,'title','Parameters')),promptkw,sourceNode);
     },
 
     prompt: function(title, kw,sourceNode) {

--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -4287,7 +4287,7 @@ dojo.declare("gnr.widgets.BaseCombo", gnr.widgets.baseDojo, {
             if (val.indexOf(':') > 0) {
                 val = val.split(':');
                 xval['id'] = val[0];
-                xval['caption'] = val[1];
+                xval['caption'] = _T(val[1]);
             } else {
                 xval['id'] = val;
                 xval['caption'] = val;

--- a/gnrjs/gnr_d20/js/genro_dlg.js
+++ b/gnrjs/gnr_d20/js/genro_dlg.js
@@ -664,7 +664,7 @@ dojo.declare("gnr.GnrDlgHandler", null, {
             }
             funcApply(cb, parameters, sourceNode,argnames,argvalues);
         }
-        genro.dlg.prompt(objectPop(promptkw,'title','Parameters'),promptkw,sourceNode);
+        genro.dlg.prompt(_T(objectPop(promptkw,'title','Parameters')),promptkw,sourceNode);
     },
 
     prompt: function(title, kw,sourceNode) {

--- a/gnrjs/gnr_d20/js/genro_widgets.js
+++ b/gnrjs/gnr_d20/js/genro_widgets.js
@@ -4273,7 +4273,7 @@ dojo.declare("gnr.widgets.BaseCombo", gnr.widgets.baseDojo, {
             if (val.indexOf(':') > 0) {
                 val = val.split(':');
                 xval['id'] = val[0];
-                xval['caption'] = val[1];
+                xval['caption'] = _T(val[1]);
             } else {
                 xval['id'] = val;
                 xval['caption'] = val;


### PR DESCRIPTION
## Summary

- Apply `_T()` localization to `filteringSelect` caption values in `storeFromValues` (both `d11` and `d20`)
- Apply `_T()` localization to the ask dialog title in `askParameters` (both `d11` and `d20`)

## Problem

When using `attachmentMultiButtonFrame` with an `ask` parameter containing `!![en]` localization markers inside a `values` string, the dropdown captions were displayed as raw markers (e.g. `[!![en]Image]`) instead of translated text.

The `title` and `lbl` fields were already localized (title by Python-side Bag serialization, lbl by `formbuilder.addField`), but the `values` string in `filteringSelect` was parsed by `storeFromValues` which set captions directly without calling `_T()`.

## Test case

Tested on `th_prodotto` with:

```python
pane.attachmentMultiButtonFrame(ask=dict(
    title='!![en]New attachment',
    fields=[
        dict(name='atc_type', lbl='!![en]Attachment type', tag='filteringSelect',
             values="IMG:[!![en]Image],DOC:[!![en]Document],ALTRO:[!![en]Other]",
             validate_notnull=True)
    ]
))
```

**Before:** dropdown showed `[!![en]Image]`, `[!![en]Document]`, `[!![en]Other]`
**After:** dropdown shows properly translated labels

Fixes #12