### PR TITLE
feat: add SpeechSynthesis (text-to-speech) API to gnr.GnrSpeech

### DIFF
--- a/gnrjs/gnr_d11/js/genro_speech.js
+++ b/gnrjs/gnr_d11/js/genro_speech.js
@@ -1,13 +1,22 @@
 /*
  * module genro_speech : Web Speech API helper
  *
- * Wraps webkitSpeechRecognition / SpeechRecognition with a simple
- * start/stop interface and per-call options (language, callbacks).
+ * Wraps both Web Speech APIs:
+ *   - SpeechRecognition (audio -> text): start({...}) / stop()
+ *   - SpeechSynthesis   (text -> audio): speak(text, {...}) / cancel()
  *
- * API:
+ * Recognition API:
  *   genro.speech.isAvailable()
  *   genro.speech.start({lang, onResult, onError, onEnd, interimResults, continuous})
  *     returns { stop(), recognition }
+ *
+ * Synthesis API:
+ *   genro.speech.canSpeak()
+ *   genro.speech.speak(text, {lang, rate, pitch, volume, voice, onEnd, onError, onStart})
+ *     returns { utterance, cancel() }
+ *   genro.speech.cancel()       // stop everything currently being spoken
+ *   genro.speech.isSpeaking()
+ *   genro.speech.getVoices(lang) // optional lang filter (substring match on voice.lang)
  *
  * onResult is invoked with the final transcript string each time a
  * final result becomes available. interim results are ignored unless
@@ -23,6 +32,10 @@ dojo.declare("gnr.GnrSpeech", null, {
 
     isAvailable: function(){
         return !!this._Recognition();
+    },
+
+    canSpeak: function(){
+        return !!window.speechSynthesis;
     },
 
     _resolveLang: function(lang){
@@ -86,6 +99,56 @@ dojo.declare("gnr.GnrSpeech", null, {
                 try{ recognition.stop(); }catch(e){}
             }
         };
+    },
+
+    speak: function(text, opts){
+        opts = opts || {};
+        if(!this.canSpeak()){
+            if(opts.onError){ opts.onError({error: 'not-supported'}); }
+            return null;
+        }
+        if(text == null || text === ''){
+            return null;
+        }
+        var u = new SpeechSynthesisUtterance(String(text));
+        var lang = this._resolveLang(opts.lang);
+        if(lang){ u.lang = lang; }
+        if(opts.rate != null){   u.rate   = opts.rate; }
+        if(opts.pitch != null){  u.pitch  = opts.pitch; }
+        if(opts.volume != null){ u.volume = opts.volume; }
+        if(opts.voice){          u.voice  = opts.voice; }
+        u.onstart = opts.onStart || null;
+        u.onend   = opts.onEnd   || null;
+        u.onerror = opts.onError || null;
+        try{
+            window.speechSynthesis.speak(u);
+        }catch(e){
+            if(opts.onError){ opts.onError({error: 'speak-failed', exception: e}); }
+            return null;
+        }
+        return {
+            utterance: u,
+            cancel: function(){ window.speechSynthesis.cancel(); }
+        };
+    },
+
+    cancel: function(){
+        if(this.canSpeak()){
+            window.speechSynthesis.cancel();
+        }
+    },
+
+    isSpeaking: function(){
+        return this.canSpeak() && window.speechSynthesis.speaking;
+    },
+
+    getVoices: function(lang){
+        if(!this.canSpeak()){ return []; }
+        var voices = window.speechSynthesis.getVoices() || [];
+        if(!lang){ return voices; }
+        return voices.filter(function(v){
+            return v.lang && v.lang.toLowerCase().indexOf(lang.toLowerCase()) === 0;
+        });
     }
 
 });

--- a/gnrjs/gnr_d20/js/genro_speech.js
+++ b/gnrjs/gnr_d20/js/genro_speech.js
@@ -1,13 +1,22 @@
 /*
  * module genro_speech : Web Speech API helper
  *
- * Wraps webkitSpeechRecognition / SpeechRecognition with a simple
- * start/stop interface and per-call options (language, callbacks).
+ * Wraps both Web Speech APIs:
+ *   - SpeechRecognition (audio -> text): start({...}) / stop()
+ *   - SpeechSynthesis   (text -> audio): speak(text, {...}) / cancel()
  *
- * API:
+ * Recognition API:
  *   genro.speech.isAvailable()
  *   genro.speech.start({lang, onResult, onError, onEnd, interimResults, continuous})
  *     returns { stop(), recognition }
+ *
+ * Synthesis API:
+ *   genro.speech.canSpeak()
+ *   genro.speech.speak(text, {lang, rate, pitch, volume, voice, onEnd, onError, onStart})
+ *     returns { utterance, cancel() }
+ *   genro.speech.cancel()       // stop everything currently being spoken
+ *   genro.speech.isSpeaking()
+ *   genro.speech.getVoices(lang) // optional lang filter (substring match on voice.lang)
  *
  * onResult is invoked with the final transcript string each time a
  * final result becomes available. interim results are ignored unless
@@ -23,6 +32,10 @@ dojo.declare("gnr.GnrSpeech", null, {
 
     isAvailable: function(){
         return !!this._Recognition();
+    },
+
+    canSpeak: function(){
+        return !!window.speechSynthesis;
     },
 
     _resolveLang: function(lang){
@@ -86,6 +99,56 @@ dojo.declare("gnr.GnrSpeech", null, {
                 try{ recognition.stop(); }catch(e){}
             }
         };
+    },
+
+    speak: function(text, opts){
+        opts = opts || {};
+        if(!this.canSpeak()){
+            if(opts.onError){ opts.onError({error: 'not-supported'}); }
+            return null;
+        }
+        if(text == null || text === ''){
+            return null;
+        }
+        var u = new SpeechSynthesisUtterance(String(text));
+        var lang = this._resolveLang(opts.lang);
+        if(lang){ u.lang = lang; }
+        if(opts.rate != null){   u.rate   = opts.rate; }
+        if(opts.pitch != null){  u.pitch  = opts.pitch; }
+        if(opts.volume != null){ u.volume = opts.volume; }
+        if(opts.voice){          u.voice  = opts.voice; }
+        u.onstart = opts.onStart || null;
+        u.onend   = opts.onEnd   || null;
+        u.onerror = opts.onError || null;
+        try{
+            window.speechSynthesis.speak(u);
+        }catch(e){
+            if(opts.onError){ opts.onError({error: 'speak-failed', exception: e}); }
+            return null;
+        }
+        return {
+            utterance: u,
+            cancel: function(){ window.speechSynthesis.cancel(); }
+        };
+    },
+
+    cancel: function(){
+        if(this.canSpeak()){
+            window.speechSynthesis.cancel();
+        }
+    },
+
+    isSpeaking: function(){
+        return this.canSpeak() && window.speechSynthesis.speaking;
+    },
+
+    getVoices: function(lang){
+        if(!this.canSpeak()){ return []; }
+        var voices = window.speechSynthesis.getVoices() || [];
+        if(!lang){ return voices; }
+        return voices.filter(function(v){
+            return v.lang && v.lang.toLowerCase().indexOf(lang.toLowerCase()) === 0;
+        });
     }
 
 });


### PR DESCRIPTION
## Summary

Extend `gnr.GnrSpeech` (introduced in #837) with the text-to-speech half of the Web Speech API: utterance creation, voice listing, speaking-state detection, and cancellation. The recognition and synthesis APIs are naturally paired in the standard, so it makes sense to keep them under the same helper.

**Note**: this PR is based on `feature/speech-recognition` (#837) and depends on it. Please merge #837 first; this can then be retargeted to `develop` automatically.

## API

```js
genro.speech.canSpeak()                  // feature detect speechSynthesis
genro.speech.speak(text, opts)           // returns { utterance, cancel() }
genro.speech.cancel()                    // stop all speaking
genro.speech.isSpeaking()
genro.speech.getVoices(lang)             // optional lang prefix filter
```

`speak()` opts: `{lang, rate, pitch, volume, voice, onStart, onEnd, onError}`.
Language defaults to `genro.locale()` (BCP-47) — same convention as `start()`.

## Files

- `gnrjs/gnr_d11/js/genro_speech.js` + `gnrjs/gnr_d20/js/genro_speech.js` — extended

No widget changes, no CSS, no Python. The API is available for any component or page that wants text-to-speech (toast read-aloud, accessibility announcements, async job notifications, etc.).

## Test plan

- [ ] Open `/test/inputfields/speechinput` and run from the JS console:
  ```js
  genro.speech.speak('Ciao mondo')
  ```
  → audio playback in the user's locale
- [ ] `genro.speech.getVoices('it')` → array of Italian voices on the host
- [ ] `genro.speech.speak('test'); genro.speech.cancel()` → silenced immediately
- [ ] Empty string / null is a no-op (no exception)