### PR TITLE
Introduce neutral AsyncSession core (depends on #852)

### DIFF
--- a/gnrpy/gnr/web/gnrasync_session.py
+++ b/gnrpy/gnr/web/gnrasync_session.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+# --------------------------------------------------------------------------
+# package       : GenroPy core - see LICENSE for details
+# module gnrasync_session : neutral full-duplex async session core
+# --------------------------------------------------------------------------
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+
+"""Neutral, modern async session core for GenroPy.
+
+The module exposes an :class:`AsyncSession` class that bridges a server-side
+peer with a browser-side WebSocket client and an :class:`AsyncSessionManager`
+that owns session lifecycles. Three semantic operations are exposed to the
+peer side:
+
+- ``notify(payload)``: fire-and-forget event peer -> client.
+- ``request(payload, timeout=...)``: peer asks client and awaits the
+  correlated response.
+- ``events()``: async iterator of unsolicited client -> peer messages.
+
+Wire framing defaults to JSON, but ``encode_to_client``/``decode_from_client``
+hooks let consumers plug a different format. The internal request/response
+correlation is hidden from the consumer: the manager wraps requests with a
+``_request_id`` field and the client side answers with ``_response_to``.
+
+There is no global state. Sessions live inside an async-context-manager
+scope owned by the manager and the broker tasks are managed via
+:class:`asyncio.TaskGroup`, so cancellation and cleanup are structural.
+"""
+
+import asyncio
+import json
+import uuid
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Generic,
+    TypeVar,
+)
+
+
+T = TypeVar('T')
+U = TypeVar('U')
+
+
+# Reserved framing keys used by the default JSON encoder/decoder.
+_REQUEST_ID_KEY = '_request_id'
+_RESPONSE_TO_KEY = '_response_to'
+_PAYLOAD_KEY = 'payload'
+_EVENT_KEY = 'event'
+
+# Internal sentinel pushed onto the events queue when the session closes,
+# so that any consumer awaiting events() wakes up immediately instead of
+# polling the closed flag.
+_CLOSE_SENTINEL = object()
+
+
+def _default_encode(message: Any) -> str:
+    """Serialize an internal framing dict to a JSON string.
+
+    The encoder operates on the wrapper dict produced by :class:`AsyncSession`
+    (e.g. ``{'event': payload}`` or ``{'_request_id': 'id', 'payload': ...}``),
+    not on the raw consumer payload.
+    """
+    return json.dumps(message)
+
+
+def _default_decode(raw: str | bytes) -> object:
+    """Deserialize a raw text/bytes WebSocket message as JSON."""
+    if isinstance(raw, bytes):
+        raw = raw.decode('utf-8')
+    return json.loads(raw)
+
+
+@dataclass
+class AsyncSession(Generic[T, U]):
+    """A full-duplex async session bridging a server-side peer with a
+    browser-side WebSocket client.
+
+    Three semantic operations:
+
+    - ``notify(payload)``: fire-and-forget event peer -> client.
+    - ``request(payload, timeout=...)``: peer asks client and awaits the
+      response (correlated by an internal request id).
+    - ``events()``: async iterator of events client -> peer that are not
+      responses to a pending :meth:`request`.
+
+    The session is created and managed by :class:`AsyncSessionManager` and
+    must not be instantiated directly. Lifecycle is bound to the manager's
+    ``session()`` async context manager: when the context exits, the broker
+    tasks are cancelled cleanly via :class:`asyncio.TaskGroup`.
+
+    Two hooks customize message framing:
+
+    - ``encode_to_client(message)``: serializes the wrapper dict before
+      sending it to the WebSocket. Default: JSON via :func:`json.dumps`.
+    - ``decode_from_client(raw)``: deserializes the raw text/bytes coming
+      from the WebSocket. Default: JSON via :func:`json.loads`.
+
+    The default JSON framing reserves two keys in client messages:
+    ``_response_to`` (a string) marks a message as the response to a
+    previous :meth:`request`; otherwise the message is yielded by
+    :meth:`events`. The peer side never sees the correlation id: it is
+    injected and stripped under the hood.
+
+    Type parameter ``T`` is the consumer's outbound payload type (the
+    argument of :meth:`notify` / :meth:`request`); ``U`` is the inbound
+    event type yielded by :meth:`events`. Both default to ``object``.
+    """
+
+    key: str
+    on_send: Callable[[str | bytes], Awaitable[None]]
+    page_id: str | None = None
+    encode_to_client: Callable[[Any], str | bytes] = field(
+        default=_default_encode
+    )
+    decode_from_client: Callable[[str | bytes], object] = field(
+        default=_default_decode
+    )
+
+    # Internal state
+    _events_queue: asyncio.Queue[object] = field(
+        default_factory=asyncio.Queue, init=False, repr=False
+    )
+    _pending: dict[str, asyncio.Future[object]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _send_lock: asyncio.Lock = field(
+        default_factory=asyncio.Lock, init=False, repr=False
+    )
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    async def notify(self, payload: T) -> None:
+        """Send a fire-and-forget event to the client.
+
+        :param payload: The application-level payload to deliver.
+        :raises RuntimeError: If the session has already been closed.
+        """
+        if self._closed:
+            raise RuntimeError(f'session {self.key!r} is closed')
+        message = {_EVENT_KEY: payload}
+        await self._send(message)
+
+    async def request(
+        self,
+        payload: T,
+        *,
+        timeout: float | None = None,
+    ) -> object:
+        """Send a request to the client and await its correlated response.
+
+        The wrapper injects an internal ``_request_id`` so the client can
+        echo it back as ``_response_to`` and the corresponding future is
+        resolved with the response payload.
+
+        :param payload: The application-level payload to deliver.
+        :param timeout: Optional timeout in seconds. ``None`` waits forever.
+        :returns: The payload contained in the client's response message,
+            with the correlation key already stripped.
+        :raises RuntimeError: If the session has already been closed.
+        :raises TimeoutError: If no response arrives within ``timeout``.
+        """
+        if self._closed:
+            raise RuntimeError(f'session {self.key!r} is closed')
+        request_id = uuid.uuid4().hex
+        future: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        message = {_REQUEST_ID_KEY: request_id, _PAYLOAD_KEY: payload}
+        try:
+            await self._send(message)
+            if timeout is None:
+                return await future
+            async with asyncio.timeout(timeout):
+                return await future
+        finally:
+            self._pending.pop(request_id, None)
+
+    async def events(self) -> AsyncIterator[object]:
+        """Yield unsolicited client -> peer messages in arrival order.
+
+        The iterator yields messages that the client sent without a
+        ``_response_to`` field, i.e. those that are not answers to a
+        pending :meth:`request`. The iterator runs until the session is
+        closed; closure pushes an internal sentinel onto the queue so
+        the iterator wakes up and returns immediately, without polling.
+        """
+        while True:
+            item = await self._events_queue.get()
+            if item is _CLOSE_SENTINEL:
+                return
+            yield item
+
+    async def feed_from_client(self, raw: str | bytes) -> None:
+        """Dispatch a raw client -> peer WebSocket frame.
+
+        This method is meant to be called by whichever component owns the
+        WebSocket read loop. The frame is decoded via
+        :attr:`decode_from_client`; if it carries a ``_response_to`` key
+        whose value matches a pending :meth:`request`, the corresponding
+        future is resolved with the rest of the message; otherwise the
+        message is enqueued for :meth:`events`.
+
+        :param raw: The text or bytes frame received from the WebSocket.
+        """
+        if self._closed:
+            return
+        message = self.decode_from_client(raw)
+        if isinstance(message, dict) and _RESPONSE_TO_KEY in message:
+            request_id = message.get(_RESPONSE_TO_KEY)
+            future = self._pending.get(request_id) if isinstance(request_id, str) else None
+            if future is not None and not future.done():
+                response_payload = {
+                    k: v for k, v in message.items() if k != _RESPONSE_TO_KEY
+                }
+                # Unwrap a bare 'payload' field if that is the only remaining
+                # key, so consumers see the same shape they sent in request().
+                if list(response_payload.keys()) == [_PAYLOAD_KEY]:
+                    future.set_result(response_payload[_PAYLOAD_KEY])
+                else:
+                    future.set_result(response_payload)
+                return
+            # Orphan response (no pending future): drop silently. A noisy
+            # log here would conflate test setup races with real errors.
+            return
+        await self._events_queue.put(message)
+
+    async def _send(self, message: Any) -> None:
+        """Encode ``message`` and forward it to :attr:`on_send`.
+
+        A lock is held around the encoded write so that concurrent
+        :meth:`notify` / :meth:`request` calls do not interleave a single
+        frame's bytes on the underlying transport.
+        """
+        encoded = self.encode_to_client(message)
+        async with self._send_lock:
+            await self.on_send(encoded)
+
+    def _close(self) -> None:
+        """Mark the session closed and cancel any pending requests.
+
+        Called by :class:`AsyncSessionManager` when the session's async
+        context exits. Idempotent.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        for future in self._pending.values():
+            if not future.done():
+                future.cancel()
+        self._pending.clear()
+        # Wake up any consumer awaiting events() so it returns immediately.
+        self._events_queue.put_nowait(_CLOSE_SENTINEL)
+
+
+class AsyncSessionManager:
+    """Registry of active sessions with structural lifecycle management.
+
+    Sessions are created and disposed only via the :meth:`session` async
+    context manager, which guarantees that the registry is consistent and
+    that broker tasks are cancelled on exit (cleanly via
+    :class:`asyncio.TaskGroup`). Per-page lookup (:meth:`keys_for_page`)
+    and bulk close (:meth:`close_for_page`) are first-class so a page
+    teardown can release every session it owns in one call.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, AsyncSession] = {}
+        self._by_page: defaultdict[str, set[str]] = defaultdict(set)
+
+    @asynccontextmanager
+    async def session(
+        self,
+        key: str,
+        on_send: Callable[[str | bytes], Awaitable[None]],
+        *,
+        page_id: str | None = None,
+        encode_to_client: Callable[[Any], str | bytes] | None = None,
+        decode_from_client: Callable[[str | bytes], object] | None = None,
+    ) -> AsyncIterator[AsyncSession]:
+        """Open a new session under ``key`` and yield it to the caller.
+
+        On entry the session is registered and (if ``page_id`` is given)
+        indexed under that page. On exit the session is unregistered, its
+        broker tasks are cancelled via :class:`asyncio.TaskGroup`, and any
+        pending :meth:`AsyncSession.request` futures are cancelled.
+
+        :param key: Unique session key. Must not already be in use.
+        :param on_send: Coroutine invoked with each encoded outbound frame
+            (typically the WebSocket ``send_str`` / ``send_bytes`` method).
+        :param page_id: Optional page identifier used by
+            :meth:`keys_for_page` and :meth:`close_for_page`.
+        :param encode_to_client: Optional custom encoder. Defaults to JSON.
+        :param decode_from_client: Optional custom decoder. Defaults to JSON.
+        :raises ValueError: If ``key`` is already registered.
+        """
+        if key in self._sessions:
+            raise ValueError(f'session key {key!r} already in use')
+        kwargs: dict[str, Any] = {
+            'key': key,
+            'on_send': on_send,
+            'page_id': page_id,
+        }
+        if encode_to_client is not None:
+            kwargs['encode_to_client'] = encode_to_client
+        if decode_from_client is not None:
+            kwargs['decode_from_client'] = decode_from_client
+        sess: AsyncSession = AsyncSession(**kwargs)
+        self._sessions[key] = sess
+        if page_id is not None:
+            self._by_page[page_id].add(key)
+        try:
+            async with asyncio.TaskGroup():
+                # The TaskGroup is entered to enforce structured cancellation
+                # semantics on any background task a future consumer may
+                # spawn within the session scope. The core itself does not
+                # spawn brokers (feed_from_client is driven by the WS read
+                # loop owned by the caller), but the TaskGroup boundary is
+                # what guarantees clean teardown for any subclass or wrapper.
+                yield sess
+        finally:
+            sess._close()
+            self._unregister(key, page_id)
+
+    def get(self, key: str) -> AsyncSession | None:
+        """Return the live session with the given key, or ``None``."""
+        return self._sessions.get(key)
+
+    def keys_for_page(self, page_id: str) -> list[str]:
+        """Return the list of session keys registered for ``page_id``."""
+        return list(self._by_page.get(page_id, ()))
+
+    async def close_for_page(self, page_id: str) -> None:
+        """Close every session registered under ``page_id``.
+
+        Each session is marked closed and removed from the registry; any
+        active ``async with manager.session(...)`` block will observe
+        :attr:`AsyncSession._closed` and exit on next iteration of
+        :meth:`AsyncSession.events` or on the next call to
+        :meth:`AsyncSession.notify` / :meth:`AsyncSession.request`.
+        """
+        for key in self.keys_for_page(page_id):
+            sess = self._sessions.get(key)
+            if sess is not None:
+                sess._close()
+                self._unregister(key, page_id)
+
+    def _unregister(self, key: str, page_id: str | None) -> None:
+        """Remove the session from the primary and per-page indexes."""
+        self._sessions.pop(key, None)
+        if page_id is not None:
+            keys = self._by_page.get(page_id)
+            if keys is not None:
+                keys.discard(key)
+                if not keys:
+                    self._by_page.pop(page_id, None)

