### PR TITLE
Automatic per-cell row-height estimation in grid prints

### DIFF
--- a/gnrpy/gnr/core/gnrbaghtml.py
+++ b/gnrpy/gnr/core/gnrbaghtml.py
@@ -281,6 +281,7 @@ class BagToHtml(object):
             baseTemplate.pop('next_letterhead')
             baseTemplate.walk(self.fillLetterheadSourceData)
             top_layer =  baseTemplate['#%i' %(len(baseTemplate)-1)]
+        self._letterhead_top_layer = top_layer
         d = self.__dict__
         paper_height = float(d.get('page_height') or top_layer['main.page.height'] or self.paperHeight)
         paper_width = float(d.get('page_width') or top_layer['main.page.width'] or self.paperWidth)
@@ -559,6 +560,23 @@ class BagToHtml(object):
         """TODO"""
         return (self.page_width - self.page_margin_left - self.page_margin_right -\
                 self.page_leftbar_width - self.page_rightbar_width)
+
+    def contentAreaWidth(self):
+        """Return the width of the band the copies are actually rendered into.
+
+        With a ``headline`` letterhead the content goes into the template's
+        center_center cell, whose side bands are ``layout.center.left/right``
+        (see ``letterhead_layer``): the ``layout.left/right`` widths that
+        ``prepareTemplates`` loads into ``page_leftbar/rightbar_width`` only
+        shape the ``sidebar`` design, so ``copyWidth()`` would subtract them
+        even when they take no horizontal space.
+        """
+        top_layer = getattr(self, '_letterhead_top_layer', None)
+        if top_layer and top_layer['main.design'] == 'headline':
+            return (self.page_width - self.page_margin_left - self.page_margin_right
+                    - float(top_layer['layout.center.left?width'] or 0)
+                    - float(top_layer['layout.center.right?width'] or 0))
+        return self.copyWidth()
 
     def lineIterator(self,nodes):
         lastNode = nodes[-1]
@@ -1319,7 +1337,7 @@ class BagToHtml(object):
         if self.grid_width:
             outer_width = self.grid_width
         else:
-            outer_width = self.copyWidth() - layoutPars.get('left', 0) - layoutPars.get('right', 0)
+            outer_width = self.contentAreaWidth() - layoutPars.get('left', 0) - layoutPars.get('right', 0)
         #the nested grid layout loses its left/right offsets and side borders (finalize_layout)
         grid_width = gridPars.get('width') or \
                      (outer_width - gridPars.get('left', 0) - gridPars.get('right', 0) - 2 * border_width)

--- a/gnrpy/gnr/core/gnrbaghtml.py
+++ b/gnrpy/gnr/core/gnrbaghtml.py
@@ -65,6 +65,7 @@ class BagToHtml(object):
     grid_columnsets = {}
     grid_row_height = 4.5
     font_family = None  # font name or CSS stack applied to the main layout and used for row-height estimation
+    main_font_family = None  # font name or CSS stack injected by the application on the whole document (wins over the layout font by CSS specificity)
     auto_row_height = True  # estimate multi-line row heights from wrappable cell content
     grid_cell_text_margin = 1.5  # mm taken from the cell width by the aligned_left/aligned_right content margin
     renderMode = None
@@ -939,7 +940,7 @@ class BagToHtml(object):
         return rowData.get(field_getter or field)
 
     def rowCell(self, field=None, value=None, default=None, locale=None,
-                format=None, mask=None, currency=None,white_space='nowrap',align_class=None,
+                format=None, mask=None, currency=None,white_space=None,align_class=None,
                 content_class=None, totalize=None,**kwargs):
 
         """Allow to get data from record. You can use it in the :meth:`prepareRow` method
@@ -956,6 +957,9 @@ class BagToHtml(object):
         self.currColumn = self.currColumn + 1
         if curr_attr.get('hidden'):
             return
+        #falling back on the column attribute keeps rendering and row-height
+        #estimation (which only sees column attributes) on the same setting
+        white_space = white_space or curr_attr.get('white_space') or 'nowrap'
         if field:
             if callable(field):
                 value = field()
@@ -1263,12 +1267,17 @@ class BagToHtml(object):
     def gridFontMetrics(self):
         """Return ``(font_name, font_size_pt)`` used to measure grid cell text.
 
