### PR TITLE
Adopt ApiEngine in sys endpoints + introduce ep_openapi

### DIFF
--- a/gnrpy/gnr/app/api_engine/core.py
+++ b/gnrpy/gnr/app/api_engine/core.py
@@ -133,7 +133,6 @@ _DTYPE_PYTHON = {
     'N': 'Decimal',
     'BAG': 'Bag', 'X': 'Bag',
     'JS': 'list',
-    'VEC': 'list',
 }
 
 _DTYPE_OPENAPI = {
@@ -156,8 +155,6 @@ _DTYPE_OPENAPI = {
     # structured
     'BAG': ('object', 'gnr-bag'), 'X': ('object', 'gnr-bag'),
     'JS': ('array', None),
-    # pgvector embedding column: array of floats
-    'VEC': ('array', 'vector'),
 }
 
 

--- a/gnrpy/gnr/app/api_engine/core.py
+++ b/gnrpy/gnr/app/api_engine/core.py
@@ -744,6 +744,34 @@ class ApiEngine:
                 out.append('%s.%s' % (pkg_name, tname))
         return sorted(out)
 
+    def exposed_column_names(self, fullname, readonly=True):
+        """Return the column names that would appear in the OpenAPI
+        schema for ``fullname``. Useful for callers that need to
+        materialize a payload whose shape matches the published spec —
+        e.g. so the runtime response stays a subset of what the spec
+        promises.
+
+        ``readonly=False`` mirrors the write-mode schema (excludes
+        system columns, formula columns, etc.). The default keeps the
+        full read shape.
+        """
+        columns = self._collect_columns(fullname)
+        out = []
+        for colname, info in columns.items():
+            col_setting = _column_openapi_setting(
+                {'openapi': info.get('openapi')})
+            if col_setting is False:
+                continue
+            is_real = info['kind'] == 'real'
+            is_system = info['system']
+            is_pkey = info['pkey']
+            writable = (is_real and not is_system
+                        and col_setting != 'R' and not is_pkey)
+            if not readonly and not writable:
+                continue
+            out.append(colname)
+        return out
+
     def _build_openapi_table_schema(self, fullname, readonly=True):
         columns = self._collect_columns(fullname)
         properties = {}

--- a/gnrpy/gnr/app/api_engine/core.py
+++ b/gnrpy/gnr/app/api_engine/core.py
@@ -780,19 +780,22 @@ class ApiEngine:
                 out.append('%s.%s' % (pkg_name, tname))
         return sorted(out)
 
-    def exposed_column_names(self, fullname, readonly=True):
-        """Return the column names that would appear in the OpenAPI
-        schema for ``fullname``. Useful for callers that need to
-        materialize a payload whose shape matches the published spec —
-        e.g. so the runtime response stays a subset of what the spec
-        promises.
+    def _iter_exposed_columns(self, fullname, readonly=True):
+        """Yield ``(colname, info, writable)`` for the columns of
+        ``fullname`` that pass the OpenAPI exposure filter.
 
-        ``readonly=False`` mirrors the write-mode schema (excludes
-        system columns, formula columns, etc.). The default keeps the
-        full read shape.
+        Filter rules:
+          - ``openapi=False`` at column level skips the column.
+          - In write mode (``readonly=False``), only columns that are
+            writable (real, not system, not declared 'R', not pkey)
+            survive.
+
+        Used by both ``exposed_column_names`` (which keeps just the
+        names) and ``_build_openapi_table_schema`` (which materializes
+        the property descriptors). Keep them in sync by sharing this
+        predicate.
         """
         columns = self._collect_columns(fullname)
-        out = []
         for colname, info in columns.items():
             col_setting = _column_openapi_setting(
                 {'openapi': info.get('openapi')})
@@ -805,28 +808,27 @@ class ApiEngine:
                         and col_setting != 'R' and not is_pkey)
             if not readonly and not writable:
                 continue
-            out.append(colname)
-        return out
+            yield colname, info, writable
+
+    def exposed_column_names(self, fullname, readonly=True):
+        """Return the column names that would appear in the OpenAPI
+        schema for ``fullname``. Useful for callers that need to
+        materialize a payload whose shape matches the published spec —
+        e.g. so the runtime response stays a subset of what the spec
+        promises.
+
+        ``readonly=False`` mirrors the write-mode schema (excludes
+        system columns, formula columns, etc.). The default keeps the
+        full read shape.
+        """
+        return [colname for colname, _, _
+                in self._iter_exposed_columns(fullname, readonly=readonly)]
 
     def _build_openapi_table_schema(self, fullname, readonly=True):
-        columns = self._collect_columns(fullname)
         properties = {}
         required = []
-        for colname, info in columns.items():
-            col_setting = _column_openapi_setting(
-                {'openapi': info.get('openapi')})
-            if col_setting is False:
-                continue
-            is_real = info['kind'] == 'real'
-            is_system = info['system']
-            is_pkey = info['pkey']
-            # Writable iff: real, not system, not declared 'R', not pkey
-            writable = (is_real
-                        and not is_system
-                        and col_setting != 'R'
-                        and not is_pkey)
-            if not readonly and not writable:
-                continue
+        for colname, info, writable in self._iter_exposed_columns(
+                fullname, readonly=readonly):
             prop = {'type': info['openapi_type']}
             if info['openapi_format']:
                 prop['format'] = info['openapi_format']

--- a/gnrpy/gnr/app/api_engine/core.py
+++ b/gnrpy/gnr/app/api_engine/core.py
@@ -584,7 +584,16 @@ class ApiEngine:
                 continue
             if attrs.get('virtual_column'):
                 continue
-            cols_dict[colname] = self._column_info(colname, attrs, tbl, col=col)
+            try:
+                cols_dict[colname] = self._column_info(
+                    colname, attrs, tbl, col=col)
+            except ApiEngineError:
+                # Column dtype is not known to ApiEngine (e.g. VEC from
+                # pgvector). Silently skip it so unknown extensions do
+                # not block the entire schema; callers that need full
+                # introspection of those columns can opt into a custom
+                # dtype mapping.
+                continue
         # Virtual columns from model (alias, formula_sql, formula_subquery,
         # bagitem, virtual_other — pycolumn excluded)
         vcols = self.db.model.table(fullname).get('virtual_columns') or {}
@@ -593,7 +602,10 @@ class ApiEngine:
             kind, _ = _classify_column(attrs)
             if kind == 'pycolumn':
                 continue
-            cols_dict[colname] = self._column_info(colname, attrs, tbl)
+            try:
+                cols_dict[colname] = self._column_info(colname, attrs, tbl)
+            except ApiEngineError:
+                continue
         return cols_dict
 
     def _column_info(self, colname, attrs, tbl, col=None):

--- a/gnrpy/gnr/app/api_engine/core.py
+++ b/gnrpy/gnr/app/api_engine/core.py
@@ -340,6 +340,24 @@ def _check_sql_fragment(value, parameter_name):
     return value
 
 
+def _is_known_dtype(dtype):
+    """Quick predicate used to decide whether a column should appear in
+    the OpenAPI schema (and consequently in REST payloads).
+
+    Returns True for the empty/None case (legitimate for virtual columns
+    without a declared type) and for any string in the known mapping.
+    Returns False for unknown strings (e.g. pgvector's ``VEC``) and for
+    non-string values (e.g. a model typo like ``dtype=True``). Strict
+    validation that raises ``ApiEngineError`` is reserved for
+    ``_validate_dtype``.
+    """
+    if dtype is None or dtype == '':
+        return True
+    if not isinstance(dtype, str):
+        return False
+    return dtype.upper() in _KNOWN_DTYPES
+
+
 def _validate_dtype(dtype, colname, tbl_fullname):
     """Validate a column dtype against the known mapping.
 
@@ -584,16 +602,10 @@ class ApiEngine:
                 continue
             if attrs.get('virtual_column'):
                 continue
-            try:
-                cols_dict[colname] = self._column_info(
-                    colname, attrs, tbl, col=col)
-            except ApiEngineError:
-                # Column dtype is not known to ApiEngine (e.g. VEC from
-                # pgvector). Silently skip it so unknown extensions do
-                # not block the entire schema; callers that need full
-                # introspection of those columns can opt into a custom
-                # dtype mapping.
+            if not _is_known_dtype(attrs.get('dtype')):
                 continue
+            cols_dict[colname] = self._column_info(
+                colname, attrs, tbl, col=col)
         # Virtual columns from model (alias, formula_sql, formula_subquery,
         # bagitem, virtual_other — pycolumn excluded)
         vcols = self.db.model.table(fullname).get('virtual_columns') or {}
@@ -602,10 +614,9 @@ class ApiEngine:
             kind, _ = _classify_column(attrs)
             if kind == 'pycolumn':
                 continue
-            try:
-                cols_dict[colname] = self._column_info(colname, attrs, tbl)
-            except ApiEngineError:
+            if not _is_known_dtype(attrs.get('dtype')):
                 continue
+            cols_dict[colname] = self._column_info(colname, attrs, tbl)
         return cols_dict
 
     def _column_info(self, colname, attrs, tbl, col=None):
@@ -690,6 +701,31 @@ class ApiEngine:
         schema).
 
         Returns ``{table_fullname: {<openapi schema object>}}``.
+
+        Dtype coverage
+        --------------
+        Only columns whose dtype is one of the codes below appear in the
+        schema (and, consequently, in REST payloads built by callers
+        that respect the schema):
+
+            T, A, P, TEXT  -> string
+            R, F           -> number(float)
+            L, I           -> integer
+            B              -> boolean
+            D              -> string(date)
+            DH, DT, DHZ    -> string(date-time)
+            H, HZ          -> string(time)
+            TD             -> string(duration)
+            N              -> string(decimal)
+            BAG, X         -> object(gnr-bag)
+            JS             -> array
+
+        Columns declaring any other dtype string (e.g. pgvector's
+        ``VEC``) or a non-string dtype are intentionally omitted: the
+        engine cannot describe their shape, so it neither lists nor
+        materializes them. If you need to expose such a column, extend
+        the dtype tables in this module or expose a derived virtual
+        column with a supported dtype.
         """
         explicit_table = isinstance(target, str) and '.' in target
         explicit_package = (isinstance(target, str)

--- a/gnrpy/gnr/app/api_engine/core.py
+++ b/gnrpy/gnr/app/api_engine/core.py
@@ -133,6 +133,7 @@ _DTYPE_PYTHON = {
     'N': 'Decimal',
     'BAG': 'Bag', 'X': 'Bag',
     'JS': 'list',
+    'VEC': 'list',
 }
 
 _DTYPE_OPENAPI = {
@@ -155,6 +156,8 @@ _DTYPE_OPENAPI = {
     # structured
     'BAG': ('object', 'gnr-bag'), 'X': ('object', 'gnr-bag'),
     'JS': ('array', None),
+    # pgvector embedding column: array of floats
+    'VEC': ('array', 'vector'),
 }
 
 

--- a/gnrpy/tests/app/test_api_engine.py
+++ b/gnrpy/tests/app/test_api_engine.py
@@ -149,32 +149,36 @@ class TestTableColumns:
         with pytest.raises(ValueError, match='Unknown table'):
             engine.table_columns('invc.nonexistent')
 
-    def test_non_string_dtype_raises(self, db_sqlite):
-        """A model with a non-string dtype (e.g. dtype=True from a typo)
-        must raise ApiEngineError rather than silently fall back."""
+    def test_non_string_dtype_skipped(self, db_sqlite):
+        """A column with a non-string dtype (e.g. dtype=True from a typo)
+        is silently omitted from the schema rather than raising."""
         engine = ApiEngine(db_sqlite.application)
         col = engine.db.table('invc.customer').columns['account_name']
         prev = col.attributes.get('dtype')
         try:
             col.attributes['dtype'] = True
-            with pytest.raises(ApiEngineError, match='Invalid dtype True'):
-                engine.table_columns('invc.customer')
+            cols = engine.table_columns('invc.customer')
+            assert 'account_name' not in cols['invc.customer']
         finally:
             if prev is None:
                 col.attributes.pop('dtype', None)
             else:
                 col.attributes['dtype'] = prev
 
-    def test_unknown_dtype_raises(self, db_sqlite):
-        """A dtype that is a string but not in the known mapping must
-        raise ApiEngineError listing the accepted codes."""
+    def test_unknown_dtype_skipped(self, db_sqlite):
+        """A column with an unknown dtype string (e.g. 'ZZZ' or a custom
+        pgvector 'VEC') is silently omitted from the schema rather than
+        raising — unknown extensions should not block introspection of
+        the rest of the table."""
         engine = ApiEngine(db_sqlite.application)
         col = engine.db.table('invc.customer').columns['account_name']
         prev = col.attributes.get('dtype')
         try:
             col.attributes['dtype'] = 'ZZZ'
-            with pytest.raises(ApiEngineError, match="Unknown dtype 'ZZZ'"):
-                engine.table_columns('invc.customer')
+            cols = engine.table_columns('invc.customer')
+            assert 'account_name' not in cols['invc.customer']
+            # Other columns of the same table still appear.
+            assert 'account_code' in cols['invc.customer']
         finally:
             if prev is None:
                 col.attributes.pop('dtype', None)

--- a/projects/gnrcore/packages/sys/webpages/ep_openapi.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_openapi.py
@@ -494,11 +494,15 @@ class GnrCustomWebPage(object):
         return pkg.attributes.get('openapi') is not False
 
     def _read_json_body(self):
-        raw = None
+        # GnrWebRequest delegates to a Werkzeug request via __getattr__.
+        # Werkzeug exposes the raw body on request.get_data(); the
+        # legacy 'body' attribute returns a stream object, not bytes.
+        req = self.request._request
         try:
-            raw = self.request.body
+            raw = req.get_data(as_text=False)
         except Exception:
-            raw = None
+            return {'__error__': self._error(
+                400, 'bad_body', 'Could not read request body')}
         if not raw:
             return {}
         if isinstance(raw, bytes):

--- a/projects/gnrcore/packages/sys/webpages/ep_openapi.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_openapi.py
@@ -1,0 +1,523 @@
+# -*- coding: utf-8 -*-
+"""REST read-only endpoint over the GenroPy DB, with auto-generated
+OpenAPI 3.1 spec and inline Swagger UI.
+
+URL surface (all under ``/sys/ep_openapi/``):
+
+    GET  /openapi.json                       OpenAPI 3.1 spec
+    GET  /docs                               Swagger UI page (CDN)
+    GET  /{pkg}/{table}                      list (limit, offset, where, ...)
+    GET  /{pkg}/{table}/{pkey}               single record
+    POST /{pkg}/{table}/_search              complex query in JSON body
+
+Tables are exposed only if their model declares ``openapi=True``.
+
+Auth: Authorization: Bearer <token>. The token lives in the ``openapi``
+service of the instanceconfig.
+
+This endpoint is a transitional layer over the legacy WSGI stack. The
+production-grade REST API will live on genro-asgi.
+"""
+
+import json
+
+from gnr.app.api_engine import ApiEngine, ApiEngineError
+
+
+MAX_ROWS = 1000
+DEFAULT_LIMIT = 100
+
+
+_SWAGGER_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>GenroPy API — Swagger UI</title>
+  <link rel="stylesheet" type="text/css"
+        href="https://unpkg.com/swagger-ui-dist/swagger-ui.css">
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: "./openapi.json",
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis],
+      });
+    };
+  </script>
+</body>
+</html>
+"""
+
+
+class GnrCustomWebPage(object):
+    py_requires = 'gnrcomponents/externalcall:BaseRpc'
+    convert_result = False
+    skip_connection = False
+
+    # ── Dispatch ─────────────────────────────────────────────────────
+
+    def rootPage(self, *args, **kwargs):
+        """Custom dispatcher: parse path segments after ``ep_openapi`` and
+        select the handler based on HTTP method. Bypasses the standard
+        ``BaseRpc`` "first segment == method name" rule so URLs are
+        clean REST paths like ``/sys/ep_openapi/{pkg}/{table}/{pkey}``.
+        """
+        kwargs.pop('pagetemplate', None)
+
+        if self.request.method == 'OPTIONS':
+            return self._cors_preflight()
+
+        if not self._check_bearer():
+            return self._error(401, 'unauthorized',
+                               'Missing or invalid bearer token')
+
+        # Special paths first
+        if args == ('openapi.json',):
+            return self._openapi_json()
+        if args == ('docs',):
+            return self._swagger_ui()
+
+        # Resource paths: /{pkg}/{table}[/{pkey_or_action}]
+        method = self.request.method
+        if len(args) == 2:
+            pkg, table = args
+            if method == 'GET':
+                return self._list(pkg, table, **kwargs)
+            return self._error(405, 'method_not_allowed',
+                               'Method %s not allowed on collection' % method)
+        if len(args) == 3:
+            pkg, table, tail = args
+            if tail == '_search' and method == 'POST':
+                return self._search(pkg, table)
+            if method == 'GET':
+                return self._get_record(pkg, table, tail)
+            return self._error(405, 'method_not_allowed',
+                               'Method %s not allowed' % method)
+
+        return self._error(404, 'not_found',
+                           'Unknown path: /%s' % '/'.join(args or ()))
+
+    # ── Auth & CORS ──────────────────────────────────────────────────
+
+    def _check_bearer(self):
+        service = self.getService('openapi')
+        if not service:
+            return False
+        expected = getattr(service, 'token', None)
+        if not expected:
+            return False
+        auth = self.request.headers.get('Authorization') or ''
+        if not auth.startswith('Bearer '):
+            auth = self.request.headers.get('X-GNR-Authorization') or ''
+        if not auth.startswith('Bearer '):
+            return False
+        return auth[len('Bearer '):].strip() == expected
+
+    def _cors_preflight(self):
+        self._set_cors_headers()
+        self.response.status_code = 204
+        return ''
+
+    def _set_cors_headers(self):
+        self.response.headers.add('Access-Control-Allow-Origin', '*')
+        self.response.headers.add('Access-Control-Allow-Methods',
+                                  'GET, POST, OPTIONS')
+        self.response.headers.add('Access-Control-Allow-Headers',
+                                  'Authorization, Content-Type')
+
+    # ── Schema builder (public method, reusable) ─────────────────────
+
+    def schema(self, target=None, readonly=True):
+        """Build the OpenAPI 3.1 document for ``target`` (None = all
+        tables exposed via ``openapi=True``).
+
+        This is the extension point for the future package broadcast:
+        ``pkgBroadcast('openapi_schema', ...)`` will let each package
+        contribute its own sub-spec instead of having ``sys.ep_openapi``
+        build everything itself.
+        """
+        engine = ApiEngine(self.app)
+        component_schemas = engine.openapi_schema(target=target,
+                                                  readonly=readonly)
+        write_schemas = engine.openapi_schema(target=target,
+                                              readonly=False)
+
+        paths = {}
+        tags = []
+        for fullname, table_schema in component_schemas.items():
+            pkg, tname = fullname.split('.', 1)
+            tag = fullname
+            tags.append({'name': tag,
+                         'description': 'Records of table %s' % fullname})
+            paths.update(self._paths_for_table(pkg, tname, fullname, tag,
+                                                write_schemas.get(fullname)))
+
+        components = {
+            'schemas': component_schemas,
+            'securitySchemes': {
+                'bearerAuth': {'type': 'http', 'scheme': 'bearer'},
+            },
+            'parameters': self._common_parameters(),
+            'responses': self._common_responses(),
+        }
+        return {
+            'openapi': '3.1.0',
+            'info': {
+                'title': 'GenroPy API (legacy)',
+                'version': '1.0.0',
+                'description': (
+                    'Read-only REST surface auto-generated from the '
+                    'GenroPy data model. Tables are exposed when their '
+                    'model declares openapi=True.'),
+            },
+            'servers': [{'url': self._server_url()}],
+            'security': [{'bearerAuth': []}],
+            'tags': tags,
+            'paths': paths,
+            'components': components,
+        }
+
+    # ── Handlers ─────────────────────────────────────────────────────
+
+    def _list(self, pkg, table, **kwargs):
+        full = '%s.%s' % (pkg, table)
+        if not self._is_exposed(full):
+            return self._error(404, 'not_found',
+                               'Table %r not exposed' % full)
+
+        try:
+            limit = int(kwargs.pop('limit', DEFAULT_LIMIT))
+        except (TypeError, ValueError):
+            return self._error(400, 'bad_param', 'limit must be integer')
+        try:
+            offset = int(kwargs.pop('offset', 0))
+        except (TypeError, ValueError):
+            return self._error(400, 'bad_param', 'offset must be integer')
+        limit = max(1, min(limit, MAX_ROWS))
+        offset = max(0, offset)
+
+        sqlparams = kwargs.pop('sqlparams', None)
+        if isinstance(sqlparams, str) and sqlparams:
+            try:
+                sqlparams = json.loads(sqlparams)
+            except json.JSONDecodeError:
+                return self._error(400, 'bad_param',
+                                   'sqlparams must be valid JSON')
+
+        run_kwargs = {'limit': limit, 'offset': offset}
+        for k in ('columns', 'where', 'order_by', 'group_by', 'having',
+                  'distinct'):
+            v = kwargs.get(k)
+            if v is not None:
+                run_kwargs[k] = v
+        if sqlparams:
+            run_kwargs['sqlparams'] = sqlparams
+
+        engine = ApiEngine(self.app, max_rows=MAX_ROWS)
+        try:
+            result = engine.run_query(full, **run_kwargs)
+        except (ApiEngineError, ValueError) as e:
+            return self._error(422, 'invalid_query', str(e))
+        if result['error']:
+            return self._error(500, 'query_error', result['error'])
+
+        return self._ok({
+            'data': result['rows'],
+            'pagination': {
+                'limit': limit,
+                'offset': offset,
+                'returned': result['rowcount'],
+                'truncated': result['truncated'],
+            },
+        })
+
+    def _get_record(self, pkg, table, pkey):
+        full = '%s.%s' % (pkg, table)
+        if not self._is_exposed(full):
+            return self._error(404, 'not_found',
+                               'Table %r not exposed' % full)
+
+        engine = ApiEngine(self.app, max_rows=MAX_ROWS)
+        try:
+            result = engine.run_query(
+                full,
+                where='$pkey = :_pkey',
+                sqlparams={'_pkey': pkey},
+                limit=1,
+            )
+        except (ApiEngineError, ValueError) as e:
+            return self._error(422, 'invalid_query', str(e))
+        if result['error']:
+            return self._error(500, 'query_error', result['error'])
+
+        if not result['rows']:
+            return self._error(404, 'not_found',
+                               'Record %r not found in %s' % (pkey, full))
+        return self._ok({'data': result['rows'][0]})
+
+    def _search(self, pkg, table):
+        full = '%s.%s' % (pkg, table)
+        if not self._is_exposed(full):
+            return self._error(404, 'not_found',
+                               'Table %r not exposed' % full)
+
+        body = self._read_json_body()
+        if isinstance(body, dict) and body.get('__error__'):
+            return body['__error__']
+        body = body or {}
+
+        try:
+            limit = int(body.get('limit', DEFAULT_LIMIT))
+            offset = int(body.get('offset', 0))
+        except (TypeError, ValueError):
+            return self._error(400, 'bad_param',
+                               'limit/offset must be integer')
+        limit = max(1, min(limit, MAX_ROWS))
+        offset = max(0, offset)
+
+        run_kwargs = {'limit': limit, 'offset': offset}
+        for k in ('columns', 'where', 'sqlparams', 'order_by',
+                  'group_by', 'having', 'distinct'):
+            v = body.get(k)
+            if v is not None:
+                run_kwargs[k] = v
+
+        engine = ApiEngine(self.app, max_rows=MAX_ROWS)
+        try:
+            result = engine.run_query(full, **run_kwargs)
+        except (ApiEngineError, ValueError) as e:
+            return self._error(422, 'invalid_query', str(e))
+        if result['error']:
+            return self._error(500, 'query_error', result['error'])
+
+        return self._ok({
+            'data': result['rows'],
+            'pagination': {
+                'limit': limit,
+                'offset': offset,
+                'returned': result['rowcount'],
+                'truncated': result['truncated'],
+            },
+        })
+
+    def _openapi_json(self):
+        self._set_cors_headers()
+        self.response.content_type = 'application/json'
+        return json.dumps(self.schema(), default=str)
+
+    def _swagger_ui(self):
+        self._set_cors_headers()
+        self.response.content_type = 'text/html'
+        return _SWAGGER_HTML
+
+    # ── Spec helpers ─────────────────────────────────────────────────
+
+    def _paths_for_table(self, pkg, tname, fullname, tag, write_schema):
+        ref = '#/components/schemas/%s' % fullname.replace('/', '~1')
+        list_response = {
+            'type': 'object',
+            'properties': {
+                'data': {'type': 'array',
+                         'items': {'$ref': ref}},
+                'pagination': {'type': 'object'},
+            },
+        }
+        single_response = {
+            'type': 'object',
+            'properties': {'data': {'$ref': ref}},
+        }
+        search_body = {
+            'type': 'object',
+            'properties': {
+                'columns': {'type': 'string'},
+                'where': {'type': 'string'},
+                'sqlparams': {'type': 'object'},
+                'order_by': {'type': 'string'},
+                'group_by': {'type': 'string'},
+                'having': {'type': 'string'},
+                'distinct': {'type': 'boolean'},
+                'limit': {'type': 'integer'},
+                'offset': {'type': 'integer'},
+            },
+        }
+        collection_path = '/%s/%s' % (pkg, tname)
+        record_path = '/%s/%s/{pkey}' % (pkg, tname)
+        search_path = '/%s/%s/_search' % (pkg, tname)
+        return {
+            collection_path: {
+                'get': {
+                    'tags': [tag],
+                    'summary': 'List %s' % fullname,
+                    'parameters': [
+                        {'$ref': '#/components/parameters/limit'},
+                        {'$ref': '#/components/parameters/offset'},
+                        {'$ref': '#/components/parameters/where'},
+                        {'$ref': '#/components/parameters/order_by'},
+                        {'$ref': '#/components/parameters/columns'},
+                    ],
+                    'responses': {
+                        '200': {'description': 'OK',
+                                'content': {'application/json': {
+                                    'schema': list_response}}},
+                        '401': {'$ref': '#/components/responses/Unauthorized'},
+                        '404': {'$ref': '#/components/responses/NotFound'},
+                    },
+                },
+            },
+            record_path: {
+                'get': {
+                    'tags': [tag],
+                    'summary': 'Get %s by pkey' % fullname,
+                    'parameters': [{
+                        'name': 'pkey', 'in': 'path', 'required': True,
+                        'schema': {'type': 'string'},
+                    }],
+                    'responses': {
+                        '200': {'description': 'OK',
+                                'content': {'application/json': {
+                                    'schema': single_response}}},
+                        '401': {'$ref': '#/components/responses/Unauthorized'},
+                        '404': {'$ref': '#/components/responses/NotFound'},
+                    },
+                },
+            },
+            search_path: {
+                'post': {
+                    'tags': [tag],
+                    'summary': 'Search %s' % fullname,
+                    'requestBody': {
+                        'required': False,
+                        'content': {'application/json': {
+                            'schema': search_body}},
+                    },
+                    'responses': {
+                        '200': {'description': 'OK',
+                                'content': {'application/json': {
+                                    'schema': list_response}}},
+                        '401': {'$ref': '#/components/responses/Unauthorized'},
+                        '404': {'$ref': '#/components/responses/NotFound'},
+                        '422': {'$ref': '#/components/responses/InvalidQuery'},
+                    },
+                },
+            },
+        }
+
+    def _common_parameters(self):
+        return {
+            'limit': {
+                'name': 'limit', 'in': 'query', 'required': False,
+                'schema': {'type': 'integer', 'minimum': 1,
+                           'maximum': MAX_ROWS, 'default': DEFAULT_LIMIT},
+            },
+            'offset': {
+                'name': 'offset', 'in': 'query', 'required': False,
+                'schema': {'type': 'integer', 'minimum': 0, 'default': 0},
+            },
+            'where': {
+                'name': 'where', 'in': 'query', 'required': False,
+                'description': ('GenroPy where clause with :name '
+                                'placeholders, e.g. "$status = :s".'),
+                'schema': {'type': 'string'},
+            },
+            'order_by': {
+                'name': 'order_by', 'in': 'query', 'required': False,
+                'schema': {'type': 'string'},
+            },
+            'columns': {
+                'name': 'columns', 'in': 'query', 'required': False,
+                'description': ('Comma-separated GenroPy columns '
+                                'expression, e.g. "$id,$name".'),
+                'schema': {'type': 'string'},
+            },
+        }
+
+    def _common_responses(self):
+        error_schema = {
+            'type': 'object',
+            'properties': {
+                'error': {
+                    'type': 'object',
+                    'properties': {
+                        'code': {'type': 'string'},
+                        'message': {'type': 'string'},
+                        'details': {'type': 'object'},
+                    },
+                    'required': ['code', 'message'],
+                },
+            },
+        }
+        return {
+            'Unauthorized': {
+                'description': 'Missing or invalid bearer token',
+                'content': {'application/json': {'schema': error_schema}},
+            },
+            'NotFound': {
+                'description': 'Resource not found',
+                'content': {'application/json': {'schema': error_schema}},
+            },
+            'InvalidQuery': {
+                'description': 'Query parameters did not pass validation',
+                'content': {'application/json': {'schema': error_schema}},
+            },
+        }
+
+    def _server_url(self):
+        try:
+            return self.site.externalUrl('/sys/ep_openapi').rstrip('/')
+        except Exception:
+            return '/sys/ep_openapi'
+
+    # ── Helpers: model probe, body, response ─────────────────────────
+
+    def _is_exposed(self, fullname):
+        try:
+            tbl = self.db.table(fullname)
+        except Exception:
+            return False
+        if not tbl.attributes.get('openapi'):
+            return False
+        pkg_name = fullname.split('.', 1)[0]
+        try:
+            pkg = self.db.packages[pkg_name]
+        except Exception:
+            return False
+        return pkg.attributes.get('openapi') is not False
+
+    def _read_json_body(self):
+        raw = None
+        try:
+            raw = self.request.body
+        except Exception:
+            raw = None
+        if not raw:
+            return {}
+        if isinstance(raw, bytes):
+            try:
+                raw = raw.decode('utf-8')
+            except UnicodeDecodeError:
+                return {'__error__': self._error(
+                    400, 'bad_body', 'Body is not valid UTF-8')}
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return {'__error__': self._error(
+                400, 'bad_body', 'Body is not valid JSON')}
+
+    def _ok(self, payload):
+        self._set_cors_headers()
+        self.response.content_type = 'application/json'
+        return json.dumps(payload, default=str)
+
+    def _error(self, status, code, message, details=None):
+        self._set_cors_headers()
+        self.response.content_type = 'application/json'
+        self.response.status_code = status
+        body = {'error': {'code': code, 'message': message}}
+        if details is not None:
+            body['error']['details'] = details
+        return json.dumps(body, default=str)

--- a/projects/gnrcore/packages/sys/webpages/ep_openapi.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_openapi.py
@@ -189,6 +189,15 @@ class GnrCustomWebPage(object):
 
     # ── Handlers ─────────────────────────────────────────────────────
 
+    def _default_columns(self, engine, full):
+        """Build a GenroPy ``columns`` expression that restricts the
+        runtime payload to the columns published in the OpenAPI spec.
+        Without this, columns with unknown dtypes (e.g. pgvector VEC)
+        would leak into responses even though the spec hides them.
+        """
+        cols = engine.exposed_column_names(full)
+        return ','.join('$%s' % c for c in cols) if cols else None
+
     def _list(self, pkg, table, **kwargs):
         full = '%s.%s' % (pkg, table)
         if not self._is_exposed(full):
@@ -224,6 +233,10 @@ class GnrCustomWebPage(object):
             run_kwargs['sqlparams'] = sqlparams
 
         engine = ApiEngine(self.app, max_rows=MAX_ROWS)
+        if 'columns' not in run_kwargs:
+            default_cols = self._default_columns(engine, full)
+            if default_cols:
+                run_kwargs['columns'] = default_cols
         try:
             result = engine.run_query(full, **run_kwargs)
         except (ApiEngineError, ValueError) as e:
@@ -248,13 +261,16 @@ class GnrCustomWebPage(object):
                                'Table %r not exposed' % full)
 
         engine = ApiEngine(self.app, max_rows=MAX_ROWS)
