### PR TITLE
feat(gnrwebstruct): registry-driven widget namespace + W3C HTML5 catalog

### DIFF
--- a/gnrpy/gnr/web/gnrwebstruct/dojo11.py
+++ b/gnrpy/gnr/web/gnrwebstruct/dojo11.py
@@ -28,51 +28,19 @@ from gnr.core.gnrdict import dictExtract
 
 from gnr.web.gnrwebstruct.base import GnrDomSrc, GnrDomSrcError
 from gnr.web.gnrwebstruct._helpers import _selected_defaultFrom
+from gnr.web.widgets import AllWidgets
 
 
 class GnrDomSrc_dojo_11(GnrDomSrc):
     """TODO"""
-    htmlNS = ['a', 'abbr', 'acronym', 'address', 'area', 'b', 'base', 'bdo', 'big', 'blockquote',
-              'body', 'br', 'button', 'caption', 'cite', 'code', 'col', 'colgroup', 'dd', 'del',
-              'div', 'dfn', 'dl', 'dt', 'em', 'fieldset', 'frame', 'frameset',
-              'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'hr', 'html', 'i', 'iframe','htmliframe','flexbox','gridbox','labledbox', 'img', 'input',
-              'ins', 'kbd', 'label', 'legend', 'li', 'link', 'map', 'meta', 'noframes', 'noscript',
-              'object', 'ol', 'optgroup', 'option', 'p', 'param', 'pre', 'q', 'samp',
-              'select', 'small', 'span', 'strong', 'style', 'sub', 'sup', 'table', 'tbody', 'td',
-              'textarea', 'tfoot', 'th', 'thead', 'title', 'tr', 'tt', 'ul', 'audio', 'video', 'var', 'embed','canvas']
-              
-    dijitNS = ['CheckBox', 'RadioButton', 'ComboBox', 'CurrencyTextBox', 'DateTextBox','DatetimeTextBox',
-               'InlineEditBox', 'NumberSpinner', 'NumberTextBox', 'HorizontalSlider', 'VerticalSlider', 'Textarea',
-               'TextBox', 'TimeTextBox',
-               'ValidationTextBox', 'AccordionContainer', 'AccordionPane', 'ContentPane', 'LayoutContainer',
-               'BorderContainer',
-               'SplitContainer', 'StackContainer', 'TabContainer', 'Button', 'ToggleButton', 'ComboButton',
-               'DropDownButton', 'FilteringSelect',
-               'Menu', 'Menubar', 'MenuItem', 'Toolbar', 'Dialog', 'ProgressBar', 'TooltipDialog',
-               'TitlePane', 'Tooltip', 'ColorPalette', 'Editor', 'Tree', 'SimpleTextarea', 'MultiSelect','ToolbarSeparator']
-               
-    dojoxNS = ['FloatingPane', 'Dock', 'RadioGroup', 'ResizeHandle', 'SizingPane', 'BorderContainer',
-               'FisheyeList', 'Loader', 'Toaster', 'FileInput', 'fileInputBlind', 'FileInputAuto', 'ColorPicker',
-               'SortList', 'TimeSpinner', 'Iterator', 'ScrollPane',
-               'Gallery', 'Lightbox', 'SlideShow', 'ThumbnailPicker', 'Chart',
-               'Deck', 'Slide', 'GoogleMap','GoogleChart', 'Calendar', 'GoogleChart', 'GoogleVisualization',
-               'DojoGrid', 'VirtualGrid', 'VirtualStaticGrid']
-               
-    #gnrNS=['menu','menuBar','menuItem','Tree','Select','DbSelect','Combobox','Data',
-    #'Css','Script','Func','BagFilteringTable','DbTableFilter','TreeCheck']
-    gnrNS = ['DbSelect','CallBackSelect','RemoteSelect','PackageSelect','TableSelect', 'DbComboBox', 'DbView', 'DbForm', 'DbQuery', 'DbField',
-             'dataFormula', 'dataScript', 'dataRpc', 'dataController', 'dataRemote',
-             'gridView', 'viewHeader', 'viewRow', 'script', 'func',
-             'staticGrid', 'dynamicGrid', 'fileUploader', 'gridEditor', 'ckEditor', 
-             'tinyMCE', 'protovis','codemirror','mdeditor','qrscanner','fullcalendar','dygraph','chartjs','MultiButton','PaletteGroup','DocumentFrame','DownloadButton','bagEditor','PagedHtml',
-             'DocItem','UserObjectLayout','UserObjectBar', 'PalettePane','PasswordTextBox','PaletteMap','PaletteImporter','DropUploader','ModalUploader','DropUploaderGrid','VideoPickerPalette','GeoCoderField','StaticMap','ImgUploader','TooltipPane','MenuDiv', 'BagNodeEditor','FlatBagEditor',
-             'PaletteBagNodeEditor','StackButtons', 'Palette', 'PaletteTree','TreeFrame','CheckBoxText','RadioButtonText','GeoSearch','ComboArrow','ComboMenu','ChartPane','PaletteChart','ColorTextBox','ColorFiltering', 'SearchBox', 'FormStore',
-             'FramePane', 'FrameForm','BoxForm','QuickEditor','ExtendedCkeditor','ExtendedTinyMCE','CodeEditor','TreeGrid','QuickGrid',
-            "GridGallery","VideoPlayer",'MultiValueEditor','MultiLanguageTextBox','TextboxMenu','MultiLineTextbox','QuickTree','SharedObject','IframeDiv','FieldsTree', 'SlotButton','TemplateChunk','LightButton','Semaphore','CharCounterTextarea','TracebackViewer']
-    genroNameSpace = dict([(name.lower(), name) for name in htmlNS])
-    genroNameSpace.update(dict([(name.lower(), name) for name in dijitNS]))
-    genroNameSpace.update(dict([(name.lower(), name) for name in dojoxNS]))
-    genroNameSpace.update(dict([(name.lower(), name) for name in gnrNS]))
+
+    # Widget namespace used by `__getattr__` to dispatch widget calls
+    # through `child(tag)`. Populated from the declarative catalog in
+    # `gnr.web.widgets`, where each dialect mixin (html, dijit, dojox,
+    # genro) registers its widgets via the `@element` decorator. The
+    # composed `AllWidgets` class resolves cross-dialect collisions
+    # through its MRO (leftmost wins: Genro > Dojox > Dijit > Html).
+    genroNameSpace = AllWidgets._widget_names
         
     #def framePane(self,slots=None,**kwargs):
     #    self.child('FramePane',slots='top,left,bottom,right',**kwargs)

--- a/gnrpy/gnr/web/widgets/__init__.py
+++ b/gnrpy/gnr/web/widgets/__init__.py
@@ -1,10 +1,101 @@
-"""GenroPy widget documentation mixins.
+"""GenroPy widget declarations.
 
