### PR TITLE
Pr attachment filename

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1469,7 +1469,7 @@ class GnrWsgiSite(object):
         headers = getattr(tool, 'headers', [])
         download_name = getattr(tool, 'download_name', None)
         if download_name:
-            headers.append(("Content-Disposition", f"attachment; filename={download_name}"))
+            headers.append(("Content-Disposition", '''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
         for header_name, header_value in headers:
             response.headers[header_name] = header_value
         if isinstance(result, Response):

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1355,7 +1355,7 @@ class GnrWsgiSite(object):
                     content_type = getattr(page,'forced_mimetype',None) or mimetypes.guess_type(download_name)[0]
                     if content_type:
                         page.response.content_type = content_type
-                    page.response.add_header("Content-Disposition", str("attachment; filename=%s" %download_name))
+                    page.response.add_header("Content-Disposition", str('''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
 
                 try:
                     file_types = file, io.IOBase

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1356,7 +1356,8 @@ class GnrWsgiSite(object):
                     content_type = getattr(page,'forced_mimetype',None) or mimetypes.guess_type(download_name)[0]
                     if content_type:
                         page.response.content_type = content_type
-                    page.response.add_header("Content-Disposition", str('''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
+                    page.response.add_header("Content-Disposition",
+                                             f"attachment; filename*=UTF-8''{urllib.parse.quote(download_name)}")
 
                 try:
                     file_types = file, io.IOBase
@@ -1470,7 +1471,8 @@ class GnrWsgiSite(object):
         headers = getattr(tool, 'headers', [])
         download_name = getattr(tool, 'download_name', None)
         if download_name:
-            headers.append(("Content-Disposition", '''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
+            headers.append(("Content-Disposition",
+                            f"attachment; filename*=UTF-8''{urllib.parse.quote(download_name)}"))
         for header_name, header_value in headers:
             response.headers[header_name] = header_value
         if isinstance(result, Response):

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1461,7 +1461,7 @@ class GnrWsgiSite(object):
         headers = getattr(tool, 'headers', [])
         download_name = getattr(tool, 'download_name', None)
         if download_name:
-            headers.append(("Content-Disposition", f"attachment; filename={download_name}"))
+            headers.append(("Content-Disposition", '''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
         for header_name, header_value in headers:
             response.headers[header_name] = header_value
         if isinstance(result, Response):

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1347,7 +1347,7 @@ class GnrWsgiSite(object):
                     content_type = getattr(page,'forced_mimetype',None) or mimetypes.guess_type(download_name)[0]
                     if content_type:
                         page.response.content_type = content_type
-                    page.response.add_header("Content-Disposition", str("attachment; filename=%s" %download_name))
+                    page.response.add_header("Content-Disposition", str('''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
 
                 try:
                     file_types = file, io.IOBase

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1347,7 +1347,8 @@ class GnrWsgiSite(object):
                     content_type = getattr(page,'forced_mimetype',None) or mimetypes.guess_type(download_name)[0]
                     if content_type:
                         page.response.content_type = content_type
-                    page.response.add_header("Content-Disposition", str('''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
+                    page.response.add_header("Content-Disposition",
+                                             f"attachment; filename*=UTF-8''{urllib.parse.quote(download_name)}")
 
                 try:
                     file_types = file, io.IOBase
@@ -1461,7 +1462,8 @@ class GnrWsgiSite(object):
         headers = getattr(tool, 'headers', [])
         download_name = getattr(tool, 'download_name', None)
         if download_name:
-            headers.append(("Content-Disposition", '''attachment; filename*=UTF-8''%s'''%urllib.parse.quote(download_name)))
+            headers.append(("Content-Disposition",
+                            f"attachment; filename*=UTF-8''{urllib.parse.quote(download_name)}"))
         for header_name, header_value in headers:
             response.headers[header_name] = header_value
         if isinstance(result, Response):

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
@@ -136,7 +136,7 @@ class StaticHandler(object):
         file_args = dict()
         if download or download_name:
             download_name = download_name or os.path.basename(fullpath)
-            file_args['content_disposition'] = '''attachment; filename*=UTF-8''%s'''%quote(download_name)
+            file_args['content_disposition'] = f"attachment; filename*=UTF-8''{quote(download_name)}"
         file_responder = fileapp.FileApp(fullpath, **file_args)
         if self.site.cache_max_age:
             file_responder.cache_control(max_age=self.site.cache_max_age)

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
@@ -5,7 +5,7 @@ import os
 import sys
 import random
 import tempfile
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 from paste import fileapp
 from paste.httpheaders import ETAG
@@ -136,7 +136,7 @@ class StaticHandler(object):
         file_args = dict()
         if download or download_name:
             download_name = download_name or os.path.basename(fullpath)
-            file_args['content_disposition'] = "attachment; filename=%s" % download_name
+            file_args['content_disposition'] = '''attachment; filename*=UTF-8''%s'''%quote(download_name)
         file_responder = fileapp.FileApp(fullpath, **file_args)
         if self.site.cache_max_age:
             file_responder.cache_control(max_age=self.site.cache_max_age)

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
@@ -5,7 +5,7 @@ import os
 import sys
 import random
 import tempfile
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 from gnr.core.gnrsys import expandpath
 from gnr.core.gnrbag import Bag
@@ -134,7 +134,7 @@ class StaticHandler(object):
         file_args = dict()
         if download or download_name:
             download_name = download_name or os.path.basename(fullpath)
-            file_args['content_disposition'] = "attachment; filename=%s" % download_name
+            file_args['content_disposition'] = '''attachment; filename*=UTF-8''%s'''%quote(download_name)
         file_responder = _SimpleFileApp(fullpath, **file_args)
         if self.site.cache_max_age:
             file_responder.cache_control(max_age=self.site.cache_max_age)

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstatichandler.py
@@ -134,7 +134,7 @@ class StaticHandler(object):
         file_args = dict()
         if download or download_name:
             download_name = download_name or os.path.basename(fullpath)
-            file_args['content_disposition'] = '''attachment; filename*=UTF-8''%s'''%quote(download_name)
+            file_args['content_disposition'] = f"attachment; filename*=UTF-8''{quote(download_name)}"
         file_responder = _SimpleFileApp(fullpath, **file_args)
         if self.site.cache_max_age:
             file_responder.cache_control(max_age=self.site.cache_max_age)


### PR DESCRIPTION
A batch returns a file path, allowing Genropy to serve it as a download.
Unfortunately, when the path contained special characters (a comma?), it stopped working.

I found that the filename value in the Content-Disposition header was missing quotes:

```
filename=name.pdf  => wrong
filename="name.pdf"  => ok
```

I also added UTF-8 encoding support:
```
filename*=UTF-8''name.pdf
```

Also added ```urllib.parse.quote``` for non-ASCII characters. 
Note that ```.quote``` has the argument ```safe=''``` to escape the slash, but I can assume that Genropy only passes the filename to it