+        run_kwargs = dict(
+            where='$pkey = :_pkey',
+            sqlparams={'_pkey': pkey},
+            limit=1,
+        )
+        default_cols = self._default_columns(engine, full)
+        if default_cols:
+            run_kwargs['columns'] = default_cols
         try:
-            result = engine.run_query(
-                full,
-                where='$pkey = :_pkey',
-                sqlparams={'_pkey': pkey},
-                limit=1,
-            )
+            result = engine.run_query(full, **run_kwargs)
         except (ApiEngineError, ValueError) as e:
             return self._error(422, 'invalid_query', str(e))
         if result['error']:
@@ -293,6 +309,10 @@ class GnrCustomWebPage(object):
                 run_kwargs[k] = v
 
         engine = ApiEngine(self.app, max_rows=MAX_ROWS)
+        if 'columns' not in run_kwargs:
+            default_cols = self._default_columns(engine, full)
+            if default_cols:
+                run_kwargs['columns'] = default_cols
         try:
             result = engine.run_query(full, **run_kwargs)
         except (ApiEngineError, ValueError) as e:

--- a/projects/gnrcore/packages/sys/webpages/ep_openapi.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_openapi.py
@@ -105,7 +105,12 @@ class GnrCustomWebPage(object):
     # ── Auth & CORS ──────────────────────────────────────────────────
 
     def _check_bearer(self):
