### PR TITLE
feat(gnrdockerize): generate docker-compose via GnrYamlBuilder

### DIFF
--- a/gnrpy/gnr/app/cli/gnrdockerize.py
+++ b/gnrpy/gnr/app/cli/gnrdockerize.py
@@ -16,6 +16,7 @@ import subprocess
 from mako.template import Template
 
 from gnr.core.cli import GnrCliArgParse
+from gnr.core.gnryaml import GnrYamlBuilder
 from gnr.app.pathresolver import PathResolver
 from gnr.dev.builder import GnrProjectBuilder
 from gnr.app import logger
@@ -264,22 +265,127 @@ stderr_logfile_maxbytes=0
 
         # docker compose conf file
         if self.options.compose:
-            extra_labels = []
-            if self.options.fqdns and self.options.router == 'traefik':
-                hosts_rule = " || ".join([f"Host(`{fqdn}`)" for fqdn in self.options.fqdns])
-                extra_labels.extend([
-                    'traefik.enable: "true"',
-                    f'traefik.http.routers.{self.instance_name}_web.rule: "({hosts_rule}) && !Path(`/websocket`))"',
-                    f'traefik.http.routers.{self.instance_name}_web.entrypoints: http',
-                    f'traefik.http.routers.{self.instance_name}_web.service: {self.instance_name}_svc_web',
-                    f'traefik.http.services.{self.instance_name}_svc_web.loadbalancer.server.port: 8888',
-                    f'traefik.http.routers.{self.instance_name}_wsk.rule: "({hosts_rule}) && Path(`/websocket`))"',
-                    f'traefik.http.routers.{self.instance_name}_wsk.entrypoints: http',
-                    f'traefik.http.routers.{self.instance_name}_wsk.service: {self.instance_name}_svc_wsk',
-                    f'traefik.http.services.{self.instance_name}_svc_wsk.loadbalancer.server.port: 9999'
-                ])
-                    
-            compose_template = """
+            content = self._generate_compose_yaml(version_tag)
+            compose_file = f"{self.instance_name}-compose.yml"
+            with open(compose_file, "w") as wfp:
+                wfp.write(content)
+            print(f"Created docker compose file {compose_file}")
+            print(f"You can now execute 'docker-compose -f {compose_file} up'")
+            print("YMMV, please adjust the generated file accordingly.")
+
+    def _compute_extra_labels(self):
+        """Build the optional traefik labels for the app service.
+
+        Returns a list of ``(key, value)`` pairs with native Python types
+        (e.g. port numbers stay int) so the YAML emitter can render them
+        without spurious quoting. Empty when no fqdn / router is set."""
+        if not (self.options.fqdns and self.options.router == 'traefik'):
+            return []
+        hosts_rule = ' || '.join(f'Host(`{fqdn}`)' for fqdn in self.options.fqdns)
+        name = self.instance_name
+        return [
+            ('traefik.enable', 'true'),
+            (f'traefik.http.routers.{name}_web.rule',
+             f'({hosts_rule}) && !Path(`/websocket`))'),
+            (f'traefik.http.routers.{name}_web.entrypoints', 'http'),
+            (f'traefik.http.routers.{name}_web.service', f'{name}_svc_web'),
+            (f'traefik.http.services.{name}_svc_web.loadbalancer.server.port', 8888),
+            (f'traefik.http.routers.{name}_wsk.rule',
+             f'({hosts_rule}) && Path(`/websocket`))'),
+            (f'traefik.http.routers.{name}_wsk.entrypoints', 'http'),
+            (f'traefik.http.routers.{name}_wsk.service', f'{name}_svc_wsk'),
+            (f'traefik.http.services.{name}_svc_wsk.loadbalancer.server.port', 9999),
+        ]
+
+    def _generate_compose_yaml(self, version_tag):
+        """Dispatch to builder (default) or legacy mako template (``--mako``)."""
+        extra_labels = self._compute_extra_labels()
+        if self.options.mako:
+            return self._compose_via_mako(version_tag, extra_labels)
+        return self._compose_via_builder(version_tag, extra_labels)
+
+    def _compose_via_builder(self, version_tag, extra_labels):
+        """Build the docker-compose document with GnrYamlBuilder.
+
+        Reads top-down like the compose file itself: volumes, then the db
+        service (postgres + healthcheck), then the app service (image,
+        traefik labels, ports, db dependency, env, volume mount)."""
+        name = self.instance_name
+
+        compose = GnrYamlBuilder()
+        compose.child('volumes').set(f'{name}_site', None)
+
+        services = compose.child('services')
+        self._compose_db(services.child(f'{name}_db'))
+        self._compose_app(services.child(name), version_tag, extra_labels)
+
+        return compose.toYaml(explicit_start=True)
+
+    def _compose_db(self, db):
+        name = self.instance_name
+        db.set('image', 'postgres:latest')
+
+        env = db.child('environment', kind='sequence')
+        env.append('POSTGRES_PASSWORD=S3cret')
+        env.append('POSTGRES_USER=genro')
+        env.append(f'POSTGRES_DB={name}')
+
+        hc = db.child('healthcheck')
+        hc.set('test', ['CMD-SHELL', f'pg_isready -U genro -d {name}'])
+        hc.set('interval', '10s')
+        hc.set('retries', 5)
+        hc.set('start_period', '30s')
+        hc.set('timeout', '10s')
+
+    def _compose_app(self, app, version_tag, extra_labels):
+        name = self.instance_name
+        app.set('image', f'{name}:{version_tag}')
+
+        if extra_labels:
+            labels = app.child('labels')
+            for key, value in extra_labels:
+                labels.set(key, value)
+
+        app.child('ports', kind='sequence').append('8888:8888')
+
+        deps = app.child('depends_on')
+        deps.child(f'{name}_db').set('condition', 'service_healthy')
+
+        env = app.child('environment')
+        env.set('GNR_DB_IMPLEMENTATION', 'postgres')
+        env.set('GNR_DB_HOST', f'${{GNR_DB_HOST:-{name}_db}}')
+        env.set('GNR_ROOTPWD', '${GNR_ROOTPWD:-admin}')
+        env.set('GNR_DB_USER', '${GNR_DB_USER:-genro}')
+        env.set('GNR_DB_PORT', '${GNR_DB_PORT:-5432}')
+        env.set('GNR_DB_PASSWORD', '${GNR_DB_PASSWORD:-S3cret}')
+        env.set('GNR_LOCALE', 'IT_it')
+
+        app.child('volumes', kind='sequence').append(
+            f'{name}_site:/home/genro/site/'
+        )
+
+    def _compose_via_mako(self, version_tag, extra_labels):
+        """Render the legacy Mako compose template (``--mako`` opt-in).
+
+        Re-flattens the typed ``(key, value)`` pairs into the
+        ``"key: value"`` string form that the historical template expects."""
+        legacy_labels = [self._format_legacy_label(k, v) for k, v in extra_labels]
+        return Template(_LEGACY_COMPOSE_TEMPLATE, strict_undefined=True).render(
+            instanceName=self.instance_name,
+            version_tag=version_tag,
+            extra_labels=legacy_labels,
+        )
+
+    @staticmethod
+    def _format_legacy_label(key, value):
+        if isinstance(value, str) and ' ' in value:
+            return f'{key}: "{value}"'
+        if isinstance(value, str) and value in ('true', 'false'):
+            return f'{key}: "{value}"'
+        return f'{key}: {value}'
+
+
+_LEGACY_COMPOSE_TEMPLATE = """
 ---
 # Docker compose file for instance ${instanceName}:${version_tag}
 
