### PR TITLE
fix: portable AFM metrics loading for pip-installed deployments

### DIFF
--- a/gnrpy/gnr/utils/fonts.py
+++ b/gnrpy/gnr/utils/fonts.py
@@ -6,28 +6,58 @@
 # Units are 1/1000 of the font size in points.
 # Example: at 10pt, 'A' in Helvetica = 667/1000 * 10 = 6.67 pt wide.
 #
-# Width data is stored in resources/common/fonts/afm_widths.json and loaded
-# at first use.
+# Width data is stored in the shared resources directory
+# (common/fonts/afm_widths.json) and loaded at first use.
 
 import json
 import os
+
+from gnr.core.gnrsys import expandpath
+from gnr.utils import logger
 
 _AFM_WIDTHS = None
 
 _DEFAULT_CHAR_WIDTH = 556  # fallback for unknown chars (avg lowercase Helvetica)
 
 
+def _afm_widths_candidates():
+    """Yield candidate paths of ``afm_widths.json``, most authoritative first.
+
+    The shared ``resources`` directory is declared in environment.xml in both
+    checkout and installed layouts, so the gnr_config lookup works everywhere
+    (same resolution used by ``resource_name_to_path``). The checkout-relative
+    path is kept as fallback for contexts without a configured environment.
+    """
+    # deferred import: gnr.core.gnrconfig imports gnr.core.gnrstring,
+    # which imports this module at load time
+    from gnr.core.gnrconfig import getGnrConfig
+    relative_path = os.path.join('common', 'fonts', 'afm_widths.json')
+    try:
+        environment_xml = getGnrConfig()['gnr.environment_xml']
+    except Exception:  # getGnrConfig raises a bare Exception when unconfigured
+        environment_xml = None
+    if environment_xml and 'resources' in environment_xml:
+        for path in environment_xml.digest('resources:#a.path'):
+            yield expandpath(os.path.join(path, relative_path))
+    yield os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                        '..', '..', '..', 'resources', relative_path))
+
+
 def _load_afm_widths():
     global _AFM_WIDTHS
     if _AFM_WIDTHS is not None:
         return _AFM_WIDTHS
-    json_path = os.path.join(
-        os.path.dirname(__file__),
-        '..', '..', '..', 'resources', 'common', 'fonts', 'afm_widths.json'
-    )
-    json_path = os.path.normpath(json_path)
-    with open(json_path, 'r', encoding='utf-8') as f:
-        _AFM_WIDTHS = json.load(f)
+    for json_path in _afm_widths_candidates():
+        if not os.path.isfile(json_path):
+            continue
+        try:
+            with open(json_path, 'r', encoding='utf-8') as f:
+                _AFM_WIDTHS = json.load(f)
+            return _AFM_WIDTHS
+        except (ValueError, OSError):
+            logger.warning('Invalid AFM metrics file %s, skipped', json_path)
+    logger.warning('AFM metrics file not found: string widths will be approximate')
+    _AFM_WIDTHS = {'Helvetica': {}}
     return _AFM_WIDTHS
 
 

