### PR TITLE
fix(groupletGrid): serialize template loader RPC for dynamic mixin support

### DIFF
--- a/resources/common/gnrcomponents/grouplet/grouplet.py
+++ b/resources/common/gnrcomponents/grouplet/grouplet.py
@@ -6,11 +6,6 @@ from gnr.core.gnrlang import gnrImport
 from gnr.web.gnrbaseclasses import BaseComponent
 from gnr.web.gnrwebstruct import struct_method
 
-# Sentinel for kwargs whose default may need to be resolved later. Lets
-# us tell "not passed" apart from "explicitly False/{}".
-_UNSET = object()
-
-
 class GroupletHandler(BaseComponent):
     css_requires = 'gnrcomponents/grouplet/grouplet'
     js_requires = 'gnrcomponents/grouplet/grouplet'
@@ -734,7 +729,7 @@ class GroupletGridHandler(BaseComponent):
                         table=None, grouplets_root=None,
                         cols=1, min_width=None, gap='12px',
                         height=None, max_height=None,
-                        additem=True, delitem=_UNSET, editmenu=_UNSET,
+                        additem=True, delitem=True, editmenu=False,
                         layout='cards',
                         titleField=None,
                         emptyTitle='!!Untitled',
@@ -756,10 +751,6 @@ class GroupletGridHandler(BaseComponent):
         # the template is cloned per row. Author-supplied nodeIds must
         # bake in `rowKey` (or similar) to stay unique.
         nodeId = nodeId or kwargs.pop('gridId', None) or f'grpgrid_{id(pane)}'
-        if delitem is _UNSET:
-            delitem = True
-        if editmenu is _UNSET:
-            editmenu = False
         # editmenu: False = no kebab; True = preset (addPrev/addNext,
         # plus delete when delitem is False); dict = custom entries.
         if editmenu is True:
@@ -770,9 +761,11 @@ class GroupletGridHandler(BaseComponent):
             editmenu = {}
         body_id = f'{nodeId}_body'
         # struct= accepts a callable (invoked on a fresh GnrGridStruct,
-        # mirroring gnr.Grid) or a pre-built Bag.
+        # mirroring gnr.Grid) or a pre-built Bag. When the grouplet is
+        # table-scoped, propagate `table` as the struct's maintable so
+        # column shortcuts (field name → table column metadata) resolve.
         if callable(struct):
-            built = pane.page.newGridStruct()
+            built = pane.page.newGridStruct(maintable=table)
             struct(built)
             struct = built
         struct_mode = struct is not None
@@ -891,7 +884,9 @@ class GroupletGridHandler(BaseComponent):
             layout=layout, titleField=titleField, emptyTitle=emptyTitle,
             defaultRow=defaultRow, minRows=minRows, maxRows=maxRows,
             counterField=counterField,
-            resolved_drag_code=resolved_drag_code)
+            resolved_drag_code=resolved_drag_code,
+            loaderrpc=self.gr_getGroupletGridTemplate,
+            mapLoaderrpc=self.gr_getGroupletGridTemplateMap)
         return container
 
     def _gr_groupletGrid_emitController(
@@ -903,12 +898,17 @@ class GroupletGridHandler(BaseComponent):
             additem_kwargs, delitem_kwargs, editmenu_kwargs,
             layout, titleField, emptyTitle,
             defaultRow, minRows, maxRows, counterField,
-            resolved_drag_code):
+            resolved_drag_code,
+            loaderrpc, mapLoaderrpc):
         # `attributeOwnerNode('_gg_root')` resolves the container at
         # runtime via the parent chain — required for nested groupletGrid
         # where the template is cloned per row (a `containerNode=container`
         # kwarg would freeze on the template's original sourceNode and
         # collide across row clones).
