### PR TITLE
Introduce neutral AsyncSession core (depends on #852)

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage_proxy/apphandler/get_selection.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/apphandler/get_selection.py
@@ -141,7 +141,8 @@ class GetSelectionMixin:
                      gridVisibleColumns: Optional[str] = None,
                      formulaVariants: Optional[Bag] = None,
                      countOnly: bool = False,
-                     **kwargs: Any) -> tuple[Bag, dict]:
+                     output_mode: Optional[str] = None,
+                     **kwargs: Any) -> tuple[Any, dict]:
         """Load a selection of records for grid display.
 
         This is the primary entry point for all grid data loading.
@@ -324,6 +325,9 @@ class GetSelectionMixin:
             resultAttributes.update(table=table, method='app.getSelection', selectionName=selectionName,
                                     row_count=row_count,
                                     totalrows=len(selection))
+        if output_mode is not None:
+            return selection.output(mode=output_mode, offset=row_start,
+                                    limit=row_count, formats=formats), resultAttributes
         generator = selection.output(mode='generator', offset=row_start, limit=row_count, formats=formats)
         _addClassesDict = dict([(k, v['_addClass']) for k, v in list(selection.colAttrs.items()) if '_addClass' in v])
         data = self.gridSelectionData(selection, generator, logicalDeletionField=tblobj.logicalDeletionField,

--- a/gnrpy/gnr/web/verifiers.py
+++ b/gnrpy/gnr/web/verifiers.py
@@ -48,8 +48,11 @@ class AuthorizationBearerVerifier(GnrVerifier):
 
     def get_bearer(self):
         """Extract the bearer token from the Authorization header.
+        Falls back to X-GNR-Authorization when the standard header is
+        missing (e.g. stripped by Tailscale Funnel or other proxies).
         Returns the token string or None if missing/invalid."""
-        auth_header = self.page.request.headers.get('Authorization', '')
+        auth_header = self.page.request.headers.get('Authorization') \
+            or self.page.request.headers.get('X-GNR-Authorization', '')
         if not auth_header.startswith('Bearer '):
             return None
         return auth_header[7:]

--- a/projects/gnrcore/packages/sys/lib/services/sourcerer.py
+++ b/projects/gnrcore/packages/sys/lib/services/sourcerer.py
@@ -37,11 +37,12 @@ class SourcererClient:
 
     def request_registration(self, host, name, callback_url):
         callback_token = secrets.token_urlsafe()
-        data = self._request('srv/request_server_registration',
-                             payload={'host': host, 'name': name,
-                                      'callback_url': callback_url,
-                                      'callback_token': callback_token},
-                             authenticated=False)
+        response = self._request('srv/request_server_registration',
+                                 payload={'host': host, 'name': name,
+                                          'callback_url': callback_url,
+                                          'callback_token': callback_token},
+                                 authenticated=False)
+        data = response.get('data') or {}
         return {
             'token': callback_token,
             'sourcerer_token': data.get('token', '')

--- a/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
+++ b/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
@@ -126,104 +126,58 @@ def _apply_statement_timeout(db, timeout_ms):
         pass
 
 
-def run_query(db, table=None, count_only=False,
+def run_query(site, table=None,
               max_rows=DEFAULT_MAX_ROWS,
               statement_timeout_ms=DEFAULT_STATEMENT_TIMEOUT_MS,
-              app=None, **kwargs):
-    """Execute a query against a GenroPy DB, returning the same shape that
-    rpc_query produces over HTTP.
-
-    Two execution paths:
-        - If ``app`` is provided, uses ``app.getSelection`` (web context: full
-          virtual_column resolution, alias expansion, etc.).
-        - Otherwise falls back to ``db.table(table).query(**kwargs).fetch()``
-          for in-process callers without a web app.
+              **kwargs):
+    """Execute a getSelection against a GenroPy site.
 
     Args:
-        db: GenroPy db connection.
-        table: Fully qualified table name (e.g. ``'fatt.fattura'``).
-        count_only: If True, return only the row count.
-        max_rows: Cap applied when ``limit`` is missing or higher.
-        statement_timeout_ms: PostgreSQL statement_timeout cap (best effort).
-        app: Optional GnrApp / web app proxy with ``getSelection``.
-        **kwargs: Forwarded to getSelection / tbl.query (columns, where,
-            distinct, group_by, having, order_by, limit, etc.).
+        site: GnrWsgiSite (provides ``site.db`` and ``site.dummyPage.app``).
+        table: fully qualified table name (e.g. ``'fatt.fattura'``).
+        max_rows: cap applied when ``limit`` is missing or higher.
+        statement_timeout_ms: PostgreSQL statement_timeout cap.
+        **kwargs: forwarded to ``app.getSelection`` (columns, where, condition,
+            distinct, group_by, having, order_by, limit, offset, pkeys,
+            sqlparams, excludeLogicalDeleted, excludeDraft, countOnly, …).
 
     Returns:
-        dict: {
-            'ok': bool,
-            'data': list[dict],
-            'info': {
-                'totalrows': int,
-                'more': bool,
-                'limit_applied': int|None,
-                'servertime_ms': int,
-                'error': str|None
-            }
-        }
+        ``{'ok': bool, 'data': list[dict], 'info': {...}}``
     """
