### PR TITLE
feat(sourcerer): rpc_query endpoint (alpha, opt-in)

### DIFF
--- a/projects/gnrcore/packages/sys/resources/services/sourcerer/sourcerer.py
+++ b/projects/gnrcore/packages/sys/resources/services/sourcerer/sourcerer.py
@@ -8,11 +8,18 @@ from gnrpkg.sys.services.sourcerer import SourcererClient
 class Service(GnrBaseService):
 
     def __init__(self, parent=None, url=None, token=None,
-                 sourcerer_token=None, **kwargs):
+                 sourcerer_token=None, query_enabled=None, **kwargs):
         self.parent = parent
         self.token = token
         self.sourcerer_token = sourcerer_token
+        self.query_enabled = query_enabled
         self.client = SourcererClient(url=url, sourcerer_token=sourcerer_token)
+
+    def is_query_enabled(self):
+        v = self.query_enabled
+        if v in (True, 'Y', 'y', 'true', 'True', '1', 1):
+            return True
+        return False
 
     def request_registration(self, host, name, callback_url):
         return self.client.request_registration(host, name, callback_url)
@@ -35,6 +42,8 @@ class ServiceParameters(BaseComponent):
                    readOnly=True, width='30em')
         fb.textbox(value='^.sourcerer_token', lbl='!!Sourcerer Token',
                    readOnly=True, width='30em')
