### PR TITLE
feat(#812): add empty grid state indicator

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
@@ -498,3 +498,11 @@
 ._common_d11 .dojoxGrid-scrollbox {
     overflow: auto;
 }
+
+/* --- Empty grid state --- */
+._common_d11 .gnr_empty_grid .dojoxGrid-scrollbox {
+    background-image: url('/_rsrc/common/css_icons/google_icons/no_results.svg');
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: 80px 80px;
+}

--- a/gnrjs/gnr_d11/js/genro_components.js
+++ b/gnrjs/gnr_d11/js/genro_components.js
@@ -6616,15 +6616,22 @@ dojo.declare("gnr.stores._Collection",null,{
     runQuery:function(cb,runKwargs){
         var that = this;
         this.runningQuery = true;
-        var result =  this.storeNode.fireNode(runKwargs);
+        var wrappedCb = function(r){
+            cb(r);
+            var empty = r && r.attr && r.attr.totalrows === 0;
+            that.gridBroadcast(function(grid){
+                grid.domNode.classList.toggle('gnr_empty_grid', empty);
+            });
+        };
+        var result = this.storeNode.fireNode(runKwargs);
         if(result instanceof dojo.Deferred){
             result.addCallback(function(r){
                 that.runningQuery = false;
-                cb(r)
+                wrappedCb(r);
             });
         }else{
             that.runningQuery = false;
-            result = cb(result);
+            result = wrappedCb(result);
         }
         return result;
     },

--- a/gnrjs/gnr_d11/js/genro_components.js
+++ b/gnrjs/gnr_d11/js/genro_components.js
@@ -6616,22 +6616,15 @@ dojo.declare("gnr.stores._Collection",null,{
     runQuery:function(cb,runKwargs){
         var that = this;
         this.runningQuery = true;
-        var wrappedCb = function(r){
-            cb(r);
-            var empty = r && r.attr && r.attr.totalrows === 0;
-            that.gridBroadcast(function(grid){
-                grid.domNode.classList.toggle('gnr_empty_grid', empty);
-            });
-        };
-        var result = this.storeNode.fireNode(runKwargs);
+        var result =  this.storeNode.fireNode(runKwargs);
         if(result instanceof dojo.Deferred){
             result.addCallback(function(r){
                 that.runningQuery = false;
-                wrappedCb(r);
+                cb(r)
             });
         }else{
             that.runningQuery = false;
-            result = wrappedCb(result);
+            result = cb(result);
         }
         return result;
     },

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -3178,7 +3178,6 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
             //this.updateColumnsetsAndFooters(); makes grids slower
             //},1,this);
         }
-        this.domNode.classList.toggle('gnr_empty_grid', this.rowCount === 0);
     },
     mixin_setSortedBy:function(sortedBy) {
         this.sortedBy = sortedBy;

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -1383,7 +1383,9 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
         dojo.connect(widget, 'onSelected', widget, '_gnrUpdateSelect');
         genro.src.onBuiltCall(dojo.hitch(widget, 'render'));
         dojo.connect(widget, 'modelAllChange', dojo.hitch(sourceNode, this.modelAllChange));
-
+        dojo.connect(widget, 'updateRowCount', function(){
+            this.domNode.classList.toggle('gnr_empty_grid', this.rowCount === 0);
+        });
 
     },
 
@@ -1391,7 +1393,6 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
         if (this.attr.rowcount) {
             this.setRelativeData(this.attr.rowcount, this.widget.rowCount);
         }
-        //this.widget._gnrUpdateSelect();
     },
     mixin_columnNodelist:function(idx, includeHeader) {
         var condition = 'td.dojoxGrid-cell[idx="' + idx + '"]';
@@ -3172,11 +3173,12 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
                 console.warn('error in updaterowcount',e);
             }
             
-            this.updateTotalsCount(); 
+            this.updateTotalsCount();
             scrollBox.scrollLeft = scrollLeft;
             //this.updateColumnsetsAndFooters(); makes grids slower
             //},1,this);
         }
+        this.domNode.classList.toggle('gnr_empty_grid', this.rowCount === 0);
     },
     mixin_setSortedBy:function(sortedBy) {
         this.sortedBy = sortedBy;

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -3178,6 +3178,9 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
             //this.updateColumnsetsAndFooters(); makes grids slower
             //},1,this);
         }
