### PR TITLE
fix: skip archived userobjects when installing from resources on migrate

### DIFF
--- a/gnrpy/gnr/sql/gnrsqltable/crud.py
+++ b/gnrpy/gnr/sql/gnrsqltable/crud.py
@@ -237,13 +237,14 @@ class CrudMixin(SqlTableBaseMixin):
         return self.db.adapter.existsRecord(self, record)
 
     def checkDuplicate(self, excludeDraft=None, ignorePartition=None,
-                       **kwargs):
+                       excludeLogicalDeleted=True, **kwargs):
         where = ' AND '.join([
             '$%s=:%s' % (k, k) for k in kwargs.keys()
         ])
         return self.query(
             where=where, excludeDraft=excludeDraft,
-            ignorePartition=ignorePartition, **kwargs,
+            ignorePartition=ignorePartition,
+            excludeLogicalDeleted=excludeLogicalDeleted, **kwargs,
         ).count() > 0
 
     def insertOrUpdate(self, record):

--- a/gnrpy/tests/sql/test_check_duplicate.py
+++ b/gnrpy/tests/sql/test_check_duplicate.py
@@ -11,6 +11,8 @@ Uses the SQLite instance of the test_invoice project.
 
 import datetime
 
+import pytest
+
 from core.common import BaseGnrTest
 
 
@@ -69,6 +71,28 @@ class TestUserobjectArchivedDuplicate:
 
     USEROBJECT = dict(code='test_uo_896', pkg='invc',
                       tbl='invc.customer', objtype='template')
+
+    @pytest.fixture(autouse=True)
+    def _purge_userobject(self, db_pg):
+        """Hard-delete the test userobject before and after each test.
+
+        The db_pg fixture may run against a persistent PostgreSQL
+        database, so the archived row would otherwise survive between
+        runs and collide with the insert through the very unique index
+        this test is about.
+        """
+        self._hard_delete(db_pg)
+        yield
+        self._hard_delete(db_pg)
+
+    def _hard_delete(self, db):
+        tbl = db.table('adm.userobject')
+        rows = tbl.query(where='$code = :c', c=self.USEROBJECT['code'],
+                         excludeLogicalDeleted=False,
+                         for_update=True).fetch()
+        for row in rows:
+            tbl.delete(dict(row))
+        db.commit()
 
     def test_archived_userobject_detected(self, db_pg):
         tbl = db_pg.table('adm.userobject')

--- a/gnrpy/tests/sql/test_check_duplicate.py
+++ b/gnrpy/tests/sql/test_check_duplicate.py
@@ -1,0 +1,86 @@
+"""Tests for Table.checkDuplicate vs logically deleted (archived) records.
+
+Covers issue #896: ``db migrate -u`` aborted with a UniqueViolation when a
+userobject installed from package resources had been archived (logically
+deleted): the duplicate check performed before inserting did not see
+logically deleted rows, so the insert collided with the unique index on
+``identifier``.
+
+Uses the SQLite instance of the test_invoice project.
+"""
+
+import datetime
+
+from core.common import BaseGnrTest
+
+
+def setup_module(module):
+    BaseGnrTest.setup_class()
+
+
+def teardown_module(module):
+    BaseGnrTest.teardown_class()
+
+
+def _archive(tbl, pkey):
+    """Logically delete a record by setting its __del_ts."""
+    row = tbl.query(where='$%s=:pk' % tbl.pkey, pk=pkey,
+                    for_update=True).fetch()[0]
+    old_record = dict(row)
+    old_record.pop('pkey', None)
+    record = dict(old_record)
+    record['__del_ts'] = datetime.datetime.now()
+    tbl.update(record, old_record=old_record)
+    tbl.db.commit()
+
+
+class TestCheckDuplicateLogicalDeleted:
+
+    def test_default_excludes_archived(self, db_sqlite):
+        tbl = db_sqlite.table('invc.customer')
+        record = tbl.insert(dict(account_name='Archived Duplicate Test'))
+        db_sqlite.commit()
+        assert tbl.checkDuplicate(account_name='Archived Duplicate Test')
+        _archive(tbl, record['id'])
+        assert not tbl.checkDuplicate(account_name='Archived Duplicate Test')
+
+    def test_exclude_logical_deleted_false_sees_archived(self, db_sqlite):
+        tbl = db_sqlite.table('invc.customer')
+        record = tbl.insert(dict(account_name='Archived Duplicate Test 2'))
+        db_sqlite.commit()
+        _archive(tbl, record['id'])
+        assert tbl.checkDuplicate(account_name='Archived Duplicate Test 2',
+                                  excludeLogicalDeleted=False)
+
+    def test_unarchived_record_still_duplicate(self, db_sqlite):
+        tbl = db_sqlite.table('invc.customer')
+        tbl.insert(dict(account_name='Live Duplicate Test'))
+        db_sqlite.commit()
+        assert tbl.checkDuplicate(account_name='Live Duplicate Test',
+                                  excludeLogicalDeleted=False)
+
+
+class TestUserobjectArchivedDuplicate:
+    """Replicates the migrate -u scenario of issue #896 on adm.userobject.
+
+    Runs on PostgreSQL because adm.userobject formula columns use
+    postgres-only functions.
+    """
+
+    USEROBJECT = dict(code='test_uo_896', pkg='invc',
+                      tbl='invc.customer', objtype='template')
+
+    def test_archived_userobject_detected(self, db_pg):
+        tbl = db_pg.table('adm.userobject')
+        record = tbl.insert(dict(data=None, private=False, userid=None,
+                                 **self.USEROBJECT))
+        db_pg.commit()
+        assert tbl.checkDuplicate(**self.USEROBJECT)
+        _archive(tbl, record['id'])
+        # the default check no longer sees the row (this is what caused
+        # the UniqueViolation on migrate), while passing
+        # excludeLogicalDeleted=False — as checkResourceUserObject now
+        # does — still detects it and prevents the insert
+        assert not tbl.checkDuplicate(**self.USEROBJECT)
+        assert tbl.checkDuplicate(excludeLogicalDeleted=False,
+                                  **self.USEROBJECT)