-        The font family is the one the grid actually renders with (the
-        ``mainLayoutParameters`` one, i.e. ``font_family`` when declared on the
-        print class) resolved to a font with AFM metrics; the size comes from
-        ``gridLayoutParameters``.
+        The font family is the one the grid actually renders with, resolved to
+        a font with AFM metrics; the size comes from ``gridLayoutParameters``.
+        ``main_font_family`` — the font the application imposes on the whole
+        document via CSS — wins over the ``mainLayoutParameters`` one because
+        its selector beats the layout inline style. Fonts without AFM metrics
+        (e.g. per-document custom fonts) resolve to plain Helvetica, wider than
+        the Narrow default: the estimate errs on the tall side, costing paper
+        rather than clipped text.
         """
-        font_family = self.mainLayoutParameters().get('font_family') or self.font_family
+        font_family = self.main_font_family \
+            or self.mainLayoutParameters().get('font_family') or self.font_family
         font_size = self.gridLayoutParameters().get('font_size') or GnrHtmlBuilder.font_size
         return resolve_font_name(font_family), font_size_pt(font_size)
 

--- a/gnrpy/gnr/core/gnrbaghtml.py
+++ b/gnrpy/gnr/core/gnrbaghtml.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from gnr.core.gnrstring import toText,templateReplace
 
 from gnr.core.gnrhtml import GnrHtmlBuilder
+from gnr.utils.fonts import resolve_font_name, font_size_pt
 from gnr.core.gnrbag import Bag, BagCbResolver
 from gnr.core.gnrclasses import GnrClassCatalog
 from gnr.core.gnrdecorator import  deprecated
@@ -63,6 +64,9 @@ class BagToHtml(object):
     grid_columns =  []
     grid_columnsets = {}
     grid_row_height = 4.5
+    font_family = None  # font name or CSS stack applied to the main layout and used for row-height estimation
+    auto_row_height = True  # estimate multi-line row heights from wrappable cell content
+    grid_cell_text_margin = 1.5  # mm taken from the cell width by the aligned_left/aligned_right content margin
     renderMode = None
     totalize_carry = False
     totalize_footer = False
@@ -507,11 +511,14 @@ class BagToHtml(object):
 
     @property
     def columnsBag(self):
+        return self.sheetColumnsBag(self.sheet)
+
+    def sheetColumnsBag(self, sheet):
+        """Return the columns Bag of the current grid for the given *sheet* index."""
         gridName = self.currentGrid or '_main_'
         if gridName not in self._gridsColumnsBag:
             self._gridsColumnsBag[gridName] = self._gridSheetsBag(gridName)
-        result = self._gridsColumnsBag[gridName][self._sheetKey(self.sheet)]['columns']
-        return result
+        return self._gridsColumnsBag[gridName][self._sheetKey(sheet)]['columns']
 
     def _gridSheetsBag(self,gridName):
         result = Bag()
@@ -614,7 +621,7 @@ class BagToHtml(object):
             gridNetHeight = self.grid_height - self.calcGridHeaderHeight() - self.calcGridFooterHeight() -\
                             carry_height - self.totalizeFooterHeight() - self.grid_row_height
             availableSpace = gridNetHeight-bodyUsed-self.grid_body_adjustment
-            rowTotalHeight = rowheight + extra_row_height + len(subtotal_rows)*rowheight
+            rowTotalHeight = rowheight + extra_row_height + len(subtotal_rows)*self.grid_row_height
             doNewPage =   rowTotalHeight > availableSpace
             if doNewPage:
                 carry_height = self.totalizeCarryHeight()
@@ -983,7 +990,7 @@ class BagToHtml(object):
         return page.layout(**self.mainLayoutParameters())
 
     def mainLayoutParameters(self):
-        return dict(font_family='Arial Narrow',font_size='11pt',
+        return dict(font_family=self.font_family or 'Arial Narrow',font_size='11pt',
                     name='mainLayout',top=1,left=1,right=1,bottom=1,border_width=0)
 
     def _openPage(self):
@@ -1221,8 +1228,125 @@ class BagToHtml(object):
         return '%02i_%02i' %(self.sheet,self.copy)
 
     def calcRowHeight(self):
-        """override for special needs"""
-        return self.grid_row_height
+        """Return the height of the current data row. Override for special needs.
+
+        When ``auto_row_height`` is true (default) the height is estimated cell
+        by cell: for every visible wrappable column (``white_space`` other than
+        ``'nowrap'``) the number of wrapped lines of the formatted value is
+        computed with AFM font metrics and the row gets
+        ``max(lines) * grid_row_height``. Columns without a ``field`` and
+        non-wrappable columns always count as a single line, so prints without
+        wrappable columns keep the flat behavior.
+        """
+        if not self.auto_row_height:
+            return self.grid_row_height
+        return max(1, self.gridMaxRowsCount()) * self.grid_row_height
+
+    def gridFontMetrics(self):
+        """Return ``(font_name, font_size_pt)`` used to measure grid cell text.
+
+        The font family is the one the grid actually renders with (the
+        ``mainLayoutParameters`` one, i.e. ``font_family`` when declared on the
+        print class) resolved to a font with AFM metrics; the size comes from
+        ``gridLayoutParameters``.
+        """
+        font_family = self.mainLayoutParameters().get('font_family') or self.font_family
+        font_size = self.gridLayoutParameters().get('font_size') or GnrHtmlBuilder.font_size
+        return resolve_font_name(font_family), font_size_pt(font_size)
+
+    def gridMaxRowsCount(self):
+        """Return the lines needed by the tallest wrappable cell of the current row.
+
+        Scans every sheet so that rows keep the same height (and stay aligned)
+        across sheets.
+        """
+        rowData = self.rowData
+        if not rowData:
+            return 1
+        font_name, font_size = self.gridFontMetrics()
+        result = 1
+        saved_render_mode = self.renderMode
+        self.renderMode = None
+        try:
+            for sheet in range(self.sheets_counter):
+                columns = [node.attr for node in self.sheetColumnsBag(sheet)]
+                cells = self._gridRowCells(columns, rowData)
+                flex_width = self._gridFlexWidth(cells)
+                for cell in cells:
+                    result = max(result, self._gridCellRowsCount(cell, rowData, flex_width,
+                                                                 font_name, font_size))
+        finally:
+            self.renderMode = saved_render_mode
+        return result
+
+    def _gridRowCells(self, columns, rowData):
+        """Resolve cell parameters applying the same colspan accumulation as renderGridCell."""
+        cells = []
+        span_cell = None
+        for col in columns:
+            #columns without a field (custom prints built from grid_col_widths) cannot
+            #be measured but still take part in the width accounting
+            pars = self.getGridCellPars(col, rowData) if col.get('field') else dict(col)
+            if pars.get('hidden'):
+                continue
+            mm_width = pars.get('mm_width') or 0
+            if span_cell is not None:
+                if mm_width:
+                    span_cell['width'] += mm_width
+                else:
+                    span_cell['flex'] = True
+                span_cell['span_count'] -= 1
+                if not span_cell['span_count']:
+                    span_cell = None
+                continue
+            cell = dict(pars=pars, width=mm_width, flex=not mm_width)
+            cells.append(cell)
+            colspan = pars.get('colspan') or 1
+            if colspan > 1:
+                cell['span_count'] = colspan - 1
+                span_cell = cell
+        return cells
+
+    def _gridFlexWidth(self, cells):
+        """Return the width an elastic cell (``mm_width`` falsy) will be rendered at:
+        the grid free width split between the elastic cells, as finalize_row does."""
+        flex_count = len([c for c in cells if c['flex']])
+        if not flex_count:
+            return 0
+        layoutPars = self.mainLayoutParameters()
+        gridPars = self.gridLayoutParameters()
+        border_width = gridPars.get('border_width') or 0
+        if self.grid_width:
+            outer_width = self.grid_width
+        else:
+            outer_width = self.copyWidth() - layoutPars.get('left', 0) - layoutPars.get('right', 0)
+        #the nested grid layout loses its left/right offsets and side borders (finalize_layout)
+        grid_width = gridPars.get('width') or \
+                     (outer_width - gridPars.get('left', 0) - gridPars.get('right', 0) - 2 * border_width)
+        fixed_width = sum(c['width'] for c in cells)
+        free_width = grid_width - fixed_width - border_width * max(len(cells) - 1, 0)
+        return free_width / flex_count
+
+    def _gridCellRowsCount(self, cell, rowData, flex_width, font_name, font_size):
+        """Return the number of wrapped lines the given cell needs (1 if it cannot wrap)."""
+        pars = cell['pars']
+        if (pars.get('white_space') or 'nowrap') == 'nowrap':
+            return 1
+        if not pars.get('field'):
+            return 1
+        width_mm = cell['width'] + (flex_width if cell['flex'] else 0) - self.grid_cell_text_margin
+        if width_mm <= 0:
+            return 1
+        value = self.getGridCellValue(pars, rowData)
+        if value is None:
+            return 1
+        text = self.toText(value, locale=pars.get('locale') or self.locale,
+                           format=pars.get('format'), mask=pars.get('mask'),
+                           encoding=self.encoding, currency=pars.get('currency'))
+        if not text or text.endswith('::HTML'):
+            return 1
+        return max(1, self.builder.calcRowsNumber(text, width_mm=width_mm,
+                                                  font_name=font_name, font_size=font_size))
 
     def calcGridHeaderHeight(self):
         """override for special needs"""

--- a/gnrpy/gnr/core/gnrhtml.py
+++ b/gnrpy/gnr/core/gnrhtml.py
@@ -10,6 +10,7 @@
 
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrstring import splitAndStrip, stringWidth
+from gnr.utils.fonts import resolve_font_name
 from gnr.core.gnrstructures import GnrStructData
 from gnr.core.gnrsys import expandpath
 from gnr.core.gnrdecorator import extract_kwargs
@@ -743,15 +744,15 @@ class GnrHtmlBuilder(object):
 
         :param text: plain text to measure
         :param width_mm: available width in mm; defaults to page width minus margins
-        :param font_name: font for AFM lookup; defaults to ``self.font_family`` or ``'Helvetica'``
+        :param font_name: font (or CSS font-family stack) for AFM lookup;
+                          defaults to ``self.font_family``, falling back to ``'Helvetica'``
         :param font_size: font size in points; defaults to ``self.font_size``
         """
         if not text:
             return 0
         if width_mm is None:
             width_mm = self.page_width - self.page_margin_left - self.page_margin_right - 2
