### PR TITLE
fix: restore grid vertical scrollbar when view uses columnsets

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
@@ -344,9 +344,12 @@ textarea.cellEditFixed {
 
 ._common_d11 .gr_wrap_footers .dojoxGrid-scrollbox{
     overflow-x:auto !important;
-    -ms-overflow-style:none;
-    scrollbar-width:none;
 }
+/* Hide only the horizontal scrollbar: the columnset header and footer panes carry their own
+   synced horizontal scroll, so the grid's own horizontal bar is redundant. scrollbar-width and
+   -ms-overflow-style are NOT axis-specific and would also hide the vertical scrollbar, so they
+   must not be used here (doing so removed the vertical scrollbar whenever columnsets/footers
+   were present). */
 ._common_d11 .gr_wrap_footers .dojoxGrid-scrollbox::-webkit-scrollbar:horizontal{
     height:0;
     display:none;

--- a/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/15_gnr_grid_extended.css
@@ -334,7 +334,7 @@ textarea.cellEditFixed {
     padding-bottom: 1px;
 }
 .gr_footer.gr_scrollbox{
-    overflow: auto;
+    overflow: hidden;        /* follower like the columnset header: no own scrollbar, follows the body via scrollLeft */
     border-top:1px solid var(--grid-border-color);
     background: var(--grid-row-bg);
 }
@@ -342,18 +342,10 @@ textarea.cellEditFixed {
     background: var(--grid-footer-item-bg);
 }
 
-._common_d11 .gr_wrap_footers .dojoxGrid-scrollbox{
-    overflow-x:auto !important;
-}
-/* Hide only the horizontal scrollbar: the columnset header and footer panes carry their own
-   synced horizontal scroll, so the grid's own horizontal bar is redundant. scrollbar-width and
-   -ms-overflow-style are NOT axis-specific and would also hide the vertical scrollbar, so they
-   must not be used here (doing so removed the vertical scrollbar whenever columnsets/footers
-   were present). */
-._common_d11 .gr_wrap_footers .dojoxGrid-scrollbox::-webkit-scrollbar:horizontal{
-    height:0;
-    display:none;
-}
+/* Grids with columnsets/footers use the standard scrollbox: the body owns both scrollbars.
+   The columnset header and footer panes are overflow:hidden followers, synced to the body
+   scrollLeft (see genro_grid.js). No per-axis scrollbar hiding is attempted here: it is not
+   possible cross-browser and was what removed the vertical scrollbar (#955). */
 .gr_noFooter .gr_footer.gr_scrollbox .gr_itemcontainer{
     background: transparent;
     min-height: 16px;

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -487,13 +487,9 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
                                             sourceNode._footers,
                                             colinfo,autoTitle);
             scrollbox = sourceNode._footersNode._value.getNode('scrollbox');
-            genro.dom.setEventListener(scrollbox.domNode,'scroll',function(e){
-                var sn = that.views.views[0].scrollboxNode;
-                sn.scrollLeft = e.target.scrollLeft;
-                if(sourceNode._columnsetsNode){
-                    sourceNode._columnsetsNode._value.getNode('scrollbox').domNode.scrollLeft = e.target.scrollLeft;
-                }
-            });
+            // The footer pane is an overflow:hidden follower (like the columnset header):
+            // only the grid body owns the scrollbars, so the horizontal sync is one-way,
+            // body -> footer + columnset header.
             var footerScrollDom = scrollbox.domNode;
             var mainScrollbox = that.views.views[0].scrollboxNode;
             genro.dom.setEventListener(mainScrollbox,'scroll',function(e){

--- a/projects/gnrcore/packages/test/webpages/components/Grid/test_flex_minwidth.py
+++ b/projects/gnrcore/packages/test/webpages/components/Grid/test_flex_minwidth.py
@@ -7,9 +7,8 @@ from gnr.core.gnrbag import Bag
 class GnrCustomWebPage(object):
     py_requires = "gnrcomponents/testhandler:TestHandlerFull,gnrcomponents/framegrid:frameGrid"
 
-    def getSampleData(self):
-        result = Bag()
-        rows = [
+    def _sampleRows(self):
+        return [
             dict(code='PROD-001', description='High performance widget with extended warranty',
                  category='Electronics', quantity=150, unit_price=29.99,
                  supplier='Acme Corp International', notes='Best seller this quarter'),
@@ -26,7 +25,20 @@ class GnrCustomWebPage(object):
                  category='Networking', quantity=12, unit_price=599.00,
                  supplier='SecureNet Global Partners', notes='Requires installation'),
         ]
-        for i, row in enumerate(rows):
+
+    def getSampleData(self):
+        result = Bag()
+        for i, row in enumerate(self._sampleRows()):
+            result.setItem('r_%i' % i, Bag(row))
+        return result
+
+    def getManyRows(self, n=120):
+        """Like getSampleData but with enough rows to force vertical overflow."""
+        base = self._sampleRows()
+        result = Bag()
+        for i in range(n):
+            row = dict(base[i % len(base)])
+            row['code'] = 'PROD-%03i' % i
             result.setItem('r_%i' % i, Bag(row))
         return result
 
@@ -140,3 +152,39 @@ class GnrCustomWebPage(object):
         center.bagGrid(frameCode='fixedem', datapath='.grid_3',
                                struct=struct, storepath='.store_3',
                                height='100%', fillDown=True)
+
+    def test_4_columnsets_vertical_scroll(self, pane):
+        """Regression test for #955: a columnset grid with enough rows to overflow
+        vertically MUST keep its vertical scrollbar. The columnset/footer wrapper
+        (gr_wrap_footers) must hide only the redundant horizontal scrollbar, never
+        the vertical one. Verify in Firefox and in Chrome >= 121 (where
+        scrollbar-width is honored): the vertical scrollbar has to be present."""
+        bc = pane.borderContainer(height='300px')
+        center = bc.contentPane(region='center')
+
+        def struct(struct):
+            r = struct.view().rows()
+            r.cell('code', width='8em', name='Product Code')
+            r.cell('description', width='auto', name='Description',
+                    columnset='product')
+            r.cell('category', width='auto', name='Category',
+                    columnset='product')
+            r.cell('quantity', width='6em', dtype='L', name='Quantity',
+                    columnset='numbers')
+            r.cell('unit_price', width='7em', dtype='N', name='Unit Price',
+                    format='#,###.00', columnset='numbers')
+            r.cell('supplier', width='auto', name='Supplier',
+                    columnset='supply')
+            r.cell('notes', width='auto', name='Notes',
+                    columnset='supply')
+
+        center.data('.sample_data', self.getManyRows(120))
+        center.dataFormula('.grid_4.store_4', 'sample_data', sample_data='=.sample_data', _onStart=True)
+
+        center.bagGrid(frameCode='colsets_vscroll', datapath='.grid_4',
+                               struct=struct, storepath='.store_4',
+                               height='100%',
+                               grid_footer='Totals',
+                               columnset_product='Product Info',
+                               columnset_numbers='Quantities',
+                               columnset_supply='Supply Chain')


### PR DESCRIPTION
## Summary

Hotfix for #955: a TableHandler grid whose view defines **columnsets** (grouped, multi-row header) lost its **vertical scrollbar** when the rows overflowed — they spilled out of the container instead of scrolling internally. The same view without columnsets scrolled correctly.

## Root cause

A grid with columnsets/footers gets the `gr_wrap_footers` wrapper, with three panes: the columnset header (`overflow:hidden`, synced to the body), the grid body (`overflow-x:auto`), and the footer (`overflow:auto`). The body and the footer each had their own horizontal scrollbar, kept in bidirectional sync. To hide the body's redundant horizontal bar the CSS used `scrollbar-width:none` and `-ms-overflow-style:none` — which are **not axis-specific** and therefore also hide the vertical scrollbar:

- **Firefox**: vertical scrollbar always hidden.
- **Chrome/Edge ≥ 121**: hidden since Chromium shipped `scrollbar-width` support (Jan 2024).
- **Safari / older Chrome**: unaffected (they ignore `scrollbar-width`).

It only surfaces when a columnset grid has enough rows to overflow vertically. Hiding a single scrollbar axis is not possible cross-browser, so keeping the body horizontally `auto` and trying to hide only its bar cannot work on Firefox (it leaves a double horizontal scrollbar).

## Fix

Make the footer pane a follower — like the columnset header already is — and let the grid body be the single scroll container:

- Footer pane `overflow:auto` → `overflow:hidden`, synced to the body via `scrollLeft`.
- Removed the `gr_wrap_footers .dojoxGrid-scrollbox` special-casing (`overflow-x:auto !important` + the WebKit horizontal rule). The body uses the standard scrollbox and owns both native scrollbars, exactly like a grid without columnsets.
- Horizontal scroll sync is now one-way: body → footer + columnset header (removed the footer → body listener and its scroll ping-pong).

This restores the vertical scrollbar on all browsers, leaves a single horizontal scrollbar, keeps trackpad/wheel horizontal scrolling over the body, and removes the cross-browser scrollbar-hiding hacks. Net −12 lines.

## Trade-off

The horizontal scrollbar now sits at the bottom of the rows (above the footer totals) — the native dojox position, matching every non-columnset grid — instead of below the totals.

## Test

`test_4_columnsets_vertical_scroll` in `test_flex_minwidth.py`: a columnset+footer grid with 120 rows in a constrained height, forcing vertical overflow (the existing `test_1` had only 5 rows and could not expose the bug).

Verified manually on **Firefox** and **Chrome**: vertical scrollbar present, single horizontal scrollbar above the totals, trackpad horizontal scroll works with header/footer in sync, header/footer right-edge alignment correct with the vertical bar visible, no regression on `test_0..test_3`.

Fixes #955