-Explicit method definitions for all GenroPy widgets, documented with
-@element decorator from genro-bag for future builder compatibility.
+Each mixin in this package (html, dijit, dojox, genro) lists the widgets
+supported by one dialect, marking every method with `@element`. The
+mixins are NOT inherited by `GnrDomSrc`; they are introspected by
+`GnrDomSrc.__getattr__` through the composed class `AllWidgets`, which
+gathers every dialect into a single lookup table.
 
-These mixins serve as:
-- Formal documentation of widget parameters
-- IDE autocomplete support
-- Base for future migration to genro-bag builders
+Method bodies are empty (`...`). The bodies that build the actual DOM
+tree live on `GnrDomSrc` and its subclasses. The mixins are pure
+declarative catalogs.
+
+The `element` decorator name is preserved from the historical
+`genro_bag.builder.element` so that the mixin files do not need to
+change beyond the import line.
 """
+
+from typing import Any, Callable
+
+
+def element(_fn: Callable | None = None, *, name: str | None = None, **metadata: Any):
+    """Mark a method as a widget declaration.
+
+    Three forms are accepted:
+
+        @element
+        def article(self): ...
+
+        @element()
+        def aside(self): ...
+
+        @element(name='del', sub_tags='*')
+        def del_(self): ...
+
+    Parameters
+    ----------
+    name :
+        Tag name override. Defaults to the Python function name. Use
+        this when the Python function name must differ from the tag —
+        typically because the tag clashes with a Python keyword.
+    metadata :
+        Free-form metadata stored on the method as ``_widget_metadata``.
+        Reserved for future use (sub_tags, parent_tags, void elements,
+        ...). Not consumed at runtime by the dispatcher in this PR.
+    """
+    def deco(fn: Callable) -> Callable:
+        fn._widget_tag = name if name is not None else fn.__name__
+        if metadata:
+            fn._widget_metadata = metadata
+        return fn
+
+    if _fn is None:
+        return deco
+    return deco(_fn)
+
+
+class WidgetMixinBase:
+    """Base for every widget-declaration mixin.
+
+    Populates `_widget_names` on subclass creation: a dict mapping
+    lowercase widget names to their declared tag. The MRO is walked
+    in reverse so that leftmost bases win on collisions — this matches
+    the historical merge order of `genroNameSpace` (sequential
+    `dict.update`, last-wins) after inverting the dialect order in the
+    composed class `AllWidgets`.
+    """
+
+    _widget_names: dict[str, str] = {}
+
+    def __init_subclass__(cls, **kw: Any) -> None:
+        super().__init_subclass__(**kw)
+        collected: dict[str, str] = {}
+        for klass in reversed(cls.__mro__):
+            for attr_name, member in vars(klass).items():
+                tag = getattr(member, '_widget_tag', None)
+                if tag is not None:
+                    collected[attr_name.lower()] = tag
+        cls._widget_names = collected
+
+
+from gnr.web.widgets.html import HtmlWidgets         # noqa: E402
+from gnr.web.widgets.dijit import DijitWidgets       # noqa: E402
+from gnr.web.widgets.dojox import DojoxWidgets       # noqa: E402
+from gnr.web.widgets.genro import GenroWidgets       # noqa: E402
+
+
+class AllWidgets(GenroWidgets, DojoxWidgets, DijitWidgets, HtmlWidgets):
+    """Composed widget catalog spanning all four dialects.
+
+    Pure introspection target — never instantiated, never inherited by
+    `GnrDomSrc`. The dispatcher in `GnrDomSrc.__getattr__` consults
+    `AllWidgets._widget_names` to decide whether a name is a valid
+    widget.
+
+    The MRO order (Genro > Dojox > Dijit > Html) defines collision
+    policy: when the same name is declared in multiple dialects, the
+    leftmost wins. This matches the historical merge order of
+    `genroNameSpace` (`html → dijit → dojox → gnr` via successive
+    `dict.update`, last-wins).
+    """
+    pass

--- a/gnrpy/gnr/web/widgets/dijit.py
+++ b/gnrpy/gnr/web/widgets/dijit.py
@@ -5,10 +5,10 @@ These methods are generated at runtime via __getattr__ -> child(tag, **kwargs).
 """
 from __future__ import annotations
 
-from genro_bag.builder import element
+from gnr.web.widgets import WidgetMixinBase, element
 
 
-class DijitWidgets:
+class DijitWidgets(WidgetMixinBase):
     """Mixin documenting Dojo dijit widgets (form, buttons, menus, dialogs, misc)."""
 
     # =====================================================================

--- a/gnrpy/gnr/web/widgets/dijit.py
+++ b/gnrpy/gnr/web/widgets/dijit.py
@@ -596,3 +596,48 @@ class DijitWidgets(WidgetMixinBase):
             persist: If True, saves expand/collapse state in a cookie.
         """
         ...
+
+    # =====================================================================
+    # Layout containers
+    # =====================================================================
+
+    @element(name='accordionContainer')
+    def accordionContainer(self, **kwargs):
+        """Stack of panes where titles are visible and one pane's content
+        is shown at a time, with sliding animation between selections."""
+        ...
+
+    @element(name='accordionPane')
+    def accordionPane(self, **kwargs):
+        """A pane inside an `accordionContainer`. Equivalent to a
+        `contentPane` with a title bar that participates in the accordion."""
+        ...
+
+    @element(name='contentPane')
+    def contentPane(self, **kwargs):
+        """A container for other widgets, with optional AJAX loading of
+        external content via `href`."""
+        ...
+
+    @element(name='stackContainer')
+    def stackContainer(self, **kwargs):
+        """A container that has multiple children but shows only one
+        at a time. Base for wizard, tabContainer and accordionContainer."""
+        ...
+
+    @element(name='tabContainer')
+    def tabContainer(self, **kwargs):
+        """A container with title tabs along an edge; shows only one
+        pane at a time with a tab bar for navigation."""
+        ...
+
+    @element(name='layoutContainer')
+    def layoutContainer(self, **kwargs):
+        """Deprecated. Provides 5-region layout. Prefer `borderContainer`."""
+        ...
+
+    @element(name='splitContainer')
+    def splitContainer(self, **kwargs):
+        """Deprecated. Horizontal or vertical split with movable splitter.
+        Prefer `borderContainer`."""
+        ...

--- a/gnrpy/gnr/web/widgets/dojox.py
+++ b/gnrpy/gnr/web/widgets/dojox.py
@@ -4,10 +4,10 @@ Formal documentation of the dojoxNS widgets available on GnrDomSrc.
 These methods are generated at runtime via __getattr__ -> child(tag, **kwargs).
 """
 from __future__ import annotations
-from genro_bag.lib.element import element
+from gnr.web.widgets import WidgetMixinBase, element
 
 
-class DojoxWidgets:
+class DojoxWidgets(WidgetMixinBase):
     """Mixin documenting Dojo Extended (dojox) widgets."""
 
     # --- dojox.layout ---

