### PR TITLE
Add user xgroup (deployment group) with _DEV_-gated UI and avatar/cookie propagation

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage_proxy/connection.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/connection.py
@@ -160,6 +160,7 @@ class GnrWebConnection(GnrBaseProxy):
         self.user_tags = avatar_dict.get('user_tags')
         self.user_name = avatar_dict.get('user_name')
         self.user_id = avatar_dict.get('user_id')
+        self.cookie_data['xgroup'] = avatar_dict.get('xgroup')
         if avatar:
             self.avatar_extra = avatar.extra_kwargs
 

--- a/projects/gnrcore/packages/adm/main.py
+++ b/projects/gnrcore/packages/adm/main.py
@@ -60,6 +60,7 @@ class Package(GnrDboPackage):
                 else:
                     kwargs['group_code'] = group_code
                 kwargs['main_group_code'] = user_record['group_code']
+                kwargs['xgroup'] = user_record['xgroup']
                 kwargs['avatar_rootpage'] = user_record['avatar_rootpage'] or group_record.get('rootpage')
                 kwargs['locale'] = user_record['locale'] or self.application.config('default?client_locale')
                 kwargs['user_name'] = user_record['fullname'] or user_record['username']

--- a/projects/gnrcore/packages/adm/model/user.py
+++ b/projects/gnrcore/packages/adm/model/user.py
@@ -36,6 +36,9 @@ class Table(object):
         tbl.column('sms_number',name_long='!!Sms Number')
         tbl.column('photo',dtype='P', name_long='!![en]Photo')
         tbl.column('group_code',size=':15',name_long='!!Group').relation('group.code',relation_name='users',mode='foreignkey')
+        tbl.column('xgroup', size=':10', name_long='!!Deployment group',
+                    batch_assign=dict(tags='_DEV_')).relation('adm.xgroup.code',
+                    relation_name='users', mode='foreignkey', onDelete='setnull')
         tbl.column('custom_menu', dtype='X', name_long='!!Custom menu')
         tbl.column('custom_fields', dtype='X', name_long='!!Custom fields')
         tbl.column('avatar_secret_2fa', dtype='T',name_long='!![en]Secret 2fa')

--- a/projects/gnrcore/packages/adm/model/xgroup.py
+++ b/projects/gnrcore/packages/adm/model/xgroup.py
@@ -1,0 +1,33 @@
+# encoding: utf-8
+
+from gnr.core.gnrdecorator import metadata
+
+
+class Table(object):
+    def config_db(self, pkg):
+        tbl = pkg.table('xgroup', pkey='code', name_long='!!Deployment group',
+                        name_plural='!!Deployment groups',
+                        caption_field='description', lookup=True)
+        self.sysFields(tbl, id=False)
+        tbl.column('code', size=':10', name_long='!!Code')
+        tbl.column('description', name_long='!!Description')
+
+    @metadata(mandatory=True)
+    def sysRecord_ALPHA(self):
+        return self.newrecord(code='ALPHA', description='Alpha')
+
+    @metadata(mandatory=True)
+    def sysRecord_CANARY(self):
+        return self.newrecord(code='CANARY', description='Canary')
+
+    @metadata(mandatory=True)
+    def sysRecord_BETA(self):
+        return self.newrecord(code='BETA', description='Beta')
+
+    @metadata(mandatory=True)
+    def sysRecord_STANDARD(self):
+        return self.newrecord(code='STANDARD', description='Standard')
+
+    @metadata(mandatory=True)
+    def sysRecord_LTS(self):
+        return self.newrecord(code='LTS', description='LTS')

--- a/projects/gnrcore/packages/adm/model/xgroup.py
+++ b/projects/gnrcore/packages/adm/model/xgroup.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from gnr.core.gnrdecorator import metadata
-
 
 class Table(object):
     def config_db(self, pkg):
@@ -12,22 +10,16 @@ class Table(object):
         tbl.column('code', size=':10', name_long='!!Code')
         tbl.column('description', name_long='!!Description')
 
-    @metadata(mandatory=True)
-    def sysRecord_ALPHA(self):
-        return self.newrecord(code='ALPHA', description='Alpha')
-
-    @metadata(mandatory=True)
-    def sysRecord_CANARY(self):
-        return self.newrecord(code='CANARY', description='Canary')
-
-    @metadata(mandatory=True)
-    def sysRecord_BETA(self):
-        return self.newrecord(code='BETA', description='Beta')
-
-    @metadata(mandatory=True)
+    # Base deployment groups, aligned with the sticky-proxy worker groups
+    # (standard/beta/canary). These are modifiable defaults, not constraints:
+    # an instance may add, rename or remove them. Codes are upper-case here;
+    # the proxy lower-cases them to match the worker group names. STANDARD is
+    # the default/fallback channel for users without an explicit group.
     def sysRecord_STANDARD(self):
         return self.newrecord(code='STANDARD', description='Standard')
 