-        if font_name is None:
-            font_name = self.font_family or 'Helvetica'
+        font_name = resolve_font_name(font_name or self.font_family)
         if font_size is None:
             font_size = self.font_size
         avail_pt = width_mm * MM_TO_PT

--- a/gnrpy/gnr/utils/fonts.py
+++ b/gnrpy/gnr/utils/fonts.py
@@ -16,6 +16,25 @@ _AFM_WIDTHS = None
 
 _DEFAULT_CHAR_WIDTH = 556  # fallback for unknown chars (avg lowercase Helvetica)
 
+_NARROW_FACTOR = 0.82  # Adobe Helvetica-Narrow is Helvetica condensed to 82%
+
+# common CSS font-family names -> AFM metrics key (matched case-insensitively)
+_FONT_ALIASES = {
+    'arial': 'Helvetica',
+    'liberation sans': 'Helvetica',
+    'sans-serif': 'Helvetica',
+    'arial narrow': 'Helvetica-Narrow',
+    'helvetica narrow': 'Helvetica-Narrow',
+    'liberation sans narrow': 'Helvetica-Narrow',
+    'times': 'Times-Roman',
+    'times new roman': 'Times-Roman',
+    'liberation serif': 'Times-Roman',
+    'serif': 'Times-Roman',
+    'courier new': 'Courier',
+    'liberation mono': 'Courier',
+    'monospace': 'Courier',
+}
+
 
 def _load_afm_widths():
     global _AFM_WIDTHS
