### PR TITLE
fix(adm.userobject): authtags widget + Form/View naming for objtype dispatch

### DIFF
--- a/projects/gnrcore/packages/adm/resources/tables/userobject/th_userobject.py
+++ b/projects/gnrcore/packages/adm/resources/tables/userobject/th_userobject.py
@@ -28,6 +28,9 @@ class View(BaseComponent):
 
     def th_order(self):
         return 'code'
+    
+    def th_query(self):
+        return dict(column='code', op='contains', val='')
 
     def th_options(self):
         return dict(virtualStore=False,addrow=False)
@@ -55,7 +58,7 @@ class View(BaseComponent):
                 dict(code='is_mail',caption='!!Mail', condition="$is_mail IS TRUE"),
                 dict(code='is_print',caption='!!Print', condition="$is_print IS TRUE"),
                 dict(code='is_row',caption='!!Row', condition="$is_row IS TRUE"),
-                dict(code='all_flags',caption='!!All flags', condition="$flags IS NOT NULL")]
+                dict(code='any',caption='!!Any', condition="$flags IS NOT NULL")]
 
     def th_sections_systemuserobject(self):
         return [dict(code='standard',caption='!!Standard',
@@ -89,7 +92,7 @@ class View_rpcquery(View_query):
         r.fieldcell('userid',width='6em')
         
         
-class ViewTemplate(View):
+class View_template(View):
     
     def th_top_custom(self,top):
         top.slotToolbar('2,sections@flags,*',childname='upper',_position='<bar')
@@ -161,7 +164,7 @@ class Form(BaseComponent):
         fb.field('tbl', hasDownArrow=True)
         fb.field('private')
         fb.field('authtags', tag='checkBoxText', lbl='!![en]Auth Tags',
-                 table='adm.htag', popup=True)
+                 table='adm.htag', alternatePkey='authorization_tag', popup=True)
         
         fb.field('flags', tag='checkBoxText', lbl='!![en]Flags',
                  values='is_print:[!![en]Print],is_row:[!![en]Row],is_mail:[!![en]Mail]',
@@ -195,7 +198,8 @@ class Form_query(Form):
         fb.field('code')
         fb.field('description')
         fb.field('notes')
-        fb.field('authtags')
+        fb.field('authtags', tag='checkBoxText', lbl='!![en]Auth Tags',
+                 table='adm.htag', alternatePkey='authorization_tag', popup=True)
         fb.field('private')
         fb.field('quicklist')
         
@@ -299,9 +303,9 @@ class FormCustomColumn(BaseComponent):
                     duplicate=True)
 
 
-class FormTemplate(Form):
-    
-     def th_options(self):
-        return dict(default_objtype='template', 
+class Form_template(Form):
+
+    def th_options(self):
+        return dict(default_objtype='template',
                     duplicate=True,
                     defaultPrompt=self.addUserObjectPrompt())


### PR DESCRIPTION
## Summary

Two related fixes on the `adm.userobject` resource file:

1. **Auth Tags widget** — the `checkBoxText` bound to `adm.htag` on the userobject form was saving the **padded primary keys** of `htag` (e.g. `_DEV__________________`) instead of the `authorization_tag` codes used at runtime (e.g. `_DEV_`). Since `checkResourcePermission` does a `like()` match between the two, **no user ever matched** any tag saved through the widget — saved queries/views/templates with tags were silently invisible to everyone (the empty-tags fallback masked the symptom only when `authtags` was `NULL`). Fixed by adding `alternatePkey='authorization_tag'` on both `objectParameters` (line 163-164) and `Form_query.th_form` (line 198-199), following the same pattern already used in `adm/resources/preference.py:42`.

2. **Form/View naming for objtype dispatch (partial #192)** — `_th_remoteUserObjectEditor` resolves classes via the convention `Form_<objtype>` / `View_<objtype>` (lowercase, snake_case) — see `resources/common/th/th_view.py:217-218`. `FormTemplate` and `ViewTemplate` did not follow the convention and were therefore dead code, never picked up by the dispatcher when editing templates from the remote editor dialog. Renamed to `Form_template` / `View_template`. Issue #192 stays open for the proper editor implementations across the other objtypes (rpcquery, list_in, view, grpview, chartjs, gridprint, dash_groupby, pdfform, query-edit-on-dblclick).

Verified via grep: `FormTemplate` / `ViewTemplate` were not referenced anywhere outside the renamed file, so the rename is safe.

Minor cosmetic touches included: default search column on the userobject view, `all_flags` section renamed to `any`.

## Test plan

- [ ] On the userobject form (Auth Tags field), select one or more tags from the picker and save — verify the DB stores `authorization_tag` codes (no padding).
- [ ] As a user holding a tag (e.g. `TAGSEDE_NAZ`), confirm a saved query/view tagged with that code appears in the saved-queries menu.
- [ ] Open a template from the remote userobject editor dialog (the path that uses `_th_remoteUserObjectEditor`) and verify the form now renders correctly (it would previously show a missing-resource error because `Form_template` did not exist).