### PR TITLE
feat(attachmanager): customizable, localized attachmentGrid drop label

### DIFF
--- a/gnrpy/RELEASE_NOTES.rst
+++ b/gnrpy/RELEASE_NOTES.rst
@@ -12,6 +12,17 @@ New features
   passed the forwarded dict is empty and the uploader behaves exactly
   as before.
 
+* ``attachmentGrid`` drop uploader label is now customizable and
+  localized. Passing ``uploader_label=...`` replaces only the text
+  content of the drop area, while the styled ``atc_galleryDropArea``
+  wrapper (padding, centering, border) is always preserved; when
+  omitted, the default ("Drop document here" / "or double click to
+  upload") is used. The default label was previously hardcoded
+  English HTML with no translation marker, so it never reached the
+  localizer; the text fragments now carry the embedded ``[!!...]``
+  marker (Italian translations added). No backward-compatibility
+  impact.
+
 * Connection cleanup is now a single on-event mechanism instead of
   two parallel ones. When a page closes on the client a lottery
   (``cleanup_threshold``, default 5%) gates an attempt to spawn a

--- a/localization.xml
+++ b/localization.xml
@@ -420,6 +420,8 @@
 <en_uploader base="Uploader" de="Uploader" en="Uploader" fr="Uploader" it="Uploader"></en_uploader>
 <en_drag_here_or_double_click_to_upload base="Drag here or double click to upload" it="Trascina qui o fai doppio click" en=""></en_drag_here_or_double_click_to_upload>
 <en_double_click_to_upload base="Double click to upload" it="Doppio click per caricare" en=""></en_double_click_to_upload>
+<en_drop_document_here base="Drop document here" it="Trascina qui il documento" en=""></en_drop_document_here>
+<en_or_double_click_to_upload base="or double click to upload" it="o fai doppio click per caricare" en=""></en_or_double_click_to_upload>
 <en_attachment base="Attachment" de="Befestigung" en="Attachment" fr="Attachement" it="Allegato"></en_attachment>
 <en_attachments base="Attachments" de="Zubehör" en="Attachments" fr="Pièces jointes" it="Allegati"></en_attachments>
 <en_delete_attachment base="Delete attachment" de="Anhang löschen" en="Delete attachment" fr="Supprimer la pièce jointe" it="Elimina allegato"></en_delete_attachment>

--- a/resources/common/gnrcomponents/attachmanager/attachmanager.py
+++ b/resources/common/gnrcomponents/attachmanager/attachmanager.py
@@ -290,7 +290,7 @@ class AttachManager(BaseComponent):
                                      **kwargs)
         if uploaderButton:
             th.view.bottom.dropUploader(
-                            label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>',
+                            label='<div class="atc_galleryDropArea"><div>[!!Drop document here]</div><div>[!!or double click to upload]</div></div>',
                             height='40px',
                             ask=ask,
                             onUploadingMethod=self.onUploadingAttachment,
@@ -355,8 +355,10 @@ class AttachManager(BaseComponent):
         if screenshot:
             th.view.top.bar.replaceSlots('delrow','delrow,screenshot,5')
         if uploaderButton:
+            custom_label = uploader_kwargs.pop('label', None)
+            label_content = '<div>%s</div>' % custom_label if custom_label else '<div>[!!Drop document here]</div><div>[!!or double click to upload]</div>'
             th.view.bottom.dropUploader(
-                            label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>',
+                            label='<div class="atc_galleryDropArea">%s</div>' % label_content,
                             height='40px',
                             ask=ask,
                             onUploadingMethod=self.onUploadingAttachment,
@@ -462,7 +464,7 @@ class AttachManager(BaseComponent):
 
         if uploaderButton:
             th.view.bottom.dropUploader(
-                            label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>',
+                            label='<div class="atc_galleryDropArea"><div>[!!Drop document here]</div><div>[!!or double click to upload]</div></div>',
                             height='40px',
                             onUploadingMethod=self.onUploadingAttachment,
                             onUploadedMethod=self.onUploadedAttachment,


### PR DESCRIPTION
> **Stacked on #933.** Base is `feature/attachmentgrid-upload-maxsize` so the diff shows only this change. Once #933 merges to `develop`, this PR will be retargeted to `develop`.

## Problem

The `attachmentGrid` drop uploader label was hardcoded English HTML with no translation marker:

```python
label='<div class="atc_galleryDropArea"><div>Drop document here</div><div>or double click</div></div>'
```

Two issues:
1. **Not localized** — the string carried no `!!` marker, so the localizer never processed it and the label stayed fixed in English regardless of locale (unlike the sibling uploader messages such as `!!Drag here or double click to upload`).
2. **Not customizable** — there was no way to change the message. Passing a plain-text label would have replaced the whole HTML, including the styled `atc_galleryDropArea` wrapper, losing padding/centering/border.

## Changes

- **Localization**: the text fragments now carry the embedded `[!!...]` marker (the established Genropy idiom for translating fragments inside a larger string), leaving the surrounding HTML intact. Applied to all three drop-area labels in `attachmanager.py`. Italian translations added to `localization.xml`:
  - `Drop document here` → `Trascina qui il documento`
  - `or double click to upload` → `o fai doppio click per caricare`
- **Customizable label (`at_attachmentGrid`)**: `uploader_label=...` (forwarded via the `uploader_*` mechanism from #933) now replaces **only the text content** of the drop area; the styled `atc_galleryDropArea` wrapper is always preserved, so a custom message keeps the default look:

  ```python
  custom_label = uploader_kwargs.pop('label', None)
  label_content = '<div>%s</div>' % custom_label if custom_label else '<div>[!!Drop document here]</div><div>[!!or double click to upload]</div>'
  dropUploader(label='<div class="atc_galleryDropArea">%s</div>' % label_content, ...)
  ```

  The `pop` removes `label` from `uploader_kwargs` before it is spread onto `dropUploader`, avoiding a duplicate-keyword `TypeError`.
- `RELEASE_NOTES.rst` — entry under New features.

## Test

- Verified the `TRANSLATION` regex in `gnrlocalization.py` extracts both embedded fragments (`Drop document here`, `or double click to upload`) while leaving the HTML tags intact.
- Verified the `pop`/`**uploader_kwargs` evaluation order: with `uploader_label` set the custom text is used and no duplicate `label` reaches `dropUploader`; without it the localized default is used.
- `flake8` passes with zero errors on the modified file; `localization.xml` validates as well-formed XML.

To verify in-app: under an Italian locale, an `attachmentGrid` drop area now reads "Trascina qui il documento / o fai doppio click per caricare"; passing `uploader_label='...'` shows the custom text inside the same styled box.

## Backward compatibility

None. With no `uploader_label` the default (now localized) label is used; English behaviour is unchanged.