@@ -31,12 +50,67 @@ def _load_afm_widths():
     return _AFM_WIDTHS
 
 
+def _get_widths(font_name):
+    """Return the char-width map for *font_name*, or ``None`` if unavailable.
+
+    ``*-Narrow`` variants missing from the metrics file are derived from the
+    base font scaled by ``_NARROW_FACTOR`` (Adobe's Helvetica-Narrow is a
+    linearly condensed Helvetica) and cached for later lookups.
+    """
+    widths_map = _load_afm_widths()
+    widths = widths_map.get(font_name)
+    if widths is None and font_name and font_name.endswith('-Narrow'):
+        base = widths_map.get(font_name[:-len('-Narrow')])
+        if base is not None:
+            widths = {c: w * _NARROW_FACTOR for c, w in base.items()}
+            widths_map[font_name] = widths
+    return widths
+
+
+def resolve_font_name(font_family, default='Helvetica'):
+    """Resolve a CSS font-family stack to the name of a font with AFM metrics.
+
+    Walks the comma-separated stack and returns the first entry with known
+    metrics, either directly (e.g. ``'Courier-Bold'``) or through the alias
+    table (e.g. ``'Arial Narrow'`` -> ``'Helvetica-Narrow'``). Returns
+    *default* when nothing matches.
+    """
+    for name in str(font_family or '').split(','):
+        name = name.strip().strip('"\'').strip()
+        if not name:
+            continue
+        if _get_widths(name) is not None:
+            return name
+        alias = _FONT_ALIASES.get(name.lower())
+        if alias is not None and _get_widths(alias) is not None:
+            return alias
+    return default
+
+
+def font_size_pt(value, default=10):
+    """Return a CSS font-size value (``9``, ``'9pt'``, ``'12px'``) in points."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    v = str(value or '').strip().lower()
+    factor = 1.0
+    if v.endswith('pt'):
+        v = v[:-2]
+    elif v.endswith('px'):
+        v = v[:-2]
+        factor = 0.75  # CSS reference pixel: 1px = 3/4pt
+    try:
+        return float(v) * factor
+    except ValueError:
+        return float(default)
+
+
 def string_width(text, font_name='Helvetica', font_size=10):
     """Return the width in points of *text* rendered in *font_name* at *font_size* pt.
 
     Uses embedded AFM metrics — no font files or external dependencies needed.
     Falls back to Helvetica widths for unknown font names.
     """
-    widths_map = _load_afm_widths()
-    widths = widths_map.get(font_name) or widths_map['Helvetica']
+    widths = _get_widths(font_name)
+    if widths is None:
+        widths = _load_afm_widths()['Helvetica']
     return sum(widths.get(c, _DEFAULT_CHAR_WIDTH) for c in (text or '')) * font_size / 1000.0

--- a/gnrpy/gnr/web/gnrbaseclasses.py
+++ b/gnrpy/gnr/web/gnrbaseclasses.py
@@ -326,7 +326,6 @@ class TableScriptToHtml(BagToHtmlWeb):
     row_relation = None
     subtotal_caption_prefix = '!![en]Totals'
     record_template = None
-    font_family = None    # set to a mapped font name (e.g. 'Helvetica') to apply it to body and enable exact row-height calculation
     text_width_mm = None  # available text width in mm; if None, computed from page_width - margins
 
     def __init__(self, page=None, resource_table=None, parent=None, **kwargs):
@@ -749,15 +748,6 @@ class TableScriptToHtml(BagToHtmlWeb):
         if self.font_family:
             self.builder.font_family = self.font_family
             self.body.style('body {{ font-family: {f}; }}'.format(f=self.font_family))
-
-    def getRowWrapField(self):
-        """Override to return the text of the main wrapping field for the current row.
-
-        When *font_family* is set to a mapped font and this returns a non-empty string,
-        :meth:`GnrHtmlBuilder.calcRowsNumber` is used by :meth:`calcRowHeight` for exact height calculation.
-        Return ``None`` (default) to fall back to ``grid_row_height``.
-        """
-        return None
 
     def calcRowsNumber(self, text, width_mm=None, font_name=None, font_size=None):
         """Delegate to :meth:`GnrHtmlBuilder.calcRowsNumber`.

