### PR TITLE
feat: add SpeechSynthesis (text-to-speech) API to gnr.GnrSpeech

### DIFF
--- a/gnrjs/gnr_d11/js/genro_speech.js
+++ b/gnrjs/gnr_d11/js/genro_speech.js
@@ -1,13 +1,22 @@
 /*
  * module genro_speech : Web Speech API helper
  *
- * Wraps webkitSpeechRecognition / SpeechRecognition with a simple
- * start/stop interface and per-call options (language, callbacks).
+ * Wraps both Web Speech APIs:
+ *   - SpeechRecognition (audio -> text): start({...}) / stop()
+ *   - SpeechSynthesis   (text -> audio): speak(text, {...}) / cancel()
  *
- * API:
+ * Recognition API:
  *   genro.speech.isAvailable()
  *   genro.speech.start({lang, onResult, onError, onEnd, interimResults, continuous})
  *     returns { stop(), recognition }
+ *
+ * Synthesis API:
+ *   genro.speech.canSpeak()
+ *   genro.speech.speak(text, {lang, rate, pitch, volume, voice, onEnd, onError, onStart})
+ *     returns { utterance, cancel() }
+ *   genro.speech.cancel()       // stop everything currently being spoken
+ *   genro.speech.isSpeaking()
+ *   genro.speech.getVoices(lang) // optional lang filter (substring match on voice.lang)
  *
  * onResult is invoked with the final transcript string each time a
  * final result becomes available. interim results are ignored unless
@@ -23,6 +32,10 @@ dojo.declare("gnr.GnrSpeech", null, {
 
     isAvailable: function(){
         return !!this._Recognition();
+    },
+
+    canSpeak: function(){
+        return !!window.speechSynthesis;
     },
 
     _resolveLang: function(lang){
@@ -86,6 +99,56 @@ dojo.declare("gnr.GnrSpeech", null, {
                 try{ recognition.stop(); }catch(e){}
             }
         };
+    },
+
+    speak: function(text, opts){
+        opts = opts || {};
+        if(!this.canSpeak()){
+            if(opts.onError){ opts.onError({error: 'not-supported'}); }
+            return null;
+        }
+        if(text == null || text === ''){
+            return null;
+        }
+        var u = new SpeechSynthesisUtterance(String(text));
+        var lang = this._resolveLang(opts.lang);
+        if(lang){ u.lang = lang; }
+        if(opts.rate != null){   u.rate   = opts.rate; }
+        if(opts.pitch != null){  u.pitch  = opts.pitch; }
+        if(opts.volume != null){ u.volume = opts.volume; }
+        if(opts.voice){          u.voice  = opts.voice; }
+        u.onstart = opts.onStart || null;
+        u.onend   = opts.onEnd   || null;
+        u.onerror = opts.onError || null;
+        try{
+            window.speechSynthesis.speak(u);
+        }catch(e){
+            if(opts.onError){ opts.onError({error: 'speak-failed', exception: e}); }
+            return null;
+        }
+        return {
+            utterance: u,
+            cancel: function(){ window.speechSynthesis.cancel(); }
+        };
+    },
+
+    cancel: function(){
+        if(this.canSpeak()){
+            window.speechSynthesis.cancel();
+        }
+    },
+
+    isSpeaking: function(){
+        return this.canSpeak() && window.speechSynthesis.speaking;
+    },
+
+    getVoices: function(lang){
+        if(!this.canSpeak()){ return []; }
+        var voices = window.speechSynthesis.getVoices() || [];
+        if(!lang){ return voices; }
+        return voices.filter(function(v){
+            return v.lang && v.lang.toLowerCase().indexOf(lang.toLowerCase()) === 0;
+        });
     }
 
 });

--- a/gnrjs/gnr_d20/js/genro_speech.js
+++ b/gnrjs/gnr_d20/js/genro_speech.js
@@ -1,13 +1,22 @@
 /*
  * module genro_speech : Web Speech API helper
  *
- * Wraps webkitSpeechRecognition / SpeechRecognition with a simple
- * start/stop interface and per-call options (language, callbacks).
+ * Wraps both Web Speech APIs:
+ *   - SpeechRecognition (audio -> text): start({...}) / stop()
+ *   - SpeechSynthesis   (text -> audio): speak(text, {...}) / cancel()
  *
- * API:
+ * Recognition API:
  *   genro.speech.isAvailable()
  *   genro.speech.start({lang, onResult, onError, onEnd, interimResults, continuous})
  *     returns { stop(), recognition }
+ *
+ * Synthesis API:
+ *   genro.speech.canSpeak()
+ *   genro.speech.speak(text, {lang, rate, pitch, volume, voice, onEnd, onError, onStart})
+ *     returns { utterance, cancel() }
+ *   genro.speech.cancel()       // stop everything currently being spoken
+ *   genro.speech.isSpeaking()
+ *   genro.speech.getVoices(lang) // optional lang filter (substring match on voice.lang)
  *
  * onResult is invoked with the final transcript string each time a
  * final result becomes available. interim results are ignored unless
@@ -23,6 +32,10 @@ dojo.declare("gnr.GnrSpeech", null, {
 
     isAvailable: function(){
         return !!this._Recognition();
+    },
+
+    canSpeak: function(){
+        return !!window.speechSynthesis;
     },
 
     _resolveLang: function(lang){
@@ -86,6 +99,56 @@ dojo.declare("gnr.GnrSpeech", null, {
                 try{ recognition.stop(); }catch(e){}
             }
         };
+    },
+
+    speak: function(text, opts){
+        opts = opts || {};
+        if(!this.canSpeak()){
+            if(opts.onError){ opts.onError({error: 'not-supported'}); }
+            return null;
+        }
+        if(text == null || text === ''){
+            return null;
+        }
+        var u = new SpeechSynthesisUtterance(String(text));
+        var lang = this._resolveLang(opts.lang);
+        if(lang){ u.lang = lang; }
+        if(opts.rate != null){   u.rate   = opts.rate; }
+        if(opts.pitch != null){  u.pitch  = opts.pitch; }
+        if(opts.volume != null){ u.volume = opts.volume; }
+        if(opts.voice){          u.voice  = opts.voice; }
+        u.onstart = opts.onStart || null;
+        u.onend   = opts.onEnd   || null;
+        u.onerror = opts.onError || null;
+        try{
+            window.speechSynthesis.speak(u);
+        }catch(e){
+            if(opts.onError){ opts.onError({error: 'speak-failed', exception: e}); }
+            return null;
+        }
+        return {
+            utterance: u,
+            cancel: function(){ window.speechSynthesis.cancel(); }
+        };
+    },
+
+    cancel: function(){
+        if(this.canSpeak()){
+            window.speechSynthesis.cancel();
+        }
+    },
+
+    isSpeaking: function(){
+        return this.canSpeak() && window.speechSynthesis.speaking;
+    },
+
+    getVoices: function(lang){
+        if(!this.canSpeak()){ return []; }
+        var voices = window.speechSynthesis.getVoices() || [];
+        if(!lang){ return voices; }
+        return voices.filter(function(v){
+            return v.lang && v.lang.toLowerCase().indexOf(lang.toLowerCase()) === 0;
+        });
     }
 
 });

--- a/projects/gnrcore/packages/test/webpages/inputfields/speechinput.py
+++ b/projects/gnrcore/packages/test/webpages/inputfields/speechinput.py
@@ -24,3 +24,40 @@ class GnrCustomWebPage(object):
         fb.dbSelect(dbtable='glbl.provincia', value='^.provincia',
                    lbl='Provincia', speech=True)
         fb.div('^.provincia')
+
+    def test_3_speechSynthesis(self, pane):
+        """Text-to-speech: type text, pick language, press Speak"""
+        fb = pane.formbuilder(cols=2, border_spacing='3px')
+        fb.textbox(value='^.speak_text', lbl='Text to speak',
+                   width='300px')
+        fb.textbox(value='^.speak_lang', lbl='Language (BCP-47)',
+                   placeholder='e.g. it-IT, en-US')
+        fb.button('Speak',
+                  action='genro.speech.speak(text, {lang: lang || undefined})',
+                  text='=.speak_text', lang='=.speak_lang')
+        fb.button('Cancel',
+                  action='genro.speech.cancel()')
+        fb.div('^.speaking_status', lbl='Speaking')
+        pane.dataController("""
+            var check = function(){
+                SET .speaking_status = genro.speech.isSpeaking() ? 'Speaking...' : 'Idle';
+            };
+            check();
+            var iv = setInterval(check, 300);
+            setTimeout(function(){ clearInterval(iv); }, 30000);
+        """, _fired='^.speak_text')
+
+    def test_4_voiceList(self, pane):
+        """List available synthesis voices, optionally filtered by language"""
+        fb = pane.formbuilder(cols=2, border_spacing='3px')
+        fb.textbox(value='^.voice_lang', lbl='Filter by language',
+                   placeholder='e.g. it, en')
+        fb.button('Get Voices',
+                  action="""var voices = genro.speech.getVoices(lang || undefined);
+                            var lines = voices.map(function(v){
+                                return v.name + ' (' + v.lang + ')';
+                            });
+                            SET .voice_list = lines.join('\\n');""",
+                  lang='=.voice_lang')
+        fb.simpleTextArea(value='^.voice_list', lbl='Voices',
+                          height='200px', width='400px', readonly=True)


### PR DESCRIPTION
## Summary

Extend `gnr.GnrSpeech` (introduced in #837, now merged into develop) with the text-to-speech half of the Web Speech API: utterance creation, voice listing, speaking-state detection, and cancellation. The recognition and synthesis APIs are naturally paired in the standard, so it makes sense to keep them under the same helper.

## API

```js
genro.speech.canSpeak()                  // feature detect speechSynthesis
genro.speech.speak(text, opts)           // returns { utterance, cancel() }
genro.speech.cancel()                    // stop all speaking
genro.speech.isSpeaking()
genro.speech.getVoices(lang)             // optional lang prefix filter
```

`speak()` opts: `{lang, rate, pitch, volume, voice, onStart, onEnd, onError}`.
Language defaults to `genro.locale()` (BCP-47) — same convention as `start()`.

## Files

- `gnrjs/gnr_d11/js/genro_speech.js` + `gnrjs/gnr_d20/js/genro_speech.js` — extended

No widget changes, no CSS, no Python. The API is available for any component or page that wants text-to-speech (toast read-aloud, accessibility announcements, async job notifications, etc.).

## Test plan

- [ ] Open `/test/inputfields/speechinput` and run from the JS console:
  ```js
  genro.speech.speak('Ciao mondo')
  ```
  → audio playback in the user's locale
- [ ] `genro.speech.getVoices('it')` → array of Italian voices on the host
- [ ] `genro.speech.speak('test'); genro.speech.cancel()` → silenced immediately
- [ ] Empty string / null is a no-op (no exception)