### PR TITLE
fix(setHidden): trigger fakeResize only on real layout change

### DIFF
--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -1593,10 +1593,11 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
         var targets = this._hiddenTargets || [this.domNode || this.widget.domNode];
         var statusChanged = false;
         targets.forEach(function(domNode){
-            let currenHidden = !genro.dom.isVisible(domNode);
-            if(currenHidden != hidden){
+            let wasHidden = domNode.style.display === 'none';
+            let prevHeight = domNode.offsetHeight;
+            domNode.style.display = hidden ? 'none' : '';
+            if(wasHidden !== hidden && domNode.offsetHeight !== prevHeight){
                 statusChanged = true;
-                dojo.style(domNode, 'display', (hidden ? 'none' : ''));
             }
         });
         if(statusChanged){

--- a/gnrjs/gnr_d20/js/gnrdomsource.js
+++ b/gnrjs/gnr_d20/js/gnrdomsource.js
@@ -1593,10 +1593,11 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
         var targets = this._hiddenTargets || [this.domNode || this.widget.domNode];
         var statusChanged = false;
         targets.forEach(function(domNode){
-            let currenHidden = !genro.dom.isVisible(domNode);
-            if(currenHidden != hidden){
+            let wasHidden = domNode.style.display === 'none';
+            let prevHeight = domNode.offsetHeight;
+            domNode.style.display = hidden ? 'none' : '';
+            if(wasHidden !== hidden && domNode.offsetHeight !== prevHeight){
                 statusChanged = true;
-                dojo.style(domNode, 'display', (hidden ? 'none' : ''));
             }
         });
         if(statusChanged){

--- a/projects/gnrcore/packages/test/webpages/layout/bordercontainer.py
+++ b/projects/gnrcore/packages/test/webpages/layout/bordercontainer.py
@@ -3,8 +3,7 @@
 """borderContainer"""
 
 class GnrCustomWebPage(object):
-    py_requires = """gnrcomponents/testhandler:TestHandlerBase,th/th:TableHandler,
-                        dashboard_component/dashboard_component:DashboardItem"""
+    py_requires = "gnrcomponents/testhandler:TestHandlerBase,th/th:TableHandler"
     
     def windowTitle(self):
         return 'borderContainer'
@@ -45,8 +44,26 @@ class GnrCustomWebPage(object):
         bc.contentPane(background='yellow',title='aa').borderContainer(background='red')
     
     def test_4_region(self,pane):
-        """borderContainer with a closable contentPane inside. 
+        """borderContainer with a closable contentPane inside.
         Using closable='close' it starts closed on loading."""
         bc = pane.borderContainer(height='300px')
         bc.contentPane(region='right',width='400px',background='red',closable='close')
         bc.contentPane(region='center',background='green').div()
+
+    def test_5_top_autoheight_hidden_toggle(self,pane):
+        """borderContainer with a `top` region sized by its content (no fixed height).
+        Toggling the visibility of a child changes the top region's height,
+        so a relayout (fakeResize) must fire and the center region must shrink
+        or grow to match. This verifies that setHidden correctly triggers
+        fakeResize when the toggled node affects the parent's flow height."""
+        bc = pane.borderContainer(height='400px', border='1px solid silver')
+        top = bc.contentPane(region='top', background='#eef', padding='8px')
+        top.checkbox(value='^.show_block', label='Show big block in top region')
+        top.div('This block grows the top region — center must shrink',
+                background='#fc9', padding='20px', margin_top='8px',
+                hidden='^.show_block?=!#v')
+        top.div('Always-visible footer row', padding_top='8px', color='#666')
+
+        center = bc.contentPane(region='center', background='#efe', padding='8px')
+        center.div('Center region — height must adapt when the top toggles.',
+                   color='#363')

--- a/projects/gnrcore/packages/test/webpages/layout/framepane.py
+++ b/projects/gnrcore/packages/test/webpages/layout/framepane.py
@@ -3,8 +3,7 @@
 """framePane"""
 
 class GnrCustomWebPage(object):
-    py_requires = """gnrcomponents/testhandler:TestHandlerBase,th/th:TableHandler,
-                        dashboard_component/dashboard_component:DashboardItem"""
+    py_requires = "gnrcomponents/testhandler:TestHandlerBase,th/th:TableHandler"
     
     def windowTitle(self):
         return 'framePane'


### PR DESCRIPTION
## Summary
- PR #907 made `setHidden` idempotent by short-circuiting the `dojo.style` write when `genro.dom.isVisible(node)` matched the requested state. That short-circuit also skipped the write that the `labelWrapper` / formlet hide-propagation depended on, leaving labels visible while their widgets were hidden (visible e.g. on the login form's optional `dbSelect` / `dateTextBox` fields).
- The `display` style is now always written, so wrapper propagation works again. `fakeResize` is fired only when both the hidden state and the node's `offsetHeight` actually change — preserving #907's intent (no spurious `fakeResize` on already-selected grid row clicks; no interference with the browser's native double-click on previously-unselected rows).
- Mirrored on `gnr_d11` and `gnr_d20` to keep them in sync.

## Drive-by cleanup
- Adds `test_5_top_autoheight_hidden_toggle` in `bordercontainer.py` to verify that a region sized by its content correctly relayouts when a child is shown/hidden.
- Removes a dead `dashboard_component/dashboard_component:DashboardItem` `py_requires` from `bordercontainer.py` and `framepane.py`. The component lives in the `biz` package and is not resolvable from the `test` package, which made both pages fail to load. The symbol was never used in either file.

## Test plan
- [x] Login form: hidden optional fields no longer leak their label (regression introduced by #907 fixed)
- [x] Grid with `hidden=.grid.selectedId?=!#v` on toolbar items: native double-click on a previously-unselected row works at first try
- [x] `test/layout/bordercontainer` test_5: toggling the checkbox grows / shrinks the top region and the center region adapts accordingly
- [x] Backend test suite passes (1553 passed, 260 skipped — pre-existing skips)
- [x] flake8 clean on changed Python files