--- a/gnrpy/tests/core/gnrbaghtml_test.py
+++ b/gnrpy/tests/core/gnrbaghtml_test.py
@@ -1,4 +1,117 @@
-from gnr.core import gnrbaghtml  # noqa: F401
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrbaghtml import BagToHtml
+from gnr.core.gnrhtml import GnrHtmlBuilder
 
-def test():
-    pass
+
+LONG_TEXT = ('A reasonably long description that cannot possibly fit in a '
+             'narrow grid column and therefore wraps over several lines '
+             'when white space is normal')
+
+
+def _print_instance(columns, rowData, **attrs):
+    """Build a minimal BagToHtml ready to call calcRowHeight outside a full run."""
+    instance = BagToHtml()
+    instance.grid_columns = columns
+    instance._gridsColumnsBag = Bag()
+    instance.builder = GnrHtmlBuilder()
+    instance.currRowDataNode = rowData
+    instance.lineno = 0
+    for k, v in attrs.items():
+        setattr(instance, k, v)
+    return instance
+
+
+def _expected_height(instance, text, width_mm):
+    font_name, font_size = instance.gridFontMetrics()
+    rows = instance.builder.calcRowsNumber(text, width_mm=width_mm - instance.grid_cell_text_margin,
+                                           font_name=font_name, font_size=font_size)
+    return max(1, rows) * instance.grid_row_height
+
+
+def test_calcRowHeight_flat_when_no_wrappable_columns():
+    p = _print_instance([dict(field='a', mm_width=50), dict(field='b', mm_width=30)],
+                        dict(a=LONG_TEXT, b='x'))
+    assert p.calcRowHeight() == p.grid_row_height
+
+
+def test_calcRowHeight_wrappable_column_grows():
+    p = _print_instance([dict(field='descr', mm_width=40, white_space='normal'),
+                         dict(field='qty', mm_width=20)],
+                        dict(descr=LONG_TEXT, qty=5))
+    height = p.calcRowHeight()
+    assert height > p.grid_row_height
+    assert height == _expected_height(p, LONG_TEXT, 40)
+
+
+def test_calcRowHeight_short_text_stays_flat():
+    p = _print_instance([dict(field='descr', mm_width=40, white_space='normal')],
+                        dict(descr='short'))
+    assert p.calcRowHeight() == p.grid_row_height
+
+
+def test_calcRowHeight_explicit_newlines():
+    p = _print_instance([dict(field='notes', mm_width=60, white_space='normal')],
+                        dict(notes='one\ntwo\nthree'))
+    assert p.calcRowHeight() == 3 * p.grid_row_height
+
+
+def test_calcRowHeight_columns_without_field_stay_flat():
+    p = _print_instance([dict(mm_width=50, name='custom', white_space='normal')],
+                        dict(anything=LONG_TEXT))
+    assert p.calcRowHeight() == p.grid_row_height
+
+
+def test_calcRowHeight_hidden_column_ignored():
+    p = _print_instance([dict(field='descr', mm_width=40, white_space='normal', hidden=True),
+                         dict(field='qty', mm_width=20)],
+                        dict(descr=LONG_TEXT, qty=5))
+    assert p.calcRowHeight() == p.grid_row_height
+
+
+def test_calcRowHeight_opt_out_flag():
+    p = _print_instance([dict(field='descr', mm_width=40, white_space='normal')],
+                        dict(descr=LONG_TEXT),
+                        auto_row_height=False)
+    assert p.calcRowHeight() == p.grid_row_height
+
+
+def test_calcRowHeight_flex_column_uses_residual_width():
+    p = _print_instance([dict(field='code', mm_width=30),
+                         dict(field='descr', mm_width=0, white_space='normal')],
+                        dict(code='X1', descr=LONG_TEXT),
+                        page_width=210, page_margin_left=10, page_margin_right=10)
+    columns = [node.attr for node in p.sheetColumnsBag(0)]
+    cells = p._gridRowCells(columns, p.rowData)
+    flex_width = p._gridFlexWidth(cells)
+    assert flex_width > 30  # residual page width, much wider than the fixed column
+    assert p.calcRowHeight() == _expected_height(p, LONG_TEXT, flex_width)
+
+
+def test_calcRowHeight_max_across_sheets():
+    p = _print_instance([dict(field='a', mm_width=50, sheet=0),
+                         dict(field='descr', mm_width=40, white_space='normal', sheet=1)],
+                        dict(a='x', descr=LONG_TEXT),
+                        sheets_counter=2)
+    assert p.calcRowHeight() == _expected_height(p, LONG_TEXT, 40)
+
+
+def test_calcRowHeight_none_value_stays_flat():
+    p = _print_instance([dict(field='descr', mm_width=40, white_space='normal')],
+                        dict(descr=None))
+    assert p.calcRowHeight() == p.grid_row_height
+
+
+def test_gridFontMetrics_default_is_narrow_9pt():
+    p = _print_instance([], dict())
+    assert p.gridFontMetrics() == ('Helvetica-Narrow', 9.0)
+
+
+def test_gridFontMetrics_follows_declared_font_family():
+    p = _print_instance([], dict(), font_family='Courier New, monospace')
+    assert p.gridFontMetrics() == ('Courier', 9.0)
+
+
+def test_mainLayoutParameters_uses_declared_font_family():
+    p = _print_instance([], dict(), font_family='Courier')
+    assert p.mainLayoutParameters()['font_family'] == 'Courier'
+    assert BagToHtml().mainLayoutParameters()['font_family'] == 'Arial Narrow'

