### PR TITLE
fix(#826): allow Shift key in pasteOnGrid onkeydown

### DIFF
--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -846,7 +846,7 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
             widget.domNode.setAttribute('contenteditable',"true");
             widget.domNode.setAttribute('onpaste',"return false;");
             widget.domNode.setAttribute('oncut',"return false;");
-            widget.domNode.setAttribute('onkeydown',"if(event.metaKey || event.ctrlKey || event.target!=event.currentTarget) return true; return false;");
+            widget.domNode.setAttribute('onkeydown',"if(event.metaKey || event.ctrlKey || event.shiftKey || event.target!=event.currentTarget) return true; return false;");
             dojo.connect(widget.domNode,'onpaste', funcCreate(savedAttrs.onpaste,'event',widget));
         }
         objectFuncReplace(widget.selection, 'clickSelectEvent', function(e) {

--- a/gnrjs/gnr_d20/js/genro_grid.js
+++ b/gnrjs/gnr_d20/js/genro_grid.js
@@ -794,7 +794,7 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
             widget.domNode.setAttribute('contenteditable',"true");
             widget.domNode.setAttribute('onpaste',"return false;");
             widget.domNode.setAttribute('oncut',"return false;");
-            widget.domNode.setAttribute('onkeydown',"if(event.metaKey || event.ctrlKey || event.target!=event.currentTarget) return true; return false;");
+            widget.domNode.setAttribute('onkeydown',"if(event.metaKey || event.ctrlKey || event.shiftKey || event.target!=event.currentTarget) return true; return false;");
             dojo.connect(widget.domNode,'onpaste', funcCreate(savedAttrs.onpaste,'event',widget));
         }
         objectFuncReplace(widget.selection, 'clickSelectEvent', function(e) {


### PR DESCRIPTION
## Summary

- Add `event.shiftKey` to the `onkeydown` allow-list on contenteditable grid nodes (pasteOnGrid)
- Applied to both `gnr_d11` and `gnr_d20` versions of `genro_grid.js`

Fixes #826

## Root cause

The `onkeydown` handler on pasteOnGrid grids only allowed `metaKey` and `ctrlKey` through, blocking all Shift-only key events. After the DOM/CSS restructuring in PR #671, the contenteditable node receives keyboard focus more readily, making the Shift-scroll block manifest during normal range-selection interactions.

## Test plan

- [ ] Open a page with a pasteOnGrid grid
- [ ] Click a row, hold Shift, scroll with mouse wheel — scrolling should work
- [ ] Click a row, hold Shift, use PageDown/ArrowDown — navigation should work
- [ ] Complete a Shift+click range selection across scrolled rows
- [ ] Verify Ctrl+C / Cmd+C copy still works
- [ ] Verify paste from Excel still works