### PR TITLE
added --skip-existing to initgenropy cli command. If used, the

### DIFF
--- a/gnrpy/gnr/app/cli/initgenropy.py
+++ b/gnrpy/gnr/app/cli/initgenropy.py
@@ -6,10 +6,14 @@ description = "Initialize a new genropy environment"
 def main():
     parser = GnrCliArgParse(description=description)
     parser.add_argument('gnrdaemon_password',nargs='?')
-    parser.add_argument('-N', '--no_user',help="Avoid base user",action='store_true',)
+    parser.add_argument('-N', '--no_user', help="Avoid base user",
+                        action='store_true')
+    parser.add_argument('--skip-existing',
+                        help="Skip if the enviroment is already created",
+                        action="store_true")
     options = parser.parse_args()
     initgenropy(gnrdaemon_password=options.gnrdaemon_password,
-                avoid_baseuser=options.no_user)
+                avoid_baseuser=options.no_user, skip_existing=options.skip_existing)
 
 if __name__ == '__main__':
     main()

--- a/gnrpy/gnr/app/gnrdeploy.py
+++ b/gnrpy/gnr/app/gnrdeploy.py
@@ -125,7 +125,9 @@ def check_file(xml_path=None):
     if os.path.exists(xml_path):
         raise GnrConfigException("A file named %s already exists so i couldn't create a config file at same path" % xml_path)
 
-def initgenropy(gnrdaemon_password=None,avoid_baseuser=False):
+def initgenropy(gnrdaemon_password=None,
+                avoid_baseuser=False,
+                skip_existing=False):
     gnrpy_path = os.path.dirname(gnrbase.__file__)
     config_path  = gnrConfigPath(force_return=True)
     instanceconfig_path = os.path.join(config_path,'instanceconfig')
@@ -138,7 +140,16 @@ def initgenropy(gnrdaemon_password=None,avoid_baseuser=False):
     default_siteconfig_xml_path = os.path.join(siteconfig_path,'default.xml')
 
     for xml_path in (environment_xml_path, default_instanceconfig_xml_path, default_siteconfig_xml_path):
-        check_file(xml_path=xml_path)
+        try:
+            check_file(xml_path=xml_path)
+        except Exception as e:
+            if skip_existing:
+                logger.warning("%s", e)
+                sys.exit(0)
+            else:
+                logger.error("%s", e)
+                sys.exit(1)
+            
     gnrdaemon_password = gnrdaemon_password or get_random_password()
     gnrdaemon_port = get_gnrdaemon_port(set_last=True)
     build_environment_xml(path=environment_xml_path, gnrpy_path=gnrpy_path, gnrdaemon_password=gnrdaemon_password,


### PR DESCRIPTION
check for existing env files will just exit without failure reporting a warning. If not used, it will log an error and exit with failure

refs #938