--- a/gnrpy/tests/core/gnrbaghtml_test.py
+++ b/gnrpy/tests/core/gnrbaghtml_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrbaghtml import BagToHtml
 from gnr.core.gnrhtml import GnrHtmlBuilder
@@ -115,3 +117,49 @@ def test_mainLayoutParameters_uses_declared_font_family():
     p = _print_instance([], dict(), font_family='Courier')
     assert p.mainLayoutParameters()['font_family'] == 'Courier'
     assert BagToHtml().mainLayoutParameters()['font_family'] == 'Arial Narrow'
+
+
+def _headline_layer(center_left=10, center_right=10):
+    layer = Bag()
+    layer['main.design'] = 'headline'
+    layer.setItem('layout.center.left', None, width=center_left)
+    layer.setItem('layout.center.right', None, width=center_right)
+    return layer
+
+
+def test_contentAreaWidth_headline_letterhead():
+    # real-world geometry: the template carries 30mm layout.left/right widths that
+    # prepareTemplates loads into the side bars, but the headline center band only
+    # reserves 10+10mm, so the content area is wider than copyWidth()
+    p = _print_instance([], dict(), page_width=210,
+                        page_leftbar_width=30, page_rightbar_width=30,
+                        _letterhead_top_layer=_headline_layer())
+    assert p.copyWidth() == 150
+    assert p.contentAreaWidth() == 190
+
+
+def test_contentAreaWidth_sidebar_letterhead_matches_copyWidth():
+    layer = Bag()
+    layer['main.design'] = 'sidebar'
+    p = _print_instance([], dict(), page_width=210,
+                        page_leftbar_width=30, page_rightbar_width=30,
+                        _letterhead_top_layer=layer)
+    assert p.contentAreaWidth() == p.copyWidth() == 150
+
+
+def test_contentAreaWidth_no_letterhead_matches_copyWidth():
+    p = _print_instance([], dict(), page_width=210, page_margin_left=10, page_margin_right=10)
+    assert p.contentAreaWidth() == p.copyWidth() == 190
+
+
+def test_gridFlexWidth_headline_letterhead_uses_content_area():
+    p = _print_instance([dict(field='code', mm_width=30),
+                         dict(field='descr', mm_width=0, white_space='normal')],
+                        dict(code='X1', descr=LONG_TEXT),
+                        page_width=210, page_leftbar_width=30, page_rightbar_width=30,
+                        _letterhead_top_layer=_headline_layer())
+    columns = [node.attr for node in p.sheetColumnsBag(0)]
+    cells = p._gridRowCells(columns, p.rowData)
+    # 190 content band - 2 main layout offsets - 0.2 grid offsets - 0.6 grid side
+    # borders - 30 fixed column - 0.3 inner cell border
+    assert p._gridFlexWidth(cells) == pytest.approx(190 - 2 - 0.2 - 0.6 - 30 - 0.3)

--- a/gnrpy/tests/core/gnrbaghtml_test.py
+++ b/gnrpy/tests/core/gnrbaghtml_test.py
@@ -103,6 +103,29 @@ def test_calcRowHeight_none_value_stays_flat():
     assert p.calcRowHeight() == p.grid_row_height
 
 
+def test_rowCell_white_space_falls_back_to_column_attr():
+    #imperative prints (prepareRow + rowCell) must render with the
+    #column-declared white_space so it matches the row-height estimation,
+    #which only sees column attributes; an explicit argument still wins
+    p = _print_instance([dict(field='descr', mm_width=40, white_space='normal'),
+                         dict(field='qty', mm_width=20, white_space='normal'),
+                         dict(field='code', mm_width=20)],
+                        dict(descr=LONG_TEXT, qty=5, code='X1'))
+    p.builder = GnrHtmlBuilder(page_width=210, page_height=297)
+    p.builder.initializeSrc()
+    layout = p.builder.newPage().layout(name='testlayout', top=1, left=1,
+                                        right=1, bottom=1, border_width=0)
+    p.currRow = layout.row(height=10)
+    p.currColumn = 0
+    p.rowCell(value=LONG_TEXT)
+    p.rowCell(value=5, white_space='nowrap')
+    p.rowCell(value='X1')
+    descr_cell, qty_cell, code_cell = p.currRow.nodes
+    assert descr_cell.attr.get('white_space') == 'normal'  # from the column
+    assert qty_cell.attr.get('white_space') == 'nowrap'  # explicit argument wins
+    assert code_cell.attr.get('white_space') == 'nowrap'  # default
+
+
 def test_gridFontMetrics_default_is_narrow_9pt():
     p = _print_instance([], dict())
     assert p.gridFontMetrics() == ('Helvetica-Narrow', 9.0)
@@ -111,6 +134,21 @@ def test_gridFontMetrics_default_is_narrow_9pt():
 def test_gridFontMetrics_follows_declared_font_family():
     p = _print_instance([], dict(), font_family='Courier New, monospace')
     assert p.gridFontMetrics() == ('Courier', 9.0)
