### PR TITLE
fix: decode psql -l output bytes in listRemoteDatabases

### DIFF
--- a/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
@@ -477,7 +477,7 @@ class PostgresSqlDbBaseAdapter(SqlDbBaseAdapter):
         result = []
         if not res:
             return []
-        for dbr in res.split('\n'):
+        for dbr in res.decode('utf-8', errors='replace').split('\n'):
             dbname = dbr.split('|')[0].strip()
             if dbname:
                 result.append(dbname)

--- a/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
+++ b/gnrpy/gnr/sql/adapters/_gnrbasepostgresadapter.py
@@ -468,16 +468,12 @@ class PostgresSqlDbBaseAdapter(SqlDbBaseAdapter):
                         password=source_dbpassword or 'postgres',
                         host = source_dbhost or 'localhost',
                         port = source_dbport or '5432')
-        ps = subprocess.Popen((
+        cmd_output = subprocess.run((
             'ssh','%s@%s' %(source_ssh_user,source_ssh_host),
             '-C', 'psql','-l','-t', "user=%(user)s password=%(password)s host=%(host)s port=%(port)s" %srcdb
-            ),stdout=subprocess.PIPE)
-        res = ps.stdout.read()
-        ps.wait()
+            ),capture_output=True, encoding='utf-8', errors='replace', check=True)
         result = []
-        if not res:
-            return []
-        for dbr in res.decode('utf-8', errors='replace').split('\n'):
+        for dbr in cmd_output.stdout.split('\n'):
             dbname = dbr.split('|')[0].strip()
             if dbname:
                 result.append(dbname)

--- a/gnrpy/tests/sql/test_gnrbaseadapter.py
+++ b/gnrpy/tests/sql/test_gnrbaseadapter.py
@@ -1,5 +1,8 @@
+import io
+
 import pytest
 from gnr.sql.adapters import _gnrbaseadapter as ba
+from gnr.sql.adapters import _gnrbasepostgresadapter as pgmod
 
 class FakeCursor(object):
     def fetchall(self):
@@ -429,3 +432,51 @@ class TestSqliteAdapterMaskField:
         # Should fall back to 2-4
         assert "2" in result
         assert "4" in result
