### PR TITLE
fix(dbstores): resolve package storename via dbstores + auxstores

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -237,6 +237,8 @@ class DbStoresHandler(object):
                                         host=dbattr.get('host', self.db.host), user=dbattr.get('user', self.db.user),
                                         password=dbattr.get('password', self.db.password),
                                         port=dbattr.get('port', self.db.port),
+                                        implementation=dbattr.get('implementation'),
+                                        dbbranch=dbattr.get('dbbranch'),
                                         remote_host=dbattr.get('remote_host'),
                                         remote_port=dbattr.get('remote_port'))
         return dbattr

--- a/gnrpy/gnr/sql/gnrsqltable/utils.py
+++ b/gnrpy/gnr/sql/gnrsqltable/utils.py
@@ -802,4 +802,5 @@ class UtilsMixin(SqlTableBaseMixin):
         """Return the DB implementation for the package's storename."""
         packageStorename = self.pkg.attributes.get('storename')
         if packageStorename:
-            return self.db.dbstores[packageStorename].get('implementation')
+            storeattr = self.db.get_store_parameters(packageStorename) or {}
+            return storeattr.get('implementation')


### PR DESCRIPTION
## Problem

When an instance declares a non-default store in `instanceconfig.xml`, e.g.:

```xml
<packages>
    <legacy storename='my_legacy' readOnly='t'/>
</packages>
<dbstores>
    <my_legacy dbname="legacy_db" implementation="db2_400"/>
</dbstores>
```

any query against a table of the `legacy` package raises:

```
File ".../gnr/sql/gnrsqltable/utils.py", line 805, in dbImplementation
    return self.db.dbstores[packageStorename].get('implementation')
KeyError: 'my_legacy'
```

### Root cause

There are two distinct layers feeding the store registry:

- `DbStoresHandler.dbstores` — computed from the multi-db **storetable** (dynamic tenants).
- `DbStoresHandler.auxstores` — populated from `<dbstores>` entries in `instanceconfig.xml`.

Two bugs make this combination unusable:

1. **`SqlTable.dbImplementation`** looks up the store **only** in `db.dbstores`, so any instanceconfig-declared store raises `KeyError` before the query ever reaches the adapter. `db.get_store_parameters()` (in `gnrsql/connections.py`) already exposes the unified `dbstores or auxstores` lookup, but `dbImplementation` was not using it.
2. **`DbStoresHandler.add_auxstore`** discards the `implementation` (and `dbbranch`) attributes when copying the instanceconfig node into `auxstores`. Even if the lookup found the store, `get_connection_params()` would silently fall back to the root db's implementation, so a `db2_400` declaration ends up connecting as the host's default (e.g. postgres).

The two bugs compound: the first prevents queries from working at all, the second would make them connect to the wrong backend if the first were fixed in isolation.

## Solution

- `gnrpy/gnr/app/gnrapp.py` — `DbStoresHandler.add_auxstore` now preserves `implementation` and `dbbranch` from the instanceconfig node, so they reach `get_connection_params()` and `dbImplementation`.
- `gnrpy/gnr/sql/gnrsqltable/utils.py` — `SqlTable.dbImplementation` now resolves the store through `db.get_store_parameters(packageStorename)`, which already handles both `dbstores` and `auxstores`. No more `KeyError` for instanceconfig-declared stores; `None` is returned only when the store is truly unknown.

## Notes

- No public API change; behavior aligns `dbImplementation` with the lookup contract already used by `get_connection_params`.
- Existing tests for `DbStoresHandler` / `auxstores` still pass.
- Draft because end-to-end verification against a real non-postgres backend (e.g. db2_400) requires the corresponding adapter/driver in CI.