### PR TITLE
Public (non-presigned) url support for storage services

### DIFF
--- a/gnrpy/gnr/lib/services/storage.py
+++ b/gnrpy/gnr/lib/services/storage.py
@@ -366,6 +366,10 @@ class StorageNode(object):
         """Returns the external url of this file"""
         return self.service.url(self.path, **kwargs)
 
+    def public_url(self, **kwargs):
+        """Returns a stable public url of this file (no signature, no expiration)"""
+        return self.service.public_url(self.path, **kwargs)
+
     def internal_url(self, **kwargs):
         return self.service.internal_url(self.path, **kwargs)
 
@@ -543,6 +547,14 @@ class StorageService(GnrBaseService):
     def url(self,*args, **kwargs):
         """Returns the external url of path"""
         pass
+
+    def public_url(self, *args, **kwargs):
+        """Returns a stable public url of path: no signature, no expiration.
+
+        Services whose urls are already plain and permanent fall back to url();
+        services that sign their urls (e.g. aws_s3) override this method
+        to return an unsigned url suitable for long-lived content."""
+        return self.url(*args, **kwargs)
 
     def symbolic_url(self,*args, **kwargs):
         pass

--- a/gnrpy/tests/web/test_s3_public_url.py
+++ b/gnrpy/tests/web/test_s3_public_url.py
@@ -1,0 +1,131 @@
+import importlib.util
+import os
+
+from gnr.core.gnrbag import Bag
+from gnr.lib.services.storage import StorageNode, StorageService
+
+# The aws_s3 Service lives under projects/gnrcore/ which is not on the
+# default test sys.path.  We load it directly from the file system so the
+# test can run without requiring a full GenroPy site setup.
+_s3_module_path = os.path.join(
+    os.path.dirname(__file__), os.pardir, os.pardir, os.pardir,
+    'projects', 'gnrcore', 'packages', 'sys', 'resources',
+    'services', 'storage', 'aws_s3.py',
+)
+_s3_module_path = os.path.normpath(_s3_module_path)
+
+
+def _get_s3_service_class():
+    """Import Service from the aws_s3 module."""
+    spec = importlib.util.spec_from_file_location('aws_s3', _s3_module_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.Service
+
+
+S3Service = _get_s3_service_class()
+
+
+class FakeApp:
+    def __init__(self):
+        self.config = Bag()
+        self.config['packages'] = Bag()
+
+
+class FakeParent:
+    def __init__(self):
+        self.gnrapp = FakeApp()
+
+
+def _make_service(**kwargs):
+    kwargs.setdefault('bucket', 'mybucket')
+    kwargs.setdefault('region_name', 'eu-west-1')
+    return S3Service(parent=FakeParent(), **kwargs)
+
+
+class TestS3PublicUrl:
+    """Tests for issue #988: plain, non-expiring public urls."""
+
+    def test_default_aws_endpoint(self):
+        service = _make_service()
+        assert service.public_url('some/file.txt') == \
+            'https://s3.eu-west-1.amazonaws.com/mybucket/some/file.txt'
+
+    def test_base_path_is_included(self):
+        service = _make_service(base_path='media')
+        assert service.public_url('some/file.txt') == \
+            'https://s3.eu-west-1.amazonaws.com/mybucket/media/some/file.txt'
+
+    def test_custom_endpoint(self):
+        """A custom endpoint (e.g. SeaweedFS/MinIO gateway) replaces the AWS one."""
+        service = _make_service(custom_endpoint=True,
+                                endpoint_url='http://seaweed.local:8333')
+        assert service.public_url('some/file.txt') == \
+            'http://seaweed.local:8333/mybucket/some/file.txt'
+
+    def test_custom_endpoint_trailing_slash(self):
+        service = _make_service(custom_endpoint=True,
+                                endpoint_url='http://seaweed.local:8333/')
+        assert service.public_url('some/file.txt') == \
+            'http://seaweed.local:8333/mybucket/some/file.txt'
+
+    def test_endpoint_url_ignored_without_custom_endpoint_flag(self):
+        service = _make_service(custom_endpoint=False,
+                                endpoint_url='http://seaweed.local:8333')
+        assert service.public_url('some/file.txt') == \
+            'https://s3.eu-west-1.amazonaws.com/mybucket/some/file.txt'
+
+    def test_public_base_url_overrides_endpoint(self):
+        """public_base_url replaces both endpoint and bucket (CDN/custom domain)."""
+        service = _make_service(public_base_url='https://media.example.com')
+        assert service.public_url('some/file.txt') == \
+            'https://media.example.com/some/file.txt'
+
+    def test_public_base_url_trailing_slash(self):
+        service = _make_service(public_base_url='https://media.example.com/')
+        assert service.public_url('some/file.txt') == \
+            'https://media.example.com/some/file.txt'
+
+    def test_public_base_url_keeps_base_path(self):
+        service = _make_service(public_base_url='https://media.example.com',
+                                base_path='media')
+        assert service.public_url('some/file.txt') == \
+            'https://media.example.com/media/some/file.txt'
+
+    def test_missing_region_falls_back_to_global_endpoint(self):
+        """Without region_name (e.g. credentials from env) use the global endpoint."""
+        service = _make_service(region_name=None)
+        assert service.public_url('some/file.txt') == \
+            'https://s3.amazonaws.com/mybucket/some/file.txt'
+
+    def test_url_is_stable_across_calls(self):
+        service = _make_service()
+        first = service.public_url('some/file.txt')
+        second = service.public_url('some/file.txt')
+        assert first == second
+
+
+class TestStorageNodePublicUrl:
+
+    def test_node_delegates_to_service(self):
+        service = _make_service()
+        node = StorageNode(parent=None, path='some/file.txt', service=service)
+        assert node.public_url() == \
+            'https://s3.eu-west-1.amazonaws.com/mybucket/some/file.txt'
+
+
+class TestBaseServicePublicUrl:
+
+    def test_base_service_falls_back_to_url(self):
+        """Services without signed urls return the plain url() unchanged."""
+
+        class PlainService(StorageService):
+            def __init__(self):
+                pass
+
+            def url(self, *args, **kwargs):
+                return 'https://example.com/%s' % '/'.join(args)
+
+        service = PlainService()
+        assert service.public_url('some/file.txt') == \
+            'https://example.com/some/file.txt'

--- a/projects/gnrcore/packages/sys/localization.xml
+++ b/projects/gnrcore/packages/sys/localization.xml
@@ -222,6 +222,13 @@
 						<en_confirm fr="Confirmer" en="Confirm" de="Bestätigen" it="Conferma" base="Confirm" zh="确认"/>
 			</thresource_editor>
 		</package_editor>
+		<services>
+			<storage>
+				<aws_s3 path="resources/services/storage/aws_s3.py" ext="py">
+					<en_public_base_url base="Public Base Url" en="Public Base Url" it="Url pubblico di base"/>
+				</aws_s3>
+			</storage>
+		</services>
 		<preference path="resources/preference.py" ext="py">
 			<en_styling base="Styling" en=""/>
 				<en_print base="Print" de="Druck" en="Print" fr="Imprimer" it="Stampa"/>

--- a/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
+++ b/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
@@ -107,9 +107,10 @@ class Service(StorageService):
     def __init__(self, parent=None, bucket=None,
                 base_path=None, aws_access_key_id=None,
                 aws_secret_access_key=None, aws_session_token=None,
-                region_name=None, url_expiration=None, write_in_local=None, 
+                region_name=None, url_expiration=None, write_in_local=None,
                 readonly=None,versioned=True,
                 custom_endpoint=False, endpoint_url=None,
+                public_base_url=None,
                 disable_cert_verify=False, **kwargs):
         self.parent = parent
         self.bucket = bucket
@@ -119,6 +120,7 @@ class Service(StorageService):
         self.aws_session_token=aws_session_token
         self.region_name=region_name
         self.endpoint_url = endpoint_url if custom_endpoint else None
+        self.public_base_url = (public_base_url or '').rstrip('/')
         self.disable_cert_verify = disable_cert_verify
         self.url_expiration = url_expiration or 3600
         has_sys = 'gnrcore:sys' in self.parent.gnrapp.config['packages']
@@ -334,7 +336,28 @@ class Service(StorageService):
         return self._client.generate_presigned_url('get_object',
             Params=params,
             ExpiresIn=expiration)
-    
+
+    def public_url(self, *args, **kwargs):
+        """Returns a plain, non-expiring url for objects readable by anyone.
+
+        The object must be publicly readable (bucket policy or equivalent):
+        the service only builds the url, it does not grant access.
+        With public_base_url set, the url is {public_base_url}/{internal_path}:
+        use it for a custom or CDN domain fronting the bucket. Otherwise a
+        path-style url is built against the service endpoint: the custom
+        endpoint_url if configured (e.g. a SeaweedFS or MinIO gateway) or
+        the AWS regional endpoint https://s3.{region_name}.amazonaws.com."""
+        internal_path = self.internal_path(*args)
+        if self.public_base_url:
+            return '%s/%s' % (self.public_base_url, internal_path)
+        if self.endpoint_url:
+            endpoint = self.endpoint_url.rstrip('/')
+        elif self.region_name:
+            endpoint = 'https://s3.%s.amazonaws.com' % self.region_name
+        else:
+            endpoint = 'https://s3.amazonaws.com'
+        return '%s/%s/%s' % (endpoint, self.bucket, internal_path)
+
     def internal_url(self, *args, **kwargs):
         kwargs = kwargs or {}
         kwargs['_download'] = True
@@ -431,6 +454,7 @@ class ServiceParameters(BaseComponent):
         fb.textbox(value='^.region_name',lbl='Region Name')
         fb.checkbox(value='^.custom_endpoint',lbl='Custom Endpoint')
         fb.textbox(value='^.endpoint_url',lbl='Endpoint Url', hidden='==!custom', custom='^.custom_endpoint')
+        fb.textbox(value='^.public_base_url',lbl='Public Base Url')
         fb.checkbox(value='^.disable_cert_verify',lbl='Disable Certificate Verification')
         bc.storageTreeFrame(frameCode='bucketStorage',storagepath='^#FORM.record.service_name?=#v+":"',
                                 border='1px solid silver',margin='2px',rounded=4,

--- a/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
+++ b/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
@@ -453,8 +453,8 @@ class ServiceParameters(BaseComponent):
         fb.textbox(value='^.aws_secret_access_key',lbl='Aws Secret Access Key')
         fb.textbox(value='^.region_name',lbl='Region Name')
         fb.checkbox(value='^.custom_endpoint',lbl='Custom Endpoint')
-        fb.textbox(value='^.endpoint_url',lbl='Endpoint Url', hidden='==!custom', custom='^.custom_endpoint')
-        fb.textbox(value='^.public_base_url',lbl='Public Base Url')
+        fb.textbox(value='^.endpoint_url',lbl='Endpoint Url', hidden='^.custom_endpoint?=!#v')
+        fb.textbox(value='^.public_base_url',lbl='Public Base Url', hidden='^.custom_endpoint?=!#v')
         fb.checkbox(value='^.disable_cert_verify',lbl='Disable Certificate Verification')
         bc.storageTreeFrame(frameCode='bucketStorage',storagepath='^#FORM.record.service_name?=#v+":"',
                                 border='1px solid silver',margin='2px',rounded=4,

--- a/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
+++ b/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
@@ -454,7 +454,7 @@ class ServiceParameters(BaseComponent):
         fb.textbox(value='^.region_name',lbl='Region Name')
         fb.checkbox(value='^.custom_endpoint',lbl='Custom Endpoint')
         fb.textbox(value='^.endpoint_url',lbl='Endpoint Url', hidden='^.custom_endpoint?=!#v')
-        fb.textbox(value='^.public_base_url',lbl='Public Base Url', hidden='^.custom_endpoint?=!#v')
+        fb.textbox(value='^.public_base_url',lbl='!!Public Base Url')
         fb.checkbox(value='^.disable_cert_verify',lbl='Disable Certificate Verification')
         bc.storageTreeFrame(frameCode='bucketStorage',storagepath='^#FORM.record.service_name?=#v+":"',
                                 border='1px solid silver',margin='2px',rounded=4,


### PR DESCRIPTION
## Summary
- Add `public_url()` to `StorageNode` and `StorageService`: a stable, unsigned, non-expiring url suitable for long-lived content (statically built HTML, emails, generated PDFs). The base implementation falls back to `url()` for services whose urls are already plain and permanent.
- Implement `public_url()` in the `aws_s3` storage service as a path-style url built against the service endpoint: the custom `endpoint_url` when configured (SeaweedFS, MinIO gateways), the AWS regional endpoint `https://s3.{region_name}.amazonaws.com` otherwise, or the global `https://s3.amazonaws.com` endpoint when no region is set.
- New optional `public_base_url` service parameter (also exposed in the `ServiceParameters` panel): when set, the url becomes `{public_base_url}/{internal_path}`, for CDN or custom domains fronting the bucket.
- `url()` is untouched: presigned urls remain the default behavior, byte-for-byte identical to today. Instead of switching `url()` behavior on a parameter (as originally sketched in the issue), the public url is a separate explicit method — simpler and with zero regression surface.

Note for adopters: the object must be publicly readable (bucket policy on AWS, anonymous read configuration on SeaweedFS); the service only emits the url, it does not grant access.

## Linked Issue
Closes #988

## Test plan
- [x] New unit tests in `gnrpy/tests/web/test_s3_public_url.py` (12 tests) covering: default AWS regional endpoint, missing region fallback, custom endpoint (SeaweedFS/MinIO), `public_base_url` override, `base_path` inclusion, trailing-slash normalization, url stability across calls, `StorageNode` delegation, base-service fallback to `url()`
- [x] Existing storage tests pass (`test_s3_temporary_filename.py`, `gnrstoragehandler_test.py`)
- [x] flake8 clean on all modified files