### PR TITLE
fix: normalize dynamic _DUP_ components from userobject flags

### DIFF
--- a/gnrjs/gnr_d11/js/genro_components.js
+++ b/gnrjs/gnr_d11/js/genro_components.js
@@ -791,7 +791,7 @@ dojo.declare("gnr.widgets.FramePane", gnr.widgets.gnrwdg, {
         var frameCode = kw.frameCode;
         genro.assert(frameCode,'Missing frameCode');
         if(frameCode.indexOf('#')>=0){
-            kw.frameCode = frameCode = frameCode.replace('#',sourceNode.getStringId()); 
+            kw.frameCode = frameCode = frameCode.replace('#','_DUP_' + sourceNode.getStringId());
         }
         var frameId = frameCode+'_frame';
         genro.assert(!genro.nodeById(frameId),'existing frame');

--- a/gnrjs/gnr_d20/js/genro_components.js
+++ b/gnrjs/gnr_d20/js/genro_components.js
@@ -788,7 +788,7 @@ dojo.declare("gnr.widgets.FramePane", gnr.widgets.gnrwdg, {
         var frameCode = kw.frameCode;
         genro.assert(frameCode,'Missing frameCode');
         if(frameCode.indexOf('#')>=0){
-            kw.frameCode = frameCode = frameCode.replace('#',sourceNode.getStringId()); 
+            kw.frameCode = frameCode = frameCode.replace('#','_DUP_' + sourceNode.getStringId());
         }
         var frameId = frameCode+'_frame';
         genro.assert(!genro.nodeById(frameId),'existing frame');

--- a/projects/gnrcore/packages/adm/model/userobject.py
+++ b/projects/gnrcore/packages/adm/model/userobject.py
@@ -1,10 +1,13 @@
 # encoding: utf-8
 
 import os
+import re
 
 from gnr.core.gnrbag import Bag,DirectoryResolver
 from gnr.core.gnrdecorator import public_method,extract_kwargs
 from gnr.app import logger
+
+DUP_RE = re.compile(r'_DUP_(?:n_)?\d+')
 
 class Table(object):
     def config_db(self, pkg):
@@ -52,9 +55,17 @@ class Table(object):
         
     def trigger_onUpdating(self,record=None,old_record=None):
         self.updateRequiredPkg(record)
+        self._normalizeRecordFlags(record)
 
     def trigger_onInserting(self,record=None):
         self.updateRequiredPkg(record)
+        self._normalizeRecordFlags(record)
+
+    def _normalizeRecordFlags(self, record, pattern=None):
+        flags = record.get('flags')
+        if flags:
+            dup_re = pattern or DUP_RE
+            record['flags'] = ','.join(dup_re.sub('', f.strip()) for f in flags.split(','))
     
 
     def resourceStatus(self,record):
@@ -220,6 +231,20 @@ class Table(object):
     def deleteUserObject(self, pkey):
         self.delete(pkey)
         self.db.commit()
+
+    @public_method
+    def normalizeAllFlags(self):
+        """One-time cleanup: strip dynamic _DUP_ components from all userobject flags."""
+        records = self.query(where='$flags IS NOT NULL', columns='$id,$flags').fetch()
+        count = 0
+        for r in records:
+            old_flags = r['flags']
+            new_flags = ','.join(DUP_RE.sub('', f.strip()) for f in old_flags.split(','))
+            if new_flags != old_flags:
+                self.batchUpdate(dict(flags=new_flags), where='$id=:pk', pk=r['id'])
+                count += 1
+        self.db.commit()
+        return count
 
     @public_method
     @extract_kwargs(menuline=True)

--- a/resources/common/th/th_lib.py
+++ b/resources/common/th/th_lib.py
@@ -25,7 +25,7 @@ class TableHandlerCommon(BaseComponent):
     def _th_mangler(self,pane,table,nodeId=None):
         tableCode = table.replace('.','_')
         if nodeId and nodeId.endswith('#'):
-            nodeId = nodeId.replace('#',str(id(pane)))
+            nodeId = nodeId.replace('#','_DUP_%s' % id(pane))
         th_root = nodeId or tableCode #'%s_%i' %(tableCode,id(pane.parentNode))
         return th_root
         


### PR DESCRIPTION
## Problem

When a tableHandler uses `nodeId='xxx_#'`, the `#` placeholder is replaced at runtime with:
- `id(pane)` in Python (`_th_mangler`) — a memory address like `127835553915600`
- `getStringId()` in JS (`FramePane`) — a node counter like `n_42`

These values change every session. When a userObject (saved view, chart, dashboard) is persisted with such a gridId in its `flags` field, the object becomes **unreachable on subsequent page loads** because the dynamic component in the flags no longer matches.

**Example:** a grid saved with flags containing `sedi_V_sedi_127835553915600_grid` will never be found again because next session the same grid has a different `id(pane)`.

## Root cause

The existing `_DUP_` mechanism (used when a duplicate tableHandler appears on the same page, `th.py:87`) already marks the dynamic part with a recognizable `_DUP_` prefix. But the `#` replacement in `_th_mangler` and JS `FramePane` did **not** use any marker — the dynamic number blended seamlessly into the identifier with no way to distinguish it.

## Solution

### 1. Mark dynamic parts at source

Both `_th_mangler` (Python) and `FramePane` (JS) now prefix the `#` replacement with `_DUP_`, matching the existing convention:

- `th_lib.py`: `nodeId.replace('#', '_DUP_%s' % id(pane))` 
- `genro_components.js` (d11/d20): `frameCode.replace('#', '_DUP_' + sourceNode.getStringId())`

### 2. Strip `_DUP_` on save (single normalization point)

The `adm.userobject` triggers (`trigger_onInserting`, `trigger_onUpdating`) now normalize the `flags` field by stripping any `_DUP_<digits>` or `_DUP_n_<digits>` pattern before persisting. This ensures flags are always stable regardless of which session generated them.

### 3. Migration helper

A `normalizeAllFlags()` public method is provided for one-time cleanup of existing records that already contain dynamic components in their flags.

## Files changed

| File | Change |
|------|--------|
| `resources/common/th/th_lib.py` | `#` → `_DUP_<id(pane)>` instead of bare `<id(pane)>` |
| `gnrjs/gnr_d11/js/genro_components.js` | `#` → `_DUP_<getStringId()>` instead of bare value |
| `gnrjs/gnr_d20/js/genro_components.js` | Same as d11 |
| `projects/gnrcore/packages/adm/model/userobject.py` | Trigger normalization + `normalizeAllFlags()` |

## Migration

After deploying, run once per database:
```python
db.table('adm.userobject').normalizeAllFlags()
```

## Test plan

- [ ] Open a page with `nodeId='xxx_#'` — verify gridId now contains `_DUP_` marker
- [ ] Save a view — check `adm.userobject.flags` in DB: should be clean (no `_DUP_`)
- [ ] Reload page — verify saved view appears in menu
- [ ] Open same table from different context — verify saved view still accessible
- [ ] Test duplicate tableHandler case (two instances of same table on one page)
- [ ] Run `normalizeAllFlags()` on existing DB to clean old records