### PR TITLE
fix: allow textarea resize in both directions

### DIFF
--- a/gnrjs/gnr_d11/css/gnr_dojotheme/form/TextArea.css
+++ b/gnrjs/gnr_d11/css/gnr_dojotheme/form/TextArea.css
@@ -13,7 +13,7 @@
     position: relative;
     padding: 0.3em;
     box-sizing: border-box;
-    resize: vertical;
+    resize: both;
     min-height: 2.5em;
     font-family: inherit;
     font-size: inherit;

--- a/gnrjs/gnr_d20/css/gnr_dojotheme/form/TextArea.css
+++ b/gnrjs/gnr_d20/css/gnr_dojotheme/form/TextArea.css
@@ -13,7 +13,7 @@
     position: relative;
     padding: 0.3em;
     box-sizing: border-box;
-    resize: vertical;
+    resize: both;
     min-height: 2.5em;
     font-family: inherit;
     font-size: inherit;


### PR DESCRIPTION
## Summary
- Change `resize: vertical` to `resize: both` in TextArea.css (gnr_d11 and gnr_d20)
- Restores horizontal resizing capability that was unintentionally restricted during CSS modernization (commit 7683c91)
- Disabled and readonly textareas remain non-resizable (`resize: none`)

## Test plan
- [ ] Load a page with a textarea field
- [ ] Verify the resize handle allows dragging both vertically and horizontally
- [ ] Verify disabled/readonly textareas cannot be resized