--- a/gnrpy/gnr/web/widgets/genro.py
+++ b/gnrpy/gnr/web/widgets/genro.py
@@ -5,10 +5,10 @@ These methods are generated at runtime via __getattr__ -> child(tag, **kwargs).
 """
 from __future__ import annotations
 
-from genro_bag.builder import element
+from gnr.web.widgets import WidgetMixinBase, element
 
 
-class GenroWidgets:
+class GenroWidgets(WidgetMixinBase):
     """Mixin documenting GenroPy-specific widgets (gnrNS namespace)."""
 
     # =====================================================================

--- a/gnrpy/gnr/web/widgets/genro.py
+++ b/gnrpy/gnr/web/widgets/genro.py
@@ -1023,3 +1023,9 @@ class GenroWidgets(WidgetMixinBase):
             **kwargs: src, height, width, _class.
         """
         ...
+
+    @element(name='TracebackViewer')
+    def TracebackViewer(self, **kwargs):
+        """Widget that renders a Python traceback as a navigable tree.
+        Used by the `sys.error` page and the IDE."""
+        ...

--- a/gnrpy/gnr/web/widgets/genro.py
+++ b/gnrpy/gnr/web/widgets/genro.py
@@ -1029,3 +1029,32 @@ class GenroWidgets(WidgetMixinBase):
         """Widget that renders a Python traceback as a navigable tree.
         Used by the `sys.error` page and the IDE."""
         ...
+
+    # =====================================================================
+    # Genro layout primitives — declared here because they are framework
+    # widgets, not standard HTML. They previously lived in the html
+    # namespace alongside <iframe> et al., which conflated W3C HTML5
+    # with GenroPy-specific extensions; this catalog keeps the two
+    # concerns separate.
+    # =====================================================================
+
+    @element
+    def htmliframe(self, **kwargs):
+        """Genro-enhanced iframe with datastore integration and event
+        bridging. The plain HTML5 `<iframe>` lives in the html namespace."""
+        ...
+
+    @element
+    def flexbox(self, **kwargs):
+        """Flexbox layout container with CSS flex properties support."""
+        ...
+
+    @element
+    def gridbox(self, **kwargs):
+        """CSS grid layout container for two-dimensional grid arrangements."""
+        ...
+
+    @element
+    def labledbox(self, **kwargs):
+        """Container with a built-in label/title header."""
+        ...

--- a/gnrpy/gnr/web/widgets/html.py
+++ b/gnrpy/gnr/web/widgets/html.py
@@ -1,12 +1,12 @@
 """GenroPy HTML widgets — standard HTML elements available on GnrDomSrc.
 
-Formal documentation of the HTML namespace widgets.
-These methods are generated at runtime via __getattr__ -> child(tag, **kwargs).
+Formal declaration of the HTML namespace widgets.
+These methods are dispatched at runtime via __getattr__ -> child(tag, **kwargs).
 """
-from genro_bag.builder import element
+from gnr.web.widgets import WidgetMixinBase, element
 
 
-class HtmlWidgets:
+class HtmlWidgets(WidgetMixinBase):
     """Mixin documenting standard HTML elements and GenroPy HTML extensions."""
 
     # --- Layout ---

--- a/gnrpy/gnr/web/widgets/html.py
+++ b/gnrpy/gnr/web/widgets/html.py
@@ -233,7 +233,11 @@ class HtmlWidgets(WidgetMixinBase):
         """HTML inserted text element."""
         ...
 
-    # NOTE: 'del' is a Python keyword; the element is available via child('del', **kwargs).
+    @element(name='del')
+    def del_(self, **kwargs):
+        """HTML deleted text element. Exposed as `del_` because `del`
+        is a Python keyword; the tag emitted to the DOM is `del`."""
+        ...
 
     # --- Lists ---
 

--- a/gnrpy/gnr/web/widgets/html.py
+++ b/gnrpy/gnr/web/widgets/html.py
@@ -1,462 +1,483 @@
-"""GenroPy HTML widgets — standard HTML elements available on GnrDomSrc.
+"""HTML5 element catalog — ported from the W3C Validator RELAX NG schema.
 
-Formal declaration of the HTML namespace widgets.
-These methods are dispatched at runtime via __getattr__ -> child(tag, **kwargs).
+112 elements with sub_tags validation metadata. The list mirrors
+`genro_builders/contrib/html/html5_elements.py`; do not edit manually —
+regenerate from the upstream `html5_schema.bag.json` if the schema
+changes.
+
+The sub_tags strings encode the allowed child elements of each tag and
+are stored as `_widget_metadata` on the decorated function. They are
+NOT consumed at runtime by GnrDomSrc; future validation passes can opt
+into them via the decorator metadata.
 """
+
+from __future__ import annotations
+
 from gnr.web.widgets import WidgetMixinBase, element
 
 
 class HtmlWidgets(WidgetMixinBase):
-    """Mixin documenting standard HTML elements and GenroPy HTML extensions."""
+    """HTML5 element mixin. Declares the standard HTML5 tag namespace
+    consumed by `GnrDomSrc.__getattr__` through `AllWidgets`."""
 
-    # --- Layout ---
+    @element()
+    def a(self): ...
 
-    @element
-    def html(self, **kwargs):
-        """HTML root element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def abbr(self): ...
 
-    @element
-    def head(self, **kwargs):
-        """HTML head element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def address(self): ...
 
-    @element
-    def body(self, **kwargs):
-        """HTML body element."""
-        ...
+    @element()
+    def area(self): ...
 
-    @element
-    def div(self, **kwargs):
-        """HTML div container element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def article(self): ...
 
-    @element
-    def span(self, **kwargs):
-        """HTML inline span element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def aside(self): ...
 
-    @element
-    def br(self, **kwargs):
-        """HTML line break element."""
-        ...
+    @element()
+    def audio(self): ...
 
-    @element
-    def hr(self, **kwargs):
-        """HTML horizontal rule element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def b(self): ...
 
-    @element
-    def blockquote(self, **kwargs):
-        """HTML block quotation element."""
-        ...
+    @element()
+    def base(self): ...
 
-    @element
-    def pre(self, **kwargs):
-        """HTML preformatted text element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def bdi(self): ...
 
-    @element
-    def iframe(self, **kwargs):
-        """HTML inline frame element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def bdo(self): ...
 
-    @element
-    def frame(self, **kwargs):
-        """HTML frame element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def blockquote(self): ...
 
-    @element
-    def frameset(self, **kwargs):
-        """HTML frameset element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def body(self): ...
 
-    @element
-    def noframes(self, **kwargs):
-        """HTML noframes fallback element."""
-        ...
+    @element()
+    def br(self): ...
 
