### PR TITLE
fix(web): default sendAllEvents to false

### DIFF
--- a/gnrjs/gnr_d11/js/genro.js
+++ b/gnrjs/gnr_d11/js/genro.js
@@ -106,7 +106,7 @@ dojo.declare('gnr.GenroClient', null, {
         this.lastPing = start_ts;
         this._debugPaths = {};
         this._aliasDatapaths = {};
-        this.sendAllEvents=true;
+        this.sendAllEvents=false;
         this._lastMouseEvent = {};
         this._longClickDuration = 1500;
         this._lastUserEventTs = start_ts;


### PR DESCRIPTION
## Summary

The websocket user-event forwarding — every `click`, `mousemove`, `keydown`, `keypress`, `dblclick` is sent on the websocket via `wsk.send('user_event', …)` — was hardcoded on for every client since 2016. It feeds the `asyncdashboard` dev monitor, but generates a websocket message on every mouse move / keypress for **all** pages, always, regardless of whether anyone is observing.

This flips the default to **off**.

## Background

`genro.sendAllEvents` has always been a plain switch with no conditional logic behind it:

- `1dcb7b651` (2016-01-26) introduced the gate `if (genro.sendAllEvents …)` but never initialized the flag → `undefined` → forwarding effectively off (by accident, not by design).
- `17289bce5` (2016-02-14) added `this.sendAllEvents = true`, turning it permanently on.

A full history + working-tree scan confirms `sendAllEvents` appears **only** in core `genro.js` (the init and the gate): no application code ever sets it, and no "enable monitoring only when observed" mechanism ever existed.

## Change

`gnrjs/gnr_d11/js/genro.js`: `this.sendAllEvents = true` → `false`.

The flag stays a runtime switch: any code that needs the monitoring can re-enable it with `genro.sendAllEvents = true`. No automatic re-enable path is added.

## Verification

- Open a page with the websocket active → no more `user_event` messages on every mousemove/keypress (DevTools → Network → WS).
- Set `genro.sendAllEvents = true` in the console → messages resume and the `asyncdashboard` `evt_*` columns populate again.