### PR TITLE
deploy builder generates traefik conf snippet.

### DIFF
--- a/gnrpy/gnr/app/cli/gnrdeploybuilder.py
+++ b/gnrpy/gnr/app/cli/gnrdeploybuilder.py
@@ -6,6 +6,7 @@ create a new deploy gunicorn nginx websocket environment for a site
 usage: gnrdeploybuilder site
 
 """
+import sys
 
 from gnr.core.cli import GnrCliArgParse
 from gnr.app import logger
@@ -19,6 +20,8 @@ def main():
     parser = GnrCliArgParse(description=description)
     parser.add_argument("-d", "--domain", dest="domain",
                       help="The nginx domain")
+    parser.add_argument("-t", "--traefik", dest="traefik",
+                        action="store_true", help="Generate Traefik base config")
     parser.add_argument('-s', '--make_service',dest='make_service',
                       action="store_true", help="Make service")
     parser.add_argument('-e', '--make_virtualenv',dest='make_virtualenv',
@@ -46,9 +49,19 @@ def main():
         deployer.write_gunicorn_conf()
         deployer.local_supervisor_conf()
         deployer.main_supervisor_conf()
+        
+        if options.traefik and not options.domain:
+            print("Can't request traefik configuration without a domain")
+            sys.exit(1)
+            
         if options.domain:
-            print('Writing nginx conf in cwd please copy in /etc/nginx/sites-enabled')
-            deployer.write_nginx_conf(options.domain)
+            f = deployer.write_nginx_conf(options.domain)
+            print(f"Wrote nginx conf '{f}' in cwd, please copy in /etc/nginx/sites-enabled")
+            if options.traefik:
+                f = deployer.write_traefik_conf(options.domain)
+                print(f"Wrote traefik conf snippet in '{f}', copy into your traefik conf dir")
+
+                
         # check for missing dependencies
         app = GnrApp(site, checkdepcli=True)
         instance_deps = app.instance_packages_dependencies

--- a/gnrpy/gnr/app/gnrdeploy.py
+++ b/gnrpy/gnr/app/gnrdeploy.py
@@ -394,9 +394,9 @@ server {
 
         error_log %(logs_path)s/nginx_error.log;
         proxy_connect_timeout       1800;
-	    proxy_send_timeout          1800;
-	    proxy_read_timeout          1800;
-	    send_timeout                1800;
+        proxy_send_timeout          1800;
+        proxy_read_timeout          1800;
+        send_timeout                1800;
         location /websocket {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -418,6 +418,71 @@ server {
 
 """
 
+TRAEFIK_TEMPLATE = """
+http:
+  routers:
+    {site_name}-main:
+      rule: "Host(`{domain}`) && PathPrefix(`/`)"
+      entryPoints:
+        - websecure
+      service: gunicorn-service
+      middlewares:
+        - common-headers
+      tls:
+        certResolver: letsencrypt
+
+    {site_name}-websocket:
+      rule: "Host(`{domain}`) && PathPrefix(`/websocket`)"
+      entryPoints:
+        - websecure
+      service: websocket-service
+      middlewares:
+        - websocket-headers
+      tls:
+        certResolver: letsencrypt
+
+    {site_name}-http-redirect:
+      rule: "Host(`{domain}`)"
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https
+      service: noop
+
+  services:
+    gunicorn-service:
+      loadBalancer:
+        servers:
+          - url: "http://unix//{gunicorn_socket_path}"
+
+    websocket-service:
+      loadBalancer:
+        servers:
+          - url: "http://unix//{gnrasync_socket_path}"
+
+    noop:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1"
+
+  middlewares:
+    redirect-to-https:
+      redirectScheme:
+        scheme: https
+        permanent: true
+
+    common-headers:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: "https"
+
+    websocket-headers:
+      headers:
+        customRequestHeaders:
+          Connection: "Upgrade"
+          Upgrade: "websocket"
+          X-Forwarded-Proto: "https"
+"""
 
 class GunicornDeployBuilder(object):
     default_port = 8080
@@ -625,6 +690,23 @@ class GunicornDeployBuilder(object):
         pars['gnrasync_socket_path'] = self.gnrasync_socket_path
         pars['gunicorn_socket_path'] = self.gunicorn_socket_path
         pars['supervisord_location'] = self.supervisord_monitor_location()
-        conf_content = NGINX_TEMPLATE %pars
-        with open('%s.conf' %self.site_name,'w') as conf_file:
+        conf_content = NGINX_TEMPLATE % pars
+        filename = f"{self.site_name}.conf"
+        with open(filename,'w') as conf_file:
             conf_file.write(conf_content)
+        return filename
+    
+    def write_traefik_conf(self,domain=None):
+        pars = {}
+        pars['domain'] = domain
+        pars['site_name'] = self.site_name
+        pars['site_path'] = self.site_path
+        pars['logs_path'] = self.logs_path
+        pars['gnrasync_socket_path'] = self.gnrasync_socket_path
+        pars['gunicorn_socket_path'] = self.gunicorn_socket_path
+        pars['supervisord_location'] = self.supervisord_monitor_location()
+        conf_content = TRAEFIK_TEMPLATE.format(**pars)
+        filename = f"{self.site_name}-traefik.yaml"
+        with open(filename,'w') as conf_file:
+            conf_file.write(conf_content)
+        return filename


### PR DESCRIPTION
added option '-t' to deploybuilder in order to generate a traefik configuration

snippet, along with nginx one. Improved command output reporting the filename of generated config. Traefik options can't be used without the domain parameter.

close #788