### PR TITLE
fix(#805): restore normal flow for grid edit widgets

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
@@ -57,7 +57,6 @@
     padding: 0px 0px;
 }
 
-._common_d11 .dojoxGrid-cell:has(> .widgetInCell),
 ._common_d11 .dojoxGrid-cell:has(> .gnrcheckbox_wrapper) {
     position: relative;
 }
@@ -80,21 +79,16 @@
 }
 ._common_d11 .widgetInCell {
     color: var(--text-color);
-    position: absolute;
-    top: 1px;
-    left: 3px;
-    right: 3px;
-    width: auto !important;
-    margin: 0 !important;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    margin: 1px 1px 0 1px;
     padding: 2px 1px;
     border: 1px solid var(--border-light);
     border-radius: var(--radius-sm);
     box-shadow: 1px 1px 2px var(--text-secondary) inset;
     box-sizing: border-box;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 ._common_d11 .widgetInCell > *{
     flex: 1;
@@ -102,10 +96,16 @@
     min-width: 0;
 }
 
-._common_d11 .widgetInCell:has(.dijitTextArea),
-._common_d11 .widgetInCell.dijitTextArea {
-    bottom: 1px;
-    height: auto !important;
+textarea.cellEditFixed {
+    padding: 2px 1px;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-sm);
+    box-shadow: 1px 1px 2px var(--text-secondary) inset;
+    box-sizing: border-box;
+    background: white;
+    outline: none;
+    overflow: auto;
+    resize: none;
 }
 
 /* --- Row colors --- */

--- a/gnrjs/gnr_d11/js/genro_wdg.js
+++ b/gnrjs/gnr_d11/js/genro_wdg.js
@@ -1700,7 +1700,7 @@ dojo.declare("gnr.GridEditor", null, {
         grid.currRenderedRowIndex = lastRenderedRowIndex;
         grid.selection.select(grid.currRenderedRowIndex);
         attr.datapath = this.widgetRootNode.absDatapath('.' + rowLabel);
-        objectPop(attr, 'width'); /* width is managed by CSS via .widgetInCell absolute positioning */
+        attr.width = 'auto';
         /* checkbox centering is handled by CSS via .gnrcheckbox_wrapper flexbox */
         //attr.preventChangeIfIvalid = true;
         if ('value' in attr) {
@@ -1811,6 +1811,10 @@ dojo.declare("gnr.GridEditor", null, {
             editWidgetNode.widget.focus();
         }
         editWidgetNode.grid = gridEditor.grid;
+        var wdghandler = genro.wdg.getHandler(wdgtag);
+        if(wdghandler.cell_onStartEdit){
+            wdghandler.cell_onStartEdit(cellNode,editingInfo,fldDict.attr,editWidgetNode);
+        }
 
     },
 

--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -528,6 +528,10 @@ dojo.declare("gnr.widgets.baseHtml", null, {
         //pass
     },
 
+    cell_onStartEdit:function(cellNode,editingInfo,attr,editWidgetNode){
+        //pass
+    },
+
     cell_onDestroying:function(sourceNode,gridEditor,editingInfo){
         //pass
     }
@@ -2009,8 +2013,37 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
 
     cell_onCreating:function(gridEditor,colname,colattr){
         colattr['z_index']= 1;
-        //colattr['position'] = 'fixed';
         colattr['height'] = colattr['height'] || '100px';
+    },
+
+    cell_onStartEdit:function(cellNode,editingInfo,attr,editWidgetNode){
+        var domNode = editWidgetNode.widget ? editWidgetNode.widget.domNode : editWidgetNode.domNode;
+        if(!domNode){
+            return;
+        }
+        var h = parseInt(attr.height) || 100;
+        domNode.classList.add('cellEditFixed');
+        domNode.style.position = 'fixed';
+        domNode.style.height = h + 'px';
+        domNode.style.zIndex = '10';
+        domNode.style.margin = '0';
+        var positionTextarea = function(){
+            var rect = cellNode.getBoundingClientRect();
+            domNode.style.left = (rect.left + 1) + 'px';
+            domNode.style.top = (rect.top + 1) + 'px';
+            domNode.style.width = (rect.width - 2) + 'px';
+        };
+        positionTextarea();
+        var scrollNode = cellNode.closest('.dojoxGrid-scrollbox');
+        if(scrollNode){
+            editingInfo._scrollHandler = dojo.connect(scrollNode, 'onscroll', positionTextarea);
+        }
+    },
+
+    cell_onDestroying:function(sourceNode,gridEditor,editingInfo){
+        if(editingInfo._scrollHandler){
+            dojo.disconnect(editingInfo._scrollHandler);
+        }
     },
 
     onChanged:function(widget) {

--- a/gnrjs/gnr_d20/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/15_gnr_grid_extended.css
@@ -57,7 +57,6 @@
     padding: 0px 0px;
 }
 
-._common_d11 .dojoxGrid-cell:has(> .widgetInCell),
 ._common_d11 .dojoxGrid-cell:has(> .gnrcheckbox_wrapper) {
     position: relative;
 }
@@ -80,21 +79,16 @@
 }
 ._common_d11 .widgetInCell {
     color: var(--text-color);
-    position: absolute;
-    top: 1px;
-    left: 3px;
-    right: 3px;
-    width: auto !important;
-    margin: 0 !important;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    margin: 1px 1px 0 1px;
     padding: 2px 1px;
     border: 1px solid var(--border-light);
     border-radius: var(--radius-sm);
     box-shadow: 1px 1px 2px var(--text-secondary) inset;
     box-sizing: border-box;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 ._common_d11 .widgetInCell > *{
     flex: 1;
@@ -102,10 +96,16 @@
     min-width: 0;
 }
 
-._common_d11 .widgetInCell:has(.dijitTextArea),
-._common_d11 .widgetInCell.dijitTextArea {
-    bottom: 1px;
-    height: auto !important;
+textarea.cellEditFixed {
+    padding: 2px 1px;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-sm);
+    box-shadow: 1px 1px 2px var(--text-secondary) inset;
+    box-sizing: border-box;
+    background: white;
+    outline: none;
+    overflow: auto;
+    resize: none;
 }
 
 /* --- Row colors --- */

--- a/gnrjs/gnr_d20/js/genro_wdg.js
+++ b/gnrjs/gnr_d20/js/genro_wdg.js
@@ -1700,7 +1700,7 @@ dojo.declare("gnr.GridEditor", null, {
         grid.currRenderedRowIndex = lastRenderedRowIndex;
         grid.selection.select(grid.currRenderedRowIndex);
         attr.datapath = this.widgetRootNode.absDatapath('.' + rowLabel);
-        objectPop(attr, 'width'); /* width is managed by CSS via .widgetInCell absolute positioning */
+        attr.width = 'auto';
         /* checkbox centering is handled by CSS via .gnrcheckbox_wrapper flexbox */
         //attr.preventChangeIfIvalid = true;
         if ('value' in attr) {
@@ -1811,6 +1811,10 @@ dojo.declare("gnr.GridEditor", null, {
             editWidgetNode.widget.focus();
         }
         editWidgetNode.grid = gridEditor.grid;
+        var wdghandler = genro.wdg.getHandler(wdgtag);
+        if(wdghandler.cell_onStartEdit){
+            wdghandler.cell_onStartEdit(cellNode,editingInfo,fldDict.attr,editWidgetNode);
+        }
 
     },
 

--- a/gnrjs/gnr_d20/js/genro_widgets.js
+++ b/gnrjs/gnr_d20/js/genro_widgets.js
@@ -528,6 +528,10 @@ dojo.declare("gnr.widgets.baseHtml", null, {
         //pass
     },
 
+    cell_onStartEdit:function(cellNode,editingInfo,attr,editWidgetNode){
+        //pass
+    },
+
     cell_onDestroying:function(sourceNode,gridEditor,editingInfo){
         //pass
     }
@@ -2009,8 +2013,37 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
 
     cell_onCreating:function(gridEditor,colname,colattr){
         colattr['z_index']= 1;
-        //colattr['position'] = 'fixed';
         colattr['height'] = colattr['height'] || '100px';
+    },
+
+    cell_onStartEdit:function(cellNode,editingInfo,attr,editWidgetNode){
+        var domNode = editWidgetNode.widget ? editWidgetNode.widget.domNode : editWidgetNode.domNode;
+        if(!domNode){
+            return;
+        }
+        var h = parseInt(attr.height) || 100;
+        domNode.classList.add('cellEditFixed');
+        domNode.style.position = 'fixed';
+        domNode.style.height = h + 'px';
+        domNode.style.zIndex = '10';
+        domNode.style.margin = '0';
+        var positionTextarea = function(){
+            var rect = cellNode.getBoundingClientRect();
+            domNode.style.left = (rect.left + 1) + 'px';
+            domNode.style.top = (rect.top + 1) + 'px';
+            domNode.style.width = (rect.width - 2) + 'px';
+        };
+        positionTextarea();
+        var scrollNode = cellNode.closest('.dojoxGrid-scrollbox');
+        if(scrollNode){
+            editingInfo._scrollHandler = dojo.connect(scrollNode, 'onscroll', positionTextarea);
+        }
+    },
+
+    cell_onDestroying:function(sourceNode,gridEditor,editingInfo){
+        if(editingInfo._scrollHandler){
+            dojo.disconnect(editingInfo._scrollHandler);
+        }
     },
 
     onChanged:function(widget) {

--- a/projects/gnrcore/packages/test/webpages/components/Grid/grid_edit_widgets.py
+++ b/projects/gnrcore/packages/test/webpages/components/Grid/grid_edit_widgets.py
@@ -103,3 +103,41 @@ class GnrCustomWebPage(object):
                dtype='B', edit=True)
         r.cell('number_field', width='4em', name='Num',
                dtype='N', edit=True)
+
+    def test_2_single_column(self, pane):
+        """Single editable column: row must not disappear on double-click (#805)"""
+        pane.data('.store_single', self._sample_data())
+        frame = pane.bagGrid(
+            frameCode='single',
+            title='Single column (row height regression test)',
+            struct=self._single_column_struct,
+            storepath='.store_single',
+            datapath='.grid_single',
+            height='300px',
+            addrow=True
+        )
+
+    def _single_column_struct(self, struct):
+        r = struct.view().rows()
+        r.cell('text_field', width='20em', name='Text',
+               edit=True)
+
+    def test_3_mixed_width(self, pane):
+        """Two columns, one without explicit width: row must not shrink on edit (#805)"""
+        pane.data('.store_mixed', self._sample_data())
+        frame = pane.bagGrid(
+            frameCode='mixed',
+            title='Mixed width columns (row height regression test)',
+            struct=self._mixed_width_struct,
+            storepath='.store_mixed',
+            datapath='.grid_mixed',
+            height='300px',
+            addrow=True
+        )
+
+    def _mixed_width_struct(self, struct):
+        r = struct.view().rows()
+        r.cell('text_field', width='20em', name='Text',
+               edit=True)
+        r.cell('number_field', name='Number',
+               dtype='N', edit=True)

--- a/projects/gnrcore/packages/test/webpages/components/Grid/grid_edit_widgets.py
+++ b/projects/gnrcore/packages/test/webpages/components/Grid/grid_edit_widgets.py
@@ -107,7 +107,7 @@ class GnrCustomWebPage(object):
     def test_2_single_column(self, pane):
         """Single editable column: row must not disappear on double-click (#805)"""
         pane.data('.store_single', self._sample_data())
-        frame = pane.bagGrid(
+        pane.bagGrid(
             frameCode='single',
             title='Single column (row height regression test)',
             struct=self._single_column_struct,
@@ -125,7 +125,7 @@ class GnrCustomWebPage(object):
     def test_3_mixed_width(self, pane):
         """Two columns, one without explicit width: row must not shrink on edit (#805)"""
         pane.data('.store_mixed', self._sample_data())
-        frame = pane.bagGrid(
+        pane.bagGrid(
             frameCode='mixed',
             title='Mixed width columns (row height regression test)',
             struct=self._mixed_width_struct,


### PR DESCRIPTION
## Summary

- Remove `position: absolute` from `.widgetInCell` — edit widgets now participate in normal document flow, preventing row height collapse when editing cells
- Replace `objectPop(attr, 'width')` with `attr.width = 'auto'` for cleaner inline style management without CSS `!important`
- Add `cell_onStartEdit` hook in widget handler lifecycle for per-widget customization after widget creation
- SimpleTextarea uses `position: fixed` overlay positioned at cell coordinates with scroll-tracking, avoiding the `overflow: hidden` limitation of grid cells

Closes #805

## Test plan

- [ ] Navigate to `/test/components/grid/grid_edit_widgets`
- [ ] Test all widget types (test_0): TextBox, NumberTextBox, DateTextBox, CheckBox, FilteringSelect, SimpleTextarea, Description
- [ ] Test single column editing (test_2): row must not disappear on double-click
- [ ] Test mixed width columns (test_3): row height must stay stable on double-click
- [ ] Test textarea: must float over cell, reposition on grid scroll, close cleanly on blur
- [ ] Test checkbox: must still center correctly in cell
- [ ] Verify narrow columns (test_1): widgets must not overflow