### PR TITLE
map paramiko's remove() method to _Connection method with the same name

### DIFF
--- a/projects/gnrcore/packages/sys/resources/services/ftp/paramiko/service.py
+++ b/projects/gnrcore/packages/sys/resources/services/ftp/paramiko/service.py
@@ -31,6 +31,9 @@ class _Connection(object):
     def remove(self, path):
         self._sftp.remove(path)
 
+    def unlink(self, path):
+        self._sftp.remove(path)
+
     def get(self, remotepath, localpath, callback=None, preserve_mtime=False):
         self._sftp.get(remotepath, localpath, callback=callback)
         if preserve_mtime:

--- a/projects/gnrcore/packages/sys/resources/services/ftp/paramiko/service.py
+++ b/projects/gnrcore/packages/sys/resources/services/ftp/paramiko/service.py
@@ -28,11 +28,11 @@ class _Connection(object):
     def stat(self, path):
         return self._sftp.stat(path)
 
-    def remove(self, path):
-        self._sftp.remove(path)
+    def remove(self, remotepath):
+        self._sftp.remove(remotepath)
 
-    def unlink(self, path):
-        self._sftp.remove(path)
+    # alias, to maintain interface
+    unlink = remove
 
     def get(self, remotepath, localpath, callback=None, preserve_mtime=False):
         self._sftp.get(remotepath, localpath, callback=callback)

--- a/projects/gnrcore/packages/sys/resources/services/ftp/paramiko/service.py
+++ b/projects/gnrcore/packages/sys/resources/services/ftp/paramiko/service.py
@@ -28,6 +28,9 @@ class _Connection(object):
     def stat(self, path):
         return self._sftp.stat(path)
 
+    def remove(self, path):
+        self._sftp.remove(path)
+
     def get(self, remotepath, localpath, callback=None, preserve_mtime=False):
         self._sftp.get(remotepath, localpath, callback=callback)
         if preserve_mtime:


### PR DESCRIPTION
added remove() method as requested in #848 allowing file deletion, useful for batch that download files via sftp, removing them after the processing.

close #848