### PR TITLE
fix(gnrhtml): allow GnrHtmlBuilder without page dimensions

### DIFF
--- a/gnrpy/gnr/core/gnrhtml.py
+++ b/gnrpy/gnr/core/gnrhtml.py
@@ -290,8 +290,6 @@ class GnrHtmlBuilder(object):
         self.nextLetterhead = None
         self.page_height = page_height or top_layer['main.page.height']
         self.page_width = page_width or top_layer['main.page.width']
-        if not (self.page_height and self.page_width):
-            raise GnrHtmlSrcError('Missing page dimensions')
         self.page_margin_top = page_margin_top or top_layer['main.page.top'] or 0
         self.page_margin_left = page_margin_left or top_layer['main.page.left'] or 0
         self.page_margin_right = page_margin_right or top_layer['main.page.right'] or 0
@@ -373,12 +371,13 @@ class GnrHtmlBuilder(object):
                         }
                         """)
 
-        self.head.style(f"""
-            @page{{
-                margin:0;
-                size:{self.page_width}mm {self.page_height}mm;
-            }}
-        """)
+        if self.page_width and self.page_height:
+            self.head.style(f"""
+                @page{{
+                    margin:0;
+                    size:{self.page_width}mm {self.page_height}mm;
+                }}
+            """)
 
 
     def prepareTplLayout(self,letterhead_root):


### PR DESCRIPTION
Closes #853.

## Summary

`GnrHtmlBuilder` used to raise `GnrHtmlSrcError('Missing page dimensions')` on construction without `page_width` / `page_height`. This broke `GnrHtmlPage` and `GnrHtmlDojoPage` for any non-print use case (static rootPages, HTML emails, embedded snippets, SPA shells).

The unconditional raise was introduced by commit `e234e6c36f` (2022-07-26, "refactoring and weasyprint integration") which also removed the previous A4 defaults.

## What changes

Two lines:

1. Remove the unconditional raise. Building HTML without page dimensions is a legitimate use case.
2. Emit the `@page` CSS rule only when both dimensions are set. Without dimensions, emitting `size: Nonemm Nonemm` produces malformed CSS that breaks PDF converters and CSS validators.

## Why the fix is safe

Audit of all 28 `GnrHtmlBuilder` callsites (Sourcerer search):

- 27 of 28 are print callers and pass `page_width` / `page_height` explicitly. They keep working unchanged because their dimensions still flow through.
- 1 caller (`GnrHtmlPage.onPreIniting`) is the non-print one — the path that has been broken since 2022-07-26.

External repos with affected callers (silently broken):
- `genropynet/webpages/serverpages/home.py`
- `genromed/webpages/report/ambulatorio_occupazione.py`

## Test plan

- [x] `python -m pytest gnrpy/tests/core/gnrhtml_test.py gnrpy/tests/core/gnrbaghtml_test.py gnrpy/tests/web/gnrhtmlpage_test.py` passes (9/9).
- [x] flake8 clean on `gnrpy/gnr/core/gnrhtml.py`.
- [x] Manual smoke test:
  ```python
  b = GnrHtmlBuilder()             # no dimensions -> works, no @page emitted
  b.initializeSrc()
  b.body.div(id='mainWindow')
  b.toHtml()

  b2 = GnrHtmlBuilder(page_width=200, page_height=280)  # print -> @page included
  ```
- [ ] Manual: load `genropynet/webpages/serverpages/home.py` and verify the homepage renders.