--- a/gnrpy/tests/web/gnrasync_session_test.py
+++ b/gnrpy/tests/web/gnrasync_session_test.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the neutral AsyncSession core.
+
+Pure asyncio, no I/O, no framework mocks: the tests exercise the public
+API of :mod:`gnr.web.gnrasync_session` against a fake transport that just
+captures the bytes/strings written by ``on_send``.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from gnr.web.gnrasync_session import AsyncSessionManager
+
+
+def _make_collector():
+    """Return ``(collected, on_send)`` where ``on_send`` appends to ``collected``."""
+    collected: list[str | bytes] = []
+
+    async def on_send(message: str | bytes) -> None:
+        collected.append(message)
+
+    return collected, on_send
+
+
+@pytest.mark.asyncio
+async def test_session_lifecycle_via_context_manager():
+    manager = AsyncSessionManager()
+    _, on_send = _make_collector()
+    assert manager.get('s1') is None
+
+    async with manager.session('s1', on_send) as sess:
+        assert manager.get('s1') is sess
+        assert sess.key == 's1'
+
+    assert manager.get('s1') is None
+
+    # No leaked tasks attributable to this manager: every Task currently
+    # alive should belong to the test harness, not to the closed session.
+    current = asyncio.current_task()
+    leftover = [
+        t for t in asyncio.all_tasks()
+        if t is not current and not t.done()
+    ]
+    # The pytest-asyncio runner may keep its own tasks; we only care that
+    # no task references our session.
+    for task in leftover:
+        assert 'AsyncSession' not in repr(task)
+
+
+@pytest.mark.asyncio
+async def test_notify_encodes_and_forwards():
+    manager = AsyncSessionManager()
+    collected, on_send = _make_collector()
+
+    async with manager.session('s1', on_send) as sess:
+        await sess.notify({'kind': 'hello', 'text': 'world'})
+
+    assert len(collected) == 1
+    decoded = json.loads(collected[0])
+    assert decoded == {'event': {'kind': 'hello', 'text': 'world'}}
+    assert '_request_id' not in decoded
+
+
+@pytest.mark.asyncio
+async def test_request_response_correlation():
+    manager = AsyncSessionManager()
+    collected, on_send = _make_collector()
+
+    async with manager.session('s1', on_send) as sess:
+        async def respond_when_sent():
+            # Wait for the request frame, then synthesize a response.
+            for _ in range(50):
+                if collected:
+                    break
+                await asyncio.sleep(0.01)
+            sent = json.loads(collected[0])
+            request_id = sent['_request_id']
+            response = json.dumps({
+                '_response_to': request_id,
+                'payload': {'answer': 42},
+            })
+            await sess.feed_from_client(response)
+
+        responder = asyncio.create_task(respond_when_sent())
+        try:
+            result = await sess.request({'q': 'meaning?'}, timeout=1.0)
+        finally:
+            await responder
+
+    assert result == {'answer': 42}
+
+
+@pytest.mark.asyncio
+async def test_request_timeout_raises():
+    manager = AsyncSessionManager()
+    _, on_send = _make_collector()
+
+    async with manager.session('s1', on_send) as sess:
+        with pytest.raises(TimeoutError):
+            await sess.request({'q': 'no-answer'}, timeout=0.05)
+        # The pending dict must be cleaned up after the timeout.
+        assert sess._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_events_iterator_yields_in_order():
+    manager = AsyncSessionManager()
+    _, on_send = _make_collector()
+
+    received: list[object] = []
+
+    async with manager.session('s1', on_send) as sess:
+        await sess.feed_from_client(json.dumps({'msg': 'a'}))
+        await sess.feed_from_client(json.dumps({'msg': 'b'}))
+
+        async def consume_two():
+            count = 0
+            async for evt in sess.events():
+                received.append(evt)
+                count += 1
+                if count == 2:
+                    return
+
+        await asyncio.wait_for(consume_two(), timeout=1.0)
+
+    assert received == [{'msg': 'a'}, {'msg': 'b'}]
+
+
+@pytest.mark.asyncio
+async def test_response_does_not_leak_into_events():
+    manager = AsyncSessionManager()
+    collected, on_send = _make_collector()
+
+    received: list[object] = []
+
+    async with manager.session('s1', on_send) as sess:
+        async def producer():
+            # Wait for the request frame so we can pick up its id.
+            for _ in range(50):
+                if collected:
+                    break
+                await asyncio.sleep(0.01)
+            request_id = json.loads(collected[0])['_request_id']
+            # Feed a non-response, then the response, then another non-response.
+            await sess.feed_from_client(json.dumps({'msg': 'before'}))
+            await sess.feed_from_client(json.dumps({
+                '_response_to': request_id, 'payload': 'OK',
+            }))
+            await sess.feed_from_client(json.dumps({'msg': 'after'}))
+
+        async def consumer():
+            count = 0
+            async for evt in sess.events():
+                received.append(evt)
+                count += 1
+                if count == 2:
+                    return
+
+        prod = asyncio.create_task(producer())
+        cons = asyncio.create_task(consumer())
+
+        result = await sess.request('q', timeout=1.0)
+        await prod
+        await asyncio.wait_for(cons, timeout=1.0)
+
+    assert result == 'OK'
+    assert received == [{'msg': 'before'}, {'msg': 'after'}]
+
+
+@pytest.mark.asyncio
+async def test_multiple_sessions_are_isolated():
+    manager = AsyncSessionManager()
+    collected_a, on_send_a = _make_collector()
+    collected_b, on_send_b = _make_collector()
+
+    async with manager.session('A', on_send_a) as sa:
+        async with manager.session('B', on_send_b) as sb:
+            await sa.notify('to-A')
+            await sb.notify('to-B')
+            assert manager.get('A') is sa
+            assert manager.get('B') is sb
+
+    assert json.loads(collected_a[0]) == {'event': 'to-A'}
+    assert json.loads(collected_b[0]) == {'event': 'to-B'}
+    assert manager.get('A') is None
+    assert manager.get('B') is None
+
+
+@pytest.mark.asyncio
+async def test_close_for_page_targets_only_matching_page():
+    manager = AsyncSessionManager()
+    _, send1 = _make_collector()
+    _, send2 = _make_collector()
+    _, send3 = _make_collector()
+
+    p1_a_done = asyncio.Event()
+    p1_b_done = asyncio.Event()
+    p2_done = asyncio.Event()
+
+    async def run_session(key, page_id, on_send, done_event):
+        async with manager.session(key, on_send, page_id=page_id):
+            await done_event.wait()
+
+    t1 = asyncio.create_task(run_session('p1a', 'P1', send1, p1_a_done))
+    t2 = asyncio.create_task(run_session('p1b', 'P1', send2, p1_b_done))
+    t3 = asyncio.create_task(run_session('p2', 'P2', send3, p2_done))
+
+    # Give the tasks a chance to enter the context.
+    for _ in range(50):
+        if all(manager.get(k) is not None for k in ('p1a', 'p1b', 'p2')):
+            break
+        await asyncio.sleep(0.01)
+
+    assert sorted(manager.keys_for_page('P1')) == ['p1a', 'p1b']
+    assert manager.keys_for_page('P2') == ['p2']
+
+    await manager.close_for_page('P1')
+
+    assert manager.get('p1a') is None
+    assert manager.get('p1b') is None
+    assert manager.get('p2') is not None
+    assert manager.keys_for_page('P1') == []
+
+    # Release the still-running task contexts so the test exits cleanly.
+    p1_a_done.set()
+    p1_b_done.set()
+    p2_done.set()
+    await asyncio.gather(t1, t2, t3)
+
+
+@pytest.mark.asyncio
+async def test_custom_framing_roundtrip():
+    """Custom encoder/decoder pair: JSON wrapped with a 'B:' byte prefix."""
+    manager = AsyncSessionManager()
+    collected, on_send = _make_collector()
+
+    def encode(message):
+        return b'B:' + json.dumps(message).encode('utf-8')
+
+    def decode(raw):
+        if isinstance(raw, str):
+            raw = raw.encode('utf-8')
+        assert raw.startswith(b'B:'), f'expected B: prefix, got {raw!r}'
+        return json.loads(raw[2:].decode('utf-8'))
+
+    async with manager.session(
+        's1', on_send,
+        encode_to_client=encode, decode_from_client=decode,
+    ) as sess:
+        # notify
+        await sess.notify({'k': 1})
+        assert collected[-1].startswith(b'B:')
+        assert json.loads(collected[-1][2:]) == {'event': {'k': 1}}
+
+        # request/response roundtrip with the same custom framing
+        async def responder():
+            for _ in range(50):
+                if len(collected) >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            sent = json.loads(collected[1][2:])
+            request_id = sent['_request_id']
+            await sess.feed_from_client(
+                b'B:' + json.dumps({
+                    '_response_to': request_id, 'payload': 'ack',
+                }).encode('utf-8')
+            )
+
+        task = asyncio.create_task(responder())
+        try:
+            result = await sess.request({'q': 1}, timeout=1.0)
+        finally:
+            await task
+
+    assert result == 'ack'
+
+
+@pytest.mark.asyncio
+async def test_send_failure_propagates_and_unregisters():
+    """An exception raised inside on_send must surface and clean up state."""
+    manager = AsyncSessionManager()
+
+    class Boom(Exception):
+        pass
+
+    async def bad_send(_message):
+        raise Boom('boom')
+
+    with pytest.raises(BaseExceptionGroup) as excinfo:
+        async with manager.session('s1', bad_send) as sess:
+            await sess.notify({'x': 1})
+
+    # The TaskGroup wraps any exception escaping the body in an ExceptionGroup;
+    # we just verify our underlying error is in there.
+    flat = [
+        e for e in _flatten_exception_group(excinfo.value)
+        if isinstance(e, Boom)
+    ]
+    assert flat, f'Boom not found in {excinfo.value!r}'
+
+    # Session must be unregistered even on failure.
+    assert manager.get('s1') is None
+
+
+@pytest.mark.asyncio
+async def test_events_iterator_returns_immediately_on_close():
+    """events() must wake up at once on close, not poll for the closed flag."""
+    manager = AsyncSessionManager()
+    _, on_send = _make_collector()
+
+    loop = asyncio.get_running_loop()
+
+    async with manager.session('s1', on_send) as sess:
+        async def consume():
+            collected = []
+            async for item in sess.events():
+                collected.append(item)
+            return collected
+
+        consumer = asyncio.create_task(consume())
+        # Give the consumer a chance to suspend on queue.get().
+        await asyncio.sleep(0)
+        close_started_at = loop.time()
+
+    # The session is now closed (context exited). The iterator must
+    # complete promptly via the internal wakeup sentinel; if a polling
+    # implementation regressed, this would only complete after the
+    # polling tick (>= ~50ms in the original). We assert <10ms.
+    result = await asyncio.wait_for(consumer, timeout=0.5)
+    elapsed = loop.time() - close_started_at
+    assert result == []
+    assert elapsed < 0.01, f'events() took {elapsed * 1000:.1f}ms to wake up'
+
+
+def _flatten_exception_group(exc):
+    """Yield every leaf exception inside a (possibly nested) ExceptionGroup."""
+    if isinstance(exc, BaseExceptionGroup):
+        for inner in exc.exceptions:
+            yield from _flatten_exception_group(inner)
+    else:
+        yield exc


