### PR TITLE
force smart_open version < 8.0, since it introduces breaking api chan…

### DIFF
--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 	     "requests",
 	     "simpleeval",
 	     "six", # evaluate if needed
-	     "smart_open",
+	     "smart_open<8.0",
 	     "supervisor",
 	     "tzlocal",
 	     "unidecode",


### PR DESCRIPTION
force smart_open version < 8.0, since it introduces breaking api changes in module organization, so

from smart_open import smart_open

is no longer valid. We'll update the imports when smart_open new version will be consolidated, to continue support older versions.

Reference:

https://github.com/piskvorky/smart_open/pull/928

https://github.com/piskvorky/smart_open/blob/develop/CHANGELOG.md