### PR TITLE
fix(form): remoteSelect/callbackSelect not disabled on form lock

### DIFF
--- a/gnrjs/gnr_d11/js/genro_frm.js
+++ b/gnrjs/gnr_d11/js/genro_frm.js
@@ -81,6 +81,8 @@ dojo.declare("gnr.GnrFrmHandler", null, {
             'filteringselect':null,
             'dbselect':null,
             'dbcombobox':null,
+            'remoteselect':null,
+            'callbackselect':null,
             'input':null,
             'textarea':null,
             'datetextbox':null,


### PR DESCRIPTION
## Problem

In a table handler form, a field with a `remoteSelect` widget does not react to lock/unlock: it stays editable while the lock is closed, unlike `filteringSelect` (#144).

## Root cause

`gnr.frm.setLocked` → `applyDisabledStatus()` iterates only the nodes present in the form's `_register` and calls `node.setDisabled(disabled)` on each. A node enters `_register` via `registerChild` only if it carries `parentForm=True` or its lowercased tag is listed in `autoRegisterTags` (`genro_frm.js`).

`'remoteselect'` (and `'callbackselect'`) were missing from that dict, so those widgets were never registered: the lock/unlock loop simply never reached them. The widget itself is not the problem — `gnr.widgets.RemoteSelect` renders the same dijit `FilteringSelect` as tags already in the list, so it honors `setDisabled` correctly once called.

## Fix

Add `'remoteselect'` and `'callbackselect'` to `autoRegisterTags`. `callbackSelect` carries the identical defect through the same missing key, and covers `packageSelect` / `tableSelect` too (both render a `CallbackSelect` internally).

Notes:
- Projects that worked around the bug by passing `parentForm=True` to a `remoteSelect` keep working unchanged (that path already reached `setDisabled`).
- `checkLastSavedTags` (Shift+Space restore-last-saved) is intentionally left untouched: it is an independent behavior change.
- As with any auto-registered field, a `remoteSelect` can now be picked as the form's autofocus `_firstField`, and the `unlocked_readOnly` per-field protection now applies to it as well — both are the intended behavior for a data field.

## Verification

Static analysis of the registration/disable chain (`genro_frm.js`, `gnrdomsource.js`, `genro_widgets.js`); `node --check` on the edited file. Not yet verified in a browser; manual check: open the `docu.redirect` table handler (it has a `remoteSelect` next to a `dbselect`), lock/unlock the form and confirm both fields grey out together.