+
+
+def test_gridFontMetrics_main_font_family_wins_over_layout_font():
+    #the application-injected document font beats the layout one by CSS
+    #specificity, so it must also drive the measurement
+    p = _print_instance([], dict(), font_family='Courier',
+                        main_font_family='Times New Roman, serif')
+    assert p.gridFontMetrics() == ('Times-Roman', 9.0)
+
+
+def test_gridFontMetrics_unknown_custom_font_measures_wide():
+    #a per-document font without AFM metrics resolves to plain Helvetica,
+    #wider than the Narrow default: over-estimation costs paper, not clipping
+    p = _print_instance([], dict(), main_font_family='Lobster')
+    assert p.gridFontMetrics() == ('Helvetica', 9.0)
 
 
 def test_mainLayoutParameters_uses_declared_font_family():

--- a/gnrpy/tests/core/gnrhtml_test.py
+++ b/gnrpy/tests/core/gnrhtml_test.py
@@ -58,3 +58,18 @@ def test_calcRowsNumber_wraps_long_text():
 
 def test_calcRowsNumber_mm_to_pt_constant():
     assert MM_TO_PT == 72 / 25.4
+
+
+def test_calcRowsNumber_resolves_css_stack():
+    b = _builder()
+    text = 'aaaa ' * 40
+    narrow = b.calcRowsNumber(text, width_mm=30, font_name='"Arial Narrow", sans-serif')
+    helvetica = b.calcRowsNumber(text, width_mm=30, font_name='Helvetica')
+    assert narrow < helvetica
+
+
+def test_calcRowsNumber_unknown_font_falls_back_to_helvetica():
+    b = _builder()
+    text = 'aaaa ' * 40
+    assert b.calcRowsNumber(text, width_mm=30, font_name='Comic Sans MS') == \
+        b.calcRowsNumber(text, width_mm=30, font_name='Helvetica')

--- a/gnrpy/tests/utils/fonts_test.py
+++ b/gnrpy/tests/utils/fonts_test.py
@@ -1,0 +1,77 @@
+import pytest
+
+from gnr.utils.fonts import resolve_font_name, font_size_pt, string_width
+
+
+# ---------- resolve_font_name ----------
+
+def test_resolve_direct_name():
+    assert resolve_font_name('Helvetica') == 'Helvetica'
+    assert resolve_font_name('Courier-Bold') == 'Courier-Bold'
+
+
+def test_resolve_alias_case_insensitive():
+    assert resolve_font_name('Arial') == 'Helvetica'
+    assert resolve_font_name('arial') == 'Helvetica'
+    assert resolve_font_name('Times New Roman') == 'Times-Roman'
+
+
+def test_resolve_narrow_alias():
+    assert resolve_font_name('Arial Narrow') == 'Helvetica-Narrow'
+    assert resolve_font_name('Liberation Sans Narrow') == 'Helvetica-Narrow'
+
+
+def test_resolve_css_stack_first_mapped_wins():
+    stack = '"Arial Narrow", "Liberation Sans Narrow", sans-serif'
+    assert resolve_font_name(stack) == 'Helvetica-Narrow'
+
+
+def test_resolve_css_stack_skips_unknown_entries():
+    assert resolve_font_name('Comic Sans MS, Courier') == 'Courier'
+
+
+def test_resolve_generic_families():
+    assert resolve_font_name('sans-serif') == 'Helvetica'
+    assert resolve_font_name('serif') == 'Times-Roman'
+    assert resolve_font_name('monospace') == 'Courier'
+
+
+def test_resolve_fallback_default():
+    assert resolve_font_name('UnknownFont') == 'Helvetica'
+    assert resolve_font_name(None) == 'Helvetica'
+    assert resolve_font_name('') == 'Helvetica'
+    assert resolve_font_name('UnknownFont', default='Courier') == 'Courier'
+
+
+# ---------- derived narrow metrics ----------
+
+def test_narrow_widths_derived_from_base_font():
+    base = string_width('Sample text', 'Helvetica', 10)
+    narrow = string_width('Sample text', 'Helvetica-Narrow', 10)
+    assert narrow == pytest.approx(base * 0.82)
+
+
+def test_narrow_of_unknown_base_falls_back_to_helvetica():
+    assert string_width('abc', 'Nonexistent-Narrow', 10) == string_width('abc', 'Helvetica', 10)
+
+
+# ---------- font_size_pt ----------
+
+def test_font_size_pt_numeric():
+    assert font_size_pt(9) == 9.0
+    assert font_size_pt(10.5) == 10.5
+
+
+def test_font_size_pt_pt_string():
+    assert font_size_pt('9pt') == 9.0
+    assert font_size_pt(' 11PT ') == 11.0
+
+
+def test_font_size_pt_px_string():
+    assert font_size_pt('12px') == 9.0
+
+
+def test_font_size_pt_invalid_returns_default():
+    assert font_size_pt('large') == 10.0
+    assert font_size_pt(None) == 10.0
+    assert font_size_pt('large', default=8) == 8.0

