### PR TITLE
fix(formlet): skip reactive item_* bindings to fix use_formlets and reactive item-side

### DIFF
--- a/gnrpy/gnr/web/gnrwebstruct/base.py
+++ b/gnrpy/gnr/web/gnrwebstruct/base.py
@@ -1015,11 +1015,19 @@ class GnrDomSrc(GnrStructData):
         if formNode:
             table = table or formNode.attr.get('table')
 
-        # Extract ALL item_* parameters and propagate them to child items
+        # Promote static item_* to their unprefixed form on the gridbox so
+        # that child fields can pick them up via getInheritedAttributes()
+        # before gridbox.onChildBuilding copies _items_attr on them
+        # (buildLblWrapper runs *before* the child has been touched).
+        # Reactive bindings (^...) must NOT be promoted: they would land on
+        # the gridbox as unhandled reactive attrs and trigger rebuild loops.
         item_params = dictExtract(kwargs, 'item_', pop=False, slice_prefix=True)
         for param_name, value in item_params.items():
-            if param_name not in kwargs:  # Don't override explicit params
-                kwargs[param_name] = value
+            if param_name in kwargs:
+                continue
+            if isinstance(value, str) and value.startswith('^'):
+                continue
+            kwargs[param_name] = value
 
         result =  self.gridbox(columns=columns,
                                table=table,


### PR DESCRIPTION
## Summary

- `formlet()` was promoting every `item_*` kwarg to its unprefixed form on the gridbox so children could pick `lbl_side` and friends through `getInheritedAttributes()` before `gridbox.onChildBuilding` copies `_items_attr` on them.
- For reactive bindings (e.g. `item_side='^#boxControllers.item_side'`) the promoted attribute landed on the gridbox without a matching setter, so every change triggered the generic rebuild path — re-running `labledbox.onBuilding` and appending fresh `.labledBox_label`/`.labledBox_content` divs on each toggle.
- Promote only static `item_*` values. Reactive ones continue to reach the children through the existing `_items_attr` propagation, which routes updates through dedicated setters (e.g. `labledbox.setSide` only swaps a CSS class).

## Context

The `use_formlets` preference was historically half-working: PR #639 (closes #432) fixed the static side wrapping, but using a `formlet` with reactive `item_*` parameters — the canonical pattern for the gridbox styling controls in `test/gnrwdg/gridbox.py` `test_4_gridbox_with_labledbox` — kept duplicating label divs on every toggle. This change makes both flows behave correctly without touching the existing `_items_attr` propagation in JS.

## Test plan

- [ ] Open `test/gnrwdg/gridbox.py::test_4_gridbox_with_labledbox` and toggle Label Side / Label background / Content Padding / Rounded / Field border / Field background several times. Each `labledBox` keeps a single `.labledBox_label` and `.labledBox_content`.
- [ ] Enable `theme.use_formlets` preference and open a page that uses `formbuilder()` with a table. Labels stay left-aligned as before.
- [ ] Disable `theme.use_formlets`. Existing `formbuilder` flow is unaffected.
- [ ] `flake8` and full test suite pass (1553 passed, 260 skipped).