### PR TITLE
feat(sourcerer): rpc_relationtree endpoint (alpha, opt-in) — step 2/N

### DIFF
--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -8,6 +8,77 @@ from gnr.web.verifiers import AuthorizationBearerVerifier
 MAX_ROWS = 1000
 
 
+def _classify_column(attr):
+    if attr.get('joiner') or attr.get('tag') == 'relation':
+        return 'relation', False
+    if not attr.get('virtual_column'):
+        return 'real', False
+    if attr.get('relation_path'):
+        return 'alias', False
+    if attr.get('select'):
+        return 'formula_subquery', True
+    if attr.get('bagcolumn') or attr.get('itempath'):
+        return 'bagitem', False
+    if attr.get('sql_formula'):
+        return 'formula_sql', False
+    if attr.get('py_method') or attr.get('pyColumn'):
+        return 'pycolumn', False
+    return 'virtual_other', False
+
+
+def _attr_to_json(attr):
+    out = {}
+    for k, v in attr.items():
+        if isinstance(v, (str, int, float, bool, type(None))):
+            out[k] = v
+        elif isinstance(v, dict):
+            sub = {sk: sv for sk, sv in v.items()
+                   if isinstance(sv, (str, int, float, bool, type(None)))}
+            if sub:
+                out[k] = sub
+    return out
+
+
+def _bag_to_json(bag, depth=1):
+    if bag is None:
+        return None
+    out = {}
+    for node in bag:
+        attr = node.attr
+        kind, has_subquery = _classify_column(attr)
+        item = {'attr': _attr_to_json(attr), 'kind': kind}
+        if has_subquery:
+            item['subquery'] = True
+        v = node.value
+        if v is None:
+            pass
+        elif hasattr(v, 'load') and not hasattr(v, 'nodes'):
+            item['lazy'] = True
+        elif hasattr(v, 'nodes'):
+            if depth > 0:
+                item['children'] = _bag_to_json(v, depth=depth - 1)
+            else:
+                item['truncated'] = True
+        out[node.label] = item
+    return out
+
+
+def _build_table_schema(db, table_fullname):
+    tbl_model = db.model.table(table_fullname)
+    tree_bag = tbl_model.newRelationResolver().load()
+    schema = _bag_to_json(tree_bag) or {}
+    vcols = tbl_model.get('virtual_columns')
+    if vcols:
+        for name, vc in vcols.items():
+            attr = dict(vc.attributes)
+            kind, has_subquery = _classify_column(attr)
+            entry = {'attr': _attr_to_json(attr), 'kind': kind}
+            if has_subquery:
+                entry['subquery'] = True
+            schema[name] = entry
+    return schema
+
+
 class SourcererBearerVerifier(AuthorizationBearerVerifier):
     def get_token_to_verify(self):
         service = self.page.getService('sourcerer')
@@ -72,3 +143,43 @@ class GnrCustomWebPage(object):
             info['error'] = str(e)
             return {'ok': False, 'ticket_code': ticket_code,
                     'info': info, 'data': []}
+
+    @public_method(verifier=SourcererBearerVerifier)
+    def rpc_relationtree(self, ticket_code=None, table=None, **kwargs):
+        info = {'endpoint': 'rpc_relationtree', 'error': None}
+
+        service = self.getService('sourcerer')
+        if not service or not service.is_query_enabled():
+            info['error'] = 'endpoint_disabled'
+            return {'ok': False, 'ticket_code': ticket_code,
+                    'info': info, 'tables': None, 'trees': None}
+
+        if not table:
+            try:
+                tables = sorted(t.fullname for t in self.db.tables)
+                return {'ok': True, 'ticket_code': ticket_code,
+                        'info': info, 'tables': tables, 'trees': None}
+            except Exception as e:
+                info['error'] = str(e)
+                return {'ok': False, 'ticket_code': ticket_code,
+                        'info': info, 'tables': None, 'trees': None}
+
+        requested = [t.strip() for t in str(table).split(',') if t.strip()]
+        info['tables_requested'] = requested
+        trees = {}
+        failed = {}
+        for tname in requested:
+            try:
+                trees[tname] = _build_table_schema(self.db, tname)
+            except Exception as e:
+                failed[tname] = str(e)
+        if failed:
+            info['tables_failed'] = failed
+
+        if not trees:
+            info['error'] = 'no_table_resolved'
+            return {'ok': False, 'ticket_code': ticket_code,
+                    'info': info, 'tables': None, 'trees': None}
+
+        return {'ok': True, 'ticket_code': ticket_code,
+                'info': info, 'tables': None, 'trees': trees}


### PR DESCRIPTION
## Step 2 di #886

Questa è la naturale continuazione di #886 (`rpc_query`, ora mergiata).

#886 dava all'agente Sourcerer un canale per **eseguire query** su `getSelection`.
Questa PR aggiunge il canale per **scoprire cosa si può chiedere**: un endpoint
che ritorna lo schema (colonne + relazioni navigabili) di una o più tabelle,
con classificazione delle colonne (reali / alias / formule / subquery / bag /
python) per guidare l'agente nella costruzione di query efficienti.

Riusa lo stesso `SourcererBearerVerifier` e lo stesso flag `query_enabled`.
Disabilitato di default → niente regressione per chi non usa Sourcerer.

