### PR TITLE
fix(adm): multipage stack freezes when re-adding a page after closing all pages

### DIFF
--- a/projects/gnrcore/packages/adm/resources/frameindex.js
+++ b/projects/gnrcore/packages/adm/resources/frameindex.js
@@ -161,7 +161,7 @@ dojo.declare("gnr.FramedIndexManager", null, {
             for (let cb of onStartCallbacks) {
                 cb.call(this,this._genro);
             }
-            that.checkStartsArgs(rootPageName)
+            that.checkStartsArgs(rootPageName,this.domNode)
         };
 
         var iframe = center._('div','iframecontainer',{'height':'100%','width':'100%',overflow:'hidden'})._('iframe','iframenode',iframeattr);
@@ -189,15 +189,18 @@ dojo.declare("gnr.FramedIndexManager", null, {
         //div('<div class="multipage_add">&nbsp;</div>',connect_onclick="""FIRE gnr.multipage.new = genro.dom.getEventModifiers($1);""",_class='multibutton')
     },
 
-    checkStartsArgs:function(rootPageName){
-        var iframeDataNode = this.iframesbag.getNode(rootPageName);
-        let attr = iframeDataNode.attr
-        let openKw = attr.openKw || {};
-        var iframe = this.getCurrentIframe(rootPageName);
-        if(openKw){
-            openKw.topic = openKw.topic || 'changedStartArgs';
-            iframe.gnr.postMessage(iframe.sourceNode,openKw);
+    checkStartsArgs:function(rootPageName,iframe){
+        var iframeDataNode = this.iframesbag && this.iframesbag.getNode(rootPageName);
+        if(!iframeDataNode){
+            return;
         }
+        let openKw = iframeDataNode.attr.openKw;
+        iframe = iframe || this.getCurrentIframe(rootPageName);
+        if(!iframe || !iframe.gnr || !openKw){
+            return;
+        }
+        openKw.topic = openKw.topic || 'changedStartArgs';
+        iframe.gnr.postMessage(iframe.sourceNode,openKw);
     },
 
     selectIframePage:function(kw){
@@ -625,6 +628,9 @@ dojo.declare("gnr.FramedIndexManager", null, {
             return;
         }
         var iframePageId = iframesbag.getItem(rootPageName+'?selectedPage');
+        if(!iframePageId){
+            return;
+        }
         var iframeId = iframePageId;
         if(rootPageName!=iframePageId){
             iframeId = rootPageName+'_'+iframePageId;


### PR DESCRIPTION
## Problem

In the multipage tabbed widget: add a page, close both pages, add a new one → `Uncaught TypeError: Cannot read properties of null (reading 'gnr')` in `checkStartsArgs` (frameindex.js) and the new page is frozen (#696).

## Root cause

`checkStartsArgs` resolves "the current iframe" indirectly: `getCurrentIframe(rootPageName)` reads `iframes.<rootPageName>?selectedPage` and does `dojo.byId("iframe_"+...)`. After the stack has been emptied, that data item is `null` or names an already-destroyed page (`StackContainer.onRemoveChild` nulls it only in a `setTimeout` and only for the last selected child; `closeFinalize` switches page only when more than one page remains). `dojo.byId` then returns `null`, and `checkStartsArgs` was the **only** caller of `getCurrentIframe` that dereferenced the result unguarded — every other caller already checks it.

The freeze is a consequence, not a separate bug: `onStarted` is published synchronously inside the child page startup block (`genro.js`), so the uncaught error aborts it before `removeClass(body,'startingPage')` runs, and `.startingPage #protection_shield` keeps a full-screen blocking shield over the new page.

## Fix

- `onStarted` now passes the iframe that actually started (`this` is the iframe sourceNode, so `this.domNode` is the right element — created DOM nodes carry `.gnr`/`.sourceNode` via `genro_wdg.makeDomNode`). This also fixes a latent wrong-target bug: start args were posted to whatever iframe was *selected*, not the one that had just started, so switching tab during a slow load misdelivered them.
- `checkStartsArgs` guards data node, iframe and `openKw` before posting (the old `if(openKw)` was dead code, always truthy after `|| {}`).
- `getCurrentIframe` returns early when no page is selected, stopping `dojo.byId("iframe_X_null")` lookups at the source.

Deliberately **not** changed here: preventing the close of the last page (`closeFinalize` lives in the shared `StackButtons` used by every closable stack/tab container — a global UX change out of scope), and the page-switch-on-close ignoring which tab was closed. Both may deserve follow-ups.

## Verification

Static trace of the full chain (frameindex.js, genro_widgets.js `StackContainer`, genro.js startup, genro_wdg.js expandos); `node --check` on the edited file. Not yet verified in a browser; manual repro per the issue: multipage entry → "+" → close both pages → "+" again: the new page must render with no console error, and start-args pages (`openKw`) must still receive `changedStartArgs`.
