### PR TITLE
Support for SSL in async server for local development.

### DIFF
--- a/gnrpy/gnr/web/serverwsgi.py
+++ b/gnrpy/gnr/web/serverwsgi.py
@@ -430,7 +430,11 @@ class Server(object):
             logger.error("'gnr' entrypoint not found on PATH; async subprocess disabled")
             return
         try:
-            child = subprocess.Popen([gnr_bin, 'web', 'async', site_name, '-p', str(async_port)])
+            async_server_cmd = [gnr_bin, 'web', 'async', site_name, '-p', str(async_port)]
+            if self.options.ssl_cert and self.options.ssl_key:
+                async_server_cmd.extend(['-c', self.options.ssl_cert,
+                                         '-k', self.options.ssl_key])
+            child = subprocess.Popen(async_server_cmd)
         except Exception:
             logger.exception('failed to spawn gnr web async subprocess')
             return


### PR DESCRIPTION
if the local dev is executed with SSL support (ex. to debug passkeys), the async server must run in ssl mode as well, using the same certificates. This simple fix add the relevant SSL options to `gnr web async` command line