### PR TITLE
fix: differentiate readonly fields from normal and disabled states

### DIFF
--- a/gnrjs/gnr_d11/css/gnr_dojotheme/form/Common.css
+++ b/gnrjs/gnr_d11/css/gnr_dojotheme/form/Common.css
@@ -81,23 +81,31 @@
     background-color: var(--field-disabled-bg, #F7F7FA);
     background-image: none;
     color: var(--field-disabled-color, inherit);
+    opacity: var(--field-disabled-opacity, 0.7);
     cursor: not-allowed;
 }
 
-/* --- ReadOnly state: normal appearance, not grayed out --- */
+/* --- ReadOnly state: subtle border, white background --- */
 .gnr_dojotheme .dijitReadOnly.dijitTextBox,
 .gnr_dojotheme .dijitReadOnly.dijitTextArea,
 .gnr_dojotheme .dijitReadOnly.dijitComboBox,
 .gnr_dojotheme .dijitDisabled.dijitTextBoxReadOnly {
-    background-color: var(--field-bg, #fff);
+    background-color: var(--field-readonly-bg, #fff);
     background-image: none;
-    border-color: var(--field-border, #AEAEB2);
-    color: inherit;
+    border-color: var(--field-readonly-border, #E5E5EA);
+    color: var(--field-readonly-color, inherit);
     cursor: default;
 }
 .gnr_dojotheme .dijitDisabled.dijitTextBoxReadOnly .dijitButtonNode {
     background-color: transparent;
     color: inherit;
+    cursor: pointer;
+}
+
+/* --- CheckBoxText: interactive widget, restore normal border --- */
+.gnr_dojotheme .dijitReadOnly.dijitTextBox.checkBoxTextField {
+    border-color: var(--field-border, #AEAEB2);
+    background-color: var(--field-bg, #fff);
     cursor: pointer;
 }
 

--- a/gnrjs/gnr_d11/css/gnr_dojotheme/form/TextArea.css
+++ b/gnrjs/gnr_d11/css/gnr_dojotheme/form/TextArea.css
@@ -34,15 +34,16 @@
     background-color: var(--field-disabled-bg, #F2F2F7);
     background-image: none;
     color: var(--field-disabled-color, inherit);
+    opacity: var(--field-disabled-opacity, 0.7);
     cursor: not-allowed;
     resize: none;
 }
 
 /* --- ReadOnly --- */
 .gnr_dojotheme .dijitReadOnly.dijitTextArea {
-    background-color: var(--field-readonly-bg, #F2F2F7);
+    background-color: var(--field-readonly-bg, #fff);
     background-image: none;
-    border-color: var(--field-readonly-border, #C7C7CC);
+    border-color: var(--field-readonly-border, #E5E5EA);
     color: var(--field-readonly-color, inherit);
     opacity: 1;
     cursor: default;

--- a/gnrjs/gnr_d11/css/gnrbase_css/01_gnr_variables.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/01_gnr_variables.css
@@ -216,7 +216,9 @@
     --field-error-dot-ring: var(--surface-color, white); /* @theme */
     --field-disabled-border: var(--gray-250); /* @theme */
     --field-disabled-bg: var(--gray-100);
-    --field-readonly-border: var(--field-border);
+    --field-disabled-color: var(--gray-500);
+    --field-disabled-opacity: 0.85;
+    --field-readonly-border: var(--gray-200);
     --field-readonly-bg: var(--field-bg);
     --field-focus-bg: var(--color-bg);
     --gnrfieldlabel-color: var(--gray-700); /* @theme — readable on light form surfaces */

--- a/gnrjs/gnr_d11/js/genro_components.js
+++ b/gnrjs/gnr_d11/js/genro_components.js
@@ -5693,7 +5693,7 @@ dojo.declare("gnr.widgets.CheckBoxText", gnr.widgets.gnrwdg, {
         var table_kw = objectExtract(kw,'table_*');
         if(popup){
             var textBoxId = 'placingTextbox_'+genro.getCounter();
-            var tbkw = {'value':has_code?value+'?_displayedValue':value,position:'relative',readOnly:true,nodeId:textBoxId};
+            var tbkw = {'value':has_code?value+'?_displayedValue':value,position:'relative',readOnly:true,nodeId:textBoxId,'_class':'checkBoxTextField'};
             objectExtract(originalKwargs,'table,values,cols,identifier,labelAttribute,popup') //belongs to cbtext
             objectUpdate(tbkw,originalKwargs);
             tb = sourceNode._('textbox',tbkw);

--- a/gnrjs/gnr_d20/css/gnr_dojotheme/form/Common.css
+++ b/gnrjs/gnr_d20/css/gnr_dojotheme/form/Common.css
@@ -81,23 +81,31 @@
     background-color: var(--field-disabled-bg, #F7F7FA);
     background-image: none;
     color: var(--field-disabled-color, inherit);
+    opacity: var(--field-disabled-opacity, 0.7);
     cursor: not-allowed;
 }
 
-/* --- ReadOnly state: normal appearance, not grayed out --- */
+/* --- ReadOnly state: subtle border, white background --- */
 .gnr_dojotheme .dijitReadOnly.dijitTextBox,
 .gnr_dojotheme .dijitReadOnly.dijitTextArea,
 .gnr_dojotheme .dijitReadOnly.dijitComboBox,
 .gnr_dojotheme .dijitDisabled.dijitTextBoxReadOnly {
-    background-color: var(--field-bg, #fff);
+    background-color: var(--field-readonly-bg, #fff);
     background-image: none;
-    border-color: var(--field-border, #AEAEB2);
-    color: inherit;
+    border-color: var(--field-readonly-border, #E5E5EA);
+    color: var(--field-readonly-color, inherit);
     cursor: default;
 }
 .gnr_dojotheme .dijitDisabled.dijitTextBoxReadOnly .dijitButtonNode {
     background-color: transparent;
     color: inherit;
+    cursor: pointer;
+}
+
+/* --- CheckBoxText: interactive widget, restore normal border --- */
+.gnr_dojotheme .dijitReadOnly.dijitTextBox.checkBoxTextField {
+    border-color: var(--field-border, #AEAEB2);
+    background-color: var(--field-bg, #fff);
     cursor: pointer;
 }
 

--- a/gnrjs/gnr_d20/css/gnr_dojotheme/form/TextArea.css
+++ b/gnrjs/gnr_d20/css/gnr_dojotheme/form/TextArea.css
@@ -34,15 +34,16 @@
     background-color: var(--field-disabled-bg, #F2F2F7);
     background-image: none;
     color: var(--field-disabled-color, inherit);
+    opacity: var(--field-disabled-opacity, 0.7);
     cursor: not-allowed;
     resize: none;
 }
 
 /* --- ReadOnly --- */
 .gnr_dojotheme .dijitReadOnly.dijitTextArea {
-    background-color: var(--field-readonly-bg, #F2F2F7);
+    background-color: var(--field-readonly-bg, #fff);
     background-image: none;
-    border-color: var(--field-readonly-border, #C7C7CC);
+    border-color: var(--field-readonly-border, #E5E5EA);
     color: var(--field-readonly-color, inherit);
     opacity: 1;
     cursor: default;

--- a/gnrjs/gnr_d20/css/gnrbase_css/01_gnr_variables.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/01_gnr_variables.css
@@ -213,7 +213,9 @@
     --field-error-dot-ring: var(--surface-color, white); /* @theme */
     --field-disabled-border: var(--gray-250); /* @theme */
     --field-disabled-bg: var(--gray-100);
-    --field-readonly-border: var(--field-border);
+    --field-disabled-color: var(--gray-500);
+    --field-disabled-opacity: 0.85;
+    --field-readonly-border: var(--gray-200);
     --field-readonly-bg: var(--field-bg);
     --field-focus-bg: var(--color-bg);
     --gnrfieldlabel-color: var(--gray-700); /* @theme — readable on light form surfaces */

--- a/gnrjs/gnr_d20/js/genro_components.js
+++ b/gnrjs/gnr_d20/js/genro_components.js
@@ -5684,7 +5684,7 @@ dojo.declare("gnr.widgets.CheckBoxText", gnr.widgets.gnrwdg, {
         var table_kw = objectExtract(kw,'table_*');
         if(popup){
             var textBoxId = 'placingTextbox_'+genro.getCounter();
-            var tbkw = {'value':has_code?value+'?_displayedValue':value,position:'relative',readOnly:true,nodeId:textBoxId};
+            var tbkw = {'value':has_code?value+'?_displayedValue':value,position:'relative',readOnly:true,nodeId:textBoxId,'_class':'checkBoxTextField'};
             objectExtract(originalKwargs,'table,values,cols,identifier,labelAttribute,popup') //belongs to cbtext
             objectUpdate(tbkw,originalKwargs);
             tb = sourceNode._('textbox',tbkw);

--- a/projects/gnrcore/packages/test/webpages/gnrwdg/field_states.py
+++ b/projects/gnrcore/packages/test/webpages/gnrwdg/field_states.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+"""Visual comparison of field states: normal, readOnly, disabled"""
+
+
+class GnrCustomWebPage(object):
+    py_requires = "gnrcomponents/testhandler:TestHandlerFull"
+
+    def test_1_textbox(self, pane):
+        "TextBox: normal vs readOnly vs disabled"
+        fb = pane.formbuilder(cols=3, border_spacing='10px', fld_width='100%')
+        fb.data('.txt_val', 'Sample text')
+        fb.textbox(value='^.txt_val', lbl='Normal')
+        fb.textbox(value='^.txt_val', lbl='ReadOnly', readOnly=True)
+        fb.textbox(value='^.txt_val', lbl='Disabled', disabled=True)
+
+    def test_2_numbertextbox(self, pane):
+        "NumberTextBox: normal vs readOnly vs disabled"
+        fb = pane.formbuilder(cols=3, border_spacing='10px', fld_width='100%')
+        fb.data('.num_val', 42)
+        fb.numberTextBox(value='^.num_val', lbl='Normal')
+        fb.numberTextBox(value='^.num_val', lbl='ReadOnly', readOnly=True)
+        fb.numberTextBox(value='^.num_val', lbl='Disabled', disabled=True)
+
+    def test_3_datetextbox(self, pane):
+        "DateTextBox: normal vs readOnly vs disabled"
+        fb = pane.formbuilder(cols=3, border_spacing='10px', fld_width='100%')
+        fb.dateTextBox(value='^.date_val', lbl='Normal')
+        fb.dateTextBox(value='^.date_val', lbl='ReadOnly', readOnly=True)
+        fb.dateTextBox(value='^.date_val', lbl='Disabled', disabled=True)
+
+    def test_4_textarea(self, pane):
+        "TextArea: normal vs readOnly vs disabled"
+        fb = pane.formbuilder(cols=3, border_spacing='10px', fld_width='100%')
+        fb.data('.area_val', 'Multiline\nsample text')
+        fb.simpleTextArea(value='^.area_val', lbl='Normal', height='4em')
+        fb.simpleTextArea(value='^.area_val', lbl='ReadOnly', readOnly=True, height='4em')
+        fb.simpleTextArea(value='^.area_val', lbl='Disabled', disabled=True, height='4em')
+
+    def test_5_form(self, pane):
+        "Form with mixed field states and validation"
+        form = pane.frameForm(frameCode='testForm', datapath='.formtest',
+                              store='memory', height='400px',
+                              border='1px solid silver', rounded=6)
+        fb = form.record.formbuilder(cols=2, border_spacing='10px', fld_width='100%')
+        fb.data('.readonly_val', 'Fixed value')
+        fb.data('.readonly_num', 100)
+        fb.textbox(value='^.name', lbl='Name (notnull)',
+                   validate_notnull=True)
+        fb.textbox(value='^.surname', lbl='Surname')
+        fb.textbox(value='^.readonly_val', lbl='ReadOnly text',
+                   readOnly=True)
+        fb.numberTextBox(value='^.readonly_num', lbl='ReadOnly number',
+                         readOnly=True)
+        fb.textbox(value='^.email', lbl='Email (notnull)',
+                   validate_notnull=True)
+        fb.numberTextBox(value='^.age', lbl='Age (notnull)',
+                         validate_notnull=True)
+        fb.textbox(value='^.city', lbl='City', disabled=True)
+        fb.numberTextBox(value='^.zip', lbl='ZIP', disabled=True)
+        fb.checkboxtext(value='^.opts', values='X:One,Y:Two,Z:Three',
+                        lbl='Options popup (notnull)', popup=True,
+                        validate_notnull=True)
+        fb.checkboxtext(value='^.colors', values='R:Red,G:Green,B:Blue',
+                        lbl='Colors (no validation)')
+        fb.dateTextBox(value='^.birthdate', lbl='Date (notnull)',
+                       validate_notnull=True)
+        bar = form.bottom.slotBar('locker,*,savebtn,5')
+        bar.locker.slotButton('Locker', iconClass='iconbox lock', showLabel=False,
+                              action='this.form.publish("setLocked","toggle");',
+                              formsubscribe_onLockChange="""var locked=$1.locked;
+                              this.widget.setIconClass(locked?'iconbox lock':'iconbox unlock');""")
+        bar.savebtn.button('Save', action='this.form.save()')
+        pane.dataController("frm.newrecord()",
+                            frm=form.js_form, _onStart=True)


### PR DESCRIPTION
## Summary
- Introduce distinct visual styling for readonly fields (subtle border, white background) to clearly differentiate them from normal editable and disabled fields
- Add `opacity` and `--field-disabled-color` / `--field-disabled-opacity` CSS variables to disabled state for stronger visual distinction
- Add `checkBoxTextField` CSS class to CheckBoxText popup widget so it retains normal interactive styling when rendered as a readonly textbox
- Add visual test page (`field_states.py`) for side-by-side comparison of field states

## Test plan
- [ ] Manual visual verification of normal, readonly, and disabled field states
- [ ] CheckBoxText popup widget retains interactive border and cursor
- [ ] ReadOnly + Error state still shows error indicators correctly
- [ ] All automated tests pass (1386 passed, 260 skipped)