### PR TITLE
changed flib's default upload path from site: storage (ephemeral) to home:

### DIFF
--- a/projects/gnrcore/packages/flib/model/item.py
+++ b/projects/gnrcore/packages/flib/model/item.py
@@ -29,4 +29,4 @@ class Table(object):
         return 'flib/items' 
 
     def getUploadPath(self):
-        return 'site:uploaded_files'
+        return 'home:uploaded_files'


### PR DESCRIPTION
changed flib's default upload path from site: storage (ephemeral) to home:, which can
be this way configured with persistent storage, if needed.

refs #835