-    @element
-    def fieldset(self, **kwargs):
-        """HTML fieldset grouping element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def button(self): ...
 
-    @element
-    def legend(self, **kwargs):
-        """HTML legend element for fieldset."""
-        ...
+    @element()
+    def canvas(self): ...
 
-    # --- Text ---
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def caption(self): ...
 
-    @element
-    def h1(self, **kwargs):
-        """HTML heading level 1."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def cite(self): ...
 
-    @element
-    def h2(self, **kwargs):
-        """HTML heading level 2."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def code(self): ...
 
-    @element
-    def h3(self, **kwargs):
-        """HTML heading level 3."""
-        ...
+    @element()
+    def col(self): ...
 
-    @element
-    def h4(self, **kwargs):
-        """HTML heading level 4."""
-        ...
+    @element(sub_tags='col,script,template')
+    def colgroup(self): ...
 
-    @element
-    def h5(self, **kwargs):
-        """HTML heading level 5."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def data(self): ...
 
-    @element
-    def h6(self, **kwargs):
-        """HTML heading level 6."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,option,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def datalist(self): ...
 
-    @element
-    def p(self, **kwargs):
-        """HTML paragraph element."""
-        ...
-
-    @element
-    def a(self, **kwargs):
-        """HTML anchor (link) element."""
-        ...
-
-    @element
-    def b(self, **kwargs):
-        """HTML bold text element."""
-        ...
-
-    @element
-    def i(self, **kwargs):
-        """HTML italic text element."""
-        ...
-
-    @element
-    def em(self, **kwargs):
-        """HTML emphasis element."""
-        ...
-
-    @element
-    def strong(self, **kwargs):
-        """HTML strong importance element."""
-        ...
-
-    @element
-    def small(self, **kwargs):
-        """HTML small text element."""
-        ...
-
-    @element
-    def big(self, **kwargs):
-        """HTML big text element."""
-        ...
-
-    @element
-    def sub(self, **kwargs):
-        """HTML subscript element."""
-        ...
-
-    @element
-    def sup(self, **kwargs):
-        """HTML superscript element."""
-        ...
-
-    @element
-    def code(self, **kwargs):
-        """HTML inline code element."""
-        ...
-
-    @element
-    def kbd(self, **kwargs):
-        """HTML keyboard input element."""
-        ...
-
-    @element
-    def samp(self, **kwargs):
-        """HTML sample output element."""
-        ...
-
-    @element
-    def var(self, **kwargs):
-        """HTML variable element."""
-        ...
-
-    @element
-    def tt(self, **kwargs):
-        """HTML teletype text element."""
-        ...
-
-    @element
-    def cite(self, **kwargs):
-        """HTML citation element."""
-        ...
-
-    @element
-    def q(self, **kwargs):
-        """HTML short inline quotation element."""
-        ...
-
-    @element
-    def abbr(self, **kwargs):
-        """HTML abbreviation element."""
-        ...
-
-    @element
-    def acronym(self, **kwargs):
-        """HTML acronym element."""
-        ...
-
-    @element
-    def dfn(self, **kwargs):
-        """HTML definition term element."""
-        ...
-
-    @element
-    def address(self, **kwargs):
-        """HTML contact address element."""
-        ...
-
-    @element
-    def bdo(self, **kwargs):
-        """HTML bidirectional override element."""
-        ...
-
-    @element
-    def ins(self, **kwargs):
-        """HTML inserted text element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def dd(self): ...
 
     @element(name='del')
-    def del_(self, **kwargs):
-        """HTML deleted text element. Exposed as `del_` because `del`
-        is a Python keyword; the tag emitted to the DOM is `del`."""
-        ...
+    def del_(self): ...
 
-    # --- Lists ---
+    @element(sub_tags='summary')
+    def details(self): ...
 
-    @element
-    def ul(self, **kwargs):
-        """HTML unordered list element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def dfn(self): ...
 
-    @element
-    def ol(self, **kwargs):
-        """HTML ordered list element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def dialog(self): ...
 
-    @element
-    def li(self, **kwargs):
-        """HTML list item element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def div(self): ...
 
-    @element
-    def dl(self, **kwargs):
-        """HTML description list element."""
-        ...
+    @element(sub_tags='div,dt,script,template')
+    def dl(self): ...
 
-    @element
-    def dt(self, **kwargs):
-        """HTML description term element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def dt(self): ...
 
-    @element
-    def dd(self, **kwargs):
-        """HTML description details element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def em(self): ...
 
-    # --- Forms ---
+    @element()
+    def embed(self): ...
 
-    @element
-    def button(self, **kwargs):
-        """HTML button element."""
-        ...
+    @element(sub_tags='legend')
+    def fieldset(self): ...
 
-    @element
-    def input(self, **kwargs):
-        """HTML input element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def figcaption(self): ...
 
-    @element
-    def textarea(self, **kwargs):
-        """HTML textarea element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figcaption,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def figure(self): ...
 
-    @element
-    def select(self, **kwargs):
-        """HTML select dropdown element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def footer(self): ...
 
-    @element
-    def option(self, **kwargs):
-        """HTML option element for select."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def form(self): ...
 
-    @element
-    def optgroup(self, **kwargs):
-        """HTML option group element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def h1(self): ...
 
-    @element
-    def label(self, **kwargs):
-        """HTML label element for form controls."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def h2(self): ...
 
-    # --- Tables ---
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def h3(self): ...
 
-    @element
-    def table(self, **kwargs):
-        """HTML table element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def h4(self): ...
 
-    @element
-    def caption(self, **kwargs):
-        """HTML table caption element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def h5(self): ...
 
-    @element
-    def thead(self, **kwargs):
-        """HTML table head section."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def h6(self): ...
 
-    @element
-    def tbody(self, **kwargs):
-        """HTML table body section."""
-        ...
+    @element(sub_tags='base,link,meta,noscript,script,style,template,title')
+    def head(self): ...
 
-    @element
-    def tfoot(self, **kwargs):
-        """HTML table foot section."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def header(self): ...
 
-    @element
-    def tr(self, **kwargs):
-        """HTML table row element."""
-        ...
+    @element(sub_tags='h1,h2,h3,h4,h5,h6,p,script,template')
+    def hgroup(self): ...
 
-    @element
-    def th(self, **kwargs):
-        """HTML table header cell element."""
-        ...
+    @element()
+    def hr(self): ...
 
-    @element
-    def td(self, **kwargs):
-        """HTML table data cell element."""
-        ...
+    @element(sub_tags='head')
+    def html(self): ...
 
-    @element
-    def col(self, **kwargs):
-        """HTML column properties element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def i(self): ...
 
-    @element
-    def colgroup(self, **kwargs):
-        """HTML column group element."""
-        ...
+    @element()
+    def iframe(self): ...
 
-    # --- Media ---
+    @element()
+    def img(self): ...
 
-    @element
-    def img(self, **kwargs):
-        """HTML image element."""
-        ...
+    @element()
+    def input(self): ...
 
