### PR TITLE
GnrSqlAppDb now as "application" as mandatory

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -298,7 +298,12 @@ class DbStoresHandler(object):
 
 class GnrSqlAppDb(GnrSqlDb):
     """TODO"""
-
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get("application", None):
+            raise TypeError("'application' is mandatory for GnrSqlAppDb")
+        
+        super().__init__(*args, **kwargs)
+        
     @property
     def stores_handler(self):
         handler = getattr(self, '_stores_handler', None)

--- a/gnrpy/tests/app/gnrapp_test.py
+++ b/gnrpy/tests/app/gnrapp_test.py
@@ -154,8 +154,11 @@ class TestGnrApp(BaseGnrAppTest):
 
         FIXME: maybe this should be moved to gnr.sql
         """
-        a = ga.GnrSqlAppDb()
-        assert a.application is None
+
+        # ensure that a GnrSqlAppDb without
+        # an application raises a TypeError
+        with pytest.raises(TypeError):
+            a = ga.GnrSqlAppDb()
 
 
     def test_data_retention(self):


### PR DESCRIPTION
GnrSqlAppDb now as "application" as mandatory, raise error if not provided.

Updated tests accordingly.

close #651