### PR TITLE
excludes some types of files from automatic reload

### DIFF
--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -403,7 +403,6 @@ class Server(object):
             os.environ["WERKZEUG_SERVER_FD"] = str(srv.fileno())
 
             if self.reloader:
-
                 # werkzeug reloader expects sys.argv without
                 # spaces for the reloader on python3.8
                 if " " in sys.argv[0]:

--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -403,17 +403,24 @@ class Server(object):
             os.environ["WERKZEUG_SERVER_FD"] = str(srv.fileno())
 
             if self.reloader:
-                
+
                 # werkzeug reloader expects sys.argv without
                 # spaces for the reloader on python3.8
                 if " " in sys.argv[0]:
                     cmd_name = sys.argv.pop(0).split()
                     sys.argv = cmd_name + sys.argv
 
+                exclude_patterns = [
+                    '*/.git/*',
+                    '*/.git',
+                    '*/__pycache__/*',
+                    '*.pik',
+                    '*/site/data/*',
+                ]
                 run_with_reloader(
                     srv.serve_forever,
                     #extra_files=extra_files,
-                    #exclude_patterns=exclude_patterns,
+                    exclude_patterns=exclude_patterns,
                     interval=1,
                     reloader_type="auto",
                 )
@@ -424,4 +431,3 @@ class Server(object):
                     srv.server_close()
             if not is_running_from_reloader():
                 logger.info("Shutting down")
-

--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -405,8 +405,16 @@ class Server(object):
                 cmd_name = sys.argv.pop(0).split()
                 sys.argv = cmd_name + sys.argv
 
+            exclude_patterns = [
+                '*/.git/*',
+                '*/.git',
+                '*/__pycache__/*',
+                '*.pik',
+                '*/site/data/*',
+            ]
             run_with_reloader(
                 srv.serve_forever,
+                exclude_patterns=exclude_patterns,
                 interval=1,
                 reloader_type="auto",
             )


### PR DESCRIPTION
The ```--reload``` option of the ```gnr web wsgiserve``` server is very aggressive and also includes temporary files.
This patch exludes them

Examples:
```
..../genropy_projects/erpygel/packages/fcrm/webpages/__pycache__/proxy.cpython-312.pyc.129955984444992
..../genropy_projects/erpygel/instances/erpygel/site/data/_connections/hcv_ZoiZM9mKbM33mAIpfw/hjI0kcRqPrCezmzhA4FGHw/V_fcrm_op_opportunity.pik'
..../genropy_projects/erpygel/.git/objects/maintenance.lock

..../genropy/resources/common/gnrcomponents/__pycache__/externalcall.cpython-312.pyc.129955984445568
..../genropy/.git/objects/maintenance.lock
```
