### PR TITLE
fix(#883): honor dbSelect notnull parameter on the client

### DIFF
--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -4772,8 +4772,10 @@ dojo.declare("gnr.widgets.DynamicBaseCombo", gnr.widgets.BaseCombo, {
             attributes.hasDownArrow = false;
             attributes['tabindex'] = -1;
         }
-        var resolverAttrs = objectExtract(attributes, 'method,columns,limit,auxColumns,hiddenColumns,alternatePkey,rowcaption,order_by,preferred,invalidItemCondition,subtable');
-        resolverAttrs['notnull'] = attributes['validate_notnull'];
+        var resolverAttrs = objectExtract(attributes, 'method,columns,limit,auxColumns,hiddenColumns,alternatePkey,rowcaption,order_by,preferred,invalidItemCondition,subtable,notnull');
+        if (resolverAttrs['notnull'] === undefined) {
+            resolverAttrs['notnull'] = attributes['validate_notnull'];
+        }
         savedAttrs['auxColumns'] = resolverAttrs['auxColumns'];
         var selectedColumns = objectExtract(attributes, 'selected_*');
         var selectedCb = objectPop(attributes,'selectedCb');

--- a/gnrjs/gnr_d20/js/genro_widgets.js
+++ b/gnrjs/gnr_d20/js/genro_widgets.js
@@ -4758,8 +4758,10 @@ dojo.declare("gnr.widgets.DynamicBaseCombo", gnr.widgets.BaseCombo, {
             attributes.hasDownArrow = false;
             attributes['tabindex'] = -1;
         }
-        var resolverAttrs = objectExtract(attributes, 'method,columns,limit,auxColumns,hiddenColumns,alternatePkey,rowcaption,order_by,preferred,invalidItemCondition,subtable');
-        resolverAttrs['notnull'] = attributes['validate_notnull'];
+        var resolverAttrs = objectExtract(attributes, 'method,columns,limit,auxColumns,hiddenColumns,alternatePkey,rowcaption,order_by,preferred,invalidItemCondition,subtable,notnull');
+        if (resolverAttrs['notnull'] === undefined) {
+            resolverAttrs['notnull'] = attributes['validate_notnull'];
+        }
         savedAttrs['auxColumns'] = resolverAttrs['auxColumns'];
         var selectedColumns = objectExtract(attributes, 'selected_*');
         var selectedCb = objectPop(attributes,'selectedCb');

--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -12,6 +12,15 @@ Bugfixes
   is composed, following the official PyMuPDF workaround. No
   backward-compatibility impact: PDFs that already had a single xref
   generation are unaffected. (#872)
+* dbSelect: the ``notnull`` parameter is now honored client-side. It
+  was silently overwritten by ``validate_notnull`` in
+  ``DynamicBaseCombo.creating()``, coupling the two flags and forcing
+  callers who only wanted to suppress the empty option row to also
+  make the field mandatory. With the fix, ``notnull=True`` on the
+  widget removes the empty row without triggering required-field
+  validation, as documented in the server-side handler. No
+  backward-compatibility impact: when only ``validate_notnull`` is
+  set the behavior is unchanged. (#883)
 
   
 Release 26.05.05


### PR DESCRIPTION
## Summary

- Fixes #883: the `notnull` parameter on `dbSelect` was being silently overwritten by `validate_notnull` in `DynamicBaseCombo.creating()`, so the documented behavior (suppress the empty option row without making the field mandatory) was unreachable.
- Includes `notnull` in the `objectExtract` allow-list and only falls back to `validate_notnull` when no explicit `notnull` was provided.
- Applied symmetrically to `gnr_d11` and `gnr_d20`.

## Background

The server-side handler in `gnrpy/gnr/web/gnrwebpage_proxy/apphandler/db_select.py` has always documented `notnull` as a flag that suppresses the empty-label row, distinct from `validate_notnull` (which makes the field mandatory). The server logic at `db_select.py:195` (`if not notnull and not _id:`) is correct — but the client never delivered the flag.

In `DynamicBaseCombo.creating()` the resolver attributes were built like this:

```javascript
var resolverAttrs = objectExtract(attributes, 'method,columns,limit,...,subtable');
resolverAttrs['notnull'] = attributes['validate_notnull'];
```

`notnull` was not in the allow-list, and the next line unconditionally overwrote it. The two flags were de-facto coupled: the only way to remove the empty row was to also force the field to be mandatory.

## Test plan

- [x] Manually verified on a `dbSelect` with `notnull=True` and **no** `validate_notnull`: the empty row no longer appears and the field is **not** mandatory.
- [ ] Verify a `dbSelect` with only `validate_notnull=True` (no `notnull`): empty row removed **and** field mandatory — existing behavior preserved.
- [ ] Verify a `dbSelect` with neither flag: empty row still present (default behavior preserved).
- [ ] Hard reload the browser to bust the JS cache before testing.

## Notes

- No backward-compatibility impact: callers that only used `validate_notnull` see no change.
- Release notes updated under `Unreleased / Bugfixes`.