-    info: dict = {'error': None}
+    kwargs['limit'] = min(kwargs.get('limit') or max_rows, max_rows)
+    kwargs.setdefault('addPkeyColumn', False)
 
-    if not table and not count_only:
-        # getSelection variant lets the caller pass table inside kwargs;
-        # tbl.query variant requires it explicitly. We require it always
-        # for clarity.
-        return {'ok': False, 'data': [],
-                'info': {'error': 'missing required parameter: table'}}
-
-    # Cap limit
-    if count_only:
-        cap_applied = False
-        info['limit_applied'] = kwargs.get('limit')
-    else:
-        requested = kwargs.get('limit')
-        cap_applied = (requested is None
-                       or (isinstance(requested, int)
-                           and requested > max_rows))
-        kwargs['limit'] = max_rows if cap_applied else requested
-        info['limit_applied'] = kwargs['limit']
-
-    kwargs.pop('recordResolver', None)
-
-    _apply_statement_timeout(db, statement_timeout_ms)
+    _apply_statement_timeout(site.db, statement_timeout_ms)
 
     t0 = time.monotonic()
     try:
-        if app is not None:
-            # Web context: rich getSelection (preserves virtual cols).
-            # output_mode='dictlist' makes getSelection return a flat
-            # list of dicts directly (no Bag wrapping), so no manual
-            # post-processing is needed.
-            kwargs.setdefault('addPkeyColumn', False)
-            rows, attrs = app.getSelection(
-                table=table, recordResolver=False,
-                output_mode='dictlist',
-                countOnly=count_only, **kwargs)
-            if count_only:
-                rows = []
-            info['totalrows'] = attrs.get('totalrows', 0)
-            info['servertime_ms'] = attrs.get('servertime')
-        else:
-            # In-process: direct table.query (lighter)
-            tbl = db.table(table)
-            sel = tbl.query(**kwargs)
-            if count_only:
-                rows = []
-                info['totalrows'] = sel.count()
-            else:
-                fetched = sel.fetch()
-                rows = [dict(r) for r in fetched]
-                info['totalrows'] = len(rows)
-            info['servertime_ms'] = int(
-                (time.monotonic() - t0) * 1000)
-
-        info['more'] = (cap_applied
-                        and info['totalrows'] >= max_rows)
-        return {'ok': True, 'data': rows, 'info': info}
+        rows, attrs = site.dummyPage.app.getSelection(
+            table=table, recordResolver=False,
+            output_mode='dictlist', **kwargs)
+        if kwargs.get('countOnly'):
+            rows = []
+        total = attrs.get('totalrows', 0)
+        return {
+            'ok': True,
+            'data': rows,
+            'info': {
+                'totalrows': total,
+                'limit_applied': kwargs['limit'],
+                'more': total >= kwargs['limit'],
+                'servertime_ms': attrs.get('servertime') or int(
+                    (time.monotonic() - t0) * 1000),
+                'error': None,
+            },
+        }
     except Exception as e:
-        info['error'] = str(e)
-        info['servertime_ms'] = int((time.monotonic() - t0) * 1000)
-        return {'ok': False, 'data': [], 'info': info}
+        return {
+            'ok': False,
+            'data': [],
+            'info': {
+                'error': str(e),
+                'servertime_ms': int((time.monotonic() - t0) * 1000),
+            },
+        }
 
 
 def build_relationtree_response(db, table=None, ticket_code=None):

