### PR TITLE
fix(#872): normalize PDF xref before watermark to avoid MuPDF crash

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -1,3 +1,18 @@
+Unreleased
+==========
+
+Bugfixes
+--------
+
+* PDF watermark service: fix ``code=4: source object number out of
+  range`` when ``watermarkedPDF`` is applied to PDFs saved with
+  multiple incremental xref generations (e.g. macOS Preview
+  annotations, PAdES signatures). The source PDF is now normalized
+  with ``garbage=4, clean=True, deflate=True`` before the watermark
+  is composed, following the official PyMuPDF workaround. No
+  backward-compatibility impact: PDFs that already had a single xref
+  generation are unaffected. (#872)
+
 Release 26.04.30
 ================
 

--- a/resources/common/services/pdf/pypdf.py
+++ b/resources/common/services/pdf/pypdf.py
@@ -95,6 +95,10 @@ class Service(PdfService):
         for docpath in documents:
             with self.parent.storageNode(docpath).open('rb') as f:
                 srcdoc = fitz.open('pdf',f.read())
+                # rewrite xref to one clean generation: incremental-saved
+                # PDFs (macOS Preview, PAdES signatures, ...) otherwise make
+                # the later insert_pdf raise 'source object number out of range'
+                srcdoc = fitz.open('pdf', srcdoc.tobytes(garbage=4, clean=True, deflate=True))
                 tmpdoc = BytesIO()
                 for page in srcdoc:
                     yield page


### PR DESCRIPTION
## Summary

- Fixes ``RuntimeError: code=4: source object number out of range`` raised by ``Service.watermarkedPDF`` when the source PDF has multiple incremental xref generations (e.g. macOS Preview annotations, PAdES signatures, Adobe Reader markups).
- Rewrites the source document with ``garbage=4, clean=True, deflate=True`` at read time so the rest of the watermark pipeline always sees a single, clean xref.
- Adds a release note under a new ``Unreleased`` section in ``gnrpy/RELEASE_NOTES.rst``.

## Root cause

Inside ``multipartPDF``:

```python
srcdoc = fitz.open('pdf', f.read())
for page in srcdoc: yield page                # caller mutates pages (clean_contents + insert_textbox)
srcdoc.save(tmpdoc)                           # default save: no garbage collection
resultdoc.insert_pdf(fitz.open('pdf', tmpdoc.read()))  # crashes on incremental-saved PDFs
```

When ``srcdoc`` carries multiple xref generations, ``save()`` collapses them but leaves cross-generation references that no longer resolve, and ``insert_pdf`` trips on those orphans. This is a long-standing PyMuPDF behavior — see [pymupdf/PyMuPDF#856](https://github.com/pymupdf/PyMuPDF/issues/856) and [discussion #3640](https://github.com/pymupdf/PyMuPDF/discussions/3640). The recommended workaround in the [Using-Incremental-Saves wiki](https://github.com/pymupdf/PyMuPDF/wiki/Using-Incremental-Saves) is to rewrite the document with ``garbage=4, clean=True, deflate=True``.

## Fix

One-liner inside ``multipartPDF`` that normalizes the source document before the page iteration:

```python
srcdoc = fitz.open('pdf', f.read())
srcdoc = fitz.open('pdf', srcdoc.tobytes(garbage=4, clean=True, deflate=True))
```

Applied at read time (rather than at save time) so the entire downstream pipeline stays unchanged and any future code added to ``multipartPDF`` is automatically protected.

## Test plan

- [x] Reproduced the original crash on a real-world Preview-saved PDF (1 page, 407 KB, ``Producer: macOS ... Quartz PDFContext, AppendMode 1.1``, 3 ``%%EOF`` markers).
- [x] Imported the patched ``pypdf.Service`` directly and re-ran ``watermarkedPDF()`` on the same file: now succeeds, output 400 KB.
- [x] Re-ran on a clean control PDF (single xref): no regression, output equivalent.
- [x] ``flake8`` clean on ``resources/common/services/pdf/pypdf.py`` (``--max-line-length=120``).

## Backward compatibility

None affected. PDFs that already had a single xref generation pass through ``tobytes(garbage=4, ...)`` essentially unchanged (a few bytes of difference from the rewrite, no semantic change).

## Downstream

Tracking ticket on the field deployment that surfaced the bug: softwellsrl/anaci#337.