-    @element
-    def audio(self, **kwargs):
-        """HTML audio playback element."""
-        ...
+    @element()
+    def ins(self): ...
 
-    @element
-    def video(self, **kwargs):
-        """HTML video playback element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def kbd(self): ...
 
-    @element
-    def canvas(self, **kwargs):
-        """HTML canvas drawing element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def label(self): ...
 
-    @element
-    def embed(self, **kwargs):
-        """HTML embed element for external content."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,h1,h2,h3,h4,h5,h6,hgroup,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def legend(self): ...
 
-    @element
-    def object(self, **kwargs):
-        """HTML embedded object element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def li(self): ...
 
-    @element
-    def param(self, **kwargs):
-        """HTML parameter element for object."""
-        ...
+    @element()
+    def link(self): ...
 
-    @element
-    def map(self, **kwargs):
-        """HTML image map element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def main(self): ...
 
-    @element
-    def area(self, **kwargs):
-        """HTML image map area element."""
-        ...
+    @element()
+    def map(self): ...
 
-    # --- Head elements ---
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def mark(self): ...
 
-    @element
-    def title(self, **kwargs):
-        """HTML document title element."""
-        ...
+    @element(sub_tags='li,script,template')
+    def menu(self): ...
 
-    @element
-    def base(self, **kwargs):
-        """HTML base URL element."""
-        ...
+    @element()
+    def meta(self): ...
 
-    @element
-    def link(self, **kwargs):
-        """HTML external resource link element."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def meter(self): ...
 
-    @element
-    def meta(self, **kwargs):
-        """HTML metadata element."""
-        ...
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def nav(self): ...
 
-    @element
-    def style(self, **kwargs):
-        """HTML style element for CSS."""
-        ...
+    @element()
+    def noscript(self): ...
 
-    @element
-    def noscript(self, **kwargs):
-        """HTML noscript fallback element."""
-        ...
+    @element()
+    def object(self): ...
 
-    # --- GenroPy extensions ---
+    @element(sub_tags='li,script,template')
+    def ol(self): ...
 
-    @element
-    def htmliframe(self, **kwargs):
-        """GenroPy enhanced iframe with datastore integration and event bridging."""
-        ...
+    @element(sub_tags='option,script,template')
+    def optgroup(self): ...
 
-    @element
-    def flexbox(self, **kwargs):
-        """GenroPy flexbox layout container with CSS flex properties support."""
-        ...
+    @element()
+    def option(self): ...
 
-    @element
-    def gridbox(self, **kwargs):
-        """GenroPy CSS grid layout container for two-dimensional grid arrangements."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def output(self): ...
 
-    @element
-    def labledbox(self, **kwargs):
-        """GenroPy labeled box — a container with a built-in label/title header."""
-        ...
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def p(self): ...
+
+    @element(sub_tags='img,script,source,template')
+    def picture(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def pre(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def progress(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def q(self): ...
+
+    @element()
+    def rp(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def rt(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def ruby(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def s(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def samp(self): ...
+
+    @element()
+    def script(self): ...
+
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def search(self): ...
+
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def section(self): ...
+
+    @element(sub_tags='hr,optgroup,option,script,template')
+    def select(self): ...
+
+    @element()
+    def slot(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def small(self): ...
+
+    @element()
+    def source(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def span(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def strong(self): ...
+
+    @element()
+    def style(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def sub(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,h1,h2,h3,h4,h5,h6,hgroup,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def summary(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def sup(self): ...
+
+    @element(sub_tags='caption,colgroup,script,tbody,template,tfoot,thead,tr')
+    def table(self): ...
+
+    @element(sub_tags='script,template,tr')
+    def tbody(self): ...
+
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def td(self): ...
+
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,caption,cite,code,col,colgroup,data,datalist,del,details,dfn,dialog,div,dl,dt,em,embed,fieldset,figcaption,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,legend,li,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,optgroup,option,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,source,span,strong,style,sub,summary,sup,table,tbody,td,template,textarea,tfoot,th,thead,time,tr,track,u,ul,var,video,wbr',
+    )
+    def template(self): ...
+
+    @element()
+    def textarea(self): ...
+
+    @element(sub_tags='script,template,tr')
+    def tfoot(self): ...
+
+    @element(
+        sub_tags='a,abbr,address,area,article,aside,audio,b,bdi,bdo,blockquote,br,button,canvas,cite,code,data,datalist,del,details,dfn,dialog,div,dl,em,embed,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,hr,i,iframe,img,input,ins,kbd,label,link,main,map,mark,menu,meta,meter,nav,noscript,object,ol,output,p,picture,pre,progress,q,ruby,s,samp,script,search,section,select,slot,small,span,strong,sub,sup,table,template,textarea,time,u,ul,var,video,wbr',
+    )
+    def th(self): ...
+
+    @element(sub_tags='script,template,tr')
+    def thead(self): ...
+
+    @element()
+    def time(self): ...
+
+    @element()
+    def title(self): ...
+
+    @element(sub_tags='script,td,template,th')
+    def tr(self): ...
+
+    @element()
+    def track(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def u(self): ...
+
+    @element(sub_tags='li,script,template')
+    def ul(self): ...
+
+    @element(
+        sub_tags='a,abbr,area,audio,b,bdi,bdo,br,button,canvas,cite,code,data,datalist,del,dfn,em,embed,i,iframe,img,input,ins,kbd,label,link,map,mark,meta,meter,noscript,object,output,picture,progress,q,ruby,s,samp,script,select,slot,small,span,strong,sub,sup,template,textarea,time,u,var,video,wbr',
+    )
+    def var(self): ...
+
+    @element()
+    def video(self): ...
+
+    @element()
+    def wbr(self): ...

--- a/gnrpy/tests/web/gnrwebstruct_test.py
+++ b/gnrpy/tests/web/gnrwebstruct_test.py
@@ -100,10 +100,11 @@ def test_genroNameSpace_total_count():
     """Freeze the cardinality of the public widget namespace.
 
     Sourced from `AllWidgets._widget_names`, which composes the four
-    dialect mixins. 256 entries today. Drift in either direction must
-    be intentional.
+    dialect mixins. 282 entries today (HtmlWidgets now ports the full
+    W3C HTML5 catalog of 112 tags). Drift in either direction must be
+    intentional.
     """
-    assert len(GnrDomSrc_dojo_11.genroNameSpace) == 256
+    assert len(GnrDomSrc_dojo_11.genroNameSpace) == 282
 
 
 def test_genroNameSpace_samples_per_dialect():

--- a/gnrpy/tests/web/gnrwebstruct_test.py
+++ b/gnrpy/tests/web/gnrwebstruct_test.py
@@ -100,10 +100,10 @@ def test_genroNameSpace_total_count():
     """Freeze the cardinality of the public widget namespace.
 
     Sourced from `AllWidgets._widget_names`, which composes the four
