### PR TITLE
feat(no-mako): convert scheduler dashboard + warn on Mako fallback

### DIFF
--- a/gnrpy/gnr/web/gnrtask_new.py
+++ b/gnrpy/gnr/web/gnrtask_new.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from collections import defaultdict
 from typing import Any
 
-from mako.template import Template
+from gnr.web.gnrwebpage_proxy.frontend.basepagetemplate import PageBuilder
 import aiohttp
 import asyncio
 from aiohttp import web
@@ -451,118 +451,102 @@ class GnrTaskScheduler:
         return "ok"
     
     async def dashboard(self, request):
-        template_content = """
-        <html lang="en">
-        <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Gnr Scheduler Dashboard</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
-        </head>
-        <script>
-        setInterval(function () {
-        location.reload();
-        }, 2000); 
-        </script>
-        <body>
-        <div class="container">
-        <h1>Gnr Scheduler Dashboard</h1>
-        <h2>Status</h2>
-        <table class="table"><tbody>
-        
-        <tr><th>Startup time</th><td>${startup_time}</td>
-        <th>Server time</th><td>${scheduler_current_time}</td>
-        <th>Uptime</th><td>${server_uptime}</td></tr>
-        <tr><th>Total tasks</th><td>${total_tasks}</td>
-        <th>Total queue size</th><td>${total_queue_size}</td></tr>
-        </tbody></table>
-        
-        <h2>Queue details</h2>
-        <table class="table"><thead><tr>
-        <th scope="col">Queue</th>
-        <th scope="col">Items</th>
-        </tr></thead><tbody>
-        % for w in queues_sizes.items():
-        <tr>
-        <td>${w[0]}</td>
-        <td>${w[1]}</td>
-        </tr>
-        % endfor
-        </tbody></table>
-        
-        <h2>Running workers</h2>
-        % if workers:
-        <table class="table"><thead><tr>
-        <th scope="col">Worker ID</th>
-        <th scope="col">Queue</th>
-        <th scope="col">Last seen</th>
-        <th scope="col">Worked tasks</th>
-        </tr></thead><tbody>
-        % for w in workers.items():
-        <tr>
-        <td>${w[0]}</td>
-        <td>${w[1]['queue_name']}</td>
-        <td>${w[1]['lastseen']}</td>
-        <td>${w[1]['worked_tasks']}</td>
-        </tr>
-        % endfor
-        </tbody></table>
-        % else:
-        <div class="alert alert-danger" role="alert">
-        No workers connected!
-        </div>
-        % endif
-
-        <h2>Pending Acknowledgements</h2>
-        % if pending:
-        <table class="table"
-        <thead><tr>
-        <th scope="col">Queue</th>
-        <th scope="col">Run ID</th>
-        <th scope="col">Since</th>
-        </tr></thead><tbody>
-        % for k,v in pending.items():
-        <tr>
-        <td>${v[0]['queue_name']}</td>
-        <td>${k}</td><td>${v[1]}</td>
-        </tr>
-        % endfor
-        </tbody></table>
-        % else:
-        <div class="alert alert-success" role="alert">
-        No pending acks
-        </div>
-        % endif
-        
-        <h2>Failed tasks</h2>
-        % if failed:
-        <table class="table">
-        <thead><tr>
-        <th scope="col">Queue</th>
-        <th scope="col">Task Id</th>
-        <th scope="col">Run id</th>
-        </tr></thead><tbody>
-        % for a in failed:
-        <tr><td>${a['queue_name']}</td>
-        <td>${a['task_id']}</td>
-        <td>${a['run_id']}</td></tr>
-        % endfor
-        </tbody></table>
-        % else:
-        <div class="alert alert-success" role="alert">
-        No failed tasks.
-        </div>
-        % endif
-        </div>
-        </body></html>
-        """
-        t = Template(template_content, strict_undefined=True)
-        
         payload = self._get_status()
         return web.Response(
-            text=t.render(**payload),
+            text=self._render_dashboard(payload),
             content_type="text/html"
         )