--- a/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
+++ b/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
@@ -144,7 +144,7 @@ def run_query(site, table=None,
     Returns:
         ``{'ok': bool, 'data': list[dict], 'info': {...}}``
     """
-    kwargs['limit'] = min(kwargs.get('limit') or max_rows, max_rows)
+    kwargs['limit'] = min(int(kwargs.get('limit') or max_rows), max_rows)
     kwargs.setdefault('addPkeyColumn', False)
 
     _apply_statement_timeout(site.db, statement_timeout_ms)

--- a/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
+++ b/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
@@ -197,7 +197,8 @@ def run_query(db, table=None, count_only=False,
             kwargs.setdefault('addPkeyColumn', False)
             rows, attrs = app.getSelection(
                 table=table, recordResolver=False,
-                output_mode='dictlist', **kwargs)
+                output_mode='dictlist',
+                countOnly=count_only, **kwargs)
             if count_only:
                 rows = []
             info['totalrows'] = attrs.get('totalrows', 0)

--- a/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
+++ b/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
@@ -194,6 +194,7 @@ def run_query(db, table=None, count_only=False,
             # output_mode='dictlist' makes getSelection return a flat
             # list of dicts directly (no Bag wrapping), so no manual
             # post-processing is needed.
+            kwargs.setdefault('addPkeyColumn', False)
             rows, attrs = app.getSelection(
                 table=table, recordResolver=False,
                 output_mode='dictlist', **kwargs)

--- a/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
+++ b/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
@@ -1,0 +1,265 @@
+"""Server-side helpers for the Sourcerer integration endpoint.
+
+Functions in this module are shared between:
+    - sys/webpages/ep_sourcerer.py (HTTP entry point exposed via @public_method)
+    - downstream consumers that want to introspect/query a GenroPy DB
+      in-process with the same shape as rpc_relationtree / rpc_query
+
+Public surface:
+    - classify_column(attr) -> (kind, has_subquery)
+    - attr_to_json(attr) -> dict
+    - bag_to_json(bag, depth=1) -> dict
+    - build_table_schema(db, table_fullname, depth=1) -> dict
+    - list_table_names(db) -> list[str]
+    - run_query(db, table=None, count_only=False, max_rows=1000,
+                statement_timeout_ms=3000, **kwargs) -> dict
+"""
+
+import time
+
+DEFAULT_MAX_ROWS = 1000
+DEFAULT_STATEMENT_TIMEOUT_MS = 3000
+
+
+def classify_column(attr):
+    """Classify a GenroPy column attribute dict.
+
+    Returns:
+        (kind, has_subquery): kind is one of
+            'real', 'relation', 'alias', 'formula_subquery',
+            'formula_sql', 'bagitem', 'pycolumn', 'virtual_other'.
+        has_subquery is True only for formula_subquery (the costly kind).
+    """
+    if attr.get('joiner') or attr.get('tag') == 'relation':
+        return 'relation', False
+    if not attr.get('virtual_column'):
+        return 'real', False
+    if attr.get('relation_path'):
+        return 'alias', False
+    if attr.get('select'):
+        return 'formula_subquery', True
+    if attr.get('bagcolumn') or attr.get('itempath'):
+        return 'bagitem', False
+    if attr.get('sql_formula'):
+        return 'formula_sql', False
+    if attr.get('py_method') or attr.get('pyColumn'):
+        return 'pycolumn', False
+    return 'virtual_other', False
+
+
+def attr_to_json(attr):
+    """Convert a column attribute dict to a JSON-serializable subset."""
+    out = {}
+    for k, v in attr.items():
+        if isinstance(v, (str, int, float, bool, type(None))):
+            out[k] = v
+        elif isinstance(v, dict):
+            sub = {sk: sv for sk, sv in v.items()
+                   if isinstance(sv, (str, int, float, bool, type(None)))}
+            if sub:
+                out[k] = sub
+    return out
+
+
+def bag_to_json(bag, depth=1):
+    """Recursively convert a relation tree Bag to a JSON-serializable dict.
+
+    depth controls how deep relation children are expanded; nodes beyond
+    are marked with truncated=True.
+    """
+    if bag is None:
+        return None
+    out = {}
+    for node in bag:
+        attr = node.attr
+        kind, has_subquery = classify_column(attr)
+        item = {'attr': attr_to_json(attr), 'kind': kind}
+        if has_subquery:
+            item['subquery'] = True
+        v = node.value
+        if v is None:
+            pass
+        elif hasattr(v, 'load') and not hasattr(v, 'nodes'):
+            item['lazy'] = True
+        elif hasattr(v, 'nodes'):
+            if depth > 0:
+                item['children'] = bag_to_json(v, depth=depth - 1)
+            else:
+                item['truncated'] = True
+        out[node.label] = item
+    return out
+
+
+def build_table_schema(db, table_fullname, depth=1):
+    """Build a JSON-serializable schema dict for a single table.
+
+    Includes real columns, relations (with classification of join cardinality),
+    and virtual columns (aliases, sql formulas, subqueries, etc.).
+    """
+    tbl_model = db.model.table(table_fullname)
+    tree_bag = tbl_model.newRelationResolver().load()
+    schema = bag_to_json(tree_bag, depth=depth) or {}
+    vcols = tbl_model.get('virtual_columns')
+    if vcols:
+        for name, vc in vcols.items():
+            attr = dict(vc.attributes)
+            kind, has_subquery = classify_column(attr)
+            entry = {'attr': attr_to_json(attr), 'kind': kind}
+            if has_subquery:
+                entry['subquery'] = True
+            schema[name] = entry
+    return schema
+
+
+def list_table_names(db):
+    """Return sorted fullnames of all tables visible from the DB."""
+    return sorted(t.fullname for t in db.tables)
+
+
+def _apply_statement_timeout(db, timeout_ms):
+    """Best-effort SET LOCAL statement_timeout for PostgreSQL adapters."""
+    try:
+        adapter_name = type(db.adapter).__name__.lower()
+        if 'postgres' in adapter_name or 'pg' in adapter_name:
+            db.execute("SET LOCAL statement_timeout = %d" % int(timeout_ms))
+    except Exception:
+        pass
+
+
+def run_query(db, table=None, count_only=False,
+              max_rows=DEFAULT_MAX_ROWS,
+              statement_timeout_ms=DEFAULT_STATEMENT_TIMEOUT_MS,
+              app=None, **kwargs):
+    """Execute a query against a GenroPy DB, returning the same shape that
+    rpc_query produces over HTTP.
+
+    Two execution paths:
+        - If ``app`` is provided, uses ``app.getSelection`` (web context: full
+          virtual_column resolution, alias expansion, etc.).
+        - Otherwise falls back to ``db.table(table).query(**kwargs).fetch()``
+          for in-process callers without a web app.
+
+    Args:
+        db: GenroPy db connection.
+        table: Fully qualified table name (e.g. ``'fatt.fattura'``).
+        count_only: If True, return only the row count.
+        max_rows: Cap applied when ``limit`` is missing or higher.
+        statement_timeout_ms: PostgreSQL statement_timeout cap (best effort).
+        app: Optional GnrApp / web app proxy with ``getSelection``.
+        **kwargs: Forwarded to getSelection / tbl.query (columns, where,
+            distinct, group_by, having, order_by, limit, etc.).
+
+    Returns:
+        dict: {
+            'ok': bool,
+            'data': list[dict],
+            'info': {
+                'totalrows': int,
+                'more': bool,
+                'limit_applied': int|None,
+                'servertime_ms': int,
+                'error': str|None
+            }
+        }
+    """
+    info: dict = {'error': None}
+
+    if not table and not count_only:
+        # getSelection variant lets the caller pass table inside kwargs;
+        # tbl.query variant requires it explicitly. We require it always
+        # for clarity.
+        return {'ok': False, 'data': [],
+                'info': {'error': 'missing required parameter: table'}}
+
+    # Cap limit
+    if count_only:
+        cap_applied = False
+        info['limit_applied'] = kwargs.get('limit')
+    else:
+        requested = kwargs.get('limit')
+        cap_applied = (requested is None
+                       or (isinstance(requested, int)
+                           and requested > max_rows))
+        kwargs['limit'] = max_rows if cap_applied else requested
+        info['limit_applied'] = kwargs['limit']
+
+    kwargs.pop('recordResolver', None)
+
+    _apply_statement_timeout(db, statement_timeout_ms)
+
+    t0 = time.monotonic()
+    try:
+        if app is not None:
+            # Web context: rich getSelection (preserves virtual cols)
+            data_bag, attrs = app.getSelection(
+                table=table, recordResolver=False, **kwargs)
+            rows = []
+            if not count_only:
+                for k in data_bag.keys():
+                    node = data_bag.getNode(k)
+                    row = dict(node.attr)
+                    row.pop('_customClasses', None)
+                    row.pop('_attributes', None)
+                    rows.append(row)
+            info['totalrows'] = attrs.get('totalrows', 0)
+            info['servertime_ms'] = attrs.get('servertime')
+        else:
+            # In-process: direct table.query (lighter)
+            tbl = db.table(table)
+            sel = tbl.query(**kwargs)
+            if count_only:
+                rows = []
+                info['totalrows'] = sel.count()
+            else:
+                fetched = sel.fetch()
+                rows = [dict(r) for r in fetched]
+                info['totalrows'] = len(rows)
+            info['servertime_ms'] = int(
+                (time.monotonic() - t0) * 1000)
+
+        info['more'] = (cap_applied
+                        and info['totalrows'] >= max_rows)
+        return {'ok': True, 'data': rows, 'info': info}
+    except Exception as e:
+        info['error'] = str(e)
+        info['servertime_ms'] = int((time.monotonic() - t0) * 1000)
+        return {'ok': False, 'data': [], 'info': info}
+
+
+def build_relationtree_response(db, table=None, ticket_code=None):
+    """Compose the full rpc_relationtree response shape.
+
+    Mirrors the contract of ep_sourcerer.rpc_relationtree so callers
+    (web HTTP or in-process) get the exact same structure.
+    """
+    info: dict = {'endpoint': 'rpc_relationtree', 'error': None}
+
+    if not table:
+        try:
+            tables = list_table_names(db)
+            return {'ok': True, 'ticket_code': ticket_code,
+                    'info': info, 'tables': tables, 'trees': None}
+        except Exception as e:
+            info['error'] = str(e)
+            return {'ok': False, 'ticket_code': ticket_code,
+                    'info': info, 'tables': None, 'trees': None}
+
+    requested = [t.strip() for t in str(table).split(',') if t.strip()]
+    info['tables_requested'] = requested
+    trees = {}
+    failed = {}
+    for tname in requested:
+        try:
+            trees[tname] = build_table_schema(db, tname)
+        except Exception as e:
+            failed[tname] = str(e)
+    if failed:
+        info['tables_failed'] = failed
+
+    if not trees:
+        info['error'] = 'no_table_resolved'
+        return {'ok': False, 'ticket_code': ticket_code,
+                'info': info, 'tables': None, 'trees': None}
+
+    return {'ok': True, 'ticket_code': ticket_code,
+            'info': info, 'tables': None, 'trees': trees}

--- a/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
+++ b/projects/gnrcore/packages/sys/lib/sourcerer_endpoint.py
@@ -190,17 +190,15 @@ def run_query(db, table=None, count_only=False,
     t0 = time.monotonic()
     try:
         if app is not None:
-            # Web context: rich getSelection (preserves virtual cols)
-            data_bag, attrs = app.getSelection(
-                table=table, recordResolver=False, **kwargs)
-            rows = []
-            if not count_only:
-                for k in data_bag.keys():
-                    node = data_bag.getNode(k)
-                    row = dict(node.attr)
-                    row.pop('_customClasses', None)
-                    row.pop('_attributes', None)
-                    rows.append(row)
+            # Web context: rich getSelection (preserves virtual cols).
+            # output_mode='dictlist' makes getSelection return a flat
+            # list of dicts directly (no Bag wrapping), so no manual
+            # post-processing is needed.
+            rows, attrs = app.getSelection(
+                table=table, recordResolver=False,
+                output_mode='dictlist', **kwargs)
+            if count_only:
+                rows = []
             info['totalrows'] = attrs.get('totalrows', 0)
             info['servertime_ms'] = attrs.get('servertime')
         else:

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -4,79 +4,10 @@ from gnr.core.gnrdecorator import public_method
 from gnr.core.gnrbag import Bag
 from gnr.web.verifiers import AuthorizationBearerVerifier
 
-
-MAX_ROWS = 1000
-
-
-def _classify_column(attr):
-    if attr.get('joiner') or attr.get('tag') == 'relation':
-        return 'relation', False
-    if not attr.get('virtual_column'):
-        return 'real', False
-    if attr.get('relation_path'):
-        return 'alias', False
-    if attr.get('select'):
-        return 'formula_subquery', True
-    if attr.get('bagcolumn') or attr.get('itempath'):
-        return 'bagitem', False
-    if attr.get('sql_formula'):
-        return 'formula_sql', False
-    if attr.get('py_method') or attr.get('pyColumn'):
-        return 'pycolumn', False
-    return 'virtual_other', False
-
-
-def _attr_to_json(attr):
-    out = {}
-    for k, v in attr.items():
-        if isinstance(v, (str, int, float, bool, type(None))):
-            out[k] = v
-        elif isinstance(v, dict):
-            sub = {sk: sv for sk, sv in v.items()
-                   if isinstance(sv, (str, int, float, bool, type(None)))}
-            if sub:
-                out[k] = sub
-    return out
-
-
-def _bag_to_json(bag, depth=1):
-    if bag is None:
-        return None
-    out = {}
-    for node in bag:
-        attr = node.attr
-        kind, has_subquery = _classify_column(attr)
-        item = {'attr': _attr_to_json(attr), 'kind': kind}
-        if has_subquery:
-            item['subquery'] = True
-        v = node.value
-        if v is None:
-            pass
-        elif hasattr(v, 'load') and not hasattr(v, 'nodes'):
-            item['lazy'] = True
-        elif hasattr(v, 'nodes'):
-            if depth > 0:
-                item['children'] = _bag_to_json(v, depth=depth - 1)
-            else:
-                item['truncated'] = True
-        out[node.label] = item
-    return out
-
-
-def _build_table_schema(db, table_fullname):
-    tbl_model = db.model.table(table_fullname)
-    tree_bag = tbl_model.newRelationResolver().load()
-    schema = _bag_to_json(tree_bag) or {}
-    vcols = tbl_model.get('virtual_columns')
-    if vcols:
-        for name, vc in vcols.items():
-            attr = dict(vc.attributes)
-            kind, has_subquery = _classify_column(attr)
-            entry = {'attr': _attr_to_json(attr), 'kind': kind}
-            if has_subquery:
-                entry['subquery'] = True
-            schema[name] = entry
-    return schema
+from gnrpkg.sys.sourcerer_endpoint import (
+    build_relationtree_response,
+    run_query,
+)
 
 
 class SourcererBearerVerifier(AuthorizationBearerVerifier):
@@ -95,91 +26,30 @@ class GnrCustomWebPage(object):
 
     @public_method(verifier=SourcererBearerVerifier)
     def rpc_query(self, ticket_code=None, **kwargs):
-        info = {'endpoint': 'rpc_query', 'error': None}
+        info_base = {'endpoint': 'rpc_query', 'error': None}
 
         service = self.getService('sourcerer')
         if not service or not service.is_query_enabled():
-            info['error'] = 'endpoint_disabled'
+            info_base['error'] = 'endpoint_disabled'
             return {'ok': False, 'ticket_code': ticket_code,
-                    'info': info, 'data': []}
+                    'info': info_base, 'data': []}
 
-        count_only = bool(kwargs.get('countOnly'))
-        if count_only:
-            cap_applied = False
-            info['limit_applied'] = kwargs.get('limit')
-        else:
-            requested = kwargs.get('limit')
-            cap_applied = requested is None or (
-                isinstance(requested, int) and requested > MAX_ROWS)
-            kwargs['limit'] = MAX_ROWS if cap_applied else requested
-            info['limit_applied'] = kwargs['limit']
-
-        kwargs.pop('recordResolver', None)
-
-        try:
-            adapter_name = type(self.db.adapter).__name__.lower()
-            if 'postgres' in adapter_name or 'pg' in adapter_name:
-                self.db.execute("SET LOCAL statement_timeout = 3000")
-        except Exception:
-            pass
-
-        try:
-            data_bag, attrs = self.app.getSelection(
-                recordResolver=False, **kwargs)
-            rows = []
-            if not count_only:
-                for k in data_bag.keys():
-                    node = data_bag.getNode(k)
-                    row = dict(node.attr)
-                    row.pop('_customClasses', None)
-                    row.pop('_attributes', None)
-                    rows.append(row)
-            info['totalrows'] = attrs.get('totalrows', 0)
-            info['more'] = cap_applied and info['totalrows'] >= MAX_ROWS
-            info['servertime_ms'] = attrs.get('servertime')
-            return {'ok': True, 'ticket_code': ticket_code,
-                    'info': info, 'data': rows}
-        except Exception as e:
-            info['error'] = str(e)
-            return {'ok': False, 'ticket_code': ticket_code,
-                    'info': info, 'data': []}
+        result = run_query(self.db, app=self.app, **kwargs)
+        # merge endpoint metadata into info
+        result_info = result.get('info') or {}
+        result_info['endpoint'] = 'rpc_query'
+        result['info'] = result_info
+        result['ticket_code'] = ticket_code
+        return result
 
     @public_method(verifier=SourcererBearerVerifier)
     def rpc_relationtree(self, ticket_code=None, table=None, **kwargs):
-        info = {'endpoint': 'rpc_relationtree', 'error': None}
-
         service = self.getService('sourcerer')
         if not service or not service.is_query_enabled():
-            info['error'] = 'endpoint_disabled'
             return {'ok': False, 'ticket_code': ticket_code,
-                    'info': info, 'tables': None, 'trees': None}
+                    'info': {'endpoint': 'rpc_relationtree',
+                             'error': 'endpoint_disabled'},
+                    'tables': None, 'trees': None}
 
-        if not table:
-            try:
-                tables = sorted(t.fullname for t in self.db.tables)
-                return {'ok': True, 'ticket_code': ticket_code,
-                        'info': info, 'tables': tables, 'trees': None}
-            except Exception as e:
-                info['error'] = str(e)
-                return {'ok': False, 'ticket_code': ticket_code,
-                        'info': info, 'tables': None, 'trees': None}
-
-        requested = [t.strip() for t in str(table).split(',') if t.strip()]
-        info['tables_requested'] = requested
-        trees = {}
-        failed = {}
-        for tname in requested:
-            try:
-                trees[tname] = _build_table_schema(self.db, tname)
-            except Exception as e:
-                failed[tname] = str(e)
-        if failed:
-            info['tables_failed'] = failed
-
-        if not trees:
-            info['error'] = 'no_table_resolved'
-            return {'ok': False, 'ticket_code': ticket_code,
-                    'info': info, 'tables': None, 'trees': None}
-
-        return {'ok': True, 'ticket_code': ticket_code,
-                'info': info, 'tables': None, 'trees': trees}
+        return build_relationtree_response(
+            self.db, table=table, ticket_code=ticket_code)

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -54,7 +54,7 @@ class GnrCustomWebPage(object):
             return {'ok': False, 'ticket_code': ticket_code,
                     'info': info_base, 'data': []}
 
-        result = run_query(self.db, app=self.app, **kwargs)
+        result = run_query(self.site, **kwargs)
         # merge endpoint metadata into info
         result_info = result.get('info') or {}
         result_info['endpoint'] = 'rpc_query'

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from gnr.core.gnrdecorator import public_method
-from gnr.core.gnrbag import Bag
+from gnr.core.gnrstring import toTypedJSON
+from gnr.web.gnrwebpage import GnrUserNotAllowed, GnrBasicAuthenticationError
 from gnr.web.verifiers import AuthorizationBearerVerifier
 
 from gnrpkg.sys.sourcerer_endpoint import (
@@ -19,10 +20,29 @@ class SourcererBearerVerifier(AuthorizationBearerVerifier):
 
 class GnrCustomWebPage(object):
     py_requires = 'gnrcomponents/externalcall:BaseRpc'
+    convert_result = False
+
+    def rootPage(self, *args, **kwargs):
+        kwargs.pop('pagetemplate', None)
+        if args:
+            try:
+                method = self.getPublicMethod('rpc', args[0])
+            except (GnrUserNotAllowed, GnrBasicAuthenticationError) as err:
+                self.response.content_type = 'application/json'
+                return toTypedJSON({'error': str(err)})
+            if not method:
+                self.response.content_type = 'application/json'
+                return toTypedJSON({'error': f'Not existing method {args[0]}'})
+            args = list(args)[1:]
+        else:
+            method = self.rpc_index
+        result = method(*args, **kwargs)
+        self.response.content_type = 'application/json'
+        return toTypedJSON(result)
 
     @public_method(verifier=SourcererBearerVerifier)
     def rpc_health(self, **kwargs):
-        return Bag(dict(result='ok'))
+        return {'result': 'ok'}
 
     @public_method(verifier=SourcererBearerVerifier)
     def rpc_query(self, ticket_code=None, **kwargs):


### PR DESCRIPTION
## Summary

Reintroduces, in **modern and neutral form**, the full-duplex async-session
pattern that lived inside the legacy `DebugSession` class (removed in #852
via commit `2bd3fd1f46`).

The pattern was good infrastructure but tailored to the PDB use case.
Removing the legacy debugger without preserving the pattern would have
meant rewriting it identically at the first future use. Reintroducing it
here, neutral and well-tested, locks down the API ahead of real consumers.
The first expected one is `gnrorchestrator` (a future conversational
orchestration component).

## What it adds

A single module `gnrpy/gnr/web/gnrasync_session.py` exposing two public
classes:

- **`AsyncSession[T, U]`** — a full-duplex session bridging a server-side
  peer with a browser-side WebSocket client. Three semantic operations:
    - `notify(payload)` — fire-and-forget event peer → client
    - `request(payload, timeout=...)` — peer asks client and awaits the
      correlated response (`_request_id` under the hood)
    - `events()` — async iterator of client → peer messages that are not
      responses to a pending request
- **`AsyncSessionManager`** — registry of sessions with lifecycle managed
  by an async context manager (`async with manager.session(key, ...) as session:`).
  Per-page lookup and bulk close (`close_for_page`) are first-class.

## Design choices

- **Python 3.11+ idioms**: `asyncio.TaskGroup` for structured cancellation,
  `asyncio.timeout()`, union types `X | Y`, `@dataclass`,
  `asynccontextmanager`.
- **JSON framing by default**, with pluggable `encode_to_client` /
  `decode_from_client` hooks for consumers that need a different wire
  format (binary, msgpack, …).
- **Correlation hidden from the consumer**: the payload type `T` is
  opaque; `request()` injects `_request_id` in the wrapper and the client
  echoes `_response_to`. The consumer only sees the semantic API.
- **No global registry, no leaks**: a session exists only within the
  async-context-manager scope; the manager unregisters on exit.
  Structurally fixes the `debug_queues` leak the legacy `DebugSession`
  had.
- **Immediate wakeup of `events()` on close** via an internal sentinel —
  no busy polling.

## What it does not add (on purpose)

- No consumer. No listener (Unix socket, TCP, …). No changes to any
  existing framework file.
- The scaffold stands on its own, is covered by pure unit tests
  (no I/O, no framework mocks), and waits for its first user.

## Test plan

- [x] flake8: zero issues on added files
- [x] 11/11 unit tests in `gnrpy/tests/web/gnrasync_session_test.py` green:
      lifecycle via context manager, notify, request/response correlation,
      request timeout, events iterator, event/response separation,
      multi-session isolation, close_for_page, custom framing, error
      propagation through TaskGroup, immediate wakeup of `events()` on
      close
- [x] asyncio regression suite (`gnrasync_test.py`): 6/6 green
- [x] full `gnrpy/` test suite: 1711 passed (22 pre-existing failures on
      `feature/asyncio-migration`, in unrelated modules: `gnrlocale`,
      `gnrdate`, `test_compiler_coverage`)
- [x] no dirty imports, no logic in CLI modules

## Dependency

This PR builds on commit `2bd3fd1f46` of #852 (legacy debugger removal).
**Merge #852 first, then this one.** Back to the concept:

> #852: removes the legacy PDB debugger and completes the asyncio migration
> this PR: reintroduces the good part (async session pattern) in modern
>          form, ready for gnrorchestrator and future use cases

## Review window

cgabriel will be away from May 15 to June 6. **Please start the review
before May 15** so that both PRs (#852 and this one) can land together
without a month-long gap.