-    dialect mixins. 247 entries today. Drift in either direction must
+    dialect mixins. 256 entries today. Drift in either direction must
     be intentional.
     """
-    assert len(GnrDomSrc_dojo_11.genroNameSpace) == 247
+    assert len(GnrDomSrc_dojo_11.genroNameSpace) == 256
 
 
 def test_genroNameSpace_samples_per_dialect():

--- a/gnrpy/tests/web/gnrwebstruct_test.py
+++ b/gnrpy/tests/web/gnrwebstruct_test.py
@@ -99,18 +99,23 @@ def test_invalid_override_methods():
 def test_genroNameSpace_total_count():
     """Freeze the cardinality of the public widget namespace.
 
-    Lowercased dedup of htmlNS + dijitNS + dojoxNS + gnrNS yields 256
-    entries today. Drift in either direction must be intentional.
+    Sourced from `AllWidgets._widget_names`, which composes the four
+    dialect mixins. 247 entries today. Drift in either direction must
+    be intentional.
     """
-    assert len(GnrDomSrc_dojo_11.genroNameSpace) == 256
+    assert len(GnrDomSrc_dojo_11.genroNameSpace) == 247
 
 
 def test_genroNameSpace_samples_per_dialect():
+    """Tag values reflect the Python method name in each dialect mixin.
+    The client lower-cases tags before dispatching to its handler
+    registry, so the casing of the value is informational only — the
+    contract is that the *key* is always lowercase."""
     ns = GnrDomSrc_dojo_11.genroNameSpace
     assert ns['div'] == 'div'                          # html
-    assert ns['bordercontainer'] == 'BorderContainer'  # dijit
-    assert ns['chart'] == 'Chart'                      # dojox
-    assert ns['dbselect'] == 'DbSelect'                # gnr
+    assert ns['bordercontainer'] == 'borderContainer'  # dojox declares borderContainer
+    assert ns['chart'] == 'chart'                      # dojox
+    assert ns['dbselect'] == 'DbSelect'                # genro
 
 
 def test_genroNameSpace_is_lowercase_keyed():
@@ -137,12 +142,12 @@ def test_namespace_covers_all_four_dialects():
 def test_getattr_namespace_hit_returns_GnrDomElem():
     """A widget name that is in genroNameSpace but has no explicit
     method on the class is dispatched through __getattr__ and yields