+        if(this.sourceNode.attr.emptyIndicator){
+            this.domNode.classList.toggle('gnr_empty_grid', this.rowCount === 0);
+        }
     },
     mixin_setSortedBy:function(sortedBy) {
         this.sortedBy = sortedBy;

--- a/gnrjs/gnr_d20/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/15_gnr_grid_extended.css
@@ -492,3 +492,11 @@
 ._common_d11 .dojoxGrid-scrollbox {
     overflow: auto;
 }
+
+/* --- Empty grid state --- */
+._common_d11 .gnr_empty_grid .dojoxGrid-scrollbox {
+    background-image: url('/_rsrc/common/css_icons/google_icons/no_results.svg');
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: 80px 80px;
+}

--- a/gnrjs/gnr_d20/js/genro_grid.js
+++ b/gnrjs/gnr_d20/js/genro_grid.js
@@ -3081,10 +3081,13 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
                 console.warn('error in updaterowcount',e);
             }
             
-            this.updateTotalsCount(); 
+            this.updateTotalsCount();
             scrollBox.scrollLeft = scrollLeft;
             //this.updateColumnsetsAndFooters(); makes grids slower
             //},1,this);
+        }
+        if(this.sourceNode.attr.emptyIndicator){
+            this.domNode.classList.toggle('gnr_empty_grid', this.rowCount === 0);
         }
     },
     mixin_setSortedBy:function(sortedBy) {

--- a/resources/common/css_icons/google_icons/no_results.svg
+++ b/resources/common/css_icons/google_icons/no_results.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 58" fill="none" stroke="#bbb" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="22" cy="22" r="12" stroke-width="1.5"/>
+  <line x1="31" y1="31" x2="40" y2="40" stroke-width="2.5"/>
+  <line x1="18" y1="18" x2="26" y2="26" opacity="0.5" stroke-width="1.5"/>
+  <line x1="26" y1="18" x2="18" y2="26" opacity="0.5" stroke-width="1.5"/>
+  <text x="24" y="55" text-anchor="middle" fill="#aaa" stroke="none" font-family="system-ui, sans-serif" font-size="7" font-weight="500">No results</text>
+</svg>

--- a/resources/common/css_icons/google_icons/no_results.svg
+++ b/resources/common/css_icons/google_icons/no_results.svg
@@ -1,7 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 58" fill="none" stroke="#bbb" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none" stroke="#bbb" stroke-linecap="round" stroke-linejoin="round">
   <circle cx="22" cy="22" r="12" stroke-width="1.5"/>
   <line x1="31" y1="31" x2="40" y2="40" stroke-width="2.5"/>
   <line x1="18" y1="18" x2="26" y2="26" opacity="0.5" stroke-width="1.5"/>
   <line x1="26" y1="18" x2="18" y2="26" opacity="0.5" stroke-width="1.5"/>
-  <text x="24" y="55" text-anchor="middle" fill="#aaa" stroke="none" font-family="system-ui, sans-serif" font-size="7" font-weight="500">No results</text>
 </svg>

--- a/resources/common/th/th.py
+++ b/resources/common/th/th.py
@@ -178,6 +178,7 @@ class TableHandler(BaseComponent):
 
         rowStatusColumn = hasInvalidCheck or hasProtectionColumns if rowStatusColumn is None else rowStatusColumn
         grid_kwargs.setdefault('rowStatusColumn',rowStatusColumn)
+        grid_kwargs.setdefault('emptyIndicator',True)
         if fkeyfield:
             grid_kwargs.setdefault('excludeCols',fkeyfield)
             


### PR DESCRIPTION
## Summary

- Add `gnr_empty_grid` CSS class toggled on the grid DOM node when `rowCount === 0` in `patch_updateRowCount`
- Show a subtle `no_results.svg` icon (search lens with X) centered in the grid scrollbox as background image when the class is active
- New SVG icon at `resources/common/css_icons/google_icons/no_results.svg`

## Test plan

- [x] Open a tableHandler page (e.g. Products)
- [ ] Search for something that returns zero results → no_results icon visible centered in grid
- [x] Clear the search → icon disappears, data shows normally
- [ ] Initial page load with data → no icon visible
- [ ] d20 not yet updated (CSS and JS changes are d11 only for now)

Refs #812