### PR TITLE
fix: restore Documentation and Manuals pages broken after CodeMirror 6 migration (#962)

### DIFF
--- a/gnrjs/gnr_d11/js/genro_extra.js
+++ b/gnrjs/gnr_d11/js/genro_extra.js
@@ -782,11 +782,34 @@ dojo.declare("gnr.widgets.codemirror", gnr.widgets.baseExternalWidget, {
         }
     },
     loadCodeMirror6: function(cb){
+        if(window.CodeMirror6){
+            cb();
+            return;
+        }
+        // Dedupe concurrent loads: several editors created in the same tick all see
+        // !window.CodeMirror6 and would each append a <script> via loadJs (which does
+        // not dedupe). The bundle would then run twice, instantiating a second
+        // @codemirror/state and breaking instanceof checks across editors ("multiple
+        // instances of @codemirror/state are loaded"). Queue callbacks behind a single
+        // in-flight load instead. The handler is a singleton (gnr.wdg caches it), so
+        // this state is shared across every codemirror editor on the page.
+        this._cm6PendingCbs = this._cm6PendingCbs || [];
+        this._cm6PendingCbs.push(cb);
+        if(this._cm6Loading){
+            return;
+        }
+        this._cm6Loading = true;
+        var that = this;
         // mtime-based cache-buster: server publishes the file mtime via gnr.vendoredMtime
         // so the browser refetches the bundle whenever it gets rebuilt.
         var mtime = genro.getData('gnr.vendoredMtime.codemirror6') || 0;
         var url = '/_rsrc/js_libs/codemirror6/codemirror6.bundle.js' + (mtime ? '?mtime=' + mtime : '');
-        genro.dom.loadJs(url, cb);
+        genro.dom.loadJs(url, function(){
+            that._cm6Loading = false;
+            var cbs = that._cm6PendingCbs;
+            that._cm6PendingCbs = [];
+            for(var i = 0; i < cbs.length; i++){ cbs[i](); }
+        });
     },
     buildExtensions: function(cmAttrs, sourceNode){
         var CM = window.CodeMirror6;

--- a/projects/gnrcore/packages/docu/resources/tables/handbook/th_handbook.py
+++ b/projects/gnrcore/packages/docu/resources/tables/handbook/th_handbook.py
@@ -101,7 +101,7 @@ class Form(BaseComponent):
                     values='stack:Stack Demo/Source,stack_f:Stack Source/Demo,top:Top,left:Left,bottom:Bottom,right:Right')
 
         examples_themesSn = self.site.storageNode('rsrc:js_libs', 'codemirror', 'theme')
-        examples_themes = ','.join([s.cleanbasename for s in examples_themesSn.children() if s.basename.endswith('.css')])
+        examples_themes = ','.join([s.cleanbasename for s in (examples_themesSn.children() or []) if s.basename.endswith('.css')])
         #DP202108 In this way we build the list of available themes which will be shown in the filteringSelect
         example_pars_fb.filteringSelect(value='^.source_theme',values=examples_themes, width='8em',lbl='Source theme')
 


### PR DESCRIPTION
## Summary

Restores the **Documentation** and **Manuals** (`docu.handbook`) pages, broken after the CodeMirror 6 migration, and fixes the related `@codemirror/state` JavaScript error. Two independent root causes, one per commit.

### 1. Handbook form build crash (server-side)
`th_handbook.handbookInfo` read the editor theme list from `rsrc:js_libs/codemirror/theme`, a directory removed by the CM6 migration. `StorageNode.children()` returns `None` for a missing directory, so iterating it raised `TypeError: 'NoneType' object is not iterable`, aborting the whole form build.

Fix: fall back to an empty list when the directory is absent. The "Source theme" select renders empty, which is correct — codemirror6 exposes no selectable per-file themes.

### 2. CodeMirror 6 bundle double-load (client-side)
The `codemirror` widget loaded the bundle only `if(!window.CodeMirror6)`, but that check is synchronous and `genro.dom.loadJs` does not dedupe in-flight requests. Multiple editors built in the same tick each appended a `<script>`, running the bundle twice and instantiating a second `@codemirror/state`; facets branded by the first instance then failed `instanceof` checks, raising `Unrecognized extension value … multiple instances of @codemirror/state are loaded`.

Fix: `loadCodeMirror6` is now idempotent for concurrent calls — the first starts the load, the rest queue their callbacks behind the single in-flight request. The widget handler is a singleton (cached by `gnr.wdg`), so the bundle is fetched exactly once.

## Test scenario
1. Open the **Documentation** / **Manuals** page (`docu.handbook` thpage) → page opens without server traceback.
2. Open a page that builds two or more CodeMirror editors at once → no `multiple instances of @codemirror/state` error in the browser console; editors are interactive.

Closes #962
