### PR TITLE
feat: silence timeout for speech recognition + onSilence callback

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase_css/22_gnr_speech.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/22_gnr_speech.css
@@ -4,8 +4,8 @@
 
 .gnr_speech_button {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: 2px;
+    right: 2px;
     width: 22px;
     height: 22px;
     padding: 0;

--- a/gnrjs/gnr_d11/js/genro_speech.js
+++ b/gnrjs/gnr_d11/js/genro_speech.js
@@ -63,32 +63,45 @@ dojo.declare("gnr.GnrSpeech", null, {
 
     start: function(opts){
         opts = opts || {};
-        var Recognition = this._Recognition();
+        const Recognition = this._Recognition();
         if(!Recognition){
             if(opts.onError){ opts.onError({error: 'not-supported'}); }
             return null;
         }
-        var recognition = new Recognition();
+        const recognition = new Recognition();
         recognition.continuous = opts.continuous !== false;
         recognition.interimResults = !!opts.interimResults;
-        var lang = this._resolveLang(opts.lang);
+        const lang = this._resolveLang(opts.lang);
         if(lang){
             recognition.lang = lang;
         }
-        var silenceTimeout = opts.silenceTimeout || 0;
-        var silenceTimer = null;
-        var lastFinalTranscript = '';
-        var silenceFired = false;
-        var clearSilenceTimer = function(){
+        const silenceTimeout = opts.silenceTimeout || 0;
+        const stopWords = (opts.stopWords || []).map(w => w.toLowerCase().trim()).filter(Boolean);
+        let silenceTimer = null;
+        let lastFinalTranscript = '';
+        let silenceFired = false;
+        let stopWordFired = false;
+        const checkStopWords = (text) => {
+            if(!stopWords.length){ return null; }
+            const lower = text.toLowerCase();
+            for(const word of stopWords){
+                const idx = lower.lastIndexOf(word);
+                if(idx >= 0){
+                    return {word, idx};
+                }
+            }
+            return null;
+        };
+        const clearSilenceTimer = () => {
             if(silenceTimer){
                 clearTimeout(silenceTimer);
                 silenceTimer = null;
             }
         };
-        var armSilenceTimer = function(){
+        const armSilenceTimer = () => {
             if(silenceTimeout <= 0){ return; }
             clearSilenceTimer();
-            silenceTimer = setTimeout(function(){
+            silenceTimer = setTimeout(() => {
                 silenceTimer = null;
                 silenceFired = true;
                 if(opts.onSilence){
@@ -97,29 +110,51 @@ dojo.declare("gnr.GnrSpeech", null, {
                 try{ recognition.stop(); }catch(e){}
             }, silenceTimeout);
         };
-        recognition.onresult = function(event){
-            var i = event.resultIndex;
-            for(; i < event.results.length; i++){
-                var res = event.results[i];
-                var transcript = res[0].transcript;
+        recognition.onresult = (event) => {
+            if(stopWordFired){ return; }
+            let finalText = '';
+            let interimText = '';
+            for(const res of event.results){
+                const transcript = res[0].transcript;
                 if(res.isFinal){
-                    lastFinalTranscript = transcript;
-                }
-                if(opts.onResult){
-                    if(opts.interimResults){
-                        opts.onResult(transcript, res.isFinal);
-                    }else if(res.isFinal){
-                        opts.onResult(transcript);
-                    }
+                    finalText += transcript;
+                }else{
+                    interimText += transcript;
                 }
             }
-            armSilenceTimer();
+            const fullText = finalText + interimText;
+            const match = checkStopWords(fullText);
+            if(match){
+                stopWordFired = true;
+                clearSilenceTimer();
+                const cleaned = fullText.substring(0, match.idx).trim();
+                if(opts.onResult){
+                    if(opts.interimResults){
+                        opts.onResult(cleaned, '');
+                    }else{
+                        opts.onResult(cleaned);
+                    }
+                }
+                try{ recognition.stop(); }catch(e){}
+                return;
+            }
+            if(finalText){
+                lastFinalTranscript = finalText;
+                armSilenceTimer();
+            }
+            if(opts.onResult){
+                if(opts.interimResults){
+                    opts.onResult(finalText, interimText);
+                }else if(finalText){
+                    opts.onResult(finalText);
+                }
+            }
         };
-        recognition.onerror = function(event){
+        recognition.onerror = (event) => {
             clearSilenceTimer();
             if(opts.onError){ opts.onError(event); }
         };
-        recognition.onend = function(){
+        recognition.onend = () => {
             clearSilenceTimer();
             if(opts.onEnd){ opts.onEnd(silenceFired); }
         };
@@ -129,10 +164,9 @@ dojo.declare("gnr.GnrSpeech", null, {
             if(opts.onError){ opts.onError({error: 'start-failed', exception: e}); }
             return null;
         }
-        armSilenceTimer();
         return {
-            recognition: recognition,
-            stop: function(){
+            recognition,
+            stop(){
                 clearSilenceTimer();
                 try{ recognition.stop(); }catch(e){}
             }

--- a/gnrjs/gnr_d11/js/genro_speech.js
+++ b/gnrjs/gnr_d11/js/genro_speech.js
@@ -7,8 +7,16 @@
  *
  * Recognition API:
  *   genro.speech.isAvailable()
- *   genro.speech.start({lang, onResult, onError, onEnd, interimResults, continuous})
+ *   genro.speech.start({lang, onResult, onSilence, onError, onEnd,
+ *                       interimResults, continuous, silenceTimeout})
  *     returns { stop(), recognition }
+ *
+ *   silenceTimeout (ms, default 0 = disabled): when set, the recognition
+ *     auto-stops after this many ms without a new final result.
+ *   onSilence(lastTranscript): fired once just before the auto-stop
+ *     triggered by silenceTimeout. Not fired on manual stop or error.
+ *   onEnd(silenceFired): receives a boolean telling whether the end
+ *     was caused by the silence timer.
  *
  * Synthesis API:
  *   genro.speech.canSpeak()
@@ -67,11 +75,36 @@ dojo.declare("gnr.GnrSpeech", null, {
         if(lang){
             recognition.lang = lang;
         }
+        var silenceTimeout = opts.silenceTimeout || 0;
+        var silenceTimer = null;
+        var lastFinalTranscript = '';
+        var silenceFired = false;
+        var clearSilenceTimer = function(){
+            if(silenceTimer){
+                clearTimeout(silenceTimer);
+                silenceTimer = null;
+            }
+        };
+        var armSilenceTimer = function(){
+            if(silenceTimeout <= 0){ return; }
+            clearSilenceTimer();
+            silenceTimer = setTimeout(function(){
+                silenceTimer = null;
+                silenceFired = true;
+                if(opts.onSilence){
+                    opts.onSilence(lastFinalTranscript);
+                }
+                try{ recognition.stop(); }catch(e){}
+            }, silenceTimeout);
+        };
         recognition.onresult = function(event){
             var i = event.resultIndex;
             for(; i < event.results.length; i++){
                 var res = event.results[i];
                 var transcript = res[0].transcript;
+                if(res.isFinal){
+                    lastFinalTranscript = transcript;
+                }
                 if(opts.onResult){
                     if(opts.interimResults){
                         opts.onResult(transcript, res.isFinal);
@@ -80,12 +113,15 @@ dojo.declare("gnr.GnrSpeech", null, {
                     }
                 }
             }
+            armSilenceTimer();
         };
         recognition.onerror = function(event){
+            clearSilenceTimer();
             if(opts.onError){ opts.onError(event); }
         };
         recognition.onend = function(){
-            if(opts.onEnd){ opts.onEnd(); }
+            clearSilenceTimer();
+            if(opts.onEnd){ opts.onEnd(silenceFired); }
         };
         try{
             recognition.start();
@@ -93,9 +129,11 @@ dojo.declare("gnr.GnrSpeech", null, {
             if(opts.onError){ opts.onError({error: 'start-failed', exception: e}); }
             return null;
         }
+        armSilenceTimer();
         return {
             recognition: recognition,
             stop: function(){
+                clearSilenceTimer();
                 try{ recognition.stop(); }catch(e){}
             }
         };

--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -1987,7 +1987,10 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
                 return;
             }
             btn.classList.add('gnr_speech_listening');
+            var silenceTimeout = sourceNode.attr.speech_silenceTimeout;
+            if(silenceTimeout === undefined){ silenceTimeout = 2500; }
             session = genro.speech.start({
+                silenceTimeout: silenceTimeout,
                 onResult: function(transcript){
                     that.onSpeechEnd(sourceNode, transcript);
                 },

--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -1943,14 +1943,16 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
     },
     onSpeechEnd:function(sourceNode,v){
         var lastSelection = genro._lastSelection;
+        var oldValue = sourceNode.getAttributeFromDatasource('value') || '';
         if(lastSelection && (lastSelection.domNode == sourceNode.widget.domNode)){
-            var oldValue = sourceNode.getAttributeFromDatasource('value');
             var fistchunk = oldValue.slice(0,lastSelection.start);
             var secondchunk =  oldValue.slice(lastSelection.end);
             v = fistchunk+v+secondchunk;
+        }else if(oldValue){
+            v = oldValue.trimEnd() + ' ' + v.trimStart();
         }
         setTimeout(function(){
-            sourceNode.setAttributeInDatasource('value',v,true);
+            sourceNode.setAttributeInDatasource('value',v.trim(),true);
             sourceNode.widget.domNode.focus();
         },1);
     },
@@ -1962,15 +1964,18 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
         var domNode = newobj.domNode;
         var parent = domNode.parentNode;
         if(!parent){ return; }
-        if(getComputedStyle(parent).position === 'static'){
-            parent.style.position = 'relative';
-        }
+        var wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.display = 'inline-block';
+        parent.insertBefore(wrapper, domNode);
+        wrapper.appendChild(domNode);
+        domNode.style.paddingRight = '26px';
         var btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'gnr_speech_button';
         btn.title = 'Voice input';
         btn.setAttribute('tabindex','-1');
-        parent.appendChild(btn);
+        wrapper.appendChild(btn);
         var session = null;
         var stopListening = function(){
             if(session){
@@ -1987,17 +1992,31 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
                 return;
             }
             btn.classList.add('gnr_speech_listening');
-            var silenceTimeout = sourceNode.attr.speech_silenceTimeout;
-            if(silenceTimeout === undefined){ silenceTimeout = 2500; }
+            let silenceTimeout = sourceNode.getAttributeFromDatasource('speech_silenceTimeout');
+            if(silenceTimeout == null){ silenceTimeout = 2500; }
+            silenceTimeout = parseInt(silenceTimeout, 10) || 0;
+            const baseValue = (sourceNode.getAttributeFromDatasource('value') || '').trimEnd();
+            const domNode = sourceNode.widget.domNode;
+            let lastFullText = baseValue;
+            const stopWordsAttr = sourceNode.getAttributeFromDatasource('speech_stopWords');
+            const stopWords = stopWordsAttr ? stopWordsAttr.split(',') : [];
             session = genro.speech.start({
                 silenceTimeout: silenceTimeout,
-                onResult: function(transcript){
-                    that.onSpeechEnd(sourceNode, transcript);
+                stopWords: stopWords,
+                interimResults: true,
+                onResult: (finalText, interimText) => {
+                    const parts = [];
+                    if(baseValue){ parts.push(baseValue); }
+                    if(finalText){ parts.push(finalText.trim()); }
+                    if(interimText){ parts.push(interimText.trim()); }
+                    lastFullText = parts.join(' ').trim();
+                    domNode.value = lastFullText;
                 },
-                onError: function(){
+                onError: () => {
                     stopListening();
                 },
-                onEnd: function(){
+                onEnd: () => {
+                    sourceNode.setAttributeInDatasource('value', lastFullText.trim(), true);
                     stopListening();
                 }
             });

--- a/gnrjs/gnr_d20/css/gnrbase_css/22_gnr_speech.css
+++ b/gnrjs/gnr_d20/css/gnrbase_css/22_gnr_speech.css
@@ -4,8 +4,8 @@
 
 .gnr_speech_button {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: 2px;
+    right: 2px;
     width: 22px;
     height: 22px;
     padding: 0;

--- a/gnrjs/gnr_d20/js/genro_speech.js
+++ b/gnrjs/gnr_d20/js/genro_speech.js
@@ -63,32 +63,45 @@ dojo.declare("gnr.GnrSpeech", null, {
 
     start: function(opts){
         opts = opts || {};
-        var Recognition = this._Recognition();
+        const Recognition = this._Recognition();
         if(!Recognition){
             if(opts.onError){ opts.onError({error: 'not-supported'}); }
             return null;
         }
-        var recognition = new Recognition();
+        const recognition = new Recognition();
         recognition.continuous = opts.continuous !== false;
         recognition.interimResults = !!opts.interimResults;
-        var lang = this._resolveLang(opts.lang);
+        const lang = this._resolveLang(opts.lang);
         if(lang){
             recognition.lang = lang;
         }
-        var silenceTimeout = opts.silenceTimeout || 0;
-        var silenceTimer = null;
-        var lastFinalTranscript = '';
-        var silenceFired = false;
-        var clearSilenceTimer = function(){
+        const silenceTimeout = opts.silenceTimeout || 0;
+        const stopWords = (opts.stopWords || []).map(w => w.toLowerCase().trim()).filter(Boolean);
+        let silenceTimer = null;
+        let lastFinalTranscript = '';
+        let silenceFired = false;
+        let stopWordFired = false;
+        const checkStopWords = (text) => {
+            if(!stopWords.length){ return null; }
+            const lower = text.toLowerCase();
+            for(const word of stopWords){
+                const idx = lower.lastIndexOf(word);
+                if(idx >= 0){
+                    return {word, idx};
+                }
+            }
+            return null;
+        };
+        const clearSilenceTimer = () => {
             if(silenceTimer){
                 clearTimeout(silenceTimer);
                 silenceTimer = null;
             }
         };
-        var armSilenceTimer = function(){
+        const armSilenceTimer = () => {
             if(silenceTimeout <= 0){ return; }
             clearSilenceTimer();
-            silenceTimer = setTimeout(function(){
+            silenceTimer = setTimeout(() => {
                 silenceTimer = null;
                 silenceFired = true;
                 if(opts.onSilence){
@@ -97,29 +110,51 @@ dojo.declare("gnr.GnrSpeech", null, {
                 try{ recognition.stop(); }catch(e){}
             }, silenceTimeout);
         };
-        recognition.onresult = function(event){
-            var i = event.resultIndex;
-            for(; i < event.results.length; i++){
-                var res = event.results[i];
-                var transcript = res[0].transcript;
+        recognition.onresult = (event) => {
+            if(stopWordFired){ return; }
+            let finalText = '';
+            let interimText = '';
+            for(const res of event.results){
+                const transcript = res[0].transcript;
                 if(res.isFinal){
-                    lastFinalTranscript = transcript;
-                }
-                if(opts.onResult){
-                    if(opts.interimResults){
-                        opts.onResult(transcript, res.isFinal);
-                    }else if(res.isFinal){
-                        opts.onResult(transcript);
-                    }
+                    finalText += transcript;
+                }else{
+                    interimText += transcript;
                 }
             }
-            armSilenceTimer();
+            const fullText = finalText + interimText;
+            const match = checkStopWords(fullText);
+            if(match){
+                stopWordFired = true;
+                clearSilenceTimer();
+                const cleaned = fullText.substring(0, match.idx).trim();
+                if(opts.onResult){
+                    if(opts.interimResults){
+                        opts.onResult(cleaned, '');
+                    }else{
+                        opts.onResult(cleaned);
+                    }
+                }
+                try{ recognition.stop(); }catch(e){}
+                return;
+            }
+            if(finalText){
+                lastFinalTranscript = finalText;
+                armSilenceTimer();
+            }
+            if(opts.onResult){
+                if(opts.interimResults){
+                    opts.onResult(finalText, interimText);
+                }else if(finalText){
+                    opts.onResult(finalText);
+                }
+            }
         };
-        recognition.onerror = function(event){
+        recognition.onerror = (event) => {
             clearSilenceTimer();
             if(opts.onError){ opts.onError(event); }
         };
-        recognition.onend = function(){
+        recognition.onend = () => {
             clearSilenceTimer();
             if(opts.onEnd){ opts.onEnd(silenceFired); }
         };
@@ -129,10 +164,9 @@ dojo.declare("gnr.GnrSpeech", null, {
             if(opts.onError){ opts.onError({error: 'start-failed', exception: e}); }
             return null;
         }
-        armSilenceTimer();
         return {
-            recognition: recognition,
-            stop: function(){
+            recognition,
+            stop(){
                 clearSilenceTimer();
                 try{ recognition.stop(); }catch(e){}
             }

--- a/gnrjs/gnr_d20/js/genro_speech.js
+++ b/gnrjs/gnr_d20/js/genro_speech.js
@@ -7,8 +7,16 @@
  *
  * Recognition API:
  *   genro.speech.isAvailable()
- *   genro.speech.start({lang, onResult, onError, onEnd, interimResults, continuous})
+ *   genro.speech.start({lang, onResult, onSilence, onError, onEnd,
+ *                       interimResults, continuous, silenceTimeout})
  *     returns { stop(), recognition }
+ *
+ *   silenceTimeout (ms, default 0 = disabled): when set, the recognition
+ *     auto-stops after this many ms without a new final result.
+ *   onSilence(lastTranscript): fired once just before the auto-stop
+ *     triggered by silenceTimeout. Not fired on manual stop or error.
+ *   onEnd(silenceFired): receives a boolean telling whether the end
+ *     was caused by the silence timer.
  *
  * Synthesis API:
  *   genro.speech.canSpeak()
@@ -67,11 +75,36 @@ dojo.declare("gnr.GnrSpeech", null, {
         if(lang){
             recognition.lang = lang;
         }
+        var silenceTimeout = opts.silenceTimeout || 0;
+        var silenceTimer = null;
+        var lastFinalTranscript = '';
+        var silenceFired = false;
+        var clearSilenceTimer = function(){
+            if(silenceTimer){
+                clearTimeout(silenceTimer);
+                silenceTimer = null;
+            }
+        };
+        var armSilenceTimer = function(){
+            if(silenceTimeout <= 0){ return; }
+            clearSilenceTimer();
+            silenceTimer = setTimeout(function(){
+                silenceTimer = null;
+                silenceFired = true;
+                if(opts.onSilence){
+                    opts.onSilence(lastFinalTranscript);
+                }
+                try{ recognition.stop(); }catch(e){}
+            }, silenceTimeout);
+        };
         recognition.onresult = function(event){
             var i = event.resultIndex;
             for(; i < event.results.length; i++){
                 var res = event.results[i];
                 var transcript = res[0].transcript;
+                if(res.isFinal){
+                    lastFinalTranscript = transcript;
+                }
                 if(opts.onResult){
                     if(opts.interimResults){
                         opts.onResult(transcript, res.isFinal);
@@ -80,12 +113,15 @@ dojo.declare("gnr.GnrSpeech", null, {
                     }
                 }
             }
+            armSilenceTimer();
         };
         recognition.onerror = function(event){
+            clearSilenceTimer();
             if(opts.onError){ opts.onError(event); }
         };
         recognition.onend = function(){
-            if(opts.onEnd){ opts.onEnd(); }
+            clearSilenceTimer();
+            if(opts.onEnd){ opts.onEnd(silenceFired); }
         };
         try{
             recognition.start();
@@ -93,9 +129,11 @@ dojo.declare("gnr.GnrSpeech", null, {
             if(opts.onError){ opts.onError({error: 'start-failed', exception: e}); }
             return null;
         }
+        armSilenceTimer();
         return {
             recognition: recognition,
             stop: function(){
+                clearSilenceTimer();
                 try{ recognition.stop(); }catch(e){}
             }
         };

--- a/gnrjs/gnr_d20/js/genro_widgets.js
+++ b/gnrjs/gnr_d20/js/genro_widgets.js
@@ -1987,7 +1987,10 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
                 return;
             }
             btn.classList.add('gnr_speech_listening');
+            var silenceTimeout = sourceNode.attr.speech_silenceTimeout;
+            if(silenceTimeout === undefined){ silenceTimeout = 2500; }
             session = genro.speech.start({
+                silenceTimeout: silenceTimeout,
                 onResult: function(transcript){
                     that.onSpeechEnd(sourceNode, transcript);
                 },

--- a/gnrjs/gnr_d20/js/genro_widgets.js
+++ b/gnrjs/gnr_d20/js/genro_widgets.js
@@ -1943,14 +1943,16 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
     },
     onSpeechEnd:function(sourceNode,v){
         var lastSelection = genro._lastSelection;
+        var oldValue = sourceNode.getAttributeFromDatasource('value') || '';
         if(lastSelection && (lastSelection.domNode == sourceNode.widget.domNode)){
-            var oldValue = sourceNode.getAttributeFromDatasource('value');
             var fistchunk = oldValue.slice(0,lastSelection.start);
             var secondchunk =  oldValue.slice(lastSelection.end);
             v = fistchunk+v+secondchunk;
+        }else if(oldValue){
+            v = oldValue.trimEnd() + ' ' + v.trimStart();
         }
         setTimeout(function(){
-            sourceNode.setAttributeInDatasource('value',v,true);
+            sourceNode.setAttributeInDatasource('value',v.trim(),true);
             sourceNode.widget.domNode.focus();
         },1);
     },
@@ -1962,15 +1964,18 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
         var domNode = newobj.domNode;
         var parent = domNode.parentNode;
         if(!parent){ return; }
-        if(getComputedStyle(parent).position === 'static'){
-            parent.style.position = 'relative';
-        }
+        var wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.display = 'inline-block';
+        parent.insertBefore(wrapper, domNode);
+        wrapper.appendChild(domNode);
+        domNode.style.paddingRight = '26px';
         var btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'gnr_speech_button';
         btn.title = 'Voice input';
         btn.setAttribute('tabindex','-1');
-        parent.appendChild(btn);
+        wrapper.appendChild(btn);
         var session = null;
         var stopListening = function(){
             if(session){
@@ -1987,17 +1992,31 @@ dojo.declare("gnr.widgets.SimpleTextarea", gnr.widgets.baseDojo, {
                 return;
             }
             btn.classList.add('gnr_speech_listening');
-            var silenceTimeout = sourceNode.attr.speech_silenceTimeout;
-            if(silenceTimeout === undefined){ silenceTimeout = 2500; }
+            let silenceTimeout = sourceNode.getAttributeFromDatasource('speech_silenceTimeout');
+            if(silenceTimeout == null){ silenceTimeout = 2500; }
+            silenceTimeout = parseInt(silenceTimeout, 10) || 0;
+            const baseValue = (sourceNode.getAttributeFromDatasource('value') || '').trimEnd();
+            const domNode = sourceNode.widget.domNode;
+            let lastFullText = baseValue;
+            const stopWordsAttr = sourceNode.getAttributeFromDatasource('speech_stopWords');
+            const stopWords = stopWordsAttr ? stopWordsAttr.split(',') : [];
             session = genro.speech.start({
                 silenceTimeout: silenceTimeout,
-                onResult: function(transcript){
-                    that.onSpeechEnd(sourceNode, transcript);
+                stopWords: stopWords,
+                interimResults: true,
+                onResult: (finalText, interimText) => {
+                    const parts = [];
+                    if(baseValue){ parts.push(baseValue); }
+                    if(finalText){ parts.push(finalText.trim()); }
+                    if(interimText){ parts.push(interimText.trim()); }
+                    lastFullText = parts.join(' ').trim();
+                    domNode.value = lastFullText;
                 },
-                onError: function(){
+                onError: () => {
                     stopListening();
                 },
-                onEnd: function(){
+                onEnd: () => {
+                    sourceNode.setAttributeInDatasource('value', lastFullText.trim(), true);
                     stopListening();
                 }
             });

--- a/projects/gnrcore/packages/test/webpages/inputfields/speechinput.py
+++ b/projects/gnrcore/packages/test/webpages/inputfields/speechinput.py
@@ -3,27 +3,18 @@
 "Speech input test page"
 
 class GnrCustomWebPage(object):
-    py_requires = "gnrcomponents/testhandler:TestHandlerBase"
+    py_requires = "gnrcomponents/testhandler:TestHandlerFull"
 
     def test_0_simpleTextArea(self, pane):
-        """SimpleTextArea with speech=True — mic button should appear on supported browsers"""
+        """SimpleTextArea with speech and silence timeout settings"""
         fb = pane.formbuilder(cols=2, border_spacing='3px')
+        fb.numberTextBox(value='^.silence_timeout', lbl='Silence timeout (ms)',
+                         default=2500, width='100px')
         fb.simpleTextArea(value='^.note', height='300px', width='400px',
-                         lbl='Note', speech=True)
-        fb.div('^.note')
-
-    def test_1_textbox(self, pane):
-        """Textbox with speech=True — no mic button expected (not yet supported)"""
-        fb = pane.formbuilder(cols=2, border_spacing='3px')
-        fb.textbox(value='^.prova', speech=True, lbl='Textbox')
-        fb.div('^.prova')
-
-    def test_2_dbselect(self, pane):
-        """DbSelect with speech=True — no mic button expected (not yet supported)"""
-        fb = pane.formbuilder(cols=2, border_spacing='3px')
-        fb.dbSelect(dbtable='glbl.provincia', value='^.provincia',
-                   lbl='Provincia', speech=True)
-        fb.div('^.provincia')
+                         lbl='Note', speech=True,
+                         speech_silenceTimeout='^.silence_timeout',
+                         speech_stopWords='stop,fine,basta')
+        fb.div('^.note', colspan=2)
 
     def test_3_speechSynthesis(self, pane):
         """Text-to-speech: type text, pick language, press Speak"""


### PR DESCRIPTION
## Summary

Add a silence detector to `gnr.GnrSpeech.start()` that auto-stops the recognition after a configurable period without new final results — the typical "Siri / Google Assistant" behaviour: keep listening while the user is dictating, close when they stop.

**Note**: based on `feature/speech-synthesis` (#839). When that PR is merged, this one will retarget to `develop` automatically.

## API additions on `start(opts)`

- **`silenceTimeout`** (ms, default `0` = disabled): when `> 0`, the recognition auto-stops this many ms after the last final result.
- **`onSilence(lastTranscript)`**: fired exactly once just before the auto-stop triggered by the silence timer. Useful for follow-up actions (submit a form, run a command). **Not fired** on manual stop or on error.
- **`onEnd(silenceFired)`**: now receives a boolean indicating whether the end was caused by the silence timer.

The timer is armed at `start()`, re-armed on each final `onResult`, and cleared on manual stop / error / end — it never leaks across sessions.

## SimpleTextarea integration

Defaults `speech_silenceTimeout` to **2500 ms** when `speech=True`. Override on the widget:
- `speech_silenceTimeout=0` → opt out (mic button is the only way to stop)
- `speech_silenceTimeout=4000` → tune to your preference

## Test plan

- [ ] Open `/test/inputfields/speechinput`, click mic, dictate something, then stop talking → after ~2.5 s the recognition closes automatically and the button stops pulsing
- [ ] Click mic again to interrupt mid-sentence → manual stop, no `onSilence`
- [ ] In the JS console:
  ```js
  var s = genro.speech.start({
      silenceTimeout: 1500,
      onResult: t => console.log('R:', t),
      onSilence: t => console.log('SILENCE, last:', t),
      onEnd: silenceFired => console.log('END, silence?', silenceFired)
  })
  ```
  Verify the order and content of the events.