### PR TITLE
fix(#256): defer compositeColumn formula build for order-independent validation

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmodel/model.py
+++ b/gnrpy/gnr/sql/gnrsqlmodel/model.py
@@ -1054,6 +1054,12 @@ class DbModelSrc(GnrStructData):
         Builds a SQL formula that concatenates the given columns into a
         JSON-style array string (``[val1, val2, ...]``).
 
+        The SQL formula and source-column validation are deferred to the
+        building phase (:meth:`DbModel.runOnBuildingCb`) so that source
+        columns can be declared in any order relative to this call, and
+        so that missing or virtual source columns raise at build time
+        rather than producing a broken SQL formula.
+
         Args:
             name: Column name.
             columns: Comma-separated list of source column names
@@ -1063,31 +1069,63 @@ class DbModelSrc(GnrStructData):
         Returns:
             The virtual-column source node.
         """
-        chunks: list[str] = []
-        composed_of: list[str] = []
-        for column in columns.split(','):
-            if column.startswith('$'):
-                column = column[1:]
-            dtype, val = self.column(column).attributes.get('dtype', 'T'), f'${column}'
-            if dtype in ('A', 'C', 'T'):
-                val = f""" '"' ||  ${column} || '"' """
-            elif dtype not in ('L', 'F', 'R', 'B'):
-                val = rf""" '"' ||  ${column} || '\:\:{dtype}"' """
-            composed_of.append(column)
-            chunks.append(val)
+        composed_of: list[str] = [
+            c[1:] if c.startswith('$') else c for c in columns.split(',')
+        ]
         composed_of_str = ','.join(composed_of)
         if columns != composed_of_str:
             logger.warning(
                 f"compositeColumn {name} has columns='{columns}'. "
                 f"It should be '{composed_of_str}'."
             )
+        vcsrc = self.virtual_column(
+            name, composed_of=composed_of_str, static=static,
+            sql_formula=None, dtype='JS', **kwargs,
+        )
+        self.root._dbmodel.deferOnBuilding(
+            self._buildCompositeColumnFormula,
+            name=name, composed_of=composed_of,
+        )
+        return vcsrc
 
+    def _buildCompositeColumnFormula(
+        self, name: str, composed_of: list[str],
+    ) -> None:
+        """Build and assign the SQL formula for a compositeColumn.
+
+        Runs during :meth:`DbModel.runOnBuildingCb`, when all
+        ``config_db`` methods have populated the source tree. Each
+        source column is validated against the (now complete) table
+        definition: a virtual or missing source column raises
+        :class:`GnrSqlException` immediately.
+        """
+        tblname = self.attributes.get('fullname') or self.attributes.get('name') or ''
+        chunks: list[str] = []
+        for column in composed_of:
+            colnode = self.getNode(f'columns.{column}')
+            if colnode is None:
+                if self.getNode(f'virtual_columns.{column}') is not None:
+                    raise GnrSqlException(
+                        f"compositeColumn '{name}' in table {tblname}: "
+                        f"source column '{column}' is a virtual column; "
+                        f"a physical column is required"
+                    )
+                raise GnrSqlException(
+                    f"compositeColumn '{name}' in table {tblname}: "
+                    f"source column '{column}' does not exist"
+                )
+            dtype = colnode.attr.get('dtype', 'T')
+            if dtype in ('A', 'C', 'T'):
+                val = f""" '"' ||  ${column} || '"' """
+            elif dtype in ('L', 'F', 'R', 'B'):
+                val = f'${column}'
+            else:
+                val = rf""" '"' ||  ${column} || '\:\:{dtype}"' """
+            chunks.append(val)
         sql_formula = " ||', '||".join(chunks)
         sql_formula = f"'[' || {sql_formula} || ']' "
-        return self.virtual_column(
-            name, composed_of=composed_of_str, static=static,
-            sql_formula=sql_formula, dtype='JS', **kwargs,
-        )
+        vcnode = self.getNode(f'virtual_columns.{name}')
+        vcnode.attr['sql_formula'] = sql_formula
 
     def bagItemColumn(
         self,


### PR DESCRIPTION
## Summary

Alternative approach to the now-closed PR #779. Defers the SQL-formula construction in `compositeColumn()` to the building phase so that source-column validation is **order-independent** and catches both virtual-column and missing-column cases with a hard `GnrSqlException`.

Closes #256.

## Problem

Today `compositeColumn()` builds its `sql_formula` synchronously during `config_db`. This has two issues:

1. **Order-dependent validation**: checking whether a source column is virtual (the approach in PR #779) only works if the source column has already been declared at the point `compositeColumn()` is called. If declared afterwards, the check is silently wrong.
2. **No typo detection**: referencing a non-existent source column silently creates an empty physical column via `self.column(column)` side effect, then produces a broken SQL formula that fails at runtime.

## Approach

Split `compositeColumn()` into two phases:

**Phase A — synchronous (at config_db time)**
- Normalise column names (strip `$` prefixes), warn on non-canonical input (preserved from current behaviour)
- Create the virtual-column node with `sql_formula=None` — returned immediately so `.relation()` chaining on the result keeps working
- Register a deferred callback via `self.root._dbmodel.deferOnBuilding(...)`

**Phase B — deferred (in `runOnBuildingCb`, after every `config_db` has completed)**

New private method `_buildCompositeColumnFormula(name, composed_of)`:
- Physical column → use its dtype to build the formula fragment (same logic as before)
- Virtual column → `raise GnrSqlException` (a broken `sql_formula` would fail at runtime anyway — fail fast at build time)
- Missing column → `raise GnrSqlException` (replaces the silent side-effect column creation)
- Assemble and assign `sql_formula` on the virtual-column node

The `deferOnBuilding` pattern is already established in this codebase (see `gnr/app/gnrdbo.py:406` and `:462` for `linkHierarchicalToMaster` / `addRelXtdRelidxColumn`).

## Changes

Single file, `gnrpy/gnr/sql/gnrsqlmodel/model.py`:
- `compositeColumn()` (lines 1049-1089) reworked to Phase A only
- New `_buildCompositeColumnFormula()` (lines 1091-1128) for Phase B

Made explicit a branch that was previously implicit: for `dtype in ('L', 'F', 'R', 'B')` the formula fragment is the bare `${column}` reference (in the old code this fell through as the initial `val` assignment).

## Test plan

- [x] `flake8` clean on modified file
- [x] `gnrpy/tests/sql/test_composite_column.py` — 14/14 passed (pg + sqlite, covers value format, JOINs, deep navigation, WHERE, ORDER BY)
- [x] Full `gnrpy/tests/` suite — `1575 passed`, `67 skipped`, `22 failed` (all pre-existing locale/date failures on clean `develop`, identical count with or without the patch)
- [x] `test_invoice` usages (`price_year.compositeColumn('product_year_key', ...)` and `price_year_note.compositeColumn('product_year_ref', ...).relation(...)`) work end-to-end, including composite-key JOIN navigation

## Follow-up

- [ ] Verify on real projects: start `test_invoice` server and exercise composite-key flows manually
- [ ] Consider extending the same validation to `bagItemColumn` and other virtual-column helpers (out of scope here, worth a dedicated issue)