### PR TITLE
fix(d11/d20): make setHidden idempotent to preserve native double-click

### DIFF
--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -1594,8 +1594,10 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
         var statusChanged = false;
         targets.forEach(function(domNode){
             let currenHidden = !genro.dom.isVisible(domNode);
-            statusChanged = currenHidden!=hidden;
-            dojo.style(domNode, 'display', (hidden ? 'none' : ''));
+            if(currenHidden != hidden){
+                statusChanged = true;
+                dojo.style(domNode, 'display', (hidden ? 'none' : ''));
+            }
         });
         if(statusChanged){
             genro.fakeResize()

--- a/gnrjs/gnr_d20/js/gnrdomsource.js
+++ b/gnrjs/gnr_d20/js/gnrdomsource.js
@@ -1594,8 +1594,10 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
         var statusChanged = false;
         targets.forEach(function(domNode){
             let currenHidden = !genro.dom.isVisible(domNode);
-            statusChanged = currenHidden!=hidden;
-            dojo.style(domNode, 'display', (hidden ? 'none' : ''));
+            if(currenHidden != hidden){
+                statusChanged = true;
+                dojo.style(domNode, 'display', (hidden ? 'none' : ''));
+            }
         });
         if(statusChanged){
             genro.fakeResize()


### PR DESCRIPTION
## Summary

- Make `GnrDomSourceNode.setHidden` idempotent: skip `dojo.style` write and the trailing `genro.fakeResize()` when the requested visibility already matches the current one.
- Fix a latent bug in the same method: `statusChanged` was overwritten on every iteration of the `forEach` over `_hiddenTargets`, so only the last target's transition determined whether `fakeResize` ran. It now stays `true` once any target actually changed.
- Apply the same fix symmetrically to `gnrjs/gnr_d11/js/gnrdomsource.js` and `gnrjs/gnr_d20/js/gnrdomsource.js` to keep the two dialects aligned.

## Motivation

When a hidden binding like `hidden=^.grid.selectedId?=!#v` is wired to a toolbar element above a `Grid` row, every click on the grid re-fires the binding with the same value. Pre-fix, `setHidden` always wrote `display` inline and triggered `fakeResize()`, which reflowed the layout in the middle of the click sequence and caused the browser to lose track of the native double-click on the underlying row. With the no-op short-circuit, the second click on an already-selected row no longer fires a spurious reflow and the native double-click is preserved.

## Test plan

- [x] Manual: d11 page with `Grid` + toolbar bound via `hidden=^...selectedId?=!#v` — double-click on a selected row now fires reliably.
- [x] Manual: single click toggling the toolbar visibility (selected vs. no selection) still works as before — `dojo.style` and `fakeResize` are only invoked when the state actually changes.
- [ ] Smoke check on other consumers of `setHidden` / `setHiddenChild` across the app.