@@ -322,18 +428,10 @@ services:
       GNR_LOCALE: "IT_it"
     volumes:
       - ${instanceName}_site:/home/genro/site/
-                
+
                 """
-            compose_template_file = f"{self.instance_name}-compose.yml"
-            with open(compose_template_file, "w") as wfp:
-                t = Template(compose_template, strict_undefined=True)
-                wfp.write(t.render(instanceName=self.instance_name,
-                                   version_tag=version_tag,
-                                   extra_labels=extra_labels))
-                print(f"Created docker compose file {compose_template_file}")
-                print(f"You can now execute 'docker-compose -f {compose_template_file} up'")
-                print("YMMV, please adjust the generated file accordingly.")
-                    
+
+
 def main():
     parser = GnrCliArgParse(description=description)
     parser.add_argument('-c','--compose',
@@ -402,7 +500,11 @@ def main():
                         default='traefik',
                         choices=['traefik'],
                         help="The router to use for deployment")
-    
+    parser.add_argument('--mako',
+                        action="store_true",
+                        dest="mako",
+                        help="Use the legacy Mako compose template instead of GnrYamlBuilder")
+
     parser.add_argument('instance_name')
     
     options = parser.parse_args()

--- a/gnrpy/tests/app/cli/gnrdockerize_test.py
+++ b/gnrpy/tests/app/cli/gnrdockerize_test.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+import yaml
+
+from gnr.app.cli.gnrdockerize import MultiStageDockerImageBuilder
+
+
+def _make_builder(instance_name='myapp', mako=False, fqdns=None):
+    b = MultiStageDockerImageBuilder.__new__(MultiStageDockerImageBuilder)
+    b.instance_name = instance_name
+    b.options = SimpleNamespace(
+        mako=mako, fqdns=fqdns or [], router='traefik',
+    )
+    return b
+
+
+# ---------- _compute_extra_labels ----------
+
+def test_extra_labels_empty_when_no_fqdns():
+    assert _make_builder()._compute_extra_labels() == []
+
+
+def test_extra_labels_empty_when_router_not_traefik():
+    b = _make_builder(fqdns=['myapp.local'])
+    b.options.router = 'nginx'
+    assert b._compute_extra_labels() == []
+
+
+def test_extra_labels_traefik_when_fqdns():
+    labels = _make_builder(fqdns=['myapp.local'])._compute_extra_labels()
+    keys = [k for k, _ in labels]
+    assert 'traefik.enable' in keys
+    port_key = 'traefik.http.services.myapp_svc_web.loadbalancer.server.port'
+    port_value = next(v for k, v in labels if k == port_key)
+    assert port_value == 8888 and isinstance(port_value, int)
+
+
+# ---------- builder path ----------
+
+def test_compose_builder_minimal():
+    parsed = yaml.safe_load(_make_builder()._generate_compose_yaml('1.0'))
+    assert parsed['services']['myapp']['image'] == 'myapp:1.0'
+    assert parsed['services']['myapp_db']['image'] == 'postgres:latest'
+    assert 'labels' not in parsed['services']['myapp']
+
+
+def test_compose_builder_with_traefik_labels():
+    parsed = yaml.safe_load(
+        _make_builder(fqdns=['myapp.local'])._generate_compose_yaml('1.0')
+    )
+    labels = parsed['services']['myapp']['labels']
+    assert labels['traefik.enable'] == 'true'
+    port_key = 'traefik.http.services.myapp_svc_web.loadbalancer.server.port'
+    assert labels[port_key] == 8888
+
+
+def test_compose_builder_dollar_var_preserved():
+    raw = _make_builder()._generate_compose_yaml('1.0')
+    assert '${GNR_DB_HOST:-myapp_db}' in raw
+    assert '${GNR_ROOTPWD:-admin}' in raw
+    assert '${GNR_DB_PASSWORD:-S3cret}' in raw
+
+
+def test_compose_builder_healthcheck_test_is_list():
+    parsed = yaml.safe_load(_make_builder()._generate_compose_yaml('1.0'))
+    test = parsed['services']['myapp_db']['healthcheck']['test']
+    assert test == ['CMD-SHELL', 'pg_isready -U genro -d myapp']
+
+
+def test_compose_builder_db_environment_is_sequence():
+    parsed = yaml.safe_load(_make_builder()._generate_compose_yaml('1.0'))
+    env = parsed['services']['myapp_db']['environment']
+    assert env == [
+        'POSTGRES_PASSWORD=S3cret',
+        'POSTGRES_USER=genro',
+        'POSTGRES_DB=myapp',
+    ]
+
+
+def test_compose_builder_app_volume_mount():
+    parsed = yaml.safe_load(_make_builder()._generate_compose_yaml('1.0'))
+    assert parsed['services']['myapp']['volumes'] == [
+        'myapp_site:/home/genro/site/'
+    ]
+
+
+def test_compose_builder_explicit_start_marker():
+    raw = _make_builder()._generate_compose_yaml('1.0')
+    assert raw.startswith('---\n')
+
+
+# ---------- mako legacy path ----------
+
+def test_compose_legacy_mako_minimal():
+    parsed = yaml.safe_load(
+        _make_builder(mako=True)._generate_compose_yaml('1.0')
+    )
+    assert parsed['services']['myapp']['image'] == 'myapp:1.0'
+    assert parsed['services']['myapp_db']['image'] == 'postgres:latest'
+
+
+def test_compose_legacy_mako_dollar_var_preserved():
+    raw = _make_builder(mako=True)._generate_compose_yaml('1.0')
+    assert '${GNR_DB_HOST:-myapp_db}' in raw
+    assert '${GNR_ROOTPWD:-admin}' in raw
+
+
+# ---------- semantic equivalence between paths ----------
+
+def test_compose_paths_semantically_equal_with_traefik():
+    builder_yaml = _make_builder(fqdns=['myapp.local'])._generate_compose_yaml('1.0')
+    mako_yaml = _make_builder(mako=True, fqdns=['myapp.local'])._generate_compose_yaml('1.0')
+    assert yaml.safe_load(builder_yaml) == yaml.safe_load(mako_yaml)
+
+
+def test_compose_paths_semantically_equal_without_traefik():
+    builder_yaml = _make_builder()._generate_compose_yaml('1.0')
+    mako_yaml = _make_builder(mako=True)._generate_compose_yaml('1.0')
+    assert yaml.safe_load(builder_yaml) == yaml.safe_load(mako_yaml)


### PR DESCRIPTION
Closes #859.

**Depends on #856** (`GnrYamlBuilder`). The base branch of this PR is `feature/gnryaml-builder`; once #856 is merged, this PR will be retargeted to `develop`.

## Summary

Replaces the inline Mako template used to generate `<instance>-compose.yml` in `gnrdockerize.py` with `GnrYamlBuilder`. The compose-generation block is extracted from `build_docker_image()` into three focused methods that mirror the YAML sections — `_compose_via_builder`, `_compose_db`, `_compose_app`.

A new `--mako` CLI flag (default `False`) keeps the legacy template available as an opt-in fallback while the builder is validated on real instances. Both paths are exercised by tests.

Rationale: see #859.

## Scope

- `gnrpy/gnr/app/cli/gnrdockerize.py` — refactor + new `--mako` flag, legacy Mako template kept as `_LEGACY_COMPOSE_TEMPLATE` constant
- `gnrpy/tests/app/cli/gnrdockerize_test.py` — 14 new tests (the module had no tests before)

No new dependencies.

## API

```
gnr dockerize --compose myinstance              # → GnrYamlBuilder (default)
gnr dockerize --compose --mako myinstance       # → legacy Mako template
```

## Reading the new code

`_compose_via_builder` (the dispatcher) reads top-down like the compose file itself:

```python
compose = GnrYamlBuilder()
compose.child('volumes').set(f'{name}_site', None)
services = compose.child('services')
self._compose_db(services.child(f'{name}_db'))
self._compose_app(services.child(name), version_tag, extra_labels)
return compose.toYaml(explicit_start=True)
```

`_compose_db` and `_compose_app` each populate a service node with native Python `if`/`for`, no template directives. `extra_labels` flow as `(key, value)` tuples with native types so port numbers stay int.

## Test plan

- [x] `flake8 gnrpy/gnr/app/cli/gnrdockerize.py gnrpy/tests/app/cli/gnrdockerize_test.py` — zero errors
- [x] `pytest gnrpy/tests/app/cli/gnrdockerize_test.py -v` — 14/14 passing
- [x] Builder and Mako paths produce **semantically identical** YAML: `yaml.safe_load(builder) == yaml.safe_load(mako)` verified with and without traefik labels
- [x] `${GNR_DB_HOST:-myapp_db}` and other docker env interpolations preserved byte-for-byte
- [ ] Manual CLI run on a real instance (deferred until field-level validation)

### Coverage

- Extra-labels computation: empty cases (no fqdns / non-traefik router), traefik case with port type fidelity (int, not str)
- Builder output: minimal compose, with traefik labels, `${VAR}` preservation, healthcheck `test` as list, db environment as sequence, app volume mount, `---` start marker
- Legacy Mako path: minimal compose, `${VAR}` preservation
- Cross-path: semantic equality with and without traefik

## Reviewer checklist

- [ ] Three focused methods (`_compose_via_builder`, `_compose_db`, `_compose_app`) are easier to read than the previous Mako template
- [ ] `--mako` flag default is False (builder is the new default)
- [ ] Legacy code path preserved verbatim (template stored as `_LEGACY_COMPOSE_TEMPLATE`)
- [ ] No new dependencies