## Summary

Nuovo metodo `rpc_relationtree` su `/sys/ep_sourcerer`. Tre modi d'uso:

| Input `table` | Output |
|---|---|
| omesso | `tables` = lista `pkg.tablename` disponibili |
| singolo es. `"invc.customer"` | `trees = {"invc.customer": {...schema...}}` |
| CSV es. `"invc.customer,invc.invoice"` | `trees = {tab1: ..., tab2: ...}` |

Errori parziali (alcune tabelle ok, altre no) → `ok=true`, le tabelle errate finiscono in `info.tables_failed`. Solo se nessuna si risolve → `ok=false`.

### Classificazione `kind` per ogni colonna del tree

| `kind` | Significato | Costo |
|---|---|---|
| `real` | Colonna fisica | basso |
| `alias` | `aliasColumn(relation_path=...)` | basso |
| `formula_sql` | `formulaColumn(sql_formula=...)` | basso/medio |
| `formula_subquery` | `formulaColumn(select=...)` — flag aggiuntivo `subquery: true` | **alto, una subquery per riga** |
| `bagitem` | `bagItemColumn` (xpath su campo bag XML) | basso |
| `pycolumn` | `pyColumn` (calcolo Python) | nessun SQL ma serve loop applicativo |
| `relation` | Relazione navigabile (joiner) | medio (JOIN) |

Le virtual_columns vivono in un container separato del modello (`tbl.virtual_columns`) e non sono incluse nel `RelationTreeResolver` standard — questa PR le fonde nel tree per dare all'agente la visione completa.

### Profondità

Il tree è limitato a root + 1 livello di `children` per evitare i cicli che le inverse relations (`@invoices.@customer_id.@invoices...`) creerebbero. Per esplorare oltre, l'agente fa una nuova chiamata sulla tabella target del JOIN.

## Files changed

- [projects/gnrcore/packages/sys/webpages/ep_sourcerer.py](../blob/feature/sourcerer-relationtree/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py) — nuovo `rpc_relationtree` accanto a `rpc_query` di #886, più tre helper modulo (`_classify_column`, `_attr_to_json`, `_bag_to_json`, `_build_table_schema`).

## Risposta — schema uniforme

```json
{
  "ok": true,
  "ticket_code": "<echo>",
  "info": {
    "endpoint": "rpc_relationtree",
    "error": null,
    "tables_requested": ["invc.customer"],
    "tables_failed": {}
  },
  "tables": null,
  "trees": {
    "invc.customer": {
      "id":           { "kind": "real",     "attr": {...} },
      "account_name": { "kind": "real",     "attr": {...} },
      "@state":       { "kind": "relation", "attr": {"joiner": {...}}, "children": {...} }
    }
  }
}
```

## Why this is alpha and not a regression

Stesso ragionamento di #886: il flag `query_enabled` (introdotto in #886) gata anche questo endpoint. Default OFF, opt-in esplicito dal pannello servizi del Service Sourcerer. Sites che non hanno mai configurato o abilitato il servizio non sono toccati in alcun modo.

Solo siti di test con clienti di test dovrebbero avere `query_enabled=true` durante la fase alpha della connessione Sourcerer.

## Test plan

Smoke test locali su `test_invoice` (SQLite, 71 tabelle, `invc.product` ha 22 virtual_columns che coprono tutti i casi: real, alias, formula_sql, formula_subquery, bagitem, pycolumn):

- [x] flag OFF → `endpoint_disabled`
- [x] flag ON, no `table` → lista 71 tabelle
- [x] flag ON, `table` singola → tree con classificazione corretta per ogni `kind`
- [x] flag ON, CSV multiple → 3 trees in una chiamata
- [x] errore parziale (1 buona + 1 sbagliata) → `ok=true`, `tables_failed` popolato
- [x] errore totale (tutte sbagliate) → `ok=false, error: no_table_resolved`
- [x] `total_sold` (formulaColumn con select) → `kind: formula_subquery`, `subquery: true` ✓
- [x] `detail_weight` (bagItemColumn) → `kind: bagitem` ✓ (anche se ha un sql_formula xpath sotto, classificazione corretta)
- [x] `@product_type_id.children` correttamente popolato con le colonne della tabella target
- [x] Cycle protection: depth fissa a 1 evita ricorsione infinita su `customer.@invoices.@customer_id.@invoices...`
- [x] flake8 clean
- [ ] HTTP-level Bearer auth (verifier) — deferred to field test (come #886)
- [ ] JSON serialization edge cases per attr non-trivial — deferred to field test

## Known limitations (intentional, deferred)

- No rate limiting (eredita dalla situazione di #886)
- No audit log su `sys.externalcall_log` (idem)
- Profondità tree fissa a 1 — se serve modello full-deep, fare chiamate ricorsive

## Test suite

Stesso quadro di #886: `1695 passed, 22 failed, 4 errors`. Tutti i fallimenti pre-esistenti su `gnrdate_test.py` / `gnrlocale_test.py` / `test_compiler_coverage.py` / `test_xmltrasform.py` (locale di sistema), nessuno tocca `gnrcore/sys/`. `git diff origin/develop HEAD --name-only` = solo `ep_sourcerer.py`.