### PR TITLE
fix(attachmanager): localize attachmentGrid drop area label

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -30,6 +30,13 @@ New features
 Bugfixes
 --------
 
+* attachmentGrid drop uploader: the gallery drop area label ("Drop
+  document here" / "or double click") was hardcoded English HTML
+  with no translation marker, so it never reached the localizer. The
+  text fragments are now wrapped with the embedded ``[!!...]`` marker
+  so they are localized like the other uploader messages, and the
+  Italian translations are added. No backward-compatibility impact.
+
 * PDF watermark service: fix ``code=4: source object number out of
   range`` when ``watermarkedPDF`` is applied to PDFs saved with
   multiple incremental xref generations (e.g. macOS Preview

--- a/localization.xml
+++ b/localization.xml
@@ -420,6 +420,8 @@
 <en_uploader base="Uploader" de="Uploader" en="Uploader" fr="Uploader" it="Uploader"></en_uploader>
 <en_drag_here_or_double_click_to_upload base="Drag here or double click to upload" it="Trascina qui o fai doppio click" en=""></en_drag_here_or_double_click_to_upload>
 <en_double_click_to_upload base="Double click to upload" it="Doppio click per caricare" en=""></en_double_click_to_upload>
+<en_drop_document_here base="Drop document here" it="Trascina qui il documento" en=""></en_drop_document_here>
+<en_or_double_click_to_upload base="or double click to upload" it="o fai doppio click per caricare" en=""></en_or_double_click_to_upload>
 <en_attachment base="Attachment" de="Befestigung" en="Attachment" fr="Attachement" it="Allegato"></en_attachment>
 <en_attachments base="Attachments" de="Zubehör" en="Attachments" fr="Pièces jointes" it="Allegati"></en_attachments>
 <en_delete_attachment base="Delete attachment" de="Anhang löschen" en="Delete attachment" fr="Supprimer la pièce jointe" it="Elimina allegato"></en_delete_attachment>

--- a/resources/common/gnrcomponents/attachmanager/attachmanager.py
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.py
@@ -290,7 +290,7 @@ class AttachManager(BaseComponent):
                                      **kwargs)
         if uploaderButton:
             th.view.bottom.dropUploader(
-                            label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>',
+                            label='<div class="atc_galleryDropArea"><div>[!!Drop document here]</div><div>[!!or double click to upload]</div></div>',
                             height='40px',
                             ask=ask,
                             onUploadingMethod=self.onUploadingAttachment,
@@ -356,7 +356,7 @@ class AttachManager(BaseComponent):
             th.view.top.bar.replaceSlots('delrow','delrow,screenshot,5')
         if uploaderButton:
             th.view.bottom.dropUploader(
-                            label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>',
+                            label='<div class="atc_galleryDropArea"><div>[!!Drop document here]</div><div>[!!or double click to upload]</div></div>',
                             height='40px',
                             ask=ask,
                             onUploadingMethod=self.onUploadingAttachment,
@@ -461,7 +461,7 @@ class AttachManager(BaseComponent):
 
         if uploaderButton:
             th.view.bottom.dropUploader(
-                            label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>',
+                            label='<div class="atc_galleryDropArea"><div>[!!Drop document here]</div><div>[!!or double click to upload]</div></div>',
                             height='40px',
                             onUploadingMethod=self.onUploadingAttachment,
                             onUploadedMethod=self.onUploadedAttachment,


### PR DESCRIPTION
## Problem

The gallery drop area label of the `attachmentGrid` drop uploader was hardcoded English HTML with no translation marker:

```python
label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>'
```

Because the string carried no `!!` marker, the localizer never processed it, so the label stayed fixed in English regardless of the active locale — unlike the sibling uploader messages (`!!Drag here or double click to upload`, etc.) which are correctly localized.

## Fix

Wrap the text fragments with the embedded `[!!...]` marker (the established Genropy idiom for translating fragments inside a larger string), leaving the surrounding HTML untouched:

```python
label='<div class="atc_galleryDropArea"><div>[!!Drop document here]</div><div>[!!or double click to upload]</div></div>'
```

Applied to all three occurrences in `attachmanager.py`. Added the Italian translations to `localization.xml`:

- `Drop document here` → `Trascina qui il documento`
- `or double click to upload` → `o fai doppio click per caricare`

## Test

- Verified `TRANSLATION` regex in `gnrlocalization.py` extracts both embedded fragments (`Drop document here`, `or double click to upload`) while leaving the HTML tags intact.
- `flake8` passes with zero errors on the modified file.
- `localization.xml` validates as well-formed XML.

To verify in-app: open any form with an `attachmentGrid` uploader under an Italian locale — the drop area now reads "Trascina qui il documento / o fai doppio click per caricare".

## Backward compatibility

None. Behaviour is identical for English; other locales simply get a translated label instead of fixed English text.