+
+    def _render_dashboard(self, payload):
+        builder = PageBuilder()
+        head = builder.head
+        body = builder.body
+
+        head.child('meta', charset='utf-8')
+        head.child('meta', name='viewport',
+                   content='width=device-width, initial-scale=1')
+        head.child('title', content='Gnr Scheduler Dashboard')
+        head.child(
+            'link',
+            href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css',
+            rel='stylesheet',
+            integrity='sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT',
+            crossorigin='anonymous',
+        )
+        head.child('script',
+                   content='setInterval(function () { location.reload(); }, 2000);')
+
+        container = body.child('div', _class='container')
+        container.child('h1', content='Gnr Scheduler Dashboard')
+
+        # ---- Status -----------------------------------------------------
+        container.child('h2', content='Status')
+        status_tbody = container.child('table', _class='table').child('tbody')
+        row1 = status_tbody.child('tr')
+        row1.child('th', content='Startup time')
+        row1.child('td', content=str(payload['startup_time']))
+        row1.child('th', content='Server time')
+        row1.child('td', content=str(payload['scheduler_current_time']))
+        row1.child('th', content='Uptime')
+        row1.child('td', content=str(payload['server_uptime']))
+        row2 = status_tbody.child('tr')
+        row2.child('th', content='Total tasks')
+        row2.child('td', content=str(payload['total_tasks']))
+        row2.child('th', content='Total queue size')
+        row2.child('td', content=str(payload['total_queue_size']))
+
+        # ---- Queue details ----------------------------------------------
+        container.child('h2', content='Queue details')
+        self._table(container, ['Queue', 'Items'],
+                    [(name, size) for name, size in payload['queues_sizes'].items()])
+
+        # ---- Running workers --------------------------------------------
+        container.child('h2', content='Running workers')
+        workers = payload['workers']
+        if workers:
+            self._table(container,
+                        ['Worker ID', 'Queue', 'Last seen', 'Worked tasks'],
+                        [(wid, w['queue_name'], w['lastseen'], w['worked_tasks'])
+                         for wid, w in workers.items()])
+        else:
+            container.child('div', _class='alert alert-danger', role='alert',
+                            content='No workers connected!')
+
+        # ---- Pending Acknowledgements -----------------------------------
+        container.child('h2', content='Pending Acknowledgements')
+        pending = payload['pending']
+        if pending:
+            self._table(container, ['Queue', 'Run ID', 'Since'],
+                        [(v[0]['queue_name'], k, v[1])
+                         for k, v in pending.items()])
+        else:
+            container.child('div', _class='alert alert-success', role='alert',
+                            content='No pending acks')
+
+        # ---- Failed tasks -----------------------------------------------
+        container.child('h2', content='Failed tasks')
+        failed = payload['failed']
+        if failed:
+            self._table(container, ['Queue', 'Task Id', 'Run id'],
+                        [(a['queue_name'], a['task_id'], a['run_id'])
+                         for a in failed])
+        else:
+            container.child('div', _class='alert alert-success', role='alert',
+                            content='No failed tasks.')
+
+        return builder.toHtml()
+
+    @staticmethod
+    def _table(parent, headers, rows):
+        table = parent.child('table', _class='table')
+        thead_tr = table.child('thead').child('tr')
+        for h in headers:
+            thead_tr.child('th', scope='col', content=h)
+        tbody = table.child('tbody')
+        for row in rows:
+            tr = tbody.child('tr')
+            for cell in row:
+                tr.child('td', content=str(cell))
 
     def _get_status(self):
         now = datetime.now(timezone.utc)

