### PR TITLE
fix: initialize db env before reading theme preferences in multidomain

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -1059,6 +1059,7 @@ class GnrWebPage(GnrBaseWebPage):
         if 'MSIE' in user_agent and not 'chromeframe' in user_agent:
             raise GnrUnsupportedBrowserException
         self.charset = 'utf-8'
+        self.db  # ensure db env (storename, currentDomain) is set before reading preferences
         arg_dict = self.build_arg_dict(**kwargs)
         tpl = self.pagetemplate
         if not isinstance(tpl, str):


### PR DESCRIPTION
## Summary

Small one-liner fix for **multidomain deployments** (Docker/Kubernetes clusters with multiple child instances).

### The problem

In multidomain mode, when a child instance sets its own theme/color preferences (e.g. `color_variant`) via Application Preferences, the values are correctly saved and visible in the preferences UI — but they have **no effect** on the rendered page. The page always applies the main instance's theme instead.

### Root cause

When `rootPage()` calls `build_arg_dict()` → `get_bodyclasses()` → `getPreference()`, the call chain goes through `site.getPreference()` → `adm.preference.getPreference()`, which checks `db.usingRootstore()` to decide whether to read from the child store or the main store.

However, the page's `__init__` calls `clearCurrentEnv()` (gnrwebpage.py:148) which resets `storename` to `None`. The lazy `page.db` property — which sets `storename` and `currentDomain` via `updateEnv()` — has not been accessed yet at this point.

Result: `usingRootstore()` returns `True` → `getMainStorePreference()` reads from the root store → child instance preferences are ignored.

### The fix

Access `self.db` in `rootPage()` before `build_arg_dict()`, ensuring the db environment (`storename`, `currentDomain`) is correctly initialized before any preference reading occurs.

- Single-domain installations are unaffected (the lazy property short-circuits if already initialized, and rootstore is the only store anyway)
- Only `gnrwebpage.py` is modified, one line added

## Test plan
- [x] Verify in a multidomain environment that child instance app preferences (theme, color_variant) are applied after page reload
- [x] Verify single-domain installations continue to work normally
- [x] Automated test suite passes (1386 passed, 260 skipped)