### PR TITLE
feat(gnryaml): add GnrYamlBuilder thin wrapper over PyYAML

### DIFF
--- a/gnrpy/gnr/core/gnryaml.py
+++ b/gnrpy/gnr/core/gnryaml.py
@@ -1,0 +1,52 @@
+import yaml
+
+
+_KINDS = ('mapping', 'sequence')
+
+
+class GnrYamlNode(object):
+
+    def __init__(self, kind='mapping'):
+        if kind not in _KINDS:
+            raise ValueError(f"invalid kind: {kind!r}")
+        self._kind = kind
+        self._data = {} if kind == 'mapping' else []
+
+    def child(self, key=None, kind='mapping'):
+        node = GnrYamlNode(kind=kind)
+        if self._kind == 'mapping':
+            if key is None:
+                raise TypeError("child() on mapping requires key")
+            self._data[key] = node
+        else:
+            if key is not None:
+                raise TypeError("child() on sequence does not accept key")
+            self._data.append(node)
+        return node
+
+    def set(self, key, value):
+        if self._kind != 'mapping':
+            raise TypeError("set() not allowed on sequence node")
+        self._data[key] = value
+        return self
+
+    def append(self, value):
+        if self._kind != 'sequence':
+            raise TypeError("append() not allowed on mapping node")
+        self._data.append(value)
+        return self
+
+    def to_python(self):
+        if self._kind == 'mapping':
+            return {k: v.to_python() if isinstance(v, GnrYamlNode) else v
+                    for k, v in self._data.items()}
+        return [v.to_python() if isinstance(v, GnrYamlNode) else v
+                for v in self._data]
+
+
+class GnrYamlBuilder(GnrYamlNode):
+
+    def toYaml(self, **dump_kwargs):
+        opts = dict(sort_keys=False, default_flow_style=False, allow_unicode=True)
+        opts.update(dump_kwargs)
+        return yaml.safe_dump(self.to_python(), **opts)

--- a/gnrpy/tests/core/gnryaml_test.py
+++ b/gnrpy/tests/core/gnryaml_test.py
@@ -1,0 +1,142 @@
+import pytest
+import yaml
+
+from gnr.core.gnryaml import GnrYamlBuilder, GnrYamlNode
+
+
+def test_mapping_scalars():
+    b = GnrYamlBuilder()
+    b.set('name', 'genro').set('version', 1)
+    out = b.toYaml()
+    assert yaml.safe_load(out) == {'name': 'genro', 'version': 1}
+
+
+def test_sequence_scalars():
+    b = GnrYamlBuilder(kind='sequence')
+    b.append('a').append('b').append(3)
+    assert yaml.safe_load(b.toYaml()) == ['a', 'b', 3]
+
+
+def test_nested_mapping_in_sequence():
+    b = GnrYamlBuilder()
+    services = b.child('services')
+    items = services.child('items', kind='sequence')
+    item = items.child(kind='mapping')
+    item.set('name', 'first')
+    assert yaml.safe_load(b.toYaml()) == {
+        'services': {'items': [{'name': 'first'}]}
+    }
+
+
+def test_nested_sequence_in_mapping():
+    b = GnrYamlBuilder(kind='sequence')
+    item = b.child(kind='mapping')
+    tags = item.child('tags', kind='sequence')
+    tags.append('x').append('y')
+    assert yaml.safe_load(b.toYaml()) == [{'tags': ['x', 'y']}]
+
+
+def test_set_on_sequence_raises():
+    n = GnrYamlNode(kind='sequence')
+    with pytest.raises(TypeError):
+        n.set('k', 'v')
+
+
+def test_append_on_mapping_raises():
+    n = GnrYamlNode(kind='mapping')
+    with pytest.raises(TypeError):
+        n.append('v')
+
+
+def test_child_invalid_kind():
+    with pytest.raises(ValueError):
+        GnrYamlNode(kind='scalar')
+
+
+def test_child_missing_key_on_mapping():
+    n = GnrYamlNode(kind='mapping')
+    with pytest.raises(TypeError):
+        n.child()
+
+
+def test_child_with_key_on_sequence():
+    n = GnrYamlNode(kind='sequence')
+    with pytest.raises(TypeError):
+        n.child(key='nope')
+
+
+def test_dollar_var_literal():
+    b = GnrYamlBuilder()
+    val = '${GNR_DB_HOST:-myinstance_db}'
+    b.set('host', val)
+    raw = b.toYaml()
+    assert val in raw
+    assert yaml.safe_load(raw) == {'host': val}
+
+
+def test_docker_compose_shape():
+    b = GnrYamlBuilder()
+    services = b.child('services')
+    db = services.child('myinstance_db')
+    db.set('image', 'postgres:latest')
+    env = db.child('environment', kind='sequence')
+    env.append('POSTGRES_PASSWORD=S3cret')
+    env.append('POSTGRES_USER=genro')
+    hc = db.child('healthcheck')
+    hc.set('test', ['CMD-SHELL', 'pg_isready -U genro -d myinstance'])
+    hc.set('interval', '10s')
+    app = services.child('myinstance')
+    app.set('image', 'myinstance:1.0')
+    ports = app.child('ports', kind='sequence')
+    ports.append('8888:8888')
+    deps = app.child('depends_on')
+    db_dep = deps.child('myinstance_db')
+    db_dep.set('condition', 'service_healthy')
+
+    parsed = yaml.safe_load(b.toYaml())
+    assert parsed == {
+        'services': {
+            'myinstance_db': {
+                'image': 'postgres:latest',
+                'environment': [
+                    'POSTGRES_PASSWORD=S3cret',
+                    'POSTGRES_USER=genro',
+                ],
+                'healthcheck': {
+                    'test': ['CMD-SHELL', 'pg_isready -U genro -d myinstance'],
+                    'interval': '10s',
+                },
+            },
+            'myinstance': {
+                'image': 'myinstance:1.0',
+                'ports': ['8888:8888'],
+                'depends_on': {
+                    'myinstance_db': {'condition': 'service_healthy'},
+                },
+            },
+        }
+    }
+
+
+def test_empty_mapping():
+    b = GnrYamlBuilder()
+    assert yaml.safe_load(b.toYaml()) == {}
+
+
+def test_empty_sequence():
+    b = GnrYamlBuilder(kind='sequence')
+    assert yaml.safe_load(b.toYaml()) == []
+
+
+def test_chainable_set_append():
+    m = GnrYamlNode(kind='mapping')
+    assert m.set('a', 1) is m
+    s = GnrYamlNode(kind='sequence')
+    assert s.append('x') is s
+
+
+def test_explicit_start_opt_in():
+    b = GnrYamlBuilder()
+    b.set('k', 'v')
+    out = b.toYaml(explicit_start=True)
+    assert out.startswith('---\n')


