### PR TITLE
feat(#874): unified on-event cleanup (replaces #876)

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -1,6 +1,32 @@
 Unreleased
 ==========
 
+New features
+------------
+
+* Connection cleanup is now a single on-event mechanism instead of
+  two parallel ones. When a page closes on the client a lottery
+  (``cleanup_threshold``, default 5%) gates an attempt to spawn a
+  background cleanup pass; the daemon ``claim_cleanup`` primitive
+  ensures only one pass runs per ``cleanup_interval_minutes``
+  (default 240). The pass walks ``data/_connections/`` once, drops
+  stale pages and connections from the in-memory register, and
+  ``rmtree``\s their filesystem folders. The legacy
+  ``SiteRegister.cleanup()`` (which ran on every request and only
+  expired the in-memory register, leaving folders behind) is
+  removed. The legacy ``--noclean`` / ``--counter`` CLI flags and
+  the init-time folder purge are removed too — folders are kept
+  across restarts and cleaned by the on-event pass. (#874)
+
+  Config keys (under ``<cleanup>`` in siteconfig):
+
+  - ``cleanup.threshold`` — lottery percentage [0..100], default 5
+  - ``cleanup.interval_minutes`` — claim min gap, default 240
+  - ``cleanup.connection_max_age`` — default raised from 600s to 7200s
+  - ``cleanup.page_max_age`` — unchanged
+  - ``cleanup.guest_connection_max_age`` — unchanged
+  - ``cleanup.interval`` (legacy 120s gate) — removed
+
 Bugfixes
 --------
 

--- a/gnrpy/gnr/web/cli/gnrcleanup.py
+++ b/gnrpy/gnr/web/cli/gnrcleanup.py
@@ -12,6 +12,7 @@ def main():
 
     options = parser.parse_args()
     site = GnrWsgiSite(options.site_name)
+    site._runCleanup()
 
 if __name__ == "__main__":
     main()

--- a/gnrpy/gnr/web/cli/gnrcleanup.py
+++ b/gnrpy/gnr/web/cli/gnrcleanup.py
@@ -11,7 +11,7 @@ def main():
     parser.add_argument('site_name')
 
     options = parser.parse_args()
-    site = GnrWsgiSite(options.site_name, noclean=False)
+    site = GnrWsgiSite(options.site_name)
 
 if __name__ == "__main__":
     main()

--- a/gnrpy/gnr/web/daemon/processes.py
+++ b/gnrpy/gnr/web/daemon/processes.py
@@ -150,7 +150,7 @@ class GnrRemoteProcess(object):
 
     def _makeSite(self):
         from gnr.web.gnrwsgisite import GnrWsgiSite
-        self._site =  GnrWsgiSite(self.sitename,noclean=True)
+        self._site = GnrWsgiSite(self.sitename)
         self._site_ts = datetime.now()
         self.logger.debug('Created site for PID {}'.format(os.getpid()))
     
@@ -181,7 +181,7 @@ class GnrDaemonServiceManager(object):
     def site(self):
         if not hasattr(self, '_site'):
             from gnr.web.gnrwsgisite import GnrWsgiSite
-            self._site = GnrWsgiSite(self.sitename, noclean=True)
+            self._site = GnrWsgiSite(self.sitename)
         return self._site
 
     def terminate(self):

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -692,7 +692,14 @@ class SiteRegister(BaseRemoteObject):
     def claim_cleanup(self, min_gap_seconds):
         """Atomic check-and-set on last_cleanup. Returns True if the caller
         wins the right to run a cleanup pass; False if another caller has
-        already claimed within the gap."""
+        already claimed within the gap.
+
+        ``last_cleanup`` is initialized to 0 in ``__init__``, so the very
+        first caller after a daemon restart wins immediately regardless of
+        wall-clock time (the previous lifetime's claim history is not
+        carried over). Atomicity is guaranteed by the daemon's
+        single-thread Pyro4 multiplex server: only one ``claim_cleanup``
+        executes at a time across all concurrent callers."""
         now = time.time()
         if now - self.last_cleanup < min_gap_seconds:
             return False

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -537,7 +537,7 @@ class SiteRegister(BaseRemoteObject):
         self.user_register = UserRegister(self)
         self.remotebag_handler = RemoteStoreBagHandler(self)
         self.server.daemon.register(self.remotebag_handler, 'RemoteData')
-        self.last_cleanup = time.time()
+        self.last_cleanup = 0
         self.sitename = sitename
         self.storage_path = storage_path
         self.catalog = GnrClassCatalog()
@@ -561,7 +561,6 @@ class SiteRegister(BaseRemoteObject):
 
     def setConfiguration(self, cleanup=None):
         cleanup = cleanup or dict()
-        self.cleanup_interval = int(cleanup.get('interval') or 120)
         self.page_max_age = int(cleanup.get('page_max_age') or DEFAULT_PAGE_MAX_AGE)
         self.guest_connection_max_age = int(cleanup.get('guest_connection_max_age') or 40)
         self.connection_max_age = int(cleanup.get('connection_max_age') or 600)
@@ -690,25 +689,48 @@ class SiteRegister(BaseRemoteObject):
         return self.user_register.refresh(connection['user'], last_user_ts=last_user_ts,
                                           last_rpc_ts=last_rpc_ts, refresh_ts=refresh_ts)
 
-    def cleanup(self):
-        if time.time() - self.last_cleanup < self.cleanup_interval:
-            return
+    def claim_cleanup(self, min_gap_seconds):
+        """Atomic check-and-set on last_cleanup. Returns True if the caller
+        wins the right to run a cleanup pass; False if another caller has
+        already claimed within the gap."""
+        now = time.time()
+        if now - self.last_cleanup < min_gap_seconds:
+            return False
+        self.last_cleanup = now
+        return True
+
+    def expire_pages(self, connection_id):
+        """Drop pages of `connection_id` idle longer than page_max_age
+        (or guest_connection_max_age for guest users). Returns list of
+        dropped page_ids."""
         now = datetime.now()
-        for page in self.pages():
-            page_max_age = self.page_max_age if not page['user'].startswith('guest_') else self.guest_connection_max_age
+        dropped = []
+        for page in self.page_register.pages(connection_id=connection_id):
+            max_age = (self.guest_connection_max_age
+                       if page['user'].startswith('guest_')
+                       else self.page_max_age)
             last_refresh_ts = page.get('last_refresh_ts') or page.get('start_ts')
-            if ((now - last_refresh_ts).seconds > page_max_age):
-                self.drop_page(page['register_item_id'])
-        dropped_connections = []
-        for connection in self.connections():
-            last_refresh_ts = connection.get('last_refresh_ts') or connection.get('start_ts')
-            connection_max_age = self.connection_max_age if not connection['user'].startswith('guest_') \
-                else self.guest_connection_max_age
-            if (now - last_refresh_ts).seconds > connection_max_age:
-                dropped_connections.append(connection['register_item_id'])
-                self.drop_connection(connection['register_item_id'], cascade=True)
-        self.last_cleanup = time.time()
-        return dropped_connections
+            if (now - last_refresh_ts).seconds > max_age:
+                page_id = page['register_item_id']
+                self.drop_page(page_id)
+                dropped.append(page_id)
+        return dropped
+
+    def expire_connection(self, connection_id):
+        """Drop the connection if idle longer than connection_max_age
+        (or guest_connection_max_age for guest users). Returns True if
+        dropped."""
+        connection = self.connection_register.get_item(connection_id)
+        if not connection:
+            return False
+        max_age = (self.guest_connection_max_age
+                   if connection['user'].startswith('guest_')
+                   else self.connection_max_age)
+        last_refresh_ts = connection.get('last_refresh_ts') or connection.get('start_ts')
+        if (datetime.now() - last_refresh_ts).seconds > max_age:
+            self.drop_connection(connection_id, cascade=True)
+            return True
+        return False
 
     def get_register(self, register_name):
         return getattr(self, '%s_register' % register_name)

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -563,7 +563,7 @@ class SiteRegister(BaseRemoteObject):
         cleanup = cleanup or dict()
         self.page_max_age = int(cleanup.get('page_max_age') or DEFAULT_PAGE_MAX_AGE)
         self.guest_connection_max_age = int(cleanup.get('guest_connection_max_age') or 40)
-        self.connection_max_age = int(cleanup.get('connection_max_age') or 600)
+        self.connection_max_age = int(cleanup.get('connection_max_age') or 7200)
 
     def new_connection(self, connection_id, connection_name=None, user=None, user_id=None,
                        user_name=None, user_tags=None, user_ip=None, user_agent=None, browser_name=None,

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1,4 +1,5 @@
 import os
+import random
 import re
 import io
 import shutil
@@ -520,9 +521,10 @@ class GnrWsgiSite(object):
             logger.info('End of import')
 
         cleanup = self.custom_config.getAttr('cleanup') or dict()
-        self.cleanup_interval = int(cleanup.get('interval') or 120)
+        self.cleanup_threshold = float(cleanup.get('threshold') or 5)
+        self.cleanup_interval_minutes = int(cleanup.get('interval_minutes') or 240)
         self.page_max_age = int(cleanup.get('page_max_age') or DEFAULT_PAGE_MAX_AGE)
-        self.connection_max_age = int(cleanup.get('connection_max_age')or 600)
+        self.connection_max_age = int(cleanup.get('connection_max_age') or 7200)
 
         self.db.closeConnection()
 
@@ -1254,10 +1256,6 @@ class GnrWsgiSite(object):
         self.db.currentEnv['currentDomain'] = self.currentDomain
         path_list = router.path_list or ['index']
 
-        # Cleanup expired connections (after routing to ensure domain is set in multidomain)
-        expiredConnections = self.register.cleanup()
-        if expiredConnections:
-            self.connectionLog('close',expiredConnections)
         first_segment = path_list[0]
         last_segment = path_list[-1]
         # this can be moved.
@@ -1729,6 +1727,78 @@ class GnrWsgiSite(object):
         self.pageLog('close', page_id=page_id)
         self.clearRecordLocks(page_id=page_id)
         page._closed = True
+        self._maybeRunCleanup()
+
+    def _maybeRunCleanup(self):
+        """Lottery + atomic claim + spawn cleanup thread.
+
+        Runs only when the local lottery (cleanup_threshold) wins AND
+        the daemon's claim_cleanup gates the call by interval."""
+        if random.random() * 100 >= self.cleanup_threshold:
+            return
+        interval_seconds = self.cleanup_interval_minutes * 60
+        if not self.register.claim_cleanup(interval_seconds):
+            return
+        Thread(target=self._runCleanup, daemon=True).start()
+
+    def _runCleanup(self):
+        """Worker thread: drops stale pages/connections from the register
+        and removes their filesystem folders under _connections/.
+
+        Walks _connections/ once. For each entry:
+        - if not in live connections AND old enough -> rmtree
+        - if in live connections -> expire stale pages of that connection
+          (drop from register + rmtree their per-page subfolders) and
+          expire the connection itself if stale (drop + rmtree).
+
+        Idempotent and safe to call concurrently: register expire methods
+        and rmtree(ignore_errors=True) tolerate concurrent state changes."""
+        if not os.path.isdir(self.allConnectionsFolder):
+            return
+        try:
+            live_connections = {c['register_item_id']
+                                for c in self.register.connections()}
+        except Exception:
+            logger.exception("Cleanup failed reading register")
+            return
+        dropped_pages = 0
+        dropped_connections = 0
+        removed_folders = 0
+        connection_max_age_seconds = self.connection_max_age
+        for entry in os.listdir(self.allConnectionsFolder):
+            path = os.path.join(self.allConnectionsFolder, entry)
+            if not os.path.isdir(path):
+                continue
+            if entry not in live_connections:
+                try:
+                    age = time() - os.stat(path).st_mtime
+                except OSError:
+                    continue
+                if age < connection_max_age_seconds:
+                    continue
+                shutil.rmtree(path, ignore_errors=True)
+                removed_folders += 1
+                continue
+            try:
+                stale_pages = self.register.expire_pages(entry)
+            except Exception:
+                logger.exception("expire_pages failed for %s", entry)
+                stale_pages = []
+            for page_id in stale_pages:
+                shutil.rmtree(os.path.join(path, page_id), ignore_errors=True)
+                dropped_pages += 1
+            try:
+                connection_dropped = self.register.expire_connection(entry)
+            except Exception:
+                logger.exception("expire_connection failed for %s", entry)
+                connection_dropped = False
+            if connection_dropped:
+                shutil.rmtree(path, ignore_errors=True)
+                dropped_connections += 1
+        if dropped_pages or dropped_connections or removed_folders:
+            logger.info("Cleanup: dropped %d pages, %d connections, "
+                        "removed %d orphan folders",
+                        dropped_pages, dropped_connections, removed_folders)
 
     def sqlDebugger(self,**kwargs):
         page = self.currentPage

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -406,13 +406,12 @@ class GnrWsgiSite(object):
     """TODO"""
 
     def __init__(self, script_path, site_name=None, _config=None,
-                 _gnrconfig=None, counter=None, noclean=None,
+                 _gnrconfig=None,
                  options=None, tornado=None, websockets=None,
                  debugpy=False):
-        
+
         global GNRSITE
         GNRSITE = self
-        counter = int(counter or '0')
         self.storageTypes = STORAGE_TYPES + STATIC_HANDLER_TYPES
         self.pathfile_cache = {}
         self._currentAuxInstanceNames = ThreadedDict()
@@ -513,10 +512,9 @@ class GnrWsgiSite(object):
         
         self.datacollector = DataCollector(self.register.siteregister)
         
-        if counter == 0 and self.debug:
-            self.onInited(clean=not noclean)
-            
-        if counter == 0 and options and options.source_instance:
+        self.onInited()
+
+        if options and options.source_instance:
             self.gnrapp.importFromSourceInstance(options.source_instance)
             self.db.commit()
             logger.info('End of import')
@@ -894,14 +892,9 @@ class GnrWsgiSite(object):
                 self.connFolderRemove(conn_id)
         
 
-    def onInited(self, clean):
-        """TODO
-
-        :param clean: TODO"""
-        if clean:
-            logger.info("Purging connection folders")
-            self.dropConnectionFolder()
-            self.initializePackages()
+    def onInited(self):
+        """Called once on every fresh GnrWsgiSite instantiation."""
+        self.initializePackages()
 
     def on_reloader_restart(self):
         """TODO"""

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -525,6 +525,11 @@ class GnrWsgiSite(object):
         self.cleanup_interval_minutes = int(cleanup.get('interval_minutes') or 240)
         self.page_max_age = int(cleanup.get('page_max_age') or DEFAULT_PAGE_MAX_AGE)
         self.connection_max_age = int(cleanup.get('connection_max_age') or 7200)
+        logger.info(
+            "Cleanup config: threshold=%s%%, interval=%dmin, "
+            "page_max_age=%ds, connection_max_age=%ds",
+            self.cleanup_threshold, self.cleanup_interval_minutes,
+            self.page_max_age, self.connection_max_age)
 
         self.db.closeConnection()
 
@@ -1737,7 +1742,12 @@ class GnrWsgiSite(object):
         if random.random() * 100 >= self.cleanup_threshold:
             return
         interval_seconds = self.cleanup_interval_minutes * 60
-        if not self.register.claim_cleanup(interval_seconds):
+        try:
+            won = self.register.claim_cleanup(interval_seconds)
+        except Exception:
+            logger.exception("claim_cleanup failed")
+            return
+        if not won:
             return
         Thread(target=self._runCleanup, daemon=True).start()
 

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1738,7 +1738,13 @@ class GnrWsgiSite(object):
         """Lottery + atomic claim + spawn cleanup thread.
 
         Runs only when the local lottery (cleanup_threshold) wins AND
-        the daemon's claim_cleanup gates the call by interval."""
+        the daemon's claim_cleanup gates the call by interval.
+
+        cleanup_threshold is a percentage in [0, 100]. The default 5
+        means there is a 5% chance, per page-close event, that this
+        worker attempts to spawn a cleanup pass. The interval gate on
+        the daemon (cleanup_interval_minutes) ensures that even when
+        the lottery fires often, only one pass runs per interval."""
         if random.random() * 100 >= self.cleanup_threshold:
             return
         interval_seconds = self.cleanup_interval_minutes * 60

--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -41,7 +41,6 @@ wsgi_options = dict(
         host='0.0.0.0',
         reload=False,
         debug=True,
-        noclean=False,
         restore=False,
         source_instance=None,
         remote_edit=None,
@@ -197,15 +196,6 @@ class Server(object):
                             dest='site_name_opt',
                             help="Use command on site identified by supplied name")
 
-        parser.add_argument('-n', '--noclean',
-                            dest='noclean',
-                            help="Don't perform a clean (full reset) restart",
-                            action='store_true')
-
-        parser.add_argument('--counter',
-                            dest='counter',
-                            help="Startup counter")
-
         parser.add_argument('--ssl_cert',
                             dest='ssl_cert',
                             help="SSL cert")
@@ -335,8 +325,7 @@ class Server(object):
 
             from gnr.web.gnrasync import GnrAsyncServer
             site_options= dict(_config=self.siteconfig,_gnrconfig=self.gnr_config,
-                counter=getattr(self.options, 'counter', None),
-                noclean=self.options.noclean, options=self.options)
+                options=self.options)
             logger.info(f"Starting Tornado server - listening on {self.app_host}:{self.app_port}")
             server=GnrAsyncServer(port=self.app_port, instance=site_name,
                                   web=True, autoreload=self.options.reload,
@@ -351,8 +340,6 @@ class Server(object):
                                         site_name=site_name,
                                         _config=self.siteconfig,
                                         _gnrconfig=self.gnr_config,
-                                        counter=getattr(self.options, 'counter', None),
-                                        noclean=self.options.noclean,
                                         options=self.options,
                                         debugpy=self.debugpy)
                 gnrServer._local_mode=True

--- a/gnrpy/tests/web/gnrwsgisite_folder_cleanup_test.py
+++ b/gnrpy/tests/web/gnrwsgisite_folder_cleanup_test.py
@@ -1,0 +1,398 @@
+"""Unit tests for the on-event unified cleanup (#874).
+
+Three building blocks are exercised:
+
+- ``SiteRegister.claim_cleanup``     atomic check-and-set on ``last_cleanup``
+- ``GnrWsgiSite._maybeRunCleanup``   lottery + claim + spawn
+- ``GnrWsgiSite._runCleanup``        scan, expire pages, expire connection,
+                                     rmtree orphan folders
+
+End-to-end tests that wait on real wall-clock timing are deliberately
+avoided: even with aggressive thresholds they would add minutes of
+sleep to CI. Multi-worker mutual-exclusion (gunicorn multi-process) is
+not realistically exercisable from pytest either.
+"""
+
+import logging
+import os
+import time
+
+import gnr.web.gnrwsgisite as gws
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        # SiteRegister.__init__ calls
+        # self.server.daemon.register(self.remotebag_handler, 'RemoteData')
+        # We swallow it: no Pyro4 daemon needed for these tests.
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+
+
+class _FakeRegister:
+    """Minimal stand-in for the SiteRegisterClient used by GnrWsgiSite.
+
+    Exposes the four methods the cleanup code path relies on:
+    ``claim_cleanup``, ``connections``, ``expire_pages``, ``expire_connection``.
+    Each is configurable from the test.
+    """
+
+    def __init__(self,
+                 claim_returns=True,
+                 live_connections=None,
+                 expire_pages_result=None,
+                 expire_connection_result=False,
+                 raises=None):
+        self.claim_returns = claim_returns
+        self.live_connections = live_connections or {}
+        # expire_pages_result is either a list (returned for any conn)
+        # or a dict {conn_id: [page_ids]}.
+        self.expire_pages_result = expire_pages_result or []
+        self.expire_connection_result = expire_connection_result
+        self.raises = raises or {}
+        self.claim_called_with = None
+        self.expire_pages_called = []
+        self.expire_connection_called = []
+
+    def claim_cleanup(self, min_gap_seconds):
+        self.claim_called_with = min_gap_seconds
+        return self.claim_returns
+
+    def connections(self):
+        if 'connections' in self.raises:
+            raise self.raises['connections']
+        return [{'register_item_id': k, **(v or {})}
+                for k, v in self.live_connections.items()]
+
+    def expire_pages(self, connection_id):
+        self.expire_pages_called.append(connection_id)
+        if 'expire_pages' in self.raises:
+            raise self.raises['expire_pages']
+        if isinstance(self.expire_pages_result, dict):
+            return list(self.expire_pages_result.get(connection_id, []))
+        return list(self.expire_pages_result)
+
+    def expire_connection(self, connection_id):
+        self.expire_connection_called.append(connection_id)
+        if 'expire_connection' in self.raises:
+            raise self.raises['expire_connection']
+        if isinstance(self.expire_connection_result, dict):
+            return self.expire_connection_result.get(connection_id, False)
+        return self.expire_connection_result
+
+
+class _FakeSite:
+    """Bag of attributes accessed by the cleanup methods. Methods are
+    invoked unbound: ``GnrWsgiSite._method(self_=_FakeSite(...))``."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class _UnusedThread:
+    """Stand-in for Thread that records construction without running."""
+
+    def __init__(self):
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+
+# ---------------------------------------------------------------------------
+# claim_cleanup (siteregister.py)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_cleanup_first_call_succeeds():
+    reg = SiteRegister(_FakeServer(), sitename='test')
+    # last_cleanup is initialized to 0 in __init__
+    assert reg.claim_cleanup(60) is True
+
+
+def test_claim_cleanup_subsequent_call_within_gap_fails():
+    reg = SiteRegister(_FakeServer(), sitename='test')
+    assert reg.claim_cleanup(60) is True
+    # immediate second call is within the gap
+    assert reg.claim_cleanup(60) is False
+
+
+def test_claim_cleanup_advances_last_cleanup():
+    reg = SiteRegister(_FakeServer(), sitename='test')
+    before = time.time()
+    assert reg.claim_cleanup(60) is True
+    assert reg.last_cleanup >= before
+
+
+def test_claim_cleanup_succeeds_again_after_gap_elapses():
+    reg = SiteRegister(_FakeServer(), sitename='test')
+    assert reg.claim_cleanup(60) is True
+    # Force the field back to "long ago" to simulate the gap elapsing.
+    reg.last_cleanup = 0
+    assert reg.claim_cleanup(60) is True
+
+
+# ---------------------------------------------------------------------------
+# _maybeRunCleanup (gnrwsgisite.py)
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_lottery_loses(monkeypatch):
+    """threshold=0 -> random()*100 (in [0,100)) is always >= 0 -> bail."""
+    site = _FakeSite(
+        cleanup_threshold=0,
+        cleanup_interval_minutes=240,
+        register=_FakeRegister(),
+    )
+    spawned = []
+    monkeypatch.setattr(gws, 'Thread',
+                        lambda **kw: spawned.append(kw) or _UnusedThread())
+    gws.GnrWsgiSite._maybeRunCleanup(site)
+    assert spawned == []
+    # claim_cleanup never even attempted
+    assert site.register.claim_called_with is None
+
+
+def test_maybe_claim_loses(monkeypatch):
+    """threshold=100 -> lottery always wins; claim returns False -> bail."""
+    site = _FakeSite(
+        cleanup_threshold=100,
+        cleanup_interval_minutes=4,
+        register=_FakeRegister(claim_returns=False),
+    )
+    spawned = []
+    monkeypatch.setattr(gws, 'Thread',
+                        lambda **kw: spawned.append(kw) or _UnusedThread())
+    gws.GnrWsgiSite._maybeRunCleanup(site)
+    assert spawned == []
+    # claim_cleanup was called with cleanup_interval_minutes * 60
+    assert site.register.claim_called_with == 4 * 60
+
+
+def test_maybe_both_win_spawns_thread(monkeypatch):
+    """threshold=100 + claim returns True -> Thread spawned and started."""
+    runs = []
+    site = _FakeSite(
+        cleanup_threshold=100,
+        cleanup_interval_minutes=4,
+        register=_FakeRegister(claim_returns=True),
+        _runCleanup=lambda: runs.append(True),
+    )
+    spawned = []
+
+    def fake_thread(**kw):
+        spawned.append(kw)
+        return _UnusedThread()
+
+    monkeypatch.setattr(gws, 'Thread', fake_thread)
+    gws.GnrWsgiSite._maybeRunCleanup(site)
+    assert len(spawned) == 1
+    # Thread is configured as a daemon and targets the site's _runCleanup
+    assert spawned[0]['daemon'] is True
+    assert spawned[0]['target'] is site._runCleanup
+
+
+# ---------------------------------------------------------------------------
+# _runCleanup (gnrwsgisite.py)
+# ---------------------------------------------------------------------------
+
+
+def test_runcleanup_skips_when_folder_missing(tmp_path):
+    """Bail immediately when allConnectionsFolder doesn't exist."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path / 'does_not_exist'),
+        connection_max_age=600,
+        register=_FakeRegister(),
+    )
+    # Should not raise and should not call register methods.
+    gws.GnrWsgiSite._runCleanup(site)
+    assert site.register.expire_pages_called == []
+    assert site.register.expire_connection_called == []
+
+
+def test_runcleanup_skips_non_directory_entries(tmp_path):
+    """Stray files under _connections/ are left alone."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=0,
+        register=_FakeRegister(live_connections={}),
+    )
+    stray = tmp_path / 'stray_file'
+    stray.write_text('hello')
+    old_ts = time.time() - 3600
+    os.utime(str(stray), (old_ts, old_ts))
+
+    gws.GnrWsgiSite._runCleanup(site)
+
+    assert stray.exists()
+
+
+def test_runcleanup_drops_orphan_old_folder(tmp_path):
+    """Folder not in live connections AND old enough -> rmtree."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=120,
+        register=_FakeRegister(live_connections={}),
+    )
+    (tmp_path / 'orphan_old').mkdir()
+    old_ts = time.time() - 200
+    os.utime(str(tmp_path / 'orphan_old'), (old_ts, old_ts))
+
+    gws.GnrWsgiSite._runCleanup(site)
+
+    assert not (tmp_path / 'orphan_old').exists()
+
+
+def test_runcleanup_keeps_orphan_recent_folder(tmp_path):
+    """Folder not in live connections but recent -> survives."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=120,
+        register=_FakeRegister(live_connections={}),
+    )
+    (tmp_path / 'orphan_new').mkdir()
+    new_ts = time.time() - 30
+    os.utime(str(tmp_path / 'orphan_new'), (new_ts, new_ts))
+
+    gws.GnrWsgiSite._runCleanup(site)
+
+    assert (tmp_path / 'orphan_new').exists()
+
+
+def test_runcleanup_drops_stale_pages_in_live_connection(tmp_path):
+    """Live connection: stale pages get their per-page subfolder removed,
+    the connection folder itself remains."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=600,
+        register=_FakeRegister(
+            live_connections={'live1': {}},
+            expire_pages_result={'live1': ['p_stale']},
+            expire_connection_result=False,
+        ),
+    )
+    conn_dir = tmp_path / 'live1'
+    conn_dir.mkdir()
+    (conn_dir / 'p_stale').mkdir()
+    (conn_dir / 'p_fresh').mkdir()
+
+    gws.GnrWsgiSite._runCleanup(site)
+
+    assert conn_dir.exists()
+    assert (conn_dir / 'p_fresh').exists()
+    assert not (conn_dir / 'p_stale').exists()
+
+
+def test_runcleanup_drops_stale_connection_and_folder(tmp_path):
+    """Live connection that expire_connection drops -> rmtree the folder."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=600,
+        register=_FakeRegister(
+            live_connections={'live1': {}},
+            expire_pages_result=[],
+            expire_connection_result=True,
+        ),
+    )
+    conn_dir = tmp_path / 'live1'
+    conn_dir.mkdir()
+    (conn_dir / 'p1').mkdir()
+
+    gws.GnrWsgiSite._runCleanup(site)
+
+    assert not conn_dir.exists()
+
+
+def test_runcleanup_logs_summary(tmp_path, caplog):
+    """When something is dropped, an INFO line summarises the counts."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=120,
+        register=_FakeRegister(
+            live_connections={'live1': {}},
+            expire_pages_result={'live1': ['p1']},
+            expire_connection_result=False,
+        ),
+    )
+    conn_dir = tmp_path / 'live1'
+    conn_dir.mkdir()
+    (conn_dir / 'p1').mkdir()
+    # also an orphan to bump the folder counter
+    (tmp_path / 'orphan_old').mkdir()
+    os.utime(str(tmp_path / 'orphan_old'),
+             (time.time() - 600, time.time() - 600))
+
+    with caplog.at_level(logging.INFO, logger='gnr.web'):
+        gws.GnrWsgiSite._runCleanup(site)
+
+    summaries = [r for r in caplog.records if 'Cleanup:' in r.getMessage()]
+    assert len(summaries) == 1
+    msg = summaries[0].getMessage()
+    assert 'dropped 1 pages' in msg
+    assert '0 connections' in msg
+    assert 'removed 1 orphan folders' in msg
+
+
+def test_runcleanup_no_log_when_nothing_dropped(tmp_path, caplog):
+    """No log line when the pass had nothing to do."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=120,
+        register=_FakeRegister(live_connections={}),
+    )
+
+    with caplog.at_level(logging.INFO, logger='gnr.web'):
+        gws.GnrWsgiSite._runCleanup(site)
+
+    summaries = [r for r in caplog.records if 'Cleanup:' in r.getMessage()]
+    assert summaries == []
+
+
+def test_runcleanup_swallows_connections_errors(tmp_path, caplog):
+    """If register.connections() raises, the error is logged and the
+    cleanup pass exits cleanly."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=120,
+        register=_FakeRegister(raises={'connections': RuntimeError('boom')}),
+    )
+
+    with caplog.at_level(logging.ERROR, logger='gnr.web'):
+        gws.GnrWsgiSite._runCleanup(site)
+
+    assert any('Cleanup failed reading register' in r.getMessage()
+               for r in caplog.records)
+
+
+def test_runcleanup_swallows_expire_pages_errors(tmp_path, caplog):
+    """If expire_pages() raises for a connection, the error is logged
+    and the loop continues to expire_connection for the same one."""
+    site = _FakeSite(
+        allConnectionsFolder=str(tmp_path),
+        connection_max_age=600,
+        register=_FakeRegister(
+            live_connections={'live1': {}},
+            raises={'expire_pages': RuntimeError('pages_boom')},
+            expire_connection_result=True,
+        ),
+    )
+    conn_dir = tmp_path / 'live1'
+    conn_dir.mkdir()
+
+    with caplog.at_level(logging.ERROR, logger='gnr.web'):
+        gws.GnrWsgiSite._runCleanup(site)
+
+    assert any('expire_pages failed' in r.getMessage()
+               for r in caplog.records)
+    # expire_connection still ran, dropped, rmtree happened
+    assert not conn_dir.exists()

--- a/gnrpy/tests/web/gnrwsgisite_folder_cleanup_test.py
+++ b/gnrpy/tests/web/gnrwsgisite_folder_cleanup_test.py
@@ -15,6 +15,7 @@ not realistically exercisable from pytest either.
 
 import logging
 import os
+import threading
 import time
 
 import gnr.web.gnrwsgisite as gws
@@ -65,6 +66,8 @@ class _FakeRegister:
 
     def claim_cleanup(self, min_gap_seconds):
         self.claim_called_with = min_gap_seconds
+        if 'claim_cleanup' in self.raises:
+            raise self.raises['claim_cleanup']
         return self.claim_returns
 
     def connections(self):
@@ -396,3 +399,54 @@ def test_runcleanup_swallows_expire_pages_errors(tmp_path, caplog):
                for r in caplog.records)
     # expire_connection still ran, dropped, rmtree happened
     assert not conn_dir.exists()
+
+
+def test_maybe_swallows_claim_cleanup_errors(monkeypatch, caplog):
+    """If register.claim_cleanup() raises (e.g. Pyro CommunicationError
+    when the daemon is down), the cleanup pass is silently skipped:
+    the exception is logged and no Thread is spawned. This prevents a
+    failed RPC from turning a page-close into a 500 for the client."""
+    site = _FakeSite(
+        cleanup_threshold=100,
+        cleanup_interval_minutes=4,
+        register=_FakeRegister(
+            raises={'claim_cleanup': RuntimeError('daemon unreachable')},
+        ),
+    )
+    spawned = []
+    monkeypatch.setattr(gws, 'Thread',
+                        lambda **kw: spawned.append(kw) or _UnusedThread())
+
+    with caplog.at_level(logging.ERROR, logger='gnr.web'):
+        gws.GnrWsgiSite._maybeRunCleanup(site)
+
+    assert spawned == []
+    assert any('claim_cleanup failed' in r.getMessage()
+               for r in caplog.records)
+
+
+def test_maybe_real_thread_runs_cleanup():
+    """End-to-end with a real Thread: when both gates clear, the
+    spawned thread actually invokes _runCleanup. Catches regressions
+    where the spawn idiom would silently change to .run() (sync) or
+    the target is wired wrong."""
+    started = threading.Event()
+    captured_ident = []
+
+    def _capture():
+        captured_ident.append(threading.get_ident())
+        started.set()
+
+    site = _FakeSite(
+        cleanup_threshold=100,
+        cleanup_interval_minutes=4,
+        register=_FakeRegister(claim_returns=True),
+        _runCleanup=_capture,
+    )
+
+    gws.GnrWsgiSite._maybeRunCleanup(site)
+
+    assert started.wait(timeout=5), "spawned thread did not run within 5s"
+    assert len(captured_ident) == 1
+    # The cleanup ran in a different thread than the test's main thread.
+    assert captured_ident[0] != threading.get_ident()

--- a/projects/gnrcore/packages/sys/webpages/register_explorer.py
+++ b/projects/gnrcore/packages/sys/webpages/register_explorer.py
@@ -76,8 +76,8 @@ class GnrCustomWebPage(object):
         dialog.dataRpc('dummy', 'cleanup_register', _fired='^.save', register_type='=.opener',
                        _onResult='FIRE .close;FIRE refresh_all;', max_age='=.max_age', cascade='=.cascade')
 
-    def rpc_cleanup_register(self, register_type=None, max_age=None, cascade=None):
-        self.site.register.cleanup(max_age=max_age, cascade=cascade)
+    def rpc_cleanup_register(self, **kwargs):
+        self.site._runCleanup()
 
 
     def overview_pane(self, bc):


### PR DESCRIPTION
## Summary

Rewrite of #876 (closed without merge) with a single unified cleanup mechanism instead of two parallel ones (in-memory register expire + filesystem folder purge).

## Why a rewrite

The original #876 introduced an on-event folder purge alongside the legacy `SiteRegister.cleanup()` (in-memory register expire on every request). [@fporcari's review](https://github.com/genropy/genropy/pull/876#issuecomment-4377258484) flagged two blocking issues, both stemming from the parallel-cleanup design:

1. `register.connections().keys()` raised at runtime (fake test register's shape didn't match production).
2. `claim_cleanup` shared `last_cleanup` with the legacy cleanup -> folder purge would essentially never fire.

The right fix was not to patch the parallel design but to consolidate. This PR does that.

## Design

`onClosePage` triggers `_maybeRunCleanup` (lottery + atomic claim). When both gates clear, a daemon thread runs `_runCleanup` which walks `data/_connections/` once:

- orphan connection folders older than `connection_max_age` -> `rmtree`
- live connections -> `expire_pages` (drop stale pages from register + `rmtree` per-page subfolders) + `expire_connection` (drop + `rmtree` connection folder if stale)

Per-request thread-local cleanup (`GnrWsgiSite.cleanup`) is unaffected — it's a different thing despite the name collision.

## Commits

- **`b86085e64d`** — `refactor(#874): drop legacy startup-time cleanup gates`. Removes `counter`/`noclean`/`debug` gating around `onInited()`, drops init-time `dropConnectionFolder()`, drops `--noclean` / `--counter` CLI flags. `onInited()` now runs on every fresh `GnrWsgiSite` instantiation. No-op today since the only legacy `onSiteInited` listener was removed in #877.

- **`c59148396a`** — `feat(#874): unified on-event cleanup mechanism`. Removes `SiteRegister.cleanup()` and the `register.cleanup()` call in the request dispatcher. Adds `claim_cleanup`, `expire_pages`, `expire_connection` on `SiteRegister`. Adds `_maybeRunCleanup` and `_runCleanup` on `GnrWsgiSite`. Renames config keys: `cleanup_threshold` (default 5%), `cleanup_interval_minutes` (default 240). Default `connection_max_age` raised from 600 to 7200 (2h). CLI `gnrcleanup` is now wired to `_runCleanup` (forced cleanup, bypasses lottery). 17 unit tests.

## Config changes

| Key | Old | New | Notes |
| --- | --- | --- | --- |
| `cleanup.interval` (legacy `cleanup_interval`) | 120 | removed | replaced by `claim_cleanup` min_gap |
| `cleanup.threshold` | — | `5` | new: lottery % |
| `cleanup.interval_minutes` | — | `240` | new: claim min gap |
| `cleanup.connection_max_age` | 600 | `7200` | raised to match new cadence |
| `cleanup.page_max_age` | 600 | unchanged | |
| `cleanup.guest_connection_max_age` | 40 | unchanged | |

## Related issues

- Issue #874 (parent)
- Issue #878 — `RESTART_TS` in `globalStore` triage (independent)
- Issue #879 — Robust site start timestamp design proposal (follow-up of #878, independent)

The `is_running_from_reloader()` behavior change discussed in #876's review thread is no longer relevant: the only listener of `pkgBroadcast('onSiteInited')` was in `gnrdbo_legacy.py`, removed in #877. `onSiteInited` broadcast is now a no-op until someone registers a listener.

## Test plan

- [x] `python -m pytest gnrpy/tests/web/gnrwsgisite_folder_cleanup_test.py` — 17/17 green
- [x] `python -m pytest gnrpy/tests/web/` — 106 passed, 57 skipped (require live daemon), no regressions
- [x] `flake8 gnrpy/gnr/web/ gnrpy/tests/web/gnrwsgisite_folder_cleanup_test.py` — zero new warnings
- [x] No leftover `register.cleanup()`, `noclean`, or `folder_purge_*` references in production code
- [ ] Manual smoke: spin up a site with `cleanup_threshold=100, cleanup_interval_minutes=0, page_max_age=10, connection_max_age=20`; close pages; verify INFO summary log + folders/register state