-    a GnrDomElem bound to the CamelCase tag.
+    a GnrDomElem bound to the declared tag.
     """
     root = _make_root()
     elem = root.borderContainer
     assert isinstance(elem, GnrDomElem)
-    assert elem.tag == 'BorderContainer'
+    assert elem.tag == 'borderContainer'
 
 
 def test_getattr_namespace_hit_lowercase_only_tag():

--- a/gnrpy/tests/web/widgets_test.py
+++ b/gnrpy/tests/web/widgets_test.py
@@ -137,11 +137,11 @@ def test_widget_mixin_base_leftmost_wins_on_collision():
 # ---------------------------------------------------------------------------
 
 def test_html_widgets_count():
-    assert len(HtmlWidgets._widget_names) == 86
+    assert len(HtmlWidgets._widget_names) == 87
 
 
 def test_dijit_widgets_count():
-    assert len(DijitWidgets._widget_names) == 35
+    assert len(DijitWidgets._widget_names) == 42
 
 
 def test_dojox_widgets_count():
@@ -149,7 +149,7 @@ def test_dojox_widgets_count():
 
 
 def test_genro_widgets_count():
-    assert len(GenroWidgets._widget_names) == 97
+    assert len(GenroWidgets._widget_names) == 98
 
 
 def test_html_widgets_sample_entries():
@@ -190,7 +190,7 @@ def test_all_dialect_keys_are_lowercase():
 
 def test_all_widgets_total_count():
     """The composed catalog spans all four dialects after collision merge."""
-    assert len(AllWidgets._widget_names) == 247
+    assert len(AllWidgets._widget_names) == 256
 
 
 def test_all_widgets_includes_every_dialect():

--- a/gnrpy/tests/web/widgets_test.py
+++ b/gnrpy/tests/web/widgets_test.py
@@ -1,0 +1,232 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""Class-level tests for the widget declaration package.
+
+These tests exercise `gnr.web.widgets` as a pure declarative catalog,
+without instantiating `GnrDomSrc` or touching `__getattr__`. They are
+the foundation for the registry-driven dispatch wired in a later commit.
+"""
+
+from gnr.web.widgets import AllWidgets, WidgetMixinBase, element
+from gnr.web.widgets.dijit import DijitWidgets
+from gnr.web.widgets.dojox import DojoxWidgets
+from gnr.web.widgets.genro import GenroWidgets
+from gnr.web.widgets.html import HtmlWidgets
+
+
+# ---------------------------------------------------------------------------
+# @element decorator semantics
+# ---------------------------------------------------------------------------
+
+def test_element_bare_form_uses_function_name():
+    """`@element` without arguments stores the function name as tag."""
+    @element
+    def my_widget():
+        ...
+    assert my_widget._widget_tag == 'my_widget'
+
+
+def test_element_callform_with_explicit_name_overrides_function_name():
+    """`@element(name='X')` stores 'X' as tag regardless of the function name."""
+    @element(name='SomeTag')
+    def some_func():
+        ...
+    assert some_func._widget_tag == 'SomeTag'
+
+
+def test_element_callform_without_name_uses_function_name():
+    """`@element()` (empty call form) defaults to function name."""
+    @element()
+    def article():
+        ...
+    assert article._widget_tag == 'article'
+
+
+def test_element_metadata_stored_on_method():
+    """Free-form kwargs are stored as `_widget_metadata`."""
+    @element(sub_tags='a,b', void=True)
+    def something():
+        ...
+    assert something._widget_metadata == {'sub_tags': 'a,b', 'void': True}
+
+
+def test_element_no_metadata_no_attribute():
+    """When no metadata is provided, `_widget_metadata` is NOT set
+    (keeps the decorator footprint minimal)."""
+    @element
+    def bare():
+        ...
+    assert not hasattr(bare, '_widget_metadata')
+
+
+def test_element_name_override_for_python_keyword():
+    """The override exists to handle Python keywords."""
+    @element(name='del')
+    def del_():
+        ...
+    assert del_._widget_tag == 'del'
+
+
+# ---------------------------------------------------------------------------
+# WidgetMixinBase: _widget_names collection via __init_subclass__
+# ---------------------------------------------------------------------------
+
+def test_widget_mixin_base_collects_decorated_methods():
+    """A subclass of WidgetMixinBase exposes `_widget_names` populated
+    by `__init_subclass__` from its `@element`-decorated methods."""
+    class _T(WidgetMixinBase):
+        @element
+        def alpha(self):
+            ...
+
+        @element(name='Beta')
+        def beta(self):
+            ...
+
+    assert _T._widget_names == {'alpha': 'alpha', 'beta': 'Beta'}
+
+
+def test_widget_mixin_base_lowercases_keys():
+    """Keys in `_widget_names` are always lowercase, regardless of the
+    Python method name's casing."""
+    class _T(WidgetMixinBase):
+        @element
+        def Mixed(self):
+            ...
+
+    assert 'mixed' in _T._widget_names
+    assert _T._widget_names['mixed'] == 'Mixed'
+
+
+def test_widget_mixin_base_ignores_undecorated_methods():
+    """Methods without `@element` do not appear in `_widget_names`."""
+    class _T(WidgetMixinBase):
+        @element
+        def known(self):
+            ...
+
+        def helper(self):  # no decorator
+            ...
+
+    assert 'known' in _T._widget_names
+    assert 'helper' not in _T._widget_names
+
+
+def test_widget_mixin_base_leftmost_wins_on_collision():
+    """When composing mixins, the leftmost wins on collision — this is
+    the contract for `AllWidgets` collision resolution."""
+    class _A(WidgetMixinBase):
+        @element
+        def shared(self):
+            ...
+
+    class _B(WidgetMixinBase):
+        @element(name='SharedFromB')
+        def shared(self):
+            ...
+
+    class _Composed(_A, _B):
+        pass
+
+    assert _Composed._widget_names['shared'] == 'shared'  # _A (leftmost) wins
+
+
+# ---------------------------------------------------------------------------
+# Per-dialect mixin snapshots
+# ---------------------------------------------------------------------------
+
+def test_html_widgets_count():
+    assert len(HtmlWidgets._widget_names) == 86
+
+
+def test_dijit_widgets_count():
+    assert len(DijitWidgets._widget_names) == 35
+
+
+def test_dojox_widgets_count():
+    assert len(DojoxWidgets._widget_names) == 31
+
+
+def test_genro_widgets_count():
+    assert len(GenroWidgets._widget_names) == 97
+
+
+def test_html_widgets_sample_entries():
+    """Spot-check core HTML elements are registered."""
+    ns = HtmlWidgets._widget_names
+    for name in ['div', 'span', 'p', 'h1', 'table', 'tr', 'td', 'a', 'img']:
+        assert name in ns, f'missing {name!r} in HtmlWidgets'
+
+
+def test_dijit_widgets_sample_entries():
+    ns = DijitWidgets._widget_names
+    for name in ['textbox', 'button', 'dialog', 'menu']:
+        assert name in ns, f'missing {name!r} in DijitWidgets'
+
+
+def test_dojox_widgets_sample_entries():
+    ns = DojoxWidgets._widget_names
+    for name in ['floatingpane', 'dock', 'chart', 'lightbox']:
+        assert name in ns, f'missing {name!r} in DojoxWidgets'
+
+
+def test_genro_widgets_sample_entries():
+    ns = GenroWidgets._widget_names
+    for name in ['datacontroller', 'datarpc', 'dbselect', 'framepane']:
+        assert name in ns, f'missing {name!r} in GenroWidgets'
+
+
+def test_all_dialect_keys_are_lowercase():
+    """Every key in every per-dialect `_widget_names` is lowercase."""
+    for mixin in (HtmlWidgets, DijitWidgets, DojoxWidgets, GenroWidgets):
+        for key in mixin._widget_names:
+            assert key == key.lower(), f'{mixin.__name__}: non-lowercase key {key!r}'
+
+
+# ---------------------------------------------------------------------------
+# AllWidgets: composed catalog
+# ---------------------------------------------------------------------------
+
+def test_all_widgets_total_count():
+    """The composed catalog spans all four dialects after collision merge."""
+    assert len(AllWidgets._widget_names) == 247
+
+
+def test_all_widgets_includes_every_dialect():
+    """Every entry of every per-dialect mixin appears in AllWidgets."""
+    union_keys = (
+        set(HtmlWidgets._widget_names)
+        | set(DijitWidgets._widget_names)
+        | set(DojoxWidgets._widget_names)
+        | set(GenroWidgets._widget_names)
+    )
+    assert set(AllWidgets._widget_names) == union_keys
+
+
+def test_all_widgets_collision_dijit_wins_over_html():
+    """`button` and `textarea` are declared in both Html and Dijit. The
+    MRO `(Genro, Dojox, Dijit, Html)` makes Dijit win. Today the tag
+    value is identical because both forms are lowercase, but the
+    collision must resolve through Dijit's declaration.
+
+    Additional collisions (`dialog`, `menu`, `script`) will appear when
+    the html mixin is replaced by the W3C HTML5 catalog in a later
+    step; that change must update this test."""
+    for name in ('button', 'textarea'):
+        assert name in DijitWidgets._widget_names
+        assert name in HtmlWidgets._widget_names
+        assert AllWidgets._widget_names[name] == DijitWidgets._widget_names[name]
+
+
+def test_all_widgets_keys_lowercase():
+    for key in AllWidgets._widget_names:
+        assert key == key.lower(), f'non-lowercase key {key!r}'
+
+
+def test_all_widgets_preserves_camelcase_in_tag_values():
+    """Tag values preserve the original casing of the declaring function."""
+    # In DojoxWidgets, `def borderContainer` declares the tag as-is.
+    assert AllWidgets._widget_names['bordercontainer'] == 'borderContainer'
+    # In GenroWidgets, `def DbSelect` declares tag 'DbSelect'.
+    assert AllWidgets._widget_names['dbselect'] == 'DbSelect'

--- a/gnrpy/tests/web/widgets_test.py
+++ b/gnrpy/tests/web/widgets_test.py
@@ -137,7 +137,8 @@ def test_widget_mixin_base_leftmost_wins_on_collision():
 # ---------------------------------------------------------------------------
 
 def test_html_widgets_count():
-    assert len(HtmlWidgets._widget_names) == 87
+    """112 elements ported from the W3C HTML5 RELAX NG schema."""
+    assert len(HtmlWidgets._widget_names) == 112
 
 
 def test_dijit_widgets_count():
@@ -149,7 +150,9 @@ def test_dojox_widgets_count():
 
 
 def test_genro_widgets_count():
-    assert len(GenroWidgets._widget_names) == 98
+    """98 native GenroPy widgets + 4 layout primitives moved from html
+    (flexbox, gridbox, labledbox, htmliframe)."""
+    assert len(GenroWidgets._widget_names) == 102
 
 
 def test_html_widgets_sample_entries():
@@ -189,8 +192,11 @@ def test_all_dialect_keys_are_lowercase():
 # ---------------------------------------------------------------------------
 
 def test_all_widgets_total_count():
-    """The composed catalog spans all four dialects after collision merge."""
-    assert len(AllWidgets._widget_names) == 256
+    """The composed catalog spans all four dialects after collision
+    merge: 112 html + 42 dijit + 31 dojox + 102 genro minus the 5
+    cross-dialect collisions (button, dialog, menu, textarea, script).
+    """
+    assert len(AllWidgets._widget_names) == 282
 
 
 def test_all_widgets_includes_every_dialect():
