### PR TITLE
fix(services): thread-safe resources_dirs init, explicit error for missing implementation

### DIFF
--- a/gnrpy/gnr/lib/services/__init__.py
+++ b/gnrpy/gnr/lib/services/__init__.py
@@ -27,7 +27,7 @@
 import os
 from datetime import datetime
 
-from gnr.core.gnrlang import  gnrImport
+from gnr.core.gnrlang import  gnrImport, GnrException
 from gnr.core.gnrbag import Bag
 from gnr.lib import logger
 
@@ -90,6 +90,9 @@ class BaseServiceType(object):
             return
         implementation = service_conf.pop('implementation',None) or service_conf.pop('resource',None) #resource is the oldname for implementation
         service_factory = self.getServiceFactory(implementation)
+        if service_factory is None:
+            raise GnrException('no implementation %r for service type %r (service %r)'
+                               % (implementation, self.service_type, service_name))
         service_conf = service_conf or {}
         service = service_factory(self.site, **service_conf)
         service.service_name = service_name

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1903,8 +1903,12 @@ class GnrWsgiSite(object):
 
     def _get_resources_dirs(self):
         if not hasattr(self, '_resources_dirs'):
-            self._resources_dirs = list(self.resources.values())
-            self._resources_dirs.reverse()
+            # Build locally and publish complete: assigning the attribute first and
+            # reversing in place afterwards exposes a half-initialized list to
+            # concurrent readers (see issue #984).
+            dirs = list(self.resources.values())
+            dirs.reverse()
+            self._resources_dirs = dirs
         return self._resources_dirs
 
     resources_dirs = property(_get_resources_dirs)

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
@@ -434,7 +434,10 @@ class ResourceLoader(object):
             locations = resourceDirs[:]
             locations.reverse()
         else:
-            locations = resourceDirs
+            # Defensive copy, like the css/js branch: the caller may share this
+            # list across threads (e.g. site.resources_dirs) and a concurrent
+            # in-place mutation would make the iteration skip entries (issue #984).
+            locations = resourceDirs[:]
         if ext and not path.endswith('.%s' % ext): path = '%s.%s' % (path, ext)
         if '*' in path:
             searchpath=os.path.split(path.split('*')[0])[0]

--- a/gnrpy/tests/core/services_addservice_test.py
+++ b/gnrpy/tests/core/services_addservice_test.py
@@ -1,0 +1,55 @@
+"""Regression tests for BaseServiceType.addService factory resolution.
+
+A missing service implementation used to crash with a bare
+``TypeError: 'NoneType' object is not callable`` at the factory call site
+(``service = service_factory(self.site, **service_conf)``): the same opaque
+error a cold-start race on ``site.resources_dirs`` produced in production
+(see issue #984). ``addService`` must instead raise a clear ``GnrException``
+naming the implementation and the service type.
+
+The harness exercises the real ``BaseServiceType`` and the real
+``ResourceLoader.getResourceList`` over the repository's own ``resources/common``
+tree — no site instance, no register daemon needed.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from gnr.core.gnrlang import GnrException
+from gnr.lib.services import BaseServiceType
+from gnr.web.gnrwsgisite_proxy.gnrresourceloader import ResourceLoader
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+COMMON_RESOURCES = os.path.join(REPO_ROOT, 'resources', 'common')
+
+
+def make_site():
+    """A minimal site facade: a real ResourceLoader over the repo resources."""
+    site = SimpleNamespace(
+        site_path=REPO_ROOT,
+        site_name='servicetest',
+        gnr_config=None,
+        debug=False,
+        getStatic=lambda name: None,
+        default_page=None,
+    )
+    site.resource_loader = ResourceLoader(site)
+    site.resources_dirs = [COMMON_RESOURCES]
+    return site
+
+
+def test_get_service_factory_finds_real_implementation():
+    """Positive control: the scan resolves a real implementation from resources/common."""
+    handler = BaseServiceType(site=make_site(), service_type='storage')
+    factory = handler.getServiceFactory('symbolic')
+    assert factory is not None
+    assert factory.__name__ in ('Service', 'Main')
+
+
+def test_add_service_missing_implementation_raises_clear_error():
+    """No implementations for the service type: a clear error, not a bare TypeError."""
+    handler = BaseServiceType(site=make_site(), service_type='faketype')
+    with pytest.raises(GnrException, match='faketype'):
+        handler.addService('x', implementation='any')


### PR DESCRIPTION
## What

Fixes a cold-start race that could crash the very first concurrent page dispatch on a fresh `GnrWsgiSite` with a bare `TypeError: 'NoneType' object is not callable` (500). Full analysis in #984.

## Root cause

`site.resources_dirs` was published to the attribute **before** being reversed in place:

```python
self._resources_dirs = list(self.resources.values())   # visible now...
self._resources_dirs.reverse()                          # ...reversed in place after
```

A second thread resolving `site.storage('gnr')` for its own first dispatch iterates the shared list during the `reverse()`, silently skips resource directories, the service-implementation scan comes back empty, and `addService` calls a `None` factory unchecked → opaque `TypeError`, no traceback on the console. Self-heals after the first settle (per-process lazy singletons), so it only ever hits the first concurrent dispatch — invisible to classic deployments, exposed by a pool of freshly spawned ASGI workers under a concurrent ramp-up.

## Changes

- `gnrwsgisite._get_resources_dirs`: build the list locally, reverse, then publish it complete.
- `gnrresourceloader.getResourceList`: defensive copy in the general branch too (the css/js branch already copied) — a caller sharing the list across threads no longer sees torn iterations.
- `services.addService`: raise a clear `GnrException` naming the implementation and service type instead of calling `None`, so any residual race (or a genuinely missing implementation) is diagnosable.
- New regression test `tests/core/services_addservice_test.py` pinning the crash line (real `BaseServiceType` + `ResourceLoader` over the repo resources; no daemon needed).

(1) and (2) each independently remove the race; (3) makes whatever remains diagnosable.

## Testing

- New regression test: red (`TypeError`) before the guard, green after.
- `tests/core` and the service/site neighborhood green.

Fixes #984