--- a/resources/common/tables/_default/html_res/print_gridres.py
+++ b/resources/common/tables/_default/html_res/print_gridres.py
@@ -6,8 +6,6 @@
 #  Created by Giovanni Porcari on 2007-03-24.
 #  Copyright (c) 2007 Softwell. All rights reserved.
 #
-import math
-
 from gnr.web.gnrbaseclasses import TableScriptToHtml
 from gnr.core.gnrnumber import decimalRound
 from gnr.core.gnrlang import position
@@ -55,7 +53,6 @@ class Main(TableScriptToHtml):
         totalize_mode = printParams['totalize_mode']
         totalize_footer = printParams['totalize_footer']
         totalize_carry =  printParams['totalize_carry']
-        self.cell_characters_limit = {}
         if totalize_mode or totalize_footer or totalize_carry:
             self.totalize_mode = totalize_mode or 'doc'
             self.totalize_footer = totalize_footer or True
@@ -80,7 +77,6 @@ class Main(TableScriptToHtml):
                 c['mm_width'] = max(int(c['q_width']*tot_width),min_mm_width)
             if c.get('character_limit'):
                 c['white_space'] = 'normal'
-                self.cell_characters_limit[c['field_getter']] = c.get('character_limit')
         #self.structAnalyze(struct)
         return dict(columns=self.gridColumnsFromStruct(struct=struct),
                     columnsets=self.gridColumnsetsFromStruct(struct))
@@ -162,19 +158,6 @@ class Main(TableScriptToHtml):
         row = layout.row()
         row.cell(self.getData('print_title'), content_class='caption')    
 
-
-    def calcRowHeight(self):
-        if self.font_family:
-            text = self.getRowWrapField()
-            if text:
-                return max(1, self.builder.calcRowsNumber(text, width_mm=self.text_width_mm)) * self.grid_row_height
-        if not self.cell_characters_limit:
-            return self.grid_row_height
-        l = []
-        for k,v in self.cell_characters_limit.items():
-            txt = (self.rowData.get(k) or '')
-            l.append(math.ceil(len(txt)/float(v)))
-        return max(l) * self.grid_row_height
 
     def outputDocName(self, ext=''):
         return '%s.%s' %(self.parameter('print_title') or self.page.getUuid() ,ext)


### PR DESCRIPTION
## Summary
- `BagToHtml.calcRowHeight` now estimates the row height automatically, cell by cell: every visible wrappable column (`white_space` other than `nowrap`) is measured with AFM font metrics against its rendered width — fixed, colspan-extended or elastic residual width, on every sheet — and the row gets `max(lines) * grid_row_height`. Prints without wrappable columns keep the flat behavior; `auto_row_height = False` opts out; explicit `calcRowHeight` overrides and per-row `height` attributes still win.
- Declaring `font_family` on the print class is now sufficient: it flows into `mainLayoutParameters` (so it actually reaches the rendered grid — previously the injected body CSS was beaten by the main layout inline style) and into the measurement. CSS font stacks are resolved to the first name with AFM metrics (`resolve_font_name`), and Helvetica-Narrow metrics are derived from Helvetica (Adobe 0.82 condensing factor) so the default Arial Narrow layout is measured exactly.
- Elastic columns are measured against the actual letterhead content area (`contentAreaWidth()`): with a `headline` letterhead the copies render inside the template center band (`layout.center.left/right` widths), while `copyWidth()` subtracts the `layout.left/right` side widths that only shape the `sidebar` design — measuring against it counted spurious wrap lines and doubled single-line rows.
- Cleanups superseded by the automatic path: dead `getRowWrapField` declaration in `TableScriptToHtml` (never called by the base class) and the character-limit heuristic in `print_gridres`. Also fixes the page-break accounting of subtotal rows, rendered at `grid_row_height` but previously accounted at the data-row height.

## Linked Issue
Closes #977

Follow-up of #719 (AFM exact row height) and #888 (sans-serif baseline).

## Behavior change
Existing prints with `white_space='normal'` columns (including `character_limit` ones) will get taller rows and different pagination — that is the clipped-text defect this PR fixes. Setting `auto_row_height = False` on the print class restores the previous flat behavior. Worth highlighting in the release notes.

## Test plan
- [x] 32 new unit tests: font stack resolver, derived narrow metrics, `font_size_pt`, all `calcRowHeight` paths (flat, wrap, explicit newlines, flex residual width, multi-sheet max, hidden columns, opt-out, no-field columns) and letterhead content-area geometry (`headline` vs `sidebar` vs none)
- [x] Full gnrpy suite: 1919 passed, 70 skipped, 1 pre-existing failure (`gnrlist_test::test_auto_dialect`, fails on clean develop as well)
- [x] flake8 clean on all touched files
- [x] End-to-end: full `mainLoop` print run — the wrapped row gets `lines × grid_row_height`, flat rows unchanged, opt-out restores flat; the estimated elastic column width matches the rendered cell width exactly (161.6mm)
- [x] Field-verified on a real-world application print (multi-column invoice with a `headline` letterhead): estimated flex width 86.41mm vs 85.81mm rendered — single-line rows no longer doubled; without letterhead the geometry is unchanged