### PR TITLE
feat(gnrbag): add EnvResolver, UidResolver, TsResolver utility resolvers

### DIFF
--- a/gnrpy/gnr/core/gnrbag.py
+++ b/gnrpy/gnr/core/gnrbag.py
@@ -62,7 +62,8 @@ import sys
 import re
 import copy
 import pickle as pickle
-from datetime import datetime, timedelta
+import uuid
+from datetime import datetime, timedelta, timezone
 import urllib.request, urllib.parse, urllib.error
 import urllib.parse
 
@@ -70,7 +71,7 @@ import requests
 
 from gnr.core import gnrstring, logger
 from gnr.core.gnrclasses import GnrClassCatalog
-from gnr.core.gnrlang import GnrObject, GnrException #setCallable
+from gnr.core.gnrlang import GnrObject, GnrException, getUuid #setCallable
 from gnr.core.gnrlang import file_types
 
 
@@ -2895,11 +2896,74 @@ GeoCoderBagNew = GeoCoderBag #compatibility
 class BagCbResolver(BagResolver):
     """A standard resolver. Call a callback method, passing its kwargs parameters"""
     classArgs = ['method']
-        
+
     def load(self):
         """TODO"""
         return self.method(**self.kwargs)
-        
+
+
+class EnvResolver(BagResolver):
+    """Expose an environment variable as a lazy bag node.
+
+    With ``cacheTime=0`` (default) re-reads ``os.environ`` on every access,
+    so runtime changes are visible. ``cacheTime=N`` caches for N seconds;
+    ``cacheTime=-1`` reads once and freezes."""
+    classKwargs = {'cacheTime': 0, 'readOnly': True, 'default': None}
+    classArgs = ['var_name']
+
+    def load(self):
+        return os.environ.get(self.var_name, self.default)
+
+
+class UidResolver(BagResolver):
+    """Generate a stable identifier on first access.
+
+    Default (``version=None``): 22-char base64-urlsafe id from
+    :func:`gnr.core.gnrlang.getUuid`. ``version='uuid1'`` / ``'uuid4'``
+    yield standard 36-char UUID strings.
+
+    Default ``cacheTime=-1`` makes the id stable for the lifetime of the
+    bag; pass ``cacheTime=0`` to regenerate on every access."""
+    classKwargs = {'cacheTime': -1, 'readOnly': True, 'version': None}
+    classArgs = ['version']
+
+    _generators = {
+        'uuid1': lambda: str(uuid.uuid1()),
+        'uuid4': lambda: str(uuid.uuid4()),
+    }
+
+    def load(self):
+        if self.version is None:
+            return getUuid()
+        gen = self._generators.get(self.version)
+        if gen is None:
+            raise ValueError(f"Unsupported UID version: {self.version!r}. "
+                             f"Use None (default), 'uuid1' or 'uuid4'.")
+        return gen()
+
+
+class TsResolver(BagResolver):
+    """Expose the current timestamp as a lazy bag node.
+
+    Three behaviors via ``cacheTime``:
+      * ``cacheTime=0`` (default): live, re-read on every access
+      * ``cacheTime=N``: refresh every N seconds
+      * ``cacheTime=-1``: snapshot at first access, frozen forever
+        (e.g. ``created_at``)
+
+    Returns a naive ``datetime`` instance. Formatting is the consumer's
+    responsibility (``value.isoformat()``, ``value.strftime(...)``)."""
+    classKwargs = {'cacheTime': 0, 'readOnly': True, 'tz': 'local'}
+    classArgs = []
+
+    def load(self):
+        if self.tz == 'utc':
+            return datetime.now(timezone.utc).replace(tzinfo=None)
+        if self.tz == 'local':
+            return datetime.now()
+        raise ValueError(f"Unsupported tz: {self.tz!r}. Use 'local' or 'utc'.")
+
+
 class UrlResolver(BagResolver):
     """TODO"""
     classKwargs = {'cacheTime': 300, 'readOnly': True}