### PR DESCRIPTION
## Summary

Reintroduces, in **modern and neutral form**, the full-duplex async-session
pattern that lived inside the legacy `DebugSession` class (removed in #852
via commit `2bd3fd1f46`).

The pattern was good infrastructure but tailored to the PDB use case.
Removing the legacy debugger without preserving the pattern would have
meant rewriting it identically at the first future use. Reintroducing it
here, neutral and well-tested, locks down the API ahead of real consumers.
The first expected one is `gnrorchestrator` (a future conversational
orchestration component).

> **Note**: this PR supersedes #894, which was closed because of an
> operator error (wrong head branch). The content is identical.

## What it adds

A single module `gnrpy/gnr/web/gnrasync_session.py` exposing two public
classes:

- **`AsyncSession[T, U]`** — a full-duplex session bridging a server-side
  peer with a browser-side WebSocket client. Three semantic operations:
    - `notify(payload)` — fire-and-forget event peer → client
    - `request(payload, timeout=...)` — peer asks client and awaits the
      correlated response (`_request_id` under the hood)
    - `events()` — async iterator of client → peer messages that are not
      responses to a pending request
- **`AsyncSessionManager`** — registry of sessions with lifecycle managed
  by an async context manager (`async with manager.session(key, ...) as session:`).
  Per-page lookup and bulk close (`close_for_page`) are first-class.

