### PR TITLE
fix(gnrwebstruct): attached sub-nodes win over widget namespace in __getattr__

### DIFF
--- a/gnrpy/gnr/web/gnrwebstruct/base.py
+++ b/gnrpy/gnr/web/gnrwebstruct/base.py
@@ -167,10 +167,16 @@ class GnrDomSrc(GnrStructData):
             return self.parent.parentfb
     parentfb = property(_get_parentfb)
             
-    def __getattr__(self, fname): 
+    def __getattr__(self, fname):
         fnamelower = fname.lower()
         if (fname != fnamelower) and hasattr(self, fnamelower):
             return getattr(self, fnamelower)
+        # Attached sub-nodes must win over the widget catalog: an explicit
+        # named child is stateful (attributes, children), while the widget
+        # entry would build a brand-new element and orphan the existing node.
+        attachnode = self.getNode(fname)
+        if attachnode:
+            return attachnode._value
         if fnamelower in self.genroNameSpace:
             return GnrDomElem(self, '%s' % (self.genroNameSpace[fnamelower]))
         if fname in self._external_methods:
@@ -182,9 +188,6 @@ class GnrDomSrc(GnrStructData):
                     "Struct method '%s' not found in page '%s'"
                     " — check py_requires" % (method_name, page_name))
             return lambda *args, **kwargs: handler(self, *args,**kwargs)
-        attachnode = self.getNode(fname)
-        if attachnode:
-            return attachnode._value
         autoslots = self._parentNode.attr.get('autoslots')
         if autoslots:
             autoslots = autoslots.split(',')

--- a/gnrpy/tests/web/gnrwebstruct_test.py
+++ b/gnrpy/tests/web/gnrwebstruct_test.py
@@ -256,3 +256,19 @@ def test_child_creates_attached_node():
     fetched = root.getNode('greeting')
     assert fetched is not None
     assert fetched._value is node
+
+
+def test_attached_subnode_wins_over_widget_namespace():
+    """When a sub-node is attached under a name that ALSO exists in the
+    widget catalog (e.g. 'form' is both an HTML5 tag and a common
+    childname used by tableHandler), `__getattr__` must return the
+    stateful attached node, not a fresh GnrDomElem. Regression for the
+    collision introduced by porting the full HTML5 catalog into
+    AllWidgets._widget_names.
+    """
+    root = _make_root()
+    form_node = root.child('div', childname='form')
+    assert 'form' in GnrDomSrc_dojo_11.genroNameSpace
+    resolved = root.form
+    assert resolved is form_node
+    assert not isinstance(resolved, GnrDomElem)


### PR DESCRIPTION
## Summary

Fix a regression introduced in #906 by porting the full W3C HTML5 catalog into `AllWidgets._widget_names`. The new catalog registers tags such as `form`, `header`, `footer`, `section`, `nav`, `main`, `dialog`, `menu`, `select`, `button`, `a`, ... — names that are also commonly used as **attached sub-node names** inside genro structs (the tableHandler attaches a `form` sub-node to `th`, for example).

Because `GnrDomSrc.__getattr__` consulted the widget namespace **before** `getNode`, expressions like `th.form` started returning a fresh `GnrDomElem('form')` instead of the attached form sub-node. That broke every consumer that reads attributes on the attached node — concretely:

```python
File ".../resources/common/public.py", line 700, in _th_parentFrameMessageSubscription
    fid = form.attributes['formId']
AttributeError: 'GnrDomElem' object has no attribute 'attributes'
```

Any tablehandler page in any project (reproduced on the sandbox `th_prodotto` of `fatt.prodotto`) crashes on render and redirects to `/console?error=...`.

## Fix

Reorder the lookup ladder in `GnrDomSrc.__getattr__` so that `getNode(fname)` runs **before** the `genroNameSpace` lookup. An explicit named child is stateful (attributes, children, nodeId, …) and must shadow the generic constructor offered by the widget catalog. The previous order was effectively silent data loss: the attached node was orphaned and unreachable via attribute access whenever its name collided with a registered tag.

External methods (`_external_methods`) keep their historical position after the widget namespace.

The HtmlWidgets catalog and the `@element` / `AllWidgets` registry introduced by this PR are untouched — this is a dispatch-order fix, not a catalog rollback.

## Why not other approaches

- **Restricting the HTML5 catalog** (dropping `form` and friends): masks the bug but leaves the same trap for any future catalog addition. The structural fix is in the dispatcher.
- **Renaming the colliding sub-nodes** (`th.form` → `th._form`): cascades through countless callers in genropy and downstream projects.

## Regression test

Added `test_attached_subnode_wins_over_widget_namespace` in `gnrpy/tests/web/gnrwebstruct_test.py`: attaches a sub-node named `form`, asserts that `root.form` returns the attached node (and is not a `GnrDomElem`), and that `'form'` is indeed in `genroNameSpace` (so the test would have caught the pre-fix behaviour).

## Test plan

- [x] `pytest gnrpy/tests/web/gnrwebstruct_test.py` (18/18 pass, including the new regression test)
- [x] `pytest gnrpy/tests/web/widgets_test.py` (25/25)
- [x] Full pre-commit test run via hook: 1579 passed, 260 skipped
- [x] `flake8` clean on modified files
- [x] Manual repro on sandbox `th_prodotto` of `fatt.prodotto` — page renders without redirecting to `/console?error=`