### PR TITLE
fix(groupletGrid): isolate sibling bagStore on workspace controller path

### DIFF
--- a/resources/common/gnrcomponents/grouplet/grouplet.py
+++ b/resources/common/gnrcomponents/grouplet/grouplet.py
@@ -835,8 +835,21 @@ class GroupletGridHandler(BaseComponent):
         if store_identifier is not None:
             store_kw['_identifier'] = store_identifier
         store_kw['storeType'] = storeType
-        container.bagStore(storepath=storepath, storeCode=nodeId,
-                           **store_kw)
+        # In workspace mode, park the bagStore's storeNode under
+        # `#WORKSPACE.store` so CollectionStore control flags (setLocked
+        # writes `.locked`/`.disabledButton`) don't dirty the host form.
+        # storepath is anchored to the container via `#<nodeId>` so the
+        # rows Bag resolves to the same node regardless of storeNode.
+        if container_kwargs.get('_workspace'):
+            anchored_storepath = (f'#{nodeId}{storepath}'
+                                  if storepath and storepath.startswith('.')
+                                  else storepath)
+            container.bagStore(datapath='#WORKSPACE.store',
+                               storepath=anchored_storepath,
+                               storeCode=nodeId, **store_kw)
+        else:
+            container.bagStore(storepath=storepath, storeCode=nodeId,
+                               **store_kw)
         if struct_mode:
             container.data(structpath, struct)
         for side in ('top', 'bottom', 'left', 'right'):


### PR DESCRIPTION
## Summary

- The sibling `bagStore` emitted by `groupletGrid` inherited the container's `datapath`. CollectionStore base methods write control flags via `storeNode.setRelativeData('.locked', ...)` / `.disabledButton` (`setLocked`), so those flags landed **sibling to the rows Bag** — inside the host form's data area — and marked the form dirty on every lock/unlock toggle.
- In **workspace mode** (the default, when no explicit `structpath` is passed) the bagStore's `storeNode` is now parked under `#WORKSPACE.store`, isolated per-instance like the struct already is. The rows `storepath` is anchored to the container via `#<nodeId>` so the rows Bag resolves to the same node regardless of where `storeNode` lives.
- When the caller pinned `structpath` explicitly (no workspace mode), behaviour is unchanged — the caller has chosen where the grouplet's state lives and is responsible for placing `datapath` out of the edit area if needed.

## Mechanism

- `#WORKSPACE` and `#<nodeId>` are existing anchors handled by `symbolicDatapath` (`gnrjs/gnr_d20/js/gnrdomsource.js`). `BagRows` resolves `storepath` via `storeNode.absDatapath(...)` which honours both forms — no JS changes needed.
- `setLocked` keeps writing `.locked` / `.disabledButton` relative to `storeNode`, but `storeNode.datapath` now points to `gnr.workspace.<nodeId>.store` instead of the container's data area.
- `grouplet_grid.js` controller is unaffected: it looks up the sibling store via `genro.nodeById(<storeCode>).store` (nodeId-based, not datapath-based) and reads `storebag().getParentNode()` on the data Bag (not on the DOM source node).
- d11/d20 are both covered automatically by the Python-side change; `genro_components.js` is untouched in both bundles.

## Test plan

- [ ] Open a form hosting a `groupletGrid` (default args, no explicit `structpath`). Verify the record is clean.
- [ ] Toggle lock/unlock on the grid → form must stay clean (today it goes dirty).
- [ ] Insert / update / delete / move rows → data must roundtrip to the same path as before (check via `genro.getData(<abs_storepath>)`).
- [ ] Save the form after a lock toggle → server must not receive any `.locked` / `.disabledButton` field.
- [ ] Test against a page with explicit `structpath` (non-workspace branch) → behaviour identical to current.
- [ ] Spot-check on both d11 and d20 bundles.