--- a/gnrpy/tests/utils/fonts_test.py
+++ b/gnrpy/tests/utils/fonts_test.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+import importlib
+import importlib.util
+import json
+import os
+import shutil
+from contextlib import contextmanager
+
+import pytest
+
+from gnr.utils import fonts
+
+
+@contextmanager
+def gnr_environment(config_dir):
+    """Point the genro configuration at *config_dir* and reload font metrics."""
+    old = os.environ.get('GENRO_GNRFOLDER')
+    os.environ['GENRO_GNRFOLDER'] = str(config_dir)
+    try:
+        importlib.reload(fonts)
+        yield fonts
+    finally:
+        if old is None:
+            del os.environ['GENRO_GNRFOLDER']
+        else:
+            os.environ['GENRO_GNRFOLDER'] = old
+        importlib.reload(fonts)
+
+
+def make_config(tmp_path, resources_path=None):
+    """Build a minimal genro config folder with an environment.xml."""
+    config_dir = tmp_path / 'etc' / 'gnr'
+    config_dir.mkdir(parents=True)
+    resources_tag = ''
+    if resources_path is not None:
+        resources_tag = '<resources><test path="%s"/></resources>' % resources_path
+    (config_dir / 'environment.xml').write_text(
+        '<?xml version="1.0"?><GenRoBag>%s</GenRoBag>' % resources_tag)
+    return config_dir
+
+
+def write_metrics(resources_path, widths):
+    fonts_dir = resources_path / 'common' / 'fonts'
+    fonts_dir.mkdir(parents=True)
+    (fonts_dir / 'afm_widths.json').write_text(json.dumps(widths))
+
+
+def load_module_copy(tmp_dir, module_name):
+    """Load a copy of fonts.py from *tmp_dir*, simulating an installed layout."""
+    module_path = tmp_dir / 'fonts.py'
+    shutil.copy(fonts.__file__.rstrip('c'), str(module_path))
+    spec = importlib.util.spec_from_file_location(module_name, str(module_path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checkout_relative_fallback(tmp_path):
+    # without a resources declaration the loader falls back to the
+    # checkout-relative path and still finds the real metrics
+    config_dir = make_config(tmp_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(6.67)
+
+
+def test_config_resources_priority(tmp_path):
+    # metrics resolved through the environment.xml resources declaration
+    # win over the checkout-relative fallback
+    resources_path = tmp_path / 'my_resources'
+    write_metrics(resources_path, {'Helvetica': {'A': 1000}})
+    config_dir = make_config(tmp_path, resources_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(10.0)
+
+
+def test_config_resources_without_file_skipped(tmp_path):
+    # a declared resources dir without the metrics file is skipped
+    # and the next candidate wins
+    resources_path = tmp_path / 'my_resources'
+    resources_path.mkdir()
+    config_dir = make_config(tmp_path, resources_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(6.67)
+
+
+def test_invalid_metrics_file_skipped(tmp_path):
+    # an unreadable metrics file must never break prints:
+    # the next candidate wins
+    resources_path = tmp_path / 'my_resources'
+    fonts_dir = resources_path / 'common' / 'fonts'
+    fonts_dir.mkdir(parents=True)
+    (fonts_dir / 'afm_widths.json').write_text('{not valid json')
+    config_dir = make_config(tmp_path, resources_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(6.67)
+
+
+def test_installed_layout(tmp_path):
+    # regression test for issue #977: simulate a pip-installed deployment
+    # where fonts.py lives in site-packages/gnr/utils, the metrics file in
+    # site-packages/gnr/resources and no checkout-relative path exists
+    utils_dir = tmp_path / 'site-packages' / 'gnr' / 'utils'
+    utils_dir.mkdir(parents=True)
+    resources_path = tmp_path / 'site-packages' / 'gnr' / 'resources'
+    write_metrics(resources_path, {'Helvetica': {'A': 500}})
+    config_dir = make_config(tmp_path, resources_path)
+    with gnr_environment(config_dir):
+        installed_fonts = load_module_copy(utils_dir, 'installed_fonts')
+        assert installed_fonts.string_width('A', 'Helvetica', 10) == pytest.approx(5.0)
+
+
+def test_installed_layout_unconfigured_never_raises(tmp_path):
+    # worst case of issue #977: installed layout and no usable resources
+    # declaration — string_width must degrade to approximate widths
+    # instead of raising FileNotFoundError
+    utils_dir = tmp_path / 'site-packages' / 'gnr' / 'utils'
+    utils_dir.mkdir(parents=True)
+    config_dir = make_config(tmp_path)
+    with gnr_environment(config_dir):
+        installed_fonts = load_module_copy(utils_dir, 'unconfigured_fonts')
+        # every char falls back to the default width: 556/1000 * 10pt
+        assert installed_fonts.string_width('A', 'Helvetica', 10) == pytest.approx(5.56)


### PR DESCRIPTION
## Motivation

`_load_afm_widths()` in `gnr/utils/fonts.py` resolved `afm_widths.json` by climbing three directory levels from the module to the repository root. That layout only exists in a development checkout: on a pip-installed genropy the shared `resources/` directory is packaged as the `gnr.resources` package inside site-packages, so the lookup pointed to a non-existent path and any print calling `calcRowsNumber` crashed with `FileNotFoundError`. This broke invoice printing in a production deployment and forced a revert of the row-height migration on genromed (softwellsrl/genromed#44).

Fixes #978 (split from #977, which now tracks only the automatic row-height feature).

## Solution

The metrics file is now resolved like every other shared resource in the framework, through the `resources` declaration in `environment.xml` — the same `resources:#a.path` lookup used by `resource_name_to_path` in `gnrwsgisite.py`, `gnrresourceloader.py` and `PathResolver`. Since `gnr init` already writes the correct resources path in both checkout and installed layouts, no configuration change is needed.

Resolution order:
1. every path declared in `environment.xml` under `resources` (works in checkout and pip-installed layouts)
2. the previous checkout-relative path, kept as fallback for contexts running without a configured environment (e.g. CI)
3. if no candidate is readable, string widths degrade to approximate values (average char width) with a logged warning instead of raising — a metrics problem can never take a print down again

Missing or unreadable candidate files are skipped in favor of the next one. The `getGnrConfig` import is deferred inside the resolver to break the `gnrstring → fonts → gnrconfig → gnrstring` import cycle.

## Tests

`gnrpy/tests/utils/fonts_test.py`, all end-to-end with real files and real configuration (no mocks), driving the resolution through the public `GENRO_GNRFOLDER` configuration entry point:

- `test_checkout_relative_fallback`: no `resources` declaration → falls back to the checkout-relative path
- `test_config_resources_priority`: metrics declared in `environment.xml` win over the checkout fallback
- `test_config_resources_without_file_skipped`: a declared resources dir without the file is skipped
- `test_invalid_metrics_file_skipped`: a corrupt metrics file is skipped without raising
- `test_installed_layout`: regression test for #978 — module copy loaded from a simulated `site-packages/gnr/utils`, metrics in `site-packages/gnr/resources`, resolved via configuration
- `test_installed_layout_unconfigured_never_raises`: worst case, installed layout with no usable resources → approximate widths, no `FileNotFoundError`

Full test suite on this branch: 1886 passed, 67 skipped, 0 failed. flake8 clean on modified files.