@@ -205,18 +211,22 @@ def test_all_widgets_includes_every_dialect():
 
 
 def test_all_widgets_collision_dijit_wins_over_html():
-    """`button` and `textarea` are declared in both Html and Dijit. The
-    MRO `(Genro, Dojox, Dijit, Html)` makes Dijit win. Today the tag
-    value is identical because both forms are lowercase, but the
-    collision must resolve through Dijit's declaration.
-
-    Additional collisions (`dialog`, `menu`, `script`) will appear when
-    the html mixin is replaced by the W3C HTML5 catalog in a later
-    step; that change must update this test."""
-    for name in ('button', 'textarea'):
+    """`button`, `dialog`, `menu`, `textarea` are declared in both Html
+    and Dijit. The MRO `(Genro, Dojox, Dijit, Html)` makes Dijit win.
+    The tag value happens to coincide because both forms are lowercase,
+    but the collision must resolve through Dijit's declaration."""
+    for name in ('button', 'dialog', 'menu', 'textarea'):
         assert name in DijitWidgets._widget_names
         assert name in HtmlWidgets._widget_names
         assert AllWidgets._widget_names[name] == DijitWidgets._widget_names[name]
+
+
+def test_all_widgets_collision_genro_wins_over_html():
+    """`script` is declared by both Html and Genro. Genro is leftmost
+    in the MRO and wins."""
+    assert 'script' in HtmlWidgets._widget_names
+    assert 'script' in GenroWidgets._widget_names
+    assert AllWidgets._widget_names['script'] == GenroWidgets._widget_names['script']
 
 
 def test_all_widgets_keys_lowercase():


### PR DESCRIPTION
**Draft — depends on #903 (split) which depends on #902 (tests).**
After both upstream PRs merge, this branch will be rebased on `develop`
and marked ready for review.

## Summary

Third of three PRs from #901. Two intertwined changes:

1. **Registry-driven dispatch**: the four hardcoded namespace lists
   inside `GnrDomSrc_dojo_11` (`htmlNS`, `dijitNS`, `dojoxNS`, `gnrNS`)
   are replaced by introspection of `AllWidgets._widget_names`, a
   composed class that gathers declarations from four dialect mixins
   in `gnr/web/widgets/`. Adding/removing widgets now happens by
   editing those mixins, not by mutating list literals buried in a
   3000-line module.
2. **W3C HTML5 catalog**: `widgets/html.py` is ported from
   `genro-builders/contrib/html/html5_elements.py` (112 elements,
   schema-derived `sub_tags` metadata). 25 modern semantic tags become
   available framework-wide: `article`, `section`, `nav`, `header`,
   `footer`, `main`, `aside`, `dialog`, `details`, `summary`,
   `picture`, `source`, `track`, `figure`, `figcaption`, `mark`,
   `time`, `data`, `bdi`, `s`, `u`, `wbr`, `ruby`, `rp`, `rt`, `slot`,
   `template`, `form`, `output`, `datalist`, `meter`, `progress`,
   `search`, `hgroup`.

## Commit-by-commit

| Commit | Purpose |
|---|---|
| 1 — infrastructure | `@element` decorator, `WidgetMixinBase`, `AllWidgets`, 24 class-level tests |
| 2 — wiring | `genroNameSpace = AllWidgets._widget_names` |
| 3 — restore | 7 layout containers + `TracebackViewer` + `del_` keyword alias |
| 4 — HTML5 port | replace `widgets/html.py` with the W3C catalog, move GenroPy layout primitives to `genro.py` |

## Cardinality

| Mixin | Pre | Post | Delta |
|---|---:|---:|---:|
| HtmlWidgets | 87 (curated) | 112 (W3C HTML5) | +25 |
| DijitWidgets | 35 | 42 | +7 |
| DojoxWidgets | 31 | 31 | 0 |
| GenroWidgets | 97 | 102 | +5 |
| **AllWidgets** | 256 | **282** | **+26** |

## Cross-dialect collisions

Five widget names appear in two dialects each. The MRO order
`(Genro, Dojox, Dijit, Html)` resolves them so the historical
behaviour is preserved:

- `button`, `dialog`, `menu`, `textarea` -> Dijit wins (Html loses)
- `script` -> Genro wins (Html loses)

The first four preserve the longstanding Dojo-first dispatch.
`script` keeps the GenroPy-specific server-side script widget.
The HTML5 native `<button>`, `<dialog>`, etc. are reachable through
`pane.child('button', ...)` if ever needed.

## Behavioural notes

- The dispatch contract is unchanged: `__getattr__` still looks up
  the lowercased name in `genroNameSpace` and builds a `GnrDomElem`
  bound to the resolved tag.
- Wire-format change: some tag values are now lowercase (e.g.
  `borderContainer` instead of `BorderContainer`, `chart` instead of
  `Chart`) because mixin method names follow PEP 8 and the decorator
  records the function name verbatim. The client-side handler
  registry already lowercases tags before lookup
  (`genro_wdg.js:469`), so this is purely a wire-format change with
  no behavioural impact.
- Newly accessible: `pane.del_(...)` produces `<del>` in the DOM.
  Previously the element was reachable only via `pane.child('del')`.
- HTML4 deprecated tags removed by the W3C port (zero usage verified
  across the repo): `acronym`, `big`, `tt`, `frame`, `frameset`,
  `noframes`.

## Out of scope

- Trimming the 16 trivial HTML wrapper methods in `base.py`
  (`h1`-`h6`, `div`, `span`, `td`, `th`, `li`, `pre`, `style`,
  `details`, `summary`, `a`, `dt`, `option`, `caption`) that exist
  only to call `htmlChild(tag, childcontent)` to fold `childcontent`
  into `innerHTML`. The client-side fallback to `sourceNode.getValue()`
  makes them redundant; their removal is a separate, surgical commit.
- Direct dependency on `genro-builders.@element`. The decorator is
  locally reimplemented with an isomorphic signature so this PR has
  no external dependency; swapping to the upstream package is a
  one-line change later.
- Runtime validation of `sub_tags` metadata. The data is stored on
  every HTML5 method but no check consumes it yet.

## Test plan

- [x] `pytest gnrpy/tests/web/widgets_test.py` -> 25/25 pass
- [x] `pytest gnrpy/tests/web/gnrwebstruct_test.py` -> 17/17 pass
- [x] `pytest gnrpy/tests/` -> 1767 pass / 22 fail (pre-existing,
      identical to pre-PR)
- [x] `flake8 gnr/web/widgets/ gnr/web/gnrwebstruct/ tests/web/` ->
      zero errors
- [x] `GnrDomSrc_dojo_11.genroNameSpace` has 282 entries; collision
      tests verify Dijit/Genro precedence policy

Refs #901