--- a/gnrpy/gnr/web/gnrtask_new.py
+++ b/gnrpy/gnr/web/gnrtask_new.py
@@ -464,7 +464,7 @@ class GnrTaskScheduler:
 
         head.child('meta', charset='utf-8')
         head.child('meta', name='viewport',
-                   content='width=device-width, initial-scale=1')
+                   _content='width=device-width, initial-scale=1')
         head.child('title', content='Gnr Scheduler Dashboard')
         head.child(
             'link',

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -36,6 +36,7 @@ import re
 import datetime
 import traceback
 
+from gnr.web import logger
 from gnr.web.gnrwebpage_proxy.frontend.template_lookup import lookup_template_class
 
 
@@ -1077,7 +1078,8 @@ class GnrWebPage(GnrBaseWebPage):
         # struct template in the same resource dirs the Mako lookup uses.
         # If one is found, render it; otherwise fall through to Mako so a
         # missing struct template never breaks the page.
-        if self.getPreference('experimental.no_mako', pkg='sys'):
+        no_mako = self.getPreference('experimental.no_mako', pkg='sys')
+        if no_mako:
             tpl_name = tpl[:-4] if tpl.endswith('.tpl') else tpl
             template_cls = lookup_template_class(self.tpldirectories, tpl_name)
             if template_cls is not None:
@@ -1086,6 +1088,9 @@ class GnrWebPage(GnrBaseWebPage):
                     raise GnrWebPageException(
                         "Access denied for template '%s'" % tpl_name)
                 return template.render(arg_dict)
+            logger.warning(
+                "no_mako=True but no struct template '%s.py' found; "
+                "falling back to Mako '%s'", tpl_name, tpl)
         # Fallback Mako (default behaviour, unchanged)
         if not tpl.endswith('.tpl'):
             tpl = '%s.tpl' % tpl

--- a/gnrpy/gnr/web/gnrwebpage_plugin/mako.py
+++ b/gnrpy/gnr/web/gnrwebpage_plugin/mako.py
@@ -12,6 +12,7 @@ import os
 
 from mako.lookup import TemplateLookup
 
+from gnr.web import logger
 from gnr.web.gnrwebpage_plugin.gnrbaseplugin import GnrBasePlugin
 from gnr.web.gnrwsgisite import HTTPException
 from gnr.web.gnrwebpage_proxy.frontend.template_lookup import lookup_template_class
@@ -46,7 +47,8 @@ class Plugin(GnrBasePlugin):
 
         # When the no_mako preference is on, look for a struct template
         # next to the requested .tpl. Falls through to Mako otherwise.
-        if page.getPreference('experimental.no_mako', pkg='sys'):
+        no_mako = page.getPreference('experimental.no_mako', pkg='sys')
+        if no_mako:
             tpl_basename = os.path.basename(mako_path)
             tpl_name = tpl_basename[:-4] if tpl_basename.endswith('.tpl') else tpl_basename
             template_cls = lookup_template_class(tpldirectories, tpl_name)
@@ -58,6 +60,9 @@ class Plugin(GnrBasePlugin):
                 if not pdf:
                     page.response.content_type = 'text/html'
                     return output
+            logger.warning(
+                "no_mako=True but no struct template '%s.py' found; "
+                "falling back to Mako '%s'", tpl_name, mako_path)
 
         lookup = TemplateLookup(directories=tpldirectories,
                                 output_encoding='utf-8', encoding_errors='replace')


### PR DESCRIPTION
## Summary

Two related steps in the no-mako roadmap.

## 1. Scheduler dashboard → PageBuilder

`GnrTaskScheduler.dashboard` rendered a ~100-line inline Mako template. Replace with `PageBuilder` (introduced in #862). Output is functionally equivalent — same Bootstrap stylesheet, same auto-reload script, same sections and tables. The only visible difference is XHTML strict output (consistent with the templates migrated in #862).

This conversion is unconditional (no preference branch): the dashboard endpoint is standalone, simple, and there is no reason to keep a Mako fallback for it alone.

## 2. Warn on Mako fallback when `no_mako=True`

When `experimental.no_mako` is on but a struct `<name>.py` template is missing, the rootPage flow (`gnrwebpage.py`) and the Mako plugin (`gnrwebpage_plugin/mako.py`) silently fall back to the legacy Mako `.tpl`. This hides incomplete migrations.

Emit a `logger.warning` at each fallback point naming the missing struct template and the Mako template that took over. An instance running with `no_mako=True` and zero such warnings in its logs is a safe candidate for dropping the Mako fallback entirely.

## Roadmap context

This is the first step toward removing Mako:

1. **Now** (this PR): every path can run with or without Mako depending on `experimental.no_mako` (default off). Warning surfaces any gap.
2. **In ~2 weeks**: flip `experimental.no_mako` default to `True`, fallback still present.
3. **In ~4 weeks**: drop the switch, the Mako plugin, all `.tpl` files, and remove `mako` from `pyproject.toml`.

## Test plan

- [x] flake8 clean on modified files
- [x] `pytest gnrpy/tests/web/gnrtask_test.py` — 28/28 pass
- [x] Smoke test of `_render_dashboard()` with mock payload: produces valid XHTML with all expected sections
- [ ] Manual end-to-end: open the scheduler dashboard URL in a browser, verify visual parity with current Mako output
- [ ] Manual end-to-end: run an instance with `experimental.no_mako=True`, confirm no warnings in logs (= all standard templates have struct equivalents)