### PR TITLE
fix(#826): allow Shift+wheel vertical scroll on grids

### DIFF
--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -849,6 +849,16 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
             widget.domNode.setAttribute('onkeydown',"if(event.metaKey || event.ctrlKey || event.target!=event.currentTarget) return true; return false;");
             dojo.connect(widget.domNode,'onpaste', funcCreate(savedAttrs.onpaste,'event',widget));
         }
+        widget.domNode.addEventListener('wheel',function(e){
+            if(!e.shiftKey){return;}
+            var view = widget.views && widget.views.views && widget.views.views[0];
+            var sb = view && view.scrollboxNode;
+            if(!sb){return;}
+            var dy = e.deltaY;
+            if(!dy){return;}
+            sb.scrollTop += dy;
+            e.preventDefault();
+        },{capture:true, passive:false});
         objectFuncReplace(widget.selection, 'clickSelectEvent', function(e) {
             if(sourceNode.attr.selectGroupColumns && ( e.shiftKey && (e.ctrlKey || e.metaKey) ) ){
                 sourceNode.widget.groupColumnsSelect(e.rowIndex,sourceNode.attr.selectGroupColumns);

--- a/gnrjs/gnr_d20/js/genro_grid.js
+++ b/gnrjs/gnr_d20/js/genro_grid.js
@@ -797,6 +797,16 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
             widget.domNode.setAttribute('onkeydown',"if(event.metaKey || event.ctrlKey || event.target!=event.currentTarget) return true; return false;");
             dojo.connect(widget.domNode,'onpaste', funcCreate(savedAttrs.onpaste,'event',widget));
         }
+        widget.domNode.addEventListener('wheel',function(e){
+            if(!e.shiftKey){return;}
+            var view = widget.views && widget.views.views && widget.views.views[0];
+            var sb = view && view.scrollboxNode;
+            if(!sb){return;}
+            var dy = e.deltaY;
+            if(!dy){return;}
+            sb.scrollTop += dy;
+            e.preventDefault();
+        },{capture:true, passive:false});
         objectFuncReplace(widget.selection, 'clickSelectEvent', function(e) {
             if(sourceNode.attr.selectGroupColumns && ( e.shiftKey && (e.ctrlKey || e.metaKey) ) ){
                 sourceNode.widget.groupColumnsSelect(e.rowIndex,sourceNode.attr.selectGroupColumns);


### PR DESCRIPTION
## Summary

Fix the **mouse-wheel variant** of #826: holding Shift while scrolling the wheel no longer freezes the grid viewport on Windows.

This complements #830, which addresses the **keyboard variant** of the same issue (Shift+PageDown/ArrowDown on `pasteOnGrid` grids). The wheel variant is a generic regression affecting **all** grids in `gnr_d11` and `gnr_d20`, not just `pasteOnGrid`.

## Root cause

On Windows, Chrome/Edge apply a platform-specific default action for `Shift+wheel`: they target the nearest ancestor with horizontal overflow and **do not** fall back to vertical scroll if none is found. The grid viewport scroll (`views[0].scrollboxNode`) is therefore never updated, even though the browser emits a normal `wheel` event with `deltaY` set and `defaultPrevented=false`.

The bug is purely behavioral on Windows + mouse wheel; macOS + trackpad does not reproduce it because trackpad gestures generate continuous deltaX/deltaY independently rather than a discrete wheel event remapped by the OS.

The regression manifests after PR #671 (styling rework) because the new DOM/CSS makes the grid the only realistic target for Shift+wheel during normal range-selection workflows.

## Fix

Add a capture-phase `wheel` listener on `widget.domNode` for **every** grid (regardless of `pasteOnGrid`). On `shiftKey`:

- `preventDefault()` to neutralize the Windows default action,
- apply `deltaY` directly to `views.views[0].scrollboxNode.scrollTop`.

Applied in both `gnrjs/gnr_d11/js/genro_grid.js` and `gnrjs/gnr_d20/js/genro_grid.js`. The handler is no-op when Shift is not held or `deltaY` is zero, so Ctrl/Cmd+wheel (zoom), normal wheel, and trackpad behavior are unaffected.

## Relation to PR #830

#830 keeps its scope: `event.shiftKey` added to the `onkeydown` allow-list on `pasteOnGrid` grids — correct and necessary for the keyboard variant. This PR covers the wheel variant separately, with the same `hotfix` label so both ship to master together. Closing #826 is left to this PR (the merge of this PR is what makes the user-visible bug actually go away on Windows).

## Test plan

- [x] Windows + mouse wheel: click a grid row, hold Shift, scroll the wheel — grid scrolls vertically as expected
- [x] Wheel without Shift — unchanged
- [x] Ctrl/Cmd + wheel — browser zoom unchanged
- [x] Paste from Excel into a `pasteOnGrid` grid — unchanged
- [x] Range selection (click → Shift + wheel → Shift + click) — completes in a single interaction
- [ ] macOS + trackpad — non-regression check (no impact expected, listener filters on `shiftKey + deltaY`)

Fixes #826