### PR TITLE
fix: replace corner DRAFT ribbon with centered toolbar badge (#934)

### DIFF
--- a/gnrjs/gnr_d11/css/gnrbase_css/10_gnr_toolbars_formhandler.css
+++ b/gnrjs/gnr_d11/css/gnrbase_css/10_gnr_toolbars_formhandler.css
@@ -88,6 +88,40 @@
     transform: rotate(45deg);
 }
 
+/* Centered draft badge on the form bars. The --fh-draft-display variable
+   is switched on by the draft form node and switched off again inside its
+   content, so bars of nested forms only show their own badge. */
+.form_draft{
+    --fh-draft-display: block;
+}
+.form_draft[class*="draft_marker_"]{
+    --fh-draft-display: none;
+}
+.form_draft .fh_content{
+    --fh-draft-display: none;
+}
+.th_form_toolbar, .slotbar_dialog_footer{
+    position: relative;
+    z-index: 0;
+}
+.th_form_toolbar::after, .slotbar_dialog_footer::after{
+    content: var(--form-draft-label, 'DRAFT');
+    display: var(--fh-draft-display, none);
+    position: absolute;
+    left: 50%; top: 50%;
+    transform: translate(-50%, -50%);
+    padding: 1px 10px;
+    font-size: 0.75em;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--form-draft-color, #c77700);
+    border: 1px dashed var(--form-draft-color, #c77700);
+    border-radius: 9px;
+    pointer-events: none;
+    z-index: -1;
+}
+
 .form_logical_deleted .gnrfieldlabel{
     color: var(--status-error);
 }

--- a/gnrjs/gnr_d11/js/genro_frm.js
+++ b/gnrjs/gnr_d11/js/genro_frm.js
@@ -1597,6 +1597,10 @@ dojo.declare("gnr.GnrFrmHandler", null, {
         var dm = this.draftMarker;
         var dmPos = (dm === true || dm === undefined) ? 'tr' : dm;
         genro.dom.setClass(this.sourceNode,'form_draft',isDraft);
+        var domNode = this.sourceNode.getDomNode();
+        if(domNode && this.draftLabel){
+            domNode.style.setProperty('--form-draft-label','"'+this.draftLabel.replace(/"/g,'\\"')+'"');
+        }
         ['tr','tl','br','bl'].forEach(function(pos){
             genro.dom.setClass(this.sourceNode,'draft_marker_' + pos, isDraft && dmPos === pos);
         }, this);

--- a/localization.xml
+++ b/localization.xml
@@ -801,7 +801,8 @@
 <en_revert base="Revert" de="Zurückkehren" en="Revert" fr="Revenir" it="Ritornare"></en_revert>
 <en_save fr="Sauvegarder" de="Speichern" en="Save" it="Salva" base="Save"></en_save>
 <en_record_history base="Record History" it="Cronologia dei record"></en_record_history>
-<en_copy_and_paste base="Copy and paste" de="Kopieren und Einfügen" en="Copy and paste" fr="Copier coller" it="Copia e incolla"></en_copy_and_paste></th_form>
+<en_copy_and_paste base="Copy and paste" de="Kopieren und Einfügen" en="Copy and paste" fr="Copier coller" it="Copia e incolla"></en_copy_and_paste>
+<en_draft base="Draft" de="Entwurf" en="Draft" fr="Brouillon" it="Bozza"></en_draft></th_form>
 <th_groupth path="resources/common/th/th_groupth.py" ext="py"><en_grid_view base="Grid View" it="Visualizzazione a griglia"></en_grid_view>
 <en_group_by base="Group by" it="Raggruppa per"></en_group_by>
 <en_flat base="Flat" it="Piatto"></en_flat>

--- a/resources/common/th/th_form.py
+++ b/resources/common/th/th_form.py
@@ -216,7 +216,7 @@ class TableHandlerForm(BaseComponent):
         draftIfInvalid= options.pop('draftIfInvalid',False)
         allowSaveInvalid= options.pop('allowSaveInvalid',draftIfInvalid)
         avoidFloatingMessage= options.pop('avoidFloatingMessage',draftIfInvalid)
-        draftMarker = options.pop('draftMarker', True)
+        draftMarker = options.pop('draftMarker', False)
         formCaption_kwargs = dictExtract(options,'formCaption_',pop=True) 
         formCaption = options.pop('formCaption',formCaption_kwargs)
 
@@ -229,7 +229,8 @@ class TableHandlerForm(BaseComponent):
         single_record = options.get('single_record') or options.pop('linker',False)
 
         form.attributes.update(form_draftIfInvalid=draftIfInvalid,form_allowSaveInvalid=allowSaveInvalid,
-                               form_avoidFloatingMessage=avoidFloatingMessage,form_draftMarker=draftMarker)
+                               form_avoidFloatingMessage=avoidFloatingMessage,form_draftMarker=draftMarker,
+                               form_draftLabel='!!Draft')
         if autoSave:
             form.store.attributes.update(autoSave=autoSave,firstAutoSave=firstAutoSave)
 


### PR DESCRIPTION
## Summary
- The default draft indicator for th forms is now a dashed "Draft" badge centered on the form toolbar (dialog footer for modal forms), replacing the corner ribbon that could overlap toolbar buttons (print, export, +, -)
- The badge is painted below the toolbar buttons and is pointer-events:none, so buttons always stay readable and clickable, even on narrow windows
- CSS variable scoping (--fh-draft-display) turns the badge on from the draft form node and off inside its content, so nested forms only show their own badge
- The label goes through the standard localizer (new form_draftLabel attribute + en_draft entry with it/de/fr translations), falling back to 'DRAFT'; themes can tune it via --form-draft-label / --form-draft-color
- The corner ribbon remains available as an opt-in via draftMarker='tr'/'tl'/'br'/'bl' (or True); non-th frameforms keep the previous default behavior

Same fix as #966 (master), opened in parallel against develop.

## Linked Issue
Closes #934

## Test plan
- [x] Manually verified on two instances: single centered badge on the form toolbar, no overlap with toolbar buttons
- [x] Verified buttons paint above the badge when the window is narrowed
- [x] Verified localized label ("Bozza") on an Italian locale instance
- [x] flake8 clean on modified files, localization.xml validated, full test suite passes