+        fb.checkbox(value='^.query_enabled',
+                    lbl='!![en]Enable rpc_query endpoint')
         fb.button('!![en]Connect to Sourcerer',
                   hidden='^.token').dataRpc(self.rpc_connectToSourcerer,
                    _onResult="""SET .token = result.getItem('token');

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -5,6 +5,9 @@ from gnr.core.gnrbag import Bag
 from gnr.web.verifiers import AuthorizationBearerVerifier
 
 
+MAX_ROWS = 1000
+
+
 class SourcererBearerVerifier(AuthorizationBearerVerifier):
     def get_token_to_verify(self):
         service = self.page.getService('sourcerer')
@@ -18,3 +21,54 @@ class GnrCustomWebPage(object):
     @public_method(verifier=SourcererBearerVerifier)
     def rpc_health(self, **kwargs):
         return Bag(dict(result='ok'))
+
+    @public_method(verifier=SourcererBearerVerifier)
+    def rpc_query(self, ticket_code=None, **kwargs):
+        info = {'endpoint': 'rpc_query', 'error': None}
+
+        service = self.getService('sourcerer')
+        if not service or not service.is_query_enabled():
+            info['error'] = 'endpoint_disabled'
+            return {'ok': False, 'ticket_code': ticket_code,
+                    'info': info, 'data': []}
+
+        count_only = bool(kwargs.get('countOnly'))
+        if count_only:
+            cap_applied = False
+            info['limit_applied'] = kwargs.get('limit')
+        else:
+            requested = kwargs.get('limit')
+            cap_applied = requested is None or (
+                isinstance(requested, int) and requested > MAX_ROWS)
+            kwargs['limit'] = MAX_ROWS if cap_applied else requested
+            info['limit_applied'] = kwargs['limit']
+
+        kwargs.pop('recordResolver', None)
+
+        try:
+            adapter_name = type(self.db.adapter).__name__.lower()
+            if 'postgres' in adapter_name or 'pg' in adapter_name:
+                self.db.execute("SET LOCAL statement_timeout = 3000")
+        except Exception:
+            pass
+
+        try:
+            data_bag, attrs = self.app.getSelection(
+                recordResolver=False, **kwargs)
+            rows = []
+            if not count_only:
+                for k in data_bag.keys():
+                    node = data_bag.getNode(k)
+                    row = dict(node.attr)
+                    row.pop('_customClasses', None)
+                    row.pop('_attributes', None)
+                    rows.append(row)
+            info['totalrows'] = attrs.get('totalrows', 0)
+            info['more'] = cap_applied and info['totalrows'] >= MAX_ROWS
+            info['servertime_ms'] = attrs.get('servertime')
+            return {'ok': True, 'ticket_code': ticket_code,
+                    'info': info, 'data': rows}
+        except Exception as e:
+            info['error'] = str(e)
+            return {'ok': False, 'ticket_code': ticket_code,
+                    'info': info, 'data': []}


### PR DESCRIPTION
## Summary

Adds an `rpc_query` method on `/sys/ep_sourcerer` that exposes `getSelection`
to authenticated Sourcerer callers, plus a new `query_enabled` flag on the
`sourcerer` Service to gate it.

- Pass-through of `getSelection` kwargs (table, columns, where, condition, order_by, limit, offset, group_by, having, distinct, sqlparams, pkeys, subtable, countOnly + kwargs forwarded to `query()`)
- `recordResolver=False` forced server-side (lazy resolvers don't make sense outside the SPA)
- Silent cap at 1000 rows with `info.more=true` flag; `countOnly` bypasses the cap
- Postgres-only `SET LOCAL statement_timeout = 3000` (no-op on other adapters)
- Uniform JSON envelope `{ok, ticket_code, info, data}` for both success and error
- `query_enabled` flag default OFF, exposed as a checkbox in the service parameters form. When OFF the endpoint replies with `ok=false, info.error="endpoint_disabled"`.

Re-uses the existing `SourcererBearerVerifier` for auth.

## Why this is alpha and not a regression

The whole Sourcerer connection is alpha and only meaningful on test sites with test customers. **Default-off** means every existing site behaves exactly as before — `query_enabled` has to be explicitly turned on in the service parameters panel for the endpoint to do anything. Sites that never configure or enable the Sourcerer service are not affected at all.

Once we have field experience we can layer on rate limiting, audit log, table whitelisting and similar hardening.

## Files changed

- [projects/gnrcore/packages/sys/resources/services/sourcerer/sourcerer.py](../blob/feature/sourcerer-rpc-query/projects/gnrcore/packages/sys/resources/services/sourcerer/sourcerer.py) — `query_enabled` field + `is_query_enabled()` + checkbox in service form
- [projects/gnrcore/packages/sys/webpages/ep_sourcerer.py](../blob/feature/sourcerer-rpc-query/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py) — new `rpc_query` next to existing `rpc_health`

## Response shape

```json
{
  "ok": true,
  "ticket_code": "<echoed from input>",
  "info": {
    "endpoint": "rpc_query",
    "error": null,
    "limit_applied": 1000,
    "totalrows": 1000,
    "more": true,
    "servertime_ms": 5
  },
  "data": [{ "id": "...", "_pkey": "...", "...": "..." }]
}
```

On error (`endpoint_disabled`, SQL error, getSelection exception): `ok=false`, `data=[]`, `info.error` set.

## Test plan

Smoke tests done locally against `test_invoice` (SQLite, 3200 rows in `invc.customer`):

- [x] flag OFF → `endpoint_disabled`
- [x] flag ON, basic query → 5 flat rows, `_pkey` matches direct `query().fetch()`
- [x] cap silently applied (`limit=5000` → `data` 1000 rows, `info.more=true`, `info.limit_applied=1000`)
- [x] `countOnly=true` → `data=[]`, `info.totalrows=3200` (cap skipped)
- [x] SQL error → `ok=false`, `info.error` carries the message
- [x] flake8 clean on both touched files
- [ ] HTTP-level Bearer auth (verifier) — needs running server, deferred to field test
- [ ] Postgres `statement_timeout` — needs PG instance, deferred to field test (SQLite skips silently as designed)
- [ ] JSON serialization for non-trivial column types (Decimal, datetime) — `invc.customer` has none; to be checked on richer tables

## Known limitations (intentional, deferred)

- No rate limiting
- No audit log on `sys.externalcall_log`
- No table whitelisting
- Timeout effective only on Postgres