### PR TITLE
fix: use viewResource instead of gridId in userobject view flags

### DIFF
--- a/projects/gnrcore/packages/adm/model/userobject.py
+++ b/projects/gnrcore/packages/adm/model/userobject.py
@@ -175,8 +175,8 @@ class Table(object):
         if tbl:
             where.append('$tbl = :val_tbl')
         if flags:
-            where.append(' ($flags IS NULL OR $flags LIKE :_flags)  ')
-            _flags = '%%'+flags+'%%'
+            where.append(" ($flags IS NULL OR ',' || $flags || ',' LIKE :_flags) ")
+            _flags = '%%,'+flags+',%%'
         where = ' AND '.join(where)
         sel = self.query(columns='$id, $code, $objtype, $pkg, $tbl, $userid, $description, $authtags, $private, $quicklist, $flags',
                          where=where, order_by='$code',

--- a/resources/common/th/th_view.py
+++ b/resources/common/th/th_view.py
@@ -946,6 +946,7 @@ class TableHandlerView(BaseComponent):
         inattr = pane.getInheritedAttributes()
         th_root = inattr['th_root']
         table = inattr['table']
+        viewResource = inattr.get('th_viewResource', '')
         gridId = '%s_grid' %th_root
 
         #SOURCE MENUQUERIES
@@ -1011,9 +1012,10 @@ class TableHandlerView(BaseComponent):
             prefix,name=k.split('_struct_')
             q.setItem(name,self._prepareGridStruct(v,table=table),caption=v.__doc__)
         pane.data('.grid.resource_structs',q)
-        pane.data('.grid.userobject_structs',self.th_userObjectViews(table=table,th_root=th_root))
+        pane.data('.grid.viewResource',viewResource)
+        pane.data('.grid.userobject_structs',self.th_userObjectViews(table=table,th_root=th_root,viewResource=viewResource))
         pane.dataRpc('.grid.userobject_structs',self.th_userObjectViews,
-                        table=table,th_root=th_root,
+                        table=table,th_root=th_root,viewResource=viewResource,
                         _loadAfter='^.grid.reload_userobjects_struct',
                         _onResult="""if(kwargs._loadAfter!==true){
                             PUT .grid.currViewPath = null;
@@ -1620,13 +1622,17 @@ class THViewUtils(BaseComponent):
         return menu
 
     @public_method
-    def th_userObjectViews(self,table=None,th_root=None,objtype=None,**kwargs):
+    def th_userObjectViews(self,table=None,th_root=None,objtype=None,viewResource=None,**kwargs):
         objtype = objtype or 'view'
+        uoTable = self.db.table('adm.userobject')
+        userobjects = Bag()
+        if viewResource:
+            userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags='%s_RES_%s' % (self.pagename, viewResource),table=table))
+        #backward compatibility: old gridId-based flags
         flagCode = '%s_grid' %th_root.split('_DUP_')[0]
-        userobjects = self.db.table('adm.userobject').userObjectMenu(objtype=objtype,flags='%s_%s' % (self.pagename, flagCode),table=table)
+        userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags='%s_%s' % (self.pagename, flagCode),table=table))
         if self.pagename.startswith('thpage'):
-            #compatibility old saved views
-            userobjects.update(self.db.table('adm.userobject').userObjectMenu(objtype='view',flags='thpage_%s' % flagCode,table=table))
+            userobjects.update(uoTable.userObjectMenu(objtype='view',flags='thpage_%s' % flagCode,table=table))
         return userobjects
 
     

--- a/resources/common/th/th_view.py
+++ b/resources/common/th/th_view.py
@@ -1627,7 +1627,7 @@ class THViewUtils(BaseComponent):
         uoTable = self.db.table('adm.userobject')
         userobjects = Bag()
         if viewResource:
-            userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags='%s_RES_%s' % (self.pagename, viewResource),table=table))
+            userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags='RES_%s' % viewResource,table=table))
         #backward compatibility: old gridId-based flags
         flagCode = '%s_grid' %th_root.split('_DUP_')[0]
         userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags='%s_%s' % (self.pagename, flagCode),table=table))

--- a/resources/common/th/th_view.py
+++ b/resources/common/th/th_view.py
@@ -1627,12 +1627,12 @@ class THViewUtils(BaseComponent):
         uoTable = self.db.table('adm.userobject')
         userobjects = Bag()
         if viewResource:
-            userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags='RES_%s' % viewResource,table=table))
+            userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags=f'RES_{viewResource}',table=table))
         #backward compatibility: old gridId-based flags
-        flagCode = '%s_grid' %th_root.split('_DUP_')[0]
-        userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags='%s_%s' % (self.pagename, flagCode),table=table))
+        flagCode = f'{th_root.split("_DUP_")[0]}_grid'
+        userobjects.update(uoTable.userObjectMenu(objtype=objtype,flags=f'{self.pagename}_{flagCode}',table=table))
         if self.pagename.startswith('thpage'):
-            userobjects.update(uoTable.userObjectMenu(objtype='view',flags='thpage_%s' % flagCode,table=table))
+            userobjects.update(uoTable.userObjectMenu(objtype='view',flags=f'thpage_{flagCode}',table=table))
         return userobjects
 
     

--- a/resources/common/th/th_viewconfigurator.js
+++ b/resources/common/th/th_viewconfigurator.js
@@ -46,24 +46,22 @@ var genro_plugin_grid_configurator = {
         var saveCb = function(dlg) {
             var pagename = genro.getData('gnr.pagename');
             var viewResource = gridSourceNode.getRelativeData('.viewResource');
-            var flag;
-            if(viewResource){
-                flag = 'RES_'+viewResource;
-            }else{
-                flag = pagename+'_'+gridId.replace(/_DUP_.*?(?=_grid)/, "");
-            }
             var metadata = genro.getData(datapath);
-            var flags = metadata.getItem('flags');
-            if(flags){
-                if(flags.indexOf(flag)<0){
-                    flags = flags.split(',');
-                    flags.push(flag);
-                }
+            if(viewResource){
+                metadata.setItem('flags', 'RES_'+viewResource);
             }else{
-                flags = flag;
+                var flag = pagename+'_'+gridId.replace(/_DUP_.*?(?=_grid)/, "");
+                var flags = metadata.getItem('flags');
+                if(flags){
+                    if(flags.indexOf(flag)<0){
+                        flags = flags.split(',');
+                        flags.push(flag);
+                    }
+                }else{
+                    flags = flag;
+                }
+                metadata.setItem('flags', flags);
             }
-
-            metadata.setItem('flags',flags);
             genro.serverCall('_table.adm.userobject.saveUserObject',
                             {'objtype':objtype,'metadata':metadata,'data':gridSourceNode.widget.structBag,
                             table:gridSourceNode.attr.table},

--- a/resources/common/th/th_viewconfigurator.js
+++ b/resources/common/th/th_viewconfigurator.js
@@ -48,7 +48,7 @@ var genro_plugin_grid_configurator = {
             var viewResource = gridSourceNode.getRelativeData('.viewResource');
             var flag;
             if(viewResource){
-                flag = pagename+'_RES_'+viewResource;
+                flag = 'RES_'+viewResource;
             }else{
                 flag = pagename+'_'+gridId.replace(/_DUP_.*?(?=_grid)/, "");
             }

--- a/resources/common/th/th_viewconfigurator.js
+++ b/resources/common/th/th_viewconfigurator.js
@@ -45,7 +45,13 @@ var genro_plugin_grid_configurator = {
         var that = this;
         var saveCb = function(dlg) {
             var pagename = genro.getData('gnr.pagename');
-            var flag =  pagename+'_'+gridId.replace(/_DUP_.*?(?=_grid)/, "");
+            var viewResource = gridSourceNode.getRelativeData('.viewResource');
+            var flag;
+            if(viewResource){
+                flag = pagename+'_RES_'+viewResource;
+            }else{
+                flag = pagename+'_'+gridId.replace(/_DUP_.*?(?=_grid)/, "");
+            }
             var metadata = genro.getData(datapath);
             var flags = metadata.getItem('flags');
             if(flags){


### PR DESCRIPTION
## Problem

When a tableHandler uses `nodeId='xxx_#'`, the `#` gets replaced at runtime with `id(pane)` (Python memory address) or `getStringId()` (JS node counter). These values change every session, so userObjects (saved views) stored with such gridId in their `flags` field become **unreachable on subsequent page loads**.

Example from production: a grid saved with flags containing `sedi_V_sedi_127835553915600_grid` — that `127835553915600` is `id(pane)`, different every time.

## Solution

Replace gridId with the **viewResource** (`th_sedi:View`, `cliente:View`, `prospect:View`) as the flag discriminant. The viewResource:

- Is **always stable** — it identifies the resource class, not a runtime instance
- Is **semantically correct** — Python-defined struct alternatives already use this concept
- **Separates views per resource** — when the same table is used with different resources (e.g. `cliente:View` vs `prospect:View`), their saved views are correctly kept separate

New flags are prefixed with `RES_` for immediate recognition of the new pattern:
- Old format: `thpage_V_glbl_regione_grid`
- New format: `thpage_RES_th_sedi:View`

## Changes

### `resources/common/th/th_view.py`

- **`_th_menu_sources`**: extracts `th_viewResource` from inherited attributes, stores it as `.grid.viewResource` (accessible to JS), and passes it to `th_userObjectViews` calls
- **`th_userObjectViews`**: new `viewResource` parameter; searches with `RES_` prefixed flag first, then falls back to old gridId-based flag for backward compatibility

### `resources/common/th/th_viewconfigurator.js`

- **`saveGridView`**: reads `viewResource` from grid data; if present, uses `RES_`-prefixed flag; otherwise falls back to gridId-based flag (for non-tableHandler grids)

## Backward compatibility

- Old saved views (with gridId-based flags) are still found via the fallback query in `th_userObjectViews`
- New saves use the `RES_` pattern
- Re-saving an old view naturally migrates it to the new format
- Non-tableHandler grids (without viewResource) continue using the gridId-based flag

## Test plan

- [ ] Open a tableHandler page — save a view — check `adm.userobject.flags` contains `RES_` pattern
- [ ] Reload page — verify saved view appears in menu
- [ ] Verify old saved views (with gridId flags) still appear via fallback
- [ ] Open same table with different viewResource — verify views are separate
- [ ] Test with `nodeId='xxx_#'` — verify no dynamic ID issues