-    @metadata(mandatory=True)
-    def sysRecord_LTS(self):
-        return self.newrecord(code='LTS', description='LTS')
+    def sysRecord_BETA(self):
+        return self.newrecord(code='BETA', description='Beta')
+
+    def sysRecord_CANARY(self):
+        return self.newrecord(code='CANARY', description='Canary')

--- a/projects/gnrcore/packages/adm/resources/login.py
+++ b/projects/gnrcore/packages/adm/resources/login.py
@@ -236,6 +236,7 @@ class LoginComponent(BaseComponent):
         rootenv['user'] = self.avatar.user
         rootenv['user_id'] = self.avatar.user_id
         rootenv['user_group_code'] = getattr(self.avatar,'group_code',None)
+        rootenv['xgroup'] = getattr(self.avatar,'xgroup',None)
         rootenv['workdate'] = rootenv['workdate'] or self.workdate
         rootenv['login_date'] = date.today()
         rootenv['custom_workdate'] = rootenv['workdate']!=rootenv['login_date']

--- a/projects/gnrcore/packages/adm/resources/tables/user/th_user.py
+++ b/projects/gnrcore/packages/adm/resources/tables/user/th_user.py
@@ -18,6 +18,7 @@ class View(BaseComponent):
         r.fieldcell('username',name='Username',width='10em')
         r.fieldcell('fullname',name='Fullname',width='20em')
         r.fieldcell('group_code')
+        r.fieldcell('xgroup',name='!![en]Deployment group',width='10em',_tags='_DEV_')
         r.fieldcell('email',name='Email',width='20em')
         r.fieldcell('@tags.@tag_id.code',name='Tags',width='100%')
         r.fieldcell('auth_tags',name='Old tags',width='15em')
@@ -218,6 +219,7 @@ class Form(BaseComponent):
         fb.field('locale', lbl='!!Locale')
         fb.field('language', lbl='!![en]Language')
         fb.field('group_code',lbl='!![en]Main group',hasDownArrow=True)
+        fb.field('xgroup',lbl='!![en]Deployment group',hasDownArrow=True,_tags='_DEV_')
         fb.checkBoxText('^._other_groups',lbl='!![en]Other groups',
                         table='adm.group', condition='$code!=:mg', condition_mg='^.group_code',
                         _virtual_column='other_groups',popup=True)


### PR DESCRIPTION
## What

Adds an `adm.xgroup` lookup table representing the **deployment group** (Kubernetes-style release channel: `ALPHA` / `CANARY` / `BETA` / `STANDARD` / `LTS`) an application user is associated with, and relates each `adm.user` to it via a new `xgroup` column. The value is propagated to the avatar, the rootenv (and therefore the DB env), and the connection cookie, and is exposed in the user backoffice UI — everywhere gated to the `_DEV_` tag for both setting and viewing.

## Why

Scaffolding for an upcoming flow that will differentiate application behaviour by the "version"/channel a user can access (e.g. surface experimental features only to `CANARY` users).

## Changes

**Data model**
- `adm/model/xgroup.py` (new): lookup table (`pkey='code'`, `lookup=True`) seeded with five mandatory `sysRecord_*` (`ALPHA`/`CANARY`/`BETA`/`STANDARD`/`LTS`).
- `adm/model/user.py`: `xgroup` column → `adm.xgroup.code` (foreignkey, `onDelete='setnull'`, nullable — `null` is treated as `STANDARD` by callers); `batch_assign=dict(tags='_DEV_')`.

**Propagation (avatar → rootenv → cookie)**
- `adm/main.py`: include `xgroup` in the avatar during authentication, so it is available on every request (the avatar is rebuilt from the DB record each time).
- `adm/resources/login.py`: write `xgroup` into the rootenv; this also makes it available as `:env_xgroup` in the DB env for queries, `formulaColumn`s and triggers.
- `gnrwebpage_proxy/connection.py`: persist `xgroup` in the connection cookie, set unconditionally so it is cleared on guest/logout.

**UI (gated `_DEV_`)**
- `resources/tables/user/th_user.py`: `xgroup` cell in the user `View` and field in the `Form`, both `_tags='_DEV_'`.

## Reviewer notes

- **Gating**: the batch-assign tool is restricted with `batch_assign=dict(tags='_DEV_')`; the view cell and form field via `_tags='_DEV_'` (enforced server-side in `gnrwebstruct`, where forbidden nodes are dropped during serialization).
- **Deployment**: run `gnrdbsetup <instance> --upgrade` to create the `adm.xgroup` table and `user.xgroup` column and to seed the sysRecords (via `onDbUpgrade_createSysRecords`).
- **Verification**: `flake8` clean on all changed files; the model builds and the column/relation/sysRecords/`batch_assign` wiring was introspected in memory. Full test suite is green (1866 passed) except `core/gnrlist_test.py::TestCsvReader::test_auto_dialect`, a pre-existing failure unrelated to this change (CSV dialect handling — verified to fail identically on `develop`).