+        # loaderrpc / mapLoaderrpc are bound public_methods: the framework
+        # serializes them into their RPC path string when emitting the
+        # dataController, so JS receives the dynamic path that resolves
+        # the correct mixin at call time (instead of a bare name lookup).
         container.dataController("""
             var node = this.attributeOwnerNode('_gg_root');
             var bodyNode = node.getValue().walk(function(n){
@@ -939,7 +939,9 @@ class GroupletGridHandler(BaseComponent):
                 minRows: minRows,
                 maxRows: maxRows,
                 counterField: counterField,
-                dragCode: dragCode
+                dragCode: dragCode,
+                loaderrpc: loaderrpc,
+                mapLoaderrpc: mapLoaderrpc
             });
             node.externalWidget = node.gridController;
             node.registerDynAttr('storepath');
@@ -968,4 +970,6 @@ class GroupletGridHandler(BaseComponent):
             minRows=minRows,
             maxRows=maxRows,
             counterField=counterField,
-            dragCode=resolved_drag_code)
+            dragCode=resolved_drag_code,
+            loaderrpc=loaderrpc,
+            mapLoaderrpc=mapLoaderrpc)

--- a/resources/common/gnrcomponents/grouplet/grouplet_grid.js
+++ b/resources/common/gnrcomponents/grouplet/grouplet_grid.js
@@ -698,6 +698,12 @@ gnr.GroupletGridController = class GroupletGridController {
         this.maxRows = kw.maxRows || null;
         this.counterField = kw.counterField || null;
         this.dragCode = kw.dragCode || null;
+        // Server-serialized RPC paths for the template loaders. Sent by
+        // the Python widget as bound method refs, turned into path strings
+        // by the dataController emitter, so dynamic mixins resolve to the
+        // correct implementation (a bare method name would miss them).
+        this.loaderrpc = kw.loaderrpc;
+        this.mapLoaderrpc = kw.mapLoaderrpc;
         this.dnd = this.dragCode ? new gnr.GroupletGridDnD(this) : null;
         this.dataStore = new gnr.GroupletDataStore(this, {
             storepath: this.storepath,
@@ -1872,7 +1878,7 @@ gnr.GroupletGridController = class GroupletGridController {
             grouplets_root: this.grouplets_root,
             grouplet_kwargs: this.grouplet_kw
         };
-        genro.serverCall('gr_getGroupletGridTemplate', params,
+        genro.serverCall(this.loaderrpc, params,
             (tplBag, error) => {
                 if (error) {
                     console.error('[GG] template RPC failed', error);
@@ -1908,7 +1914,7 @@ gnr.GroupletGridController = class GroupletGridController {
             grouplets_root: this.grouplets_root,
             grouplet_kwargs: this.grouplet_kw
         };
-        genro.serverCall('gr_getGroupletGridTemplateMap', params,
+        genro.serverCall(this.mapLoaderrpc, params,
             (mapBag, error) => {
                 if (error) {
                     console.error('[GG] template map RPC failed', error);


### PR DESCRIPTION
## Summary

- **Bug fix**: the JS controller invoked `gr_getGroupletGridTemplate` / `gr_getGroupletGridTemplateMap` by bare name via `genro.serverCall`, which only resolved when the methods were directly on the current `WebPage`. In dynamic-mixin contexts the name lookup missed the right implementation. The Python widget now passes the two bound `public_method`s as kwargs of the `dataController`; the framework's xml serializer turns them into full RPC path strings, which the JS controller stores on `this` and uses in `serverCall`.
- **Struct maintable propagation**: when `gr_groupletGrid(..., table=..., struct=callable)` is used, `newGridStruct(maintable=table)` is now called so column shortcuts (field name → table column metadata) resolve. Grouplets can be table-scoped — this case was missed.
- **Cleanup**: removed the `_UNSET` sentinel pattern. `delitem=True` / `editmenu=False` as direct kwarg defaults are semantically identical (no caller uses `delitem=None`) and follow the codebase convention.

## Linked Issue

None — micro-fixes on `gr_groupletGrid` (merged in #905) discovered during follow-up review.

## Test plan

- [x] `flake8` clean on modified files
- [x] Full pytest suite passes (1553 passed, 260 skipped)
- [x] Browser smoke: open a page using `gr_groupletGrid(...)` in single-template mode → verify the POST hits the **serialized full RPC path** (not the bare `gr_getGroupletGridTemplate` name)
- [x] Browser smoke: open a page using `resourceField=` (multi-grouplet mode) → idem for `gr_getGroupletGridTemplateMap`
- [x] Add/remove rows and drag&drop still work
- [x] Dynamic-mixin case (the original bug): the template loads correctly when `GroupletGridHandler` is reached via mixin, not direct `py_requires`
- [x] `gr_groupletGrid(table='foo.bar', struct=lambda s: s.col('field_name'))` → struct resolves `field_name` against `foo.bar` columns