### PR TITLE
add service enable/disabled in configurations()

### DIFF
--- a/gnrpy/gnr/lib/services/__init__.py
+++ b/gnrpy/gnr/lib/services/__init__.py
@@ -109,7 +109,12 @@ class BaseServiceType(object):
         l = self.serviceConfigurationsFromSiteConfig()
         if 'sys' in list(self.site.gnrapp.packages.keys()):
             dbservices = self.site.db.table('sys.service').query(where='$service_type=:st', st=self.service_type, order_by='$service_name').fetch()
-            l += [dict(implementation=r['implementation'], service_name=r['service_name'], service_type=r['service_type']) for r in dbservices]
+            l += [dict(
+                implementation=r['implementation'],
+                service_name=r['service_name'],
+                service_type=r['service_type'],
+                service_disabled=r['disabled'] and True or False
+            ) for r in dbservices]
         return l
 
 


### PR DESCRIPTION
The PR added the service_disabled key to the service configuration, allowing a caller to serviceList() method to filter out disabled services, if needed.

For example, in oidc login resource, serviceList is used, but if an oidc service has been disabled, it will show up anyway. And you can't just simply delete the service, due to relation in oidc to the users. A separate PR for oidc is coming.

This change doesn't break anything, it will just add the disabled piece of information to the service list.