### PR TITLE
test(gnrwebstruct): add characterization tests for __getattr__ and genroNameSpace

### DIFF
--- a/gnrpy/tests/web/gnrwebstruct_test.py
+++ b/gnrpy/tests/web/gnrwebstruct_test.py
@@ -3,16 +3,59 @@
 
 import pytest
 
-from gnr.web.gnrwebstruct import GnrDomSrc, struct_method, StructMethodError
+from gnr.web.gnrwebstruct import (
+    GnrDomSrc,
+    GnrDomSrc_dojo_11,
+    GnrDomElem,
+    StructMethodError,
+    struct_method,
+)
 
-def  test_register_without_name_without_underscore():
+
+class _AppStub(object):
+    def checkResourcePermission(self, *args, **kwargs):
+        return True
+
+    def allowedByPreference(self, *args, **kwargs):
+        return True
+
+
+class _PageStub(object):
+    filepath = '/tmp/fake_page.py'
+    application = _AppStub()
+
+    def __init__(self):
+        self._register_nodeId = {}
+
+    def checkTablePermission(self, **kwargs):
+        return True
+
+
+def _make_root(page=None):
+    return GnrDomSrc_dojo_11.makeRoot(page or _PageStub())
+
+
+def _attached_node(root):
+    """Return a node that is properly attached to the tree (has a
+    `_parentNode`), required to exercise the `autoslots` and `subtag`
+    branches of `__getattr__` without crashing.
+    """
+    return root.child('div', childname='inner')
+
+
+# ---------------------------------------------------------------------------
+# @struct_method registration (pre-existing tests, kept verbatim)
+# ---------------------------------------------------------------------------
+
+def test_register_without_name_without_underscore():
     @struct_method
     def foo():
         pass
 
     assert GnrDomSrc._external_methods['foo'] == 'foo'
 
-def  test_register_without_name_with_underscore():
+
+def test_register_without_name_with_underscore():
     @struct_method
     def a_quuz():
         pass
@@ -34,8 +77,9 @@ def test_valid_override_methods():
         pass
 
     @struct_method
-    def foo1():
+    def foo1():  # noqa: F811
         pass
+
 
 def test_invalid_override_methods():
     with pytest.raises(StructMethodError):
@@ -46,3 +90,146 @@ def test_invalid_override_methods():
         @struct_method('foo1')
         def bar1():
             pass