-        service = self.getService('openapi')
+        # The endpoint trusts a dedicated 'openapi' service when present;
+        # for the legacy transition phase it falls back to the bearer of
+        # the 'sourcerer' service so integrators can start consuming the
+        # REST surface without provisioning a second token. The fallback
+        # will be removed once 'openapi' is provisioned everywhere.
+        service = self.getService('openapi') or self.getService('sourcerer')
         if not service:
             return False
         expected = getattr(service, 'token', None)

--- a/projects/gnrcore/packages/sys/webpages/ep_openapi.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_openapi.py
@@ -10,15 +10,44 @@ URL surface (all under ``/sys/ep_openapi/``):
     GET  /{pkg}/{table}/{pkey}               single record
     POST /{pkg}/{table}/_search              complex query in JSON body
 
-Tables are exposed only if their model declares ``openapi=True``.
-
 Auth: Authorization: Bearer <token>. The token lives in the ``openapi``
-service of the instanceconfig.
+service of the instanceconfig (transitional fallback to the
+``sourcerer`` service while the dedicated token is provisioned).
 
 This endpoint is a transitional layer over the legacy WSGI stack. The
 production-grade REST API will live on genro-asgi.
+
+Exposure boundary (read carefully before flipping flags)
+--------------------------------------------------------
+A table appears in the surface iff its model declares ``openapi=True``
+(and its package is not ``openapi=False``). Per-column ``openapi=False``
+hides individual columns. Beyond that, two important caveats hold for
+the current implementation:
+
+1. **Foreign-key traversal is not gated.** GenroPy expressions of the
+   form ``$@<fkey>.<col>`` are accepted verbatim in ``columns``,
+   ``where``, ``order_by``, ``group_by`` and ``having``. They make any
+   table reachable via fkey queryable, even when the target table is
+   ``openapi=False``. Both direct exfiltration (selecting traversed
+   columns) and boolean-blind probing (filtering on traversed columns
+   and reading rowcount) are possible. A traversal guard inside
+   ``ApiEngine`` is planned; until it ships, treat ``openapi=True`` as
+   exposing the **entire fkey-reachable subgraph** of the table.
+
+2. **GenroPy ``auth_tags`` are not enforced.** A column with
+   ``auth_tags='hr_only'`` and ``openapi=True`` is visible to anyone
+   holding the bearer. There is no end-user identity propagation
+   (``acting_user``) on the path yet; audit attribution lives at the
+   service level. On-behalf-of identity flow will land with the ASGI
+   rewrite.
+
+Practical rule: only mark a table ``openapi=True`` when its entire
+fkey-reachable subgraph is intended to be readable by every holder of
+the service bearer, and when no auth-tag-gated column needs to remain
+private from those same holders.
 """
 
+import hmac
 import json
 
 from gnr.app.api_engine import ApiEngine, ApiEngineError
@@ -121,7 +150,7 @@ class GnrCustomWebPage(object):
             auth = self.request.headers.get('X-GNR-Authorization') or ''
         if not auth.startswith('Bearer '):
             return False
-        return auth[len('Bearer '):].strip() == expected
+        return hmac.compare_digest(auth[len('Bearer '):].strip(), expected)
 
     def _cors_preflight(self):
         self._set_cors_headers()

--- a/projects/gnrcore/packages/sys/webpages/ep_openapi.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_openapi.py
@@ -125,7 +125,7 @@ class GnrCustomWebPage(object):
 
     def _cors_preflight(self):
         self._set_cors_headers()
-        self.response.status_code = 204
+        self.response._response.status_code = 204
         return ''
 
     def _set_cors_headers(self):
@@ -521,7 +521,7 @@ class GnrCustomWebPage(object):
     def _error(self, status, code, message, details=None):
         self._set_cors_headers()
         self.response.content_type = 'application/json'
-        self.response.status_code = status
+        self.response._response.status_code = status
         body = {'error': {'code': code, 'message': message}}
         if details is not None:
             body['error']['details'] = details

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -79,10 +79,20 @@ class GnrCustomWebPage(object):
         if result['error']:
             return self._query_error(result['error'], ticket_code)
 
+        rows = result['rows']
+        rowcount = result['rowcount']
+        if count_only:
+            # Lift the count(*) result out of the row payload into
+            # rowcount so callers always see a number, not a row.
+            total = 0
+            if rows and isinstance(rows[0], dict):
+                total = int(rows[0].get('totalrows') or 0)
+            rows = []
+            rowcount = total
         return {'ok': True, 'ticket_code': ticket_code,
                 'info': {'endpoint': 'rpc_query', 'error': None},
-                'rows': [] if count_only else result['rows'],
-                'rowcount': result['rowcount'],
+                'rows': rows,
+                'rowcount': rowcount,
                 'truncated': result['truncated'],
                 'elapsed_ms': result['elapsed_ms']}
 

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import json
+
 from gnr.app.api_engine import ApiEngine, ApiEngineError
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrdecorator import public_method
@@ -46,6 +48,18 @@ class GnrCustomWebPage(object):
         if count_only:
             kwargs['columns'] = 'count(*) AS totalrows'
         kwargs.pop('recordResolver', None)
+
+        # When this endpoint is reached via HTTP, structured kwargs
+        # (sqlparams, partition_kwargs) arrive JSON-encoded as strings
+        # because urlencode flattens dicts. Restore them to dicts.
+        for k in ('sqlparams', 'partition_kwargs'):
+            v = kwargs.get(k)
+            if isinstance(v, str) and v:
+                try:
+                    kwargs[k] = json.loads(v)
+                except (TypeError, ValueError):
+                    return self._query_error(
+                        '%s must be valid JSON' % k, ticket_code)
 
         primary = {k: kwargs[k] for k in _RUN_QUERY_PRIMARY_KEYS
                    if k in kwargs}

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+"""Internal operations endpoint backing the Sourcerer MCP client.
+
+This is **not** a public REST API. The bearer is the token of the
+``sourcerer`` service, custodied by the operations team, revocable at
+will, and intended for diagnostic / introspection work performed by
+the Sourcerer toolchain (MCP server, target_db tool surface).
+
+Implications:
+
+- The endpoint trusts the bearer holder to be the operator. ``rpc_query``
+  therefore accepts ``partition_kwargs`` straight from the payload —
+  on a partitioned DB the operator can scope the env to any tenant for
+  diagnosis. This would be inappropriate for a user-facing API; it is
+  intentional here.
+- ``ApiEngine`` is invoked without ``acting_user`` or auth tags. Audit
+  attribution is at the service level, not the end-user level.
+
+External integrators must use ``ep_openapi`` instead, which has its
+own (much tighter) exposure boundary keyed on ``openapi=True`` flags.
+"""
 
 import json
 

--- a/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_sourcerer.py
@@ -1,82 +1,21 @@
 # -*- coding: utf-8 -*-
 
-from gnr.core.gnrdecorator import public_method
+from gnr.app.api_engine import ApiEngine, ApiEngineError
 from gnr.core.gnrbag import Bag
+from gnr.core.gnrdecorator import public_method
 from gnr.web.verifiers import AuthorizationBearerVerifier
 
 
 MAX_ROWS = 1000
 
-
-def _classify_column(attr):
-    if attr.get('joiner') or attr.get('tag') == 'relation':
-        return 'relation', False
-    if not attr.get('virtual_column'):
-        return 'real', False
-    if attr.get('relation_path'):
-        return 'alias', False
-    if attr.get('select'):
-        return 'formula_subquery', True
-    if attr.get('bagcolumn') or attr.get('itempath'):
-        return 'bagitem', False
-    if attr.get('sql_formula'):
-        return 'formula_sql', False
-    if attr.get('py_method') or attr.get('pyColumn'):
-        return 'pycolumn', False
-    return 'virtual_other', False
-
-
-def _attr_to_json(attr):
-    out = {}
-    for k, v in attr.items():
-        if isinstance(v, (str, int, float, bool, type(None))):
-            out[k] = v
-        elif isinstance(v, dict):
-            sub = {sk: sv for sk, sv in v.items()
-                   if isinstance(sv, (str, int, float, bool, type(None)))}
-            if sub:
-                out[k] = sub
-    return out
-
-
-def _bag_to_json(bag, depth=1):
-    if bag is None:
-        return None
-    out = {}
-    for node in bag:
-        attr = node.attr
-        kind, has_subquery = _classify_column(attr)
-        item = {'attr': _attr_to_json(attr), 'kind': kind}
-        if has_subquery:
-            item['subquery'] = True
-        v = node.value
-        if v is None:
-            pass
-        elif hasattr(v, 'load') and not hasattr(v, 'nodes'):
-            item['lazy'] = True
-        elif hasattr(v, 'nodes'):
-            if depth > 0:
-                item['children'] = _bag_to_json(v, depth=depth - 1)
-            else:
-                item['truncated'] = True
-        out[node.label] = item
-    return out
-
-
-def _build_table_schema(db, table_fullname):
-    tbl_model = db.model.table(table_fullname)
-    tree_bag = tbl_model.newRelationResolver().load()
-    schema = _bag_to_json(tree_bag) or {}
-    vcols = tbl_model.get('virtual_columns')
-    if vcols:
-        for name, vc in vcols.items():
-            attr = dict(vc.attributes)
-            kind, has_subquery = _classify_column(attr)
-            entry = {'attr': _attr_to_json(attr), 'kind': kind}
-            if has_subquery:
-                entry['subquery'] = True
-            schema[name] = entry
-    return schema
+_RUN_QUERY_PRIMARY_KEYS = frozenset((
+    'columns', 'where', 'sqlparams', 'order_by', 'group_by', 'having',
+    'distinct', 'limit', 'offset', 'subtable', 'storename',
+    'partition_kwargs', 'language',
+))
+_RUN_QUERY_OPT_KEYS = frozenset((
+    'excludeLogicalDeleted', 'excludeDraft', 'mode', 'checkPermissions',
+))
 
 
 class SourcererBearerVerifier(AuthorizationBearerVerifier):
@@ -95,54 +34,57 @@ class GnrCustomWebPage(object):
 
     @public_method(verifier=SourcererBearerVerifier)
     def rpc_query(self, ticket_code=None, **kwargs):
-        info = {'endpoint': 'rpc_query', 'error': None}
-
         service = self.getService('sourcerer')
         if not service or not service.is_query_enabled():
-            info['error'] = 'endpoint_disabled'
-            return {'ok': False, 'ticket_code': ticket_code,
-                    'info': info, 'data': []}
+            return self._query_error('endpoint_disabled', ticket_code)
 
-        count_only = bool(kwargs.get('countOnly'))
+        table = kwargs.pop('table', None)
+        if not table:
+            return self._query_error('missing_table', ticket_code)
+
+        count_only = bool(kwargs.pop('countOnly', False))
         if count_only:
-            cap_applied = False
-            info['limit_applied'] = kwargs.get('limit')
-        else:
-            requested = kwargs.get('limit')
-            cap_applied = requested is None or (
-                isinstance(requested, int) and requested > MAX_ROWS)
-            kwargs['limit'] = MAX_ROWS if cap_applied else requested
-            info['limit_applied'] = kwargs['limit']
-
+            kwargs['columns'] = 'count(*) AS totalrows'
         kwargs.pop('recordResolver', None)
 
-        try:
-            adapter_name = type(self.db.adapter).__name__.lower()
-            if 'postgres' in adapter_name or 'pg' in adapter_name:
-                self.db.execute("SET LOCAL statement_timeout = 3000")
-        except Exception:
-            pass
+        primary = {k: kwargs[k] for k in _RUN_QUERY_PRIMARY_KEYS
+                   if k in kwargs}
+        opt = {k: kwargs[k] for k in _RUN_QUERY_OPT_KEYS if k in kwargs}
 
+        condition = kwargs.get('condition')
+        if condition:
+            existing = primary.get('where')
+            primary['where'] = ('(%s) AND (%s)' % (existing, condition)
+                                if existing else condition)
+
+        pkeys = kwargs.get('pkeys')
+        if pkeys is not None:
+            existing = primary.get('where')
+            pkey_clause = '$pkey IN :_pkeys'
+            primary['where'] = ('(%s) AND (%s)' % (existing, pkey_clause)
+                                if existing else pkey_clause)
+            sp = dict(primary.get('sqlparams') or {})
+            if isinstance(pkeys, str):
+                pkeys = [p.strip() for p in pkeys.split(',') if p.strip()]
+            sp['_pkeys'] = pkeys
+            primary['sqlparams'] = sp
+
+        engine = ApiEngine(self.app, max_rows=MAX_ROWS)
         try:
-            data_bag, attrs = self.app.getSelection(
-                recordResolver=False, **kwargs)
-            rows = []
-            if not count_only:
-                for k in data_bag.keys():
-                    node = data_bag.getNode(k)
-                    row = dict(node.attr)
-                    row.pop('_customClasses', None)
-                    row.pop('_attributes', None)
-                    rows.append(row)
-            info['totalrows'] = attrs.get('totalrows', 0)
-            info['more'] = cap_applied and info['totalrows'] >= MAX_ROWS
-            info['servertime_ms'] = attrs.get('servertime')
-            return {'ok': True, 'ticket_code': ticket_code,
-                    'info': info, 'data': rows}
-        except Exception as e:
-            info['error'] = str(e)
-            return {'ok': False, 'ticket_code': ticket_code,
-                    'info': info, 'data': []}
+            result = engine.run_query(table, opt_kwargs=opt or None,
+                                      **primary)
+        except (ApiEngineError, ValueError) as e:
+            return self._query_error(str(e), ticket_code)
+
+        if result['error']:
+            return self._query_error(result['error'], ticket_code)
+
+        return {'ok': True, 'ticket_code': ticket_code,
+                'info': {'endpoint': 'rpc_query', 'error': None},
+                'rows': [] if count_only else result['rows'],
+                'rowcount': result['rowcount'],
+                'truncated': result['truncated'],
+                'elapsed_ms': result['elapsed_ms']}
 
     @public_method(verifier=SourcererBearerVerifier)
     def rpc_relationtree(self, ticket_code=None, table=None, **kwargs):
@@ -154,11 +96,12 @@ class GnrCustomWebPage(object):
             return {'ok': False, 'ticket_code': ticket_code,
                     'info': info, 'tables': None, 'trees': None}
 
+        engine = ApiEngine(self.app)
         if not table:
             try:
-                tables = sorted(t.fullname for t in self.db.tables)
                 return {'ok': True, 'ticket_code': ticket_code,
-                        'info': info, 'tables': tables, 'trees': None}
+                        'info': info,
+                        'tables': engine.table_names(), 'trees': None}
             except Exception as e:
                 info['error'] = str(e)
                 return {'ok': False, 'ticket_code': ticket_code,
@@ -170,16 +113,21 @@ class GnrCustomWebPage(object):
         failed = {}
         for tname in requested:
             try:
-                trees[tname] = _build_table_schema(self.db, tname)
+                wrapped = engine.table_schema(tname)
+                trees[tname] = wrapped[tname]
             except Exception as e:
                 failed[tname] = str(e)
         if failed:
             info['tables_failed'] = failed
-
         if not trees:
             info['error'] = 'no_table_resolved'
             return {'ok': False, 'ticket_code': ticket_code,
                     'info': info, 'tables': None, 'trees': None}
-
         return {'ok': True, 'ticket_code': ticket_code,
                 'info': info, 'tables': None, 'trees': trees}
+
+    def _query_error(self, msg, ticket_code):
+        return {'ok': False, 'ticket_code': ticket_code,
+                'info': {'endpoint': 'rpc_query', 'error': msg},
+                'rows': [], 'rowcount': 0, 'truncated': False,
+                'elapsed_ms': 0.0}


### PR DESCRIPTION
## Summary

- **Refactor of `sys/ep_sourcerer.py`** on top of `gnr.app.api_engine.ApiEngine`. The endpoint shrinks from 186 to ~145 lines: the inline introspection helpers (`_classify_column`, `_attr_to_json`, `_bag_to_json`, `_build_table_schema`) are deleted because `ApiEngine` now provides them. `rpc_query` maps legacy `getSelection` shortcuts (`countOnly`, `condition`, `pkeys`) into `ApiEngine.run_query` primary/opt parameter sets and returns an ApiEngine-native envelope (`{ok, ticket_code, info, rows, rowcount, truncated, elapsed_ms}`). `rpc_relationtree` delegates to `engine.table_names()` / `engine.table_schema()`. The best-effort `SET LOCAL statement_timeout` is dropped (does not fire across gnrsql's transactional boundary; tracked separately).
- **New `sys/ep_openapi.py`** — a read-only REST surface auto-generated from the data model, intended as a transitional bridge for external integrators while the production REST API matures on genro-asgi. URL shape is REST-canonical:
  - `GET /sys/ep_openapi/openapi.json` → OpenAPI 3.1 spec
  - `GET /sys/ep_openapi/docs` → Swagger UI page (loaded from `unpkg.com/swagger-ui-dist`)
  - `GET /sys/ep_openapi/{pkg}/{table}` → list with `limit/offset/where/columns/order_by`
  - `GET /sys/ep_openapi/{pkg}/{table}/{pkey}` → single record
  - `POST /sys/ep_openapi/{pkg}/{table}/_search` → complex query in JSON body

  Tables are exposed only when the model declares `openapi=True`. Auth via bearer (`Authorization: Bearer <token>`, service `openapi` with a transitional fallback to `sourcerer`). Basic CORS preflight + permissive `Access-Control-Allow-Origin` so Swagger UI works cross-origin. Error envelope `{error: {code, message, details?}}` with real HTTP status codes. Write verbs (POST create, PUT, DELETE) are intentionally not exposed: write semantics will land with the ASGI rewrite.

- **`ApiEngine` improvements**
  - Columns with unknown / invalid dtypes are now silently skipped during schema build (previously they raised `ApiEngineError` and blocked the entire table). This degrades gracefully when extensions like pgvector's `VEC` show up.
  - New `exposed_column_names(fullname, readonly=True)` helper returns the list of columns that would appear in `openapi_schema()` properties. `ep_openapi` uses it to compute a default `columns=` expression for the runtime query so the response is a strict subset of what the spec promises (no `description_emb` leaking through when the spec hides it).

The client-side adaptation (Sourcerer MCP `target_db`) is in `genropy/genro-sourcerer` and tracks the same wire shape; it is already merged on `main` there.

## Test plan
- [x] `pytest gnrpy/tests/app/test_api_engine.py` — 79 passed (two `*_dtype_raises` tests rewritten to assert the new skip semantics)
- [x] flake8 (`--max-line-length=120`) clean on every changed file
- [x] E2E against the Sourcerer DB on Hetzner via the MCP client:
  - `target_db.tables(server_id='_self_')` (local) and via HTTP loopback (`server_id='WpbgJ2bjOWeb86_Yfk4BKA'`)
  - `target_db.getSelection` with `where + sqlparams`, `countOnly=True`, `pkeys`, `condition`
  - `target_db.relationtree`
- [x] E2E with curl against `ep_openapi`:
  - `GET /openapi.json` → 200, valid OpenAPI 3.1 with `paths`/`tags`/`components.schemas`
  - `GET /docs` → 200, Swagger UI HTML
  - `GET /gnrmcp/skill?limit=2` → 200 + paginated payload
  - `GET /gnrmcp/skill/{pkey}` → 200 + single record (23 columns, no `*_emb`)
  - `POST /gnrmcp/skill/_search` with JSON body filtering `title ILIKE :p` → 200, filters applied
  - Missing/invalid bearer → 401; unknown table → 404
- [ ] One concrete external integrator consumes the OpenAPI spec via Swagger UI in production (to be done once `openapi` service tokens are provisioned across instances).