--- a/gnrpy/tests/core/gnrbag_resolvers_test.py
+++ b/gnrpy/tests/core/gnrbag_resolvers_test.py
@@ -1,0 +1,139 @@
+import re
+import time
+from datetime import datetime
+
+import pytest
+
+from gnr.core.gnrbag import Bag, EnvResolver, UidResolver, TsResolver
+
+
+# ---------- EnvResolver ----------
+
+def test_env_default(monkeypatch):
+    monkeypatch.delenv('GNRTEST_NOT_SET', raising=False)
+    b = Bag()
+    b['x'] = EnvResolver('GNRTEST_NOT_SET', default='fallback')
+    assert b['x'] == 'fallback'
+
+
+def test_env_read(monkeypatch):
+    monkeypatch.setenv('GNRTEST_VAR', 'hello')
+    b = Bag()
+    b['x'] = EnvResolver('GNRTEST_VAR')
+    assert b['x'] == 'hello'
+
+
+def test_env_change_visible_with_cache_zero(monkeypatch):
+    monkeypatch.setenv('GNRTEST_VAR', 'first')
+    b = Bag()
+    b['x'] = EnvResolver('GNRTEST_VAR')
+    assert b['x'] == 'first'
+    monkeypatch.setenv('GNRTEST_VAR', 'second')
+    assert b['x'] == 'second'
+
+
+def test_env_frozen_with_cache_negative_one(monkeypatch):
+    monkeypatch.setenv('GNRTEST_VAR', 'first')
+    b = Bag()
+    b['x'] = EnvResolver('GNRTEST_VAR', cacheTime=-1)
+    assert b['x'] == 'first'
+    monkeypatch.setenv('GNRTEST_VAR', 'second')
+    assert b['x'] == 'first'
+
+
+# ---------- UidResolver ----------
+
+def test_uid_default_is_22_chars():
+    b = Bag()
+    b['uid'] = UidResolver()
+    val = b['uid']
+    assert isinstance(val, str)
+    assert len(val) == 22
+    assert re.fullmatch(r'[A-Za-z0-9_]{22}', val)
+
+
+def test_uid_stable_across_accesses():
+    b = Bag()
+    b['uid'] = UidResolver()
+    assert b['uid'] == b['uid']
+
+
+def test_uid_regenerates_with_cache_zero():
+    b = Bag()
+    b['uid'] = UidResolver(cacheTime=0)
+    assert b['uid'] != b['uid']
+
+
+def test_uid_uuid4_format():
+    b = Bag()
+    b['uid'] = UidResolver(version='uuid4')
+    val = b['uid']
+    assert len(val) == 36
+    assert val.count('-') == 4
+
+
+def test_uid_uuid1_format():
+    b = Bag()
+    b['uid'] = UidResolver(version='uuid1')
+    val = b['uid']
+    assert len(val) == 36
+    assert val.count('-') == 4
+
+
+def test_uid_invalid_version_raises():
+    b = Bag()
+    b['uid'] = UidResolver(version='bogus')
+    with pytest.raises(ValueError):
+        b['uid']
+
+
+# ---------- TsResolver ----------
+
+def test_ts_returns_datetime():
+    b = Bag()
+    b['now'] = TsResolver()
+    assert isinstance(b['now'], datetime)
+
+
+def test_ts_live_default_changes():
+    b = Bag()
+    b['now'] = TsResolver()
+    t1 = b['now']
+    time.sleep(0.002)
+    t2 = b['now']
+    assert t1 != t2
+
+
+def test_ts_frozen_when_cache_negative_one():
+    b = Bag()
+    b['created'] = TsResolver(cacheTime=-1)
+    t1 = b['created']
+    time.sleep(0.002)
+    t2 = b['created']
+    assert t1 == t2
+
+
+def test_ts_window_with_cache_seconds():
+    b = Bag()
+    b['ts'] = TsResolver(cacheTime=2)
+    t1 = b['ts']
+    time.sleep(0.05)
+    t2 = b['ts']
+    assert t1 == t2
+
+
+def test_ts_utc_branch():
+    if time.timezone == 0 and not time.daylight:
+        pytest.skip('local timezone is UTC; cannot distinguish from utc branch')
+    b = Bag()
+    b['local'] = TsResolver(tz='local', cacheTime=-1)
+    b['utc'] = TsResolver(tz='utc', cacheTime=-1)
+    delta = abs((b['local'] - b['utc']).total_seconds())
+    assert delta > 60
+
+
+def test_ts_invalid_tz_raises():
+    b = Bag()
+    b['ts'] = TsResolver(tz='bogus')
+    with pytest.raises(ValueError):
+        b['ts']