--- a/projects/gnrcore/packages/adm/model/userobject.py
+++ b/projects/gnrcore/packages/adm/model/userobject.py
@@ -121,14 +121,21 @@ class Table(object):
                 identifier = self.uo_identifier(record)
                 logger.debug("identifier: %s, code: %s, objtype: %s, pkg: %s, tbl: %s",
                             identifier, record['code'], record['objtype'], record['pkg'], record['tbl'])
-                if not self.checkDuplicate(code=record['code'], pkg=record['pkg'], tbl=record['tbl'], objtype=record['objtype']):
-                    if record['tbl'] and not record['tbl'] in tableindex:
-                        logger.warning('missing table %s, resource %s', record['tbl'], node.attr['abs_path'])
-                        return
-                    logger.info('inserting userobject %(code)s %(tbl)s %(pkg)s from resource' % record)
-                    record['__ins_ts'] = None
-                    record['__mod_ts'] = None
-                    self.insert(record)
+                duplicate_kwargs = dict(code=record['code'], pkg=record['pkg'],
+                                        tbl=record['tbl'], objtype=record['objtype'])
+                if self.checkDuplicate(**duplicate_kwargs):
+                    return
+                if self.checkDuplicate(excludeLogicalDeleted=False, **duplicate_kwargs):
+                    logger.warning('userobject %s is archived: skipping install from resource %s',
+                                   identifier, node.attr['abs_path'])
+                    return
+                if record['tbl'] and not record['tbl'] in tableindex:
+                    logger.warning('missing table %s, resource %s', record['tbl'], node.attr['abs_path'])
+                    return
+                logger.info('inserting userobject %(code)s %(tbl)s %(pkg)s from resource' % record)
+                record['__ins_ts'] = None
+                record['__mod_ts'] = None
+                self.insert(record)
 
         for pkgid, pkgobj in list(self.db.application.packages.items()):
             base_folder = os.path.join(pkgobj.packageFolder, 'resources', 'tables')


### PR DESCRIPTION
## Summary

Fixes #896.

`db migrate -u` aborted with a `UniqueViolation` on `adm_userobject_identifier_key` when a userobject shipped as a package resource had been **archived** (logically deleted) in the database.

Root cause: `Table.checkResourceUserObject()` uses `checkDuplicate()` to decide whether to insert a userobject from a resource XML. Since `adm.userobject` is `archivable=True`, the query built by `checkDuplicate` excluded logically deleted rows by default, so the archived row was invisible to the check — but its `identifier` still exists physically and is enforced by the unique index, so the subsequent `insert()` blew up the whole migration.

## Changes

- `gnrpy/gnr/sql/gnrsqltable/crud.py` — `checkDuplicate()` accepts a new `excludeLogicalDeleted` parameter (default `True`, i.e. the previous behaviour is unchanged) and forwards it to the query.
- `projects/gnrcore/packages/adm/model/userobject.py` — `checkResourceUserObject()` now performs a second duplicate check including logically deleted rows: if the userobject exists but is archived, it logs a warning and skips the insert instead of raising. Archived userobjects are deliberately left as-is.

## Test case

New test module `gnrpy/tests/sql/test_check_duplicate.py` (real databases, no mocks), following the reproduction steps in the issue:

- `TestCheckDuplicateLogicalDeleted` (SQLite, `test_invoice`): default `checkDuplicate` excludes archived rows; `excludeLogicalDeleted=False` detects them; live rows are detected in both modes.
- `TestUserobjectArchivedDuplicate` (PostgreSQL, since `adm.userobject` formula columns use postgres-only functions): inserts a userobject in `adm.userobject`, archives it by setting `__del_ts`, then verifies the default check no longer sees it (the cause of the UniqueViolation) while the check now used by `checkResourceUserObject` does, preventing the colliding insert.

Full `tests/sql` suite: 1189 passed, 10 skipped. `tests/app` suite: 147 passed. flake8 clean on modified files.