### PR TITLE
fix: pass table parameter through iframe form handler

### DIFF
--- a/resources/common/public.py
+++ b/resources/common/public.py
@@ -676,16 +676,17 @@ class TableHandlerMain(BaseComponent):
         formResource = th_kwargs.pop('formResource',None)
         root.attributes.update(overflow='hidden')
         public = boolean(th_kwargs.pop('public',False))
-        formId = th_kwargs.pop('formId',self.maintable.replace('.','_'))
+        table = th_kwargs.pop('table',None) or self.maintable
+        formId = th_kwargs.pop('formId',table.replace('.','_'))
         if  public:
             root.attributes.update(_class='pbl_root')
             root = root.rootContentPane(title=self.tblobj.name_long)
         else:
             root.attributes.update(tag='ContentPane',_class=None)
-        root.attributes.update(datapath=self.maintable.replace('.','_'))
+        root.attributes.update(datapath=table.replace('.','_'))
         formkw = kwargs
         formkw.update(th_kwargs)
-        form = root.thFormHandler(table=self.maintable,formId=formId,startKey=pkey,
+        form = root.thFormHandler(table=table,formId=formId,startKey=pkey,
                                   formResource=formResource,
                                   formCb=formCb,form_isRootForm=True,**formkw)
         if public:

--- a/resources/common/th/th.js
+++ b/resources/common/th/th.js
@@ -521,6 +521,7 @@ dojo.declare("gnr.IframeFormManager", null, {
             var that = this;
             iframeAttr['onStarted'] = function(){that.onIframeStarted(this,kw)};
             iframeAttr['main_th_formId'] = this.fakeFormId;
+            iframeAttr['main_th_table'] = this.table;
             objectUpdate(iframeAttr,{height:'100%',width:'100%',border:0});
             iframeAttr.src = iframeAttr.src || '/sys/thpage/'+this.table.replace('.','/');
             if(isNullOrBlank(this.sourceNode.attr.context_dbstore)){


### PR DESCRIPTION
## Summary
- Allow the iframe form handler to forward the `table` attribute to the form page
- In `public.py`, use the passed `table` parameter (with fallback to `self.maintable`) for `formId`, `datapath`, and `thFormHandler`
- In `th.js`, pass `main_th_table` in iframe attributes so the form page knows which table to use

## Test plan
- [ ] Open an iframe form on a table different from `self.maintable` and verify it loads correctly
- [ ] Verify standard iframe forms (without explicit table override) still work as before