### PR TITLE
fix: guard against showHider race condition in lockScreen

### DIFF
--- a/gnrjs/gnr_d11/js/genro.js
+++ b/gnrjs/gnr_d11/js/genro.js
@@ -2445,7 +2445,7 @@ dojo.declare('gnr.GenroClient', null, {
             sourceNode._lockingElements[reason] = reason;
             var showHider = function(){
                 delete sourceNode._lockTimers[reason];
-                if(!sourceNode._lockingElements[reason]){ return; }
+                if(!sourceNode._lockingElements || !sourceNode._lockingElements[reason]){ return; }
                 var message = '<div class="form_waiting"></div>';
                 if(options.thermo){
                     genro.setData('gnr.lockScreen.thermo',message);

--- a/gnrjs/gnr_d20/js/genro.js
+++ b/gnrjs/gnr_d20/js/genro.js
@@ -2445,7 +2445,7 @@ dojo.declare('gnr.GenroClient', null, {
             sourceNode._lockingElements[reason] = reason;
             var showHider = function(){
                 delete sourceNode._lockTimers[reason];
-                if(!sourceNode._lockingElements[reason]){ return; }
+                if(!sourceNode._lockingElements || !sourceNode._lockingElements[reason]){ return; }
                 var message = '<div class="form_waiting"></div>';
                 if(options.thermo){
                     genro.setData('gnr.lockScreen.thermo',message);


### PR DESCRIPTION
## Summary

- Fix TypeError `Cannot read properties of undefined (reading 'n_XXXX')` in `showHider` callback
- The `lockScreen` function schedules `showHider` via `setTimeout` (200ms delay). If the lock is released before the callback fires and the timer is already in the event queue, `clearTimeout` cannot cancel it. The unlock path deletes `_lockingElements` when empty, causing the crash.
- Added guard check for `_lockingElements` existence before accessing the reason property (both gnr_d11 and gnr_d20)

## Test plan

- [ ] Open pages that previously triggered the error (pages with splitters/lockScreen)
- [ ] Navigate and interact — no TypeError in console
- [ ] Verify lockScreen overlay still appears and disappears normally

**Note:** this fix should be cherry-picked to `develop` after merge.