### PR TITLE
Improve TimeTextBox popup styling and time cell alignment

### DIFF
--- a/gnrjs/gnr_d11/css/gnr_dojotheme/form/TimeTextBox.css
+++ b/gnrjs/gnr_d11/css/gnr_dojotheme/form/TimeTextBox.css
@@ -10,7 +10,7 @@
 .gnr_dojotheme .dijitMenu:has(.dijitTimePickerItem) {
     padding: 0;
     overflow: hidden;
-    min-width: 0;
+    min-width: 4em;
 }
 
 /* --- Up/Down arrow buttons: transparent with outline chevrons --- */
@@ -18,7 +18,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 1.8em;
+    height: 1.5em;
     background: transparent;
     border: none;
     border-radius: 0;
@@ -67,15 +67,14 @@
 
 /* --- Tick items (15-min intervals) --- */
 .gnr_dojotheme .dijitTimePickerTick {
-    color: var(--text-placeholder, #BABABB);
-    border-bottom: 1px solid var(--border-light, #E5E5EA);
+    border-bottom: none;
     border-top: none;
 }
 
 .gnr_dojotheme .dijitTimePickerTick .dijitTimePickerItemInner {
-    font-size: 0.8em;
-    padding: 2px 8px;
-    color: var(--text-secondary, #929394);
+    font-size: 0.85em;
+    padding: 0.1em 0.6em;
+    color: var(--text-secondary, #777);
 }
 
 /* --- Marker items (hour labels) --- */
@@ -83,12 +82,12 @@
     background-color: var(--surface-light, #F7F7FA);
     border-top: 1px solid var(--border-light, #E5E5EA);
     border-bottom: 1px solid var(--border-light, #E5E5EA);
-    font-weight: 500;
+    font-weight: 400;
     color: var(--text-color, #3A3A3C);
 }
 
 .gnr_dojotheme .dijitTimePickerMarker .dijitTimePickerItemInner {
-    padding: 4px 12px;
+    padding: 0.15em 0.6em;
 }
 
 /* --- Hover state --- */

--- a/gnrjs/gnr_d11/css/gnrbase_css/11_gnr_dragdrop_misc.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/11_gnr_dragdrop_misc.css
@@ -106,6 +106,10 @@ table.draggedItem {
     text-align: right;
 }
 
+.dojoxGrid td.cell_H .cellContent, .treecell.cell_H .treeCellContent, .dynamicTable td.cell_H{
+    text-align: center;
+}
+
 ._common_d11 .dojoxGrid-row td.invalidCell.dojoxGrid-cell{
     background-image: var(--icon-invalid);
     background-repeat:no-repeat;
@@ -122,6 +126,10 @@ table.draggedItem {
 
 .dtype_L, .dtype_R, .dtype_I, .dtype_N {
     text-align: right;
+}
+
+.dtype_H {
+    text-align: center;
 }
 
 .highlight_negative .negative_number {

--- a/gnrjs/gnr_d20/css/gnr_dojotheme/form/TimeTextBox.css
+++ b/gnrjs/gnr_d20/css/gnr_dojotheme/form/TimeTextBox.css
@@ -10,7 +10,7 @@
 .gnr_dojotheme .dijitMenu:has(.dijitTimePickerItem) {
     padding: 0;
     overflow: hidden;
-    min-width: 0;
+    min-width: 4em;
 }
 
 /* --- Up/Down arrow buttons: transparent with outline chevrons --- */
@@ -18,7 +18,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 1.8em;
+    height: 1.5em;
     background: transparent;
     border: none;
     border-radius: 0;
@@ -67,15 +67,14 @@
 
 /* --- Tick items (15-min intervals) --- */
 .gnr_dojotheme .dijitTimePickerTick {
-    color: var(--text-placeholder, #BABABB);
-    border-bottom: 1px solid var(--border-light, #E5E5EA);
+    border-bottom: none;
     border-top: none;
 }
 
 .gnr_dojotheme .dijitTimePickerTick .dijitTimePickerItemInner {
-    font-size: 0.8em;
-    padding: 2px 8px;
-    color: var(--text-secondary, #929394);
+    font-size: 0.85em;
+    padding: 0.1em 0.6em;
+    color: var(--text-secondary, #777);
 }
 
 /* --- Marker items (hour labels) --- */
@@ -83,12 +82,12 @@
     background-color: var(--surface-light, #F7F7FA);
     border-top: 1px solid var(--border-light, #E5E5EA);
     border-bottom: 1px solid var(--border-light, #E5E5EA);
-    font-weight: 500;
+    font-weight: 400;
     color: var(--text-color, #3A3A3C);
 }
 
 .gnr_dojotheme .dijitTimePickerMarker .dijitTimePickerItemInner {
-    padding: 4px 12px;
+    padding: 0.15em 0.6em;
 }
 
 /* --- Hover state --- */

--- a/gnrjs/gnr_d20/css/gnrbase_css/11_gnr_dragdrop_misc.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/11_gnr_dragdrop_misc.css
@@ -106,6 +106,10 @@ table.draggedItem {
     text-align: right;
 }
 
+.dojoxGrid td.cell_H .cellContent, .treecell.cell_H .treeCellContent, .dynamicTable td.cell_H{
+    text-align: center;
+}
+
 ._common_d11 .dojoxGrid-row td.invalidCell.dojoxGrid-cell{
     background-image: var(--icon-invalid);
     background-repeat:no-repeat;
@@ -122,6 +126,10 @@ table.draggedItem {
 
 .dtype_L, .dtype_R, .dtype_I, .dtype_N {
     text-align: right;
+}
+
+.dtype_H {
+    text-align: center;
 }
 
 .highlight_negative .negative_number {

--- a/projects/gnrcore/packages/test/webpages/inputfields/timetextbox.py
+++ b/projects/gnrcore/packages/test/webpages/inputfields/timetextbox.py
@@ -5,10 +5,18 @@ class GnrCustomWebPage(object):
     
     def test_1_basic(self, pane):
         "timeTextBox widget to insert time informations"
-        pane.timetextbox(value='^.ttb')
+        pane.timetextbox(value='^.ttb', width='5em')
         pane.div('^.ttb')
 
     def test_2_dh(self,pane):
         "dateTimeTextBox inserts both date and time"
         fb = pane.formbuilder()
-        fb.datetimeTextBox(value='^.dhbox',lbl='DHBOX',dtype='DHZ')
+        fb.datetimeTextBox(value='^.dhbox',lbl='DHBOX',dtype='DHZ', width='8em')
+
+    def test_3_editable_grid(self, pane):
+        "timeTextBox in editable grid"
+        grid = pane.quickGrid(value='^.schedule', height='300px')
+        grid.tools('delrow,addrow')
+        grid.column('description', edit=True, name='Description', width='15em')
+        grid.column('start_time', edit=dict(tag='timeTextBox'), name='Start', width='4em', dtype='H')
+        grid.column('end_time', edit=dict(tag='timeTextBox'), name='End', width='4em', dtype='H')


### PR DESCRIPTION
## Summary
- Compact TimePicker popup: em-based padding, reduced arrow height, lighter marker font-weight, improved tick color readability
- Add `text-align: center` for dtype H (time) cells in grids, analogous to right-alignment for numeric types
- Add `min-width: 4em` on TimePicker popup container
- Add editable grid test case for TimeTextBox

## Test plan
- [ ] Open `test/inputfields/timetextbox` and verify popup compactness
- [ ] Test TimeTextBox in editable grid (test_3)
- [ ] Verify time cells are center-aligned in grids
- [ ] Check both gnr_d11 and gnr_d20 themes render identically