### PR DESCRIPTION
Closes #855.

## Summary

Adds `GnrYamlBuilder`, a thin builder over PyYAML that lets callers construct YAML documents incrementally with native Python types — same idiom as `GnrHtmlBuilder` (`struct → toXxx()`).

Rationale and design discussion: see #855.

## Scope

Self-contained, additive. Two new files, no changes to existing modules:

- `gnrpy/gnr/core/gnryaml.py` (52 lines)
- `gnrpy/tests/core/gnryaml_test.py` (15 tests)

PyYAML is already a declared dependency (`gnrpy/pyproject.toml`).

## API

```python
class GnrYamlNode:
    def __init__(self, kind='mapping')          # 'mapping' | 'sequence'
    def child(self, key=None, kind='mapping')   # nested node (chainable target)
    def set(self, key, value)                   # mapping only, returns self
    def append(self, value)                     # sequence only, returns self
    def to_python(self)                         # recursively → dict / list

class GnrYamlBuilder(GnrYamlNode):
    def toYaml(self, **dump_kwargs)             # delegates to yaml.safe_dump
```

`toYaml()` defaults: `sort_keys=False, default_flow_style=False, allow_unicode=True`. All `safe_dump` kwargs are forwarded (e.g. `explicit_start=True` for the `---` document marker).

Out of scope (intentionally minimal): YAML anchors, aliases, custom tags.

## Error model

- `kind` not in `('mapping', 'sequence')` → `ValueError`
- `set()` on a sequence / `append()` on a mapping → `TypeError`
- `child(key=None)` on a mapping / `child(key=...)` on a sequence → `TypeError`

No defensive `isinstance` guards on values — PyYAML serializes whatever Python type it receives.

## Test plan

- [x] `flake8 gnrpy/gnr/core/gnryaml.py gnrpy/tests/core/gnryaml_test.py` → zero errors
- [x] `pytest gnrpy/tests/core/gnryaml_test.py -v` → 15/15 passing in 0.08s
- [x] Round-trip: every `safe_dump` output parses back via `safe_load` to the original `to_python()` value
- [x] Literal `${VAR}` strings (e.g. `${GNR_DB_HOST:-myapp_db}`) preserved byte-for-byte
- [x] Docker-compose-shaped fixture builds and round-trips correctly
- [x] Type errors (`set` on sequence, `append` on mapping, etc.) raise as expected
- [x] Empty mapping/sequence, chainable `set`/`append`, `explicit_start` opt-in

## Reviewer checklist

- [ ] API surface aligned with `GnrHtmlBuilder` conventions
- [x] No new dependencies
- [x] No unused imports / dead code