## Design choices

- **Python 3.11+ idioms**: `asyncio.TaskGroup` for structured cancellation,
  `asyncio.timeout()`, union types `X | Y`, `@dataclass`,
  `asynccontextmanager`.
- **JSON framing by default**, with pluggable `encode_to_client` /
  `decode_from_client` hooks for consumers that need a different wire
  format (binary, msgpack, …).
- **Correlation hidden from the consumer**: the payload type `T` is
  opaque; `request()` injects `_request_id` in the wrapper and the client
  echoes `_response_to`. The consumer only sees the semantic API.
- **No global registry, no leaks**: a session exists only within the
  async-context-manager scope; the manager unregisters on exit.
  Structurally fixes the `debug_queues` leak the legacy `DebugSession`
  had.
- **Immediate wakeup of `events()` on close** via an internal sentinel —
  no busy polling.

## What it does not add (on purpose)

- No consumer. No listener (Unix socket, TCP, …). No changes to any
  existing framework file.
- The scaffold stands on its own, is covered by pure unit tests
  (no I/O, no framework mocks), and waits for its first user.

## Test plan

- [x] flake8: zero issues on added files
- [x] 11/11 unit tests in `gnrpy/tests/web/gnrasync_session_test.py` green:
      lifecycle via context manager, notify, request/response correlation,
      request timeout, events iterator, event/response separation,
      multi-session isolation, close_for_page, custom framing, error
      propagation through TaskGroup, immediate wakeup of `events()` on
      close
- [x] asyncio regression suite (`gnrasync_test.py`): 6/6 green
- [x] full `gnrpy/` test suite: 1711 passed (22 pre-existing failures on
      `feature/asyncio-migration`, in unrelated modules: `gnrlocale`,
      `gnrdate`, `test_compiler_coverage`)
- [x] no dirty imports, no logic in CLI modules

## Dependency

This PR builds on commit `2bd3fd1f46` of #852 (legacy debugger removal).
**Merge #852 first, then this one.** Back to the concept:

> #852: removes the legacy PDB debugger and completes the asyncio migration
> this PR: reintroduces the good part (async session pattern) in modern
>          form, ready for gnrorchestrator and future use cases

## Review window

cgabriel will be away from May 15 to June 6. **Please start the review
before May 15** so that both PRs (#852 and this one) can land together
without a month-long gap.