### PR TITLE
Default language fixes and usage in migration context

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -296,7 +296,10 @@ class DbStoresHandler(object):
         
         :param storename: TODO
         :param changes: TODO. """
-        with self.db.tempEnv(storename=storename):
+
+        # current_language is set to None in the migration context like this
+        # in order to properly handle all the localized columns in the models
+        with self.db.tempEnv(storename=storename, current_language=None):
             self.db.syncOrmToSql()
 
 class GnrSqlAppDb(GnrSqlDb):

--- a/gnrpy/gnr/sql/gnrsql/db.py
+++ b/gnrpy/gnr/sql/gnrsql/db.py
@@ -173,6 +173,16 @@ class GnrSqlDb(
             'missedCommit': GnrMissedCommitException,
         }
 
+    @property
+    def default_language(self):
+        """Return the default language for database localization.
+        
+        :returns: the first language code from db languages config, or None
+        """
+        db_languages = self.extra_kw.get('languages')
+        db_languages = db_languages.split(',') if db_languages else []
+        return db_languages[0].lower() if db_languages else None
+
     # -- Encryption ----------------------------------------------------------
 
     @property

--- a/gnrpy/gnr/sql/gnrsqlmodel/columns.py
+++ b/gnrpy/gnr/sql/gnrsqlmodel/columns.py
@@ -209,7 +209,7 @@ class DbColumnObj(DbBaseColumnObj):
         """
         base_sqlname = self.attributes.get('sqlname', self.name)
         if self.attributes.get('localized'):
-            default_language = self.db.currentEnv.get('default_language')
+            default_language = self.dbroot.default_language
             current_language = self.db.currentEnv.get('current_language')
             if default_language and current_language and current_language != default_language:
                 return f"{base_sqlname}_{current_language}"

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -472,13 +472,15 @@ class GnrWebPage(GnrBaseWebPage):
 
     @property
     def default_language(self):
-        """Return the default language for database localization.
+        """Return the default language using the database default.
 
-        :returns: the first language code from db languages config, or None
+        FIXME: since this is in the page context, here could be the correct place
+        to check if, in a multi tenant deployment, the tenant has a specific default
+        language, otherwise fallback on the db's default.
+
+        :returns: the default language, or None
         """
-        db_languages = self._db.extra_kw.get('languages')
-        db_languages = db_languages.split(',') if db_languages else []
-        return db_languages[0].lower() if db_languages else None
+        return self._db.default_language
 
     @property
     def locale_language(self):


### PR DESCRIPTION
During tests with multidb package and localized fields, a problem emerged.

When executing migration in a non-page context (like using 'gnr db migrate'), everything worked fine. 

But when executed in a page context, like using ts_hosting's package UI, which invokes GnrApp's dbstore_align, localized fields didn't get created correctly - only the localized one where created, rather than original+localized. This occurs because when running a page context, current_language is populated, causing issues to the migrator itself. So the dbstore_align now executes in a tempEnv where current_language is set to None, like in a CLI execution context.

the page's 'default_language' property has been moved to gnrsql/db.py, due to the fact that the default language is set in the database configuration, so it's a scope fix. The original page's default_language has been preserved for compatibility, now using the new property. Page's property can be customized in the future to support a different default language in a multi tenant context, where each tenant can set, for example, a different default language.