### PR TITLE
fix validation error indicator not showing on readonly fields

### DIFF
--- a/gnrjs/gnr_d11/css/gnr_dojotheme/form/Common.css
+++ b/gnrjs/gnr_d11/css/gnr_dojotheme/form/Common.css
@@ -101,6 +101,18 @@
     cursor: pointer;
 }
 
+/* --- ReadOnly + Error state: error indicators must override readonly appearance --- */
+.gnr_dojotheme .dijitReadOnly.dijitTextBox.dijitError,
+.gnr_dojotheme .dijitReadOnly.dijitTextArea.dijitError,
+.gnr_dojotheme .dijitReadOnly.dijitComboBox.dijitError,
+.gnr_dojotheme .dijitDisabled.dijitTextBoxReadOnly.dijitError {
+    border-color: #c06060;
+    border-color: color-mix(in srgb, var(--status-error, #E53935) 60%, var(--field-border, #AEAEB2));
+    background-color: #fdf0f0;
+    background-color: color-mix(in srgb, var(--status-error, #E53935) 7%, var(--field-bg, white));
+    background-image: none;
+}
+
 /* --- Error state — red dot indicator --- */
 .gnr_dojotheme .dijitError {
     border-color: #c06060; /* fallback for older browsers */

--- a/gnrjs/gnr_d20/css/gnr_dojotheme/form/Common.css
+++ b/gnrjs/gnr_d20/css/gnr_dojotheme/form/Common.css
@@ -101,6 +101,18 @@
     cursor: pointer;
 }
 
+/* --- ReadOnly + Error state: error indicators must override readonly appearance --- */
+.gnr_dojotheme .dijitReadOnly.dijitTextBox.dijitError,
+.gnr_dojotheme .dijitReadOnly.dijitTextArea.dijitError,
+.gnr_dojotheme .dijitReadOnly.dijitComboBox.dijitError,
+.gnr_dojotheme .dijitDisabled.dijitTextBoxReadOnly.dijitError {
+    border-color: #c06060;
+    border-color: color-mix(in srgb, var(--status-error, #E53935) 60%, var(--field-border, #AEAEB2));
+    background-color: #fdf0f0;
+    background-color: color-mix(in srgb, var(--status-error, #E53935) 7%, var(--field-bg, white));
+    background-image: none;
+}
+
 /* --- Error state — red dot indicator --- */
 .gnr_dojotheme .dijitError {
     border-color: #c06060; /* fallback for older browsers */


### PR DESCRIPTION
## Summary
- ReadOnly CSS selectors (.dijitReadOnly.dijitTextBox) had higher specificity than the Error selector (.dijitError), so error border/background was masked on readonly fields like checkboxtext
- Added ReadOnly+Error rules with matching specificity to ensure validation indicators display correctly
- Applied to both gnr_d11 and gnr_d20

Supersedes #782