### PR DESCRIPTION
Closes #857.

## Summary

Adds three small `BagResolver` subclasses to `gnrpy/gnr/core/gnrbag.py`, all expressing the same idiom — **"lazy state derived from process context"** — and all modulated by the existing `cacheTime` machinery (no new API surface):

- **`EnvResolver`** — exposes an environment variable as a lazy bag node
- **`UidResolver`** — generates a stable identifier on first access (default: 22-char `gnrlang.getUuid`)
- **`TsResolver`** — exposes the current timestamp with selectable freshness

Rationale and motivating examples: see #857.

## Scope

Self-contained, additive. One file modified, one new test file:

- `gnrpy/gnr/core/gnrbag.py` — three new classes inserted between `BagCbResolver` and `UrlResolver`; imports extended with `uuid`, `timezone`, `getUuid`
- `gnrpy/tests/core/gnrbag_resolvers_test.py` — 16 tests

No new dependencies. No changes to existing call sites.

## API

```python
# Environment variable, lazy
b['db_host'] = EnvResolver('GNR_DB_HOST', default='localhost')

# Stable id (22-char gnrlang.getUuid by default)
b['request_id']   = UidResolver()
b['standard_id']  = UidResolver(version='uuid4')

# Current timestamp
b['now']        = TsResolver()                         # live (re-read each access)
b['created_at'] = TsResolver(cacheTime=-1)             # snapshot, frozen forever
b['cached_ts']  = TsResolver(cacheTime=60)             # refresh every 60s
b['utc_now']    = TsResolver(tz='utc')                 # naive UTC
```

`cacheTime` semantics (existing `BagResolver` convention, verified in code at `gnrbag.py:2678-2701`):

| `cacheTime` | Behavior |
|---|---|
| `0` | re-read on every access (live) |
| `> 0` | cache for N seconds |
| `< 0` | never expires (snapshot stable) |

The defaults are chosen per resolver: `EnvResolver` defaults to `0` (live), `TsResolver` to `0` (live), `UidResolver` to `-1` (stable id is the common case).

## Error model

- `UidResolver(version='bogus')` → `ValueError` on access (not at construction, to stay consistent with the lazy nature of resolvers)
- `TsResolver(tz='bogus')` → `ValueError` on access

## Test plan

- [x] `flake8 gnrpy/gnr/core/gnrbag.py gnrpy/tests/core/gnrbag_resolvers_test.py` — zero errors introduced (3 pre-existing F841 at lines 2818/3159/3376 are unrelated)
- [x] `pytest gnrpy/tests/core/gnrbag_resolvers_test.py -v` — 16/16 passing
- [x] `pytest gnrpy/tests/core/gnrbag_test.py -v` — 38/38 passing (no regression)
- [x] Manual REPL: env var change visibility, UID stability/regeneration, timestamp live/frozen/windowed modes, UTC vs local divergence

### Coverage

- `EnvResolver`: default fallback, read, runtime change visible (`cacheTime=0`), runtime change frozen (`cacheTime=-1`)
- `UidResolver`: 22-char default format (regex check), stability across accesses, regeneration with `cacheTime=0`, `uuid1`/`uuid4` standard format, invalid version raises
- `TsResolver`: returns `datetime`, live mode changes, frozen mode stable, windowed mode caches, UTC branch (skipped if local TZ is UTC), invalid tz raises

## Reviewer checklist

- [x] API surface coherent with existing `BagResolver` subclasses (`UrlResolver`, `DirectoryResolver`, …)
- [x] No new dependencies
- [x] Default `version=None` for `UidResolver` — explicit override (`'uuid1'`/`'uuid4'`) only when standard UUID is needed
- [x] `cacheTime=-1` default for `UidResolver` matches the common "stable id" use case