+
+
+class FakePopen(object):
+    """Stand-in for subprocess.Popen exposing a binary stdout pipe."""
+    def __init__(self, out=b''):
+        self.stdout = io.BytesIO(out)
+
+    def wait(self):
+        return 0
+
+
+class TestPostgresAdapterListRemoteDatabases:
+    """Test listRemoteDatabases bytes parsing for PostgreSQL adapter."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.adapter = pgmod.PostgresSqlDbBaseAdapter(FakeDbRoot(False))
+
+    def _patch_popen(self, monkeypatch, output):
+        captured = {}
+
+        def fake_popen(cmd, stdout=None):
+            captured['cmd'] = cmd
+            return FakePopen(output)
+
+        monkeypatch.setattr(pgmod.subprocess, 'Popen', fake_popen)
+        return captured
+
+    def test_parses_bytes_output(self, monkeypatch):
+        """psql -l -t output arrives as bytes from the pipe (incl. non-ascii)."""
+        fixture = (
+            b" mydb      | postgres | UTF8 | libc | C | C |  |  | \n"
+            b" caff\xc3\xa8_db  | postgres | UTF8 | libc | C | C |  |  | \n"
+            b" template0 | postgres | UTF8 | libc | C | C |  |  | =c/postgres\n"
+            b"\n"
+        )
+        captured = self._patch_popen(monkeypatch, fixture)
+        result = self.adapter.listRemoteDatabases(source_ssh_host='example.com',
+                                                  source_ssh_user='user')
+        assert result == ['mydb', 'caff\xe8_db', 'template0']
+        assert captured['cmd'][0] == 'ssh'
+        assert captured['cmd'][1] == 'user@example.com'
+
+    def test_empty_output(self, monkeypatch):
+        self._patch_popen(monkeypatch, b'')
+        result = self.adapter.listRemoteDatabases(source_ssh_host='example.com',
+                                                  source_ssh_user='user')
+        assert result == []

--- a/gnrpy/tests/sql/test_gnrbaseadapter.py
+++ b/gnrpy/tests/sql/test_gnrbaseadapter.py
@@ -1,5 +1,3 @@
-import io
-
 import pytest
 from gnr.sql.adapters import _gnrbaseadapter as ba
 from gnr.sql.adapters import _gnrbasepostgresadapter as pgmod
@@ -434,49 +432,53 @@ class TestSqliteAdapterMaskField:
         assert "4" in result
 
 
-class FakePopen(object):
-    """Stand-in for subprocess.Popen exposing a binary stdout pipe."""
-    def __init__(self, out=b''):
-        self.stdout = io.BytesIO(out)
-
-    def wait(self):
-        return 0
+class FakeCompletedProcess(object):
+    """Stand-in for the CompletedProcess returned by subprocess.run."""
+    def __init__(self, stdout=''):
+        self.stdout = stdout
+        self.returncode = 0
 
 
 class TestPostgresAdapterListRemoteDatabases:
-    """Test listRemoteDatabases bytes parsing for PostgreSQL adapter."""
+    """Test listRemoteDatabases output parsing for the PostgreSQL adapter."""
 
     @classmethod
     def setup_class(cls):
         cls.adapter = pgmod.PostgresSqlDbBaseAdapter(FakeDbRoot(False))
 
-    def _patch_popen(self, monkeypatch, output):
+    def _patch_run(self, monkeypatch, stdout):
         captured = {}
 
-        def fake_popen(cmd, stdout=None):
+        def fake_run(cmd, **kwargs):
             captured['cmd'] = cmd
-            return FakePopen(output)
+            captured['kwargs'] = kwargs
+            return FakeCompletedProcess(stdout)
 
-        monkeypatch.setattr(pgmod.subprocess, 'Popen', fake_popen)
+        monkeypatch.setattr(pgmod.subprocess, 'run', fake_run)
         return captured
 
-    def test_parses_bytes_output(self, monkeypatch):
-        """psql -l -t output arrives as bytes from the pipe (incl. non-ascii)."""
+    def test_parses_output(self, monkeypatch):
+        """psql -l -t output is parsed; non-ascii names and blank lines handled."""
         fixture = (
-            b" mydb      | postgres | UTF8 | libc | C | C |  |  | \n"
-            b" caff\xc3\xa8_db  | postgres | UTF8 | libc | C | C |  |  | \n"
-            b" template0 | postgres | UTF8 | libc | C | C |  |  | =c/postgres\n"
-            b"\n"
+            " mydb      | postgres | UTF8 | libc | C | C |  |  | \n"
+            " caff\xe8_db  | postgres | UTF8 | libc | C | C |  |  | \n"
+            " template0 | postgres | UTF8 | libc | C | C |  |  | =c/postgres\n"
+            "\n"
         )
-        captured = self._patch_popen(monkeypatch, fixture)
+        captured = self._patch_run(monkeypatch, fixture)
         result = self.adapter.listRemoteDatabases(source_ssh_host='example.com',
                                                   source_ssh_user='user')
         assert result == ['mydb', 'caff\xe8_db', 'template0']
         assert captured['cmd'][0] == 'ssh'
         assert captured['cmd'][1] == 'user@example.com'
+        # robustness contract: utf-8 decoding regardless of locale, fail-loud on error
+        assert captured['kwargs']['encoding'] == 'utf-8'
+        assert captured['kwargs']['errors'] == 'replace'
+        assert captured['kwargs']['check'] is True
+        assert captured['kwargs']['capture_output'] is True
 
     def test_empty_output(self, monkeypatch):
-        self._patch_popen(monkeypatch, b'')
+        self._patch_run(monkeypatch, '')
         result = self.adapter.listRemoteDatabases(source_ssh_host='example.com',
                                                   source_ssh_user='user')
         assert result == []


### PR DESCRIPTION
## Summary

`PostgresSqlDbBaseAdapter.listRemoteDatabases` runs `psql -l -t` over SSH via
`subprocess.Popen(..., stdout=subprocess.PIPE)` and reads the result with
`ps.stdout.read()`.

Without `text=True`/`encoding=...`, on Python 3 `read()` returns a **`bytes`**
object. The original code did `res.split('\n')` (a `str` separator) on those
bytes, which raises:

```
TypeError: a bytes-like object is required, not 'str'
```

as soon as the output is non-empty. The method was therefore broken for any
real remote database; the `if not res: return []` guard only masked it when the
output was empty (`b''` is falsy).

## Fix

Decode the bytes before splitting:

```python
for dbr in res.decode('utf-8', errors='replace').split('\n'):
```

- **UTF-8** because PostgreSQL database names can contain non-ASCII characters
  and that is `psql`'s default output encoding in modern setups.
- **`errors='replace'`** to degrade gracefully on an undecodable byte instead of
  crashing the whole listing.

## Tests

Added `TestPostgresAdapterListRemoteDatabases` in
`gnrpy/tests/sql/test_gnrbaseadapter.py`. A `FakePopen` backed by `io.BytesIO`
reproduces the real condition (the pipe yields bytes); only the external
dependency (`subprocess.Popen`/SSH) is mocked, the parsing is exercised for real:

- `test_parses_bytes_output` — bytes output including a non-ASCII db name
  (`caffè_db`); verifies UTF-8 decoding and the ssh command.
- `test_empty_output` — covers the `if not res` branch.

## Checks

- `flake8` on both files: 0 errors.
- `pytest gnrpy/tests/sql/test_gnrbaseadapter.py`: 38 passed.

> Note: a pre-existing, unrelated failure in `core/gnrlist_test.py::TestCsvReader::test_auto_dialect`
> (CSV dialect/quoting) is present on `develop` and is out of scope for this PR.