+
+
+# ---------------------------------------------------------------------------
+# genroNameSpace snapshot
+# ---------------------------------------------------------------------------
+
+def test_genroNameSpace_total_count():
+    """Freeze the cardinality of the public widget namespace.
+
+    Lowercased dedup of htmlNS + dijitNS + dojoxNS + gnrNS yields 256
+    entries today. Drift in either direction must be intentional.
+    """
+    assert len(GnrDomSrc_dojo_11.genroNameSpace) == 256
+
+
+def test_genroNameSpace_samples_per_dialect():
+    ns = GnrDomSrc_dojo_11.genroNameSpace
+    assert ns['div'] == 'div'                          # html
+    assert ns['bordercontainer'] == 'BorderContainer'  # dijit
+    assert ns['chart'] == 'Chart'                      # dojox
+    assert ns['dbselect'] == 'DbSelect'                # gnr
+
+
+def test_genroNameSpace_is_lowercase_keyed():
+    ns = GnrDomSrc_dojo_11.genroNameSpace
+    assert all(k == k.lower() for k in ns), \
+        'All keys in genroNameSpace must be lowercase'
+
+
+def test_namespace_covers_all_four_dialects():
+    """Defensive check: at least one representative from each of the
+    four source lists must survive the lowercase dedup merge.
+    """
+    ns = GnrDomSrc_dojo_11.genroNameSpace
+    assert 'abbr' in ns          # htmlNS (no explicit method)
+    assert 'combobox' in ns      # dijitNS
+    assert 'floatingpane' in ns  # dojoxNS
+    assert 'dbselect' in ns      # gnrNS
+
+
+# ---------------------------------------------------------------------------
+# __getattr__ fallback ladder
+# ---------------------------------------------------------------------------
+
+def test_getattr_namespace_hit_returns_GnrDomElem():
+    """A widget name that is in genroNameSpace but has no explicit
+    method on the class is dispatched through __getattr__ and yields
+    a GnrDomElem bound to the CamelCase tag.
+    """
+    root = _make_root()
+    elem = root.borderContainer
+    assert isinstance(elem, GnrDomElem)
+    assert elem.tag == 'BorderContainer'
+
+
+def test_getattr_namespace_hit_lowercase_only_tag():
+    """A pure-lowercase HTML tag (e.g. 'abbr') routes through the
+    namespace and produces a GnrDomElem with the tag as-is.
+    """
+    root = _make_root()
+    elem = root.abbr
+    assert isinstance(elem, GnrDomElem)
+    assert elem.tag == 'abbr'
+
+
+def test_getattr_case_insensitive_retry_to_explicit_method():
+    """When a name is requested in a different case (e.g. 'Div')
+    and a lowercase method 'div' exists on the class, __getattr__
+    delegates to the lowercase explicit method.
+    """
+    root = _make_root()
+    assert root.Div.__func__ is root.div.__func__
+
+
+def test_getattr_external_method_hit():
+    """A @struct_method registered widget is dispatched to a bound
+    handler on the page when the page exposes the underlying function.
+    """
+    @struct_method('myExternalWidget')
+    def my_external_widget_impl(struct, *args, **kwargs):  # noqa: F841
+        pass
+
+    page = _PageStub()
+
+    def handler(struct, *args, **kwargs):
+        return ('bound', args, kwargs)
+
+    page.my_external_widget_impl = handler
+    root = _make_root(page=page)
+    bound = root.myExternalWidget
+    assert callable(bound)
+    assert bound('x', y=1) == ('bound', ('x',), {'y': 1})
+
+
+def test_getattr_external_method_missing_handler_raises():
+    """When a struct_method is registered but the page lacks the
+    corresponding handler attribute, __getattr__ raises AttributeError
+    citing the resolved internal method name and the page filepath.
+    """
+    @struct_method('orphanWidget')
+    def _orphan_impl(struct):
+        pass
+
+    page = _PageStub()  # no _orphan_impl attribute
+    root = _make_root(page=page)
+    with pytest.raises(AttributeError) as excinfo:
+        _ = root.orphanWidget
+    msg = str(excinfo.value)
+    assert '_orphan_impl' in msg
+    assert 'fake_page.py' in msg
+
+
+def test_getattr_unknown_name_raises_with_page_name():
+    """Unknown widget on an attached node raises AttributeError citing
+    the missing name and the page filepath.
+    """
+    root = _make_root()
+    node = _attached_node(root)
+    with pytest.raises(AttributeError) as excinfo:
+        _ = node.this_widget_does_not_exist
+    msg = str(excinfo.value)
+    assert 'this_widget_does_not_exist' in msg
+    assert 'fake_page.py' in msg
+
+
+# ---------------------------------------------------------------------------
+# Smoke: GnrDomSrc_dojo_11 instantiation and wiring
+# ---------------------------------------------------------------------------
+
+def test_makeRoot_returns_dojo_11_instance():
+    root = _make_root()
+    assert isinstance(root, GnrDomSrc_dojo_11)
+    # _page wiring round-trips through the .page property
+    assert root.page is root._page
+
+
+def test_child_creates_attached_node():
+    root = _make_root()
+    node = root.child('div', childname='greeting')
+    assert isinstance(node, GnrDomSrc_dojo_11)
+    fetched = root.getNode('greeting')
+    assert fetched is not None
+    assert fetched._value is node


### PR DESCRIPTION
## Summary

First of three PRs from #901 — adds a characterization test suite around
`gnrpy/gnr/web/gnrwebstruct.py` before any code is moved or refactored.

The 5 existing tests on `@struct_method` are preserved verbatim (only
cosmetic whitespace). 12 new tests pin:

- `genroNameSpace` cardinality (256 entries) and per-dialect samples
- `__getattr__` six-fallback ladder: namespace hit (CamelCase + lowercase
  tags), case-insensitive retry to explicit methods, external-method
  routing (bound and orphan), unknown name with page filepath in the
  error
- smoke: `makeRoot` instantiation, `child()` round-trip via `getNode`

A minimal `_PageStub` + `_AppStub` keeps the tests free of `GnrApp` while
still satisfying `child()`'s permission checks.

No production code touched. This is the baseline against which PR #2
(module → package split) and PR #3 (lightweight `@widget` decorator +
registry-driven `genroNameSpace`) will be validated.

## Test plan

- [x] `pytest gnrpy/tests/web/gnrwebstruct_test.py -v` → 17/17 pass
- [x] `flake8 gnrpy/tests/web/gnrwebstruct_test.py` → zero errors
- [ ] reviewer can spot-check the `genroNameSpace` snapshot count (256)
      against `head -n 1402 gnrpy/gnr/web/gnrwebstruct.py | tail -n 45`

Refs #901