### PR TITLE
fix(th): th_hiddencolumns with alias or relation paths no longer break the grid

### DIFF
--- a/gnrpy/tests/web/th_view_hiddencolumns_test.py
+++ b/gnrpy/tests/web/th_view_hiddencolumns_test.py
@@ -1,0 +1,112 @@
+import importlib.util
+import os
+
+from gnr.sql.gnrsql_exceptions import GnrSqlMissingColumn
+
+TH_VIEW_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                            'resources', 'common', 'th', 'th_view.py')
+
+
+def load_th_view():
+    spec = importlib.util.spec_from_file_location('th_view_under_test',
+                                                  os.path.abspath(TH_VIEW_PATH))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeColumn:
+    def __init__(self, required_columns=None):
+        self.attributes = {}
+        if required_columns:
+            self.attributes['required_columns'] = required_columns
+
+
+class FakeModel:
+    """Mimics ModelTable.column(): resolves plain and @rel.col names,
+    raises GnrSqlMissingColumn for unknown relation paths."""
+
+    def __init__(self, columns=None, related=None):
+        self.columns = columns or {}
+        self.related = related or {}
+
+    def column(self, name):
+        if name.startswith('@'):
+            if name in self.related:
+                return self.related[name]
+            raise GnrSqlMissingColumn(
+                'relation %s does not exist in table fake' % name)
+        return self.columns.get(name)
+
+
+class FakeTable:
+    def __init__(self, model):
+        self.model = model
+
+
+class TestThAddRequiredColumns:
+    @classmethod
+    def setup_class(cls):
+        module = load_th_view()
+        cls.view = module.TableHandlerView.__new__(module.TableHandlerView)
+
+    def add_required(self, tblobj, hiddencolumns):
+        return self.view._th_addRequiredColumns(tblobj, hiddencolumns)
+
+    def test_empty_passthrough(self):
+        tblobj = FakeTable(FakeModel())
+        assert self.add_required(tblobj, None) is None
+        assert self.add_required(tblobj, '') == ''
+
+    def test_plain_columns_untouched(self):
+        tblobj = FakeTable(FakeModel(columns={'id': FakeColumn(),
+                                              'name': FakeColumn()}))
+        assert self.add_required(tblobj, '$id, $name') == '$id,$name'
+
+    def test_bare_name_untouched(self):
+        tblobj = FakeTable(FakeModel())
+        assert self.add_required(tblobj, '_h_count') == '_h_count'
+
+    def test_required_columns_appended(self):
+        model = FakeModel(columns={
+            'id': FakeColumn(),
+            'score': FakeColumn(required_columns='$account_name,$email')})
+        assert self.add_required(FakeTable(model), '$id, $score') == \
+            '$id,$score,$account_name,$email'
+
+    def test_required_columns_deduplicated(self):
+        model = FakeModel(columns={
+            'score': FakeColumn(required_columns='$email'),
+            'email': FakeColumn()})
+        assert self.add_required(FakeTable(model), '$score, $email') == \
+            '$score,$email'
+
+    def test_alias_on_plain_column(self):
+        model = FakeModel(columns={
+            'score': FakeColumn(required_columns='$email')})
+        assert self.add_required(FakeTable(model), '$score as sc') == \
+            '$score as sc,$email'
+
+    def test_relation_with_alias_does_not_raise(self):
+        # the exact case of issue #702
+        model = FakeModel(related={'@account_id.account_name': FakeColumn()})
+        hidden = '$id, @account_id.account_name as account_name'
+        assert self.add_required(FakeTable(model), hidden) == \
+            '$id,@account_id.account_name as account_name'
+
+    def test_relation_required_columns_rerooted(self):
+        model = FakeModel(related={
+            '@customer_id.score': FakeColumn(
+                required_columns='$account_name,$email')})
+        assert self.add_required(FakeTable(model), '@customer_id.score') == \
+            '@customer_id.score,@customer_id.account_name,@customer_id.email'
+
+    def test_unknown_relation_swallowed(self):
+        model = FakeModel()
+        hidden = '@nope.foo as bar, $id'
+        assert self.add_required(FakeTable(model), hidden) == \
+            '@nope.foo as bar,$id'
+
+    def test_unknown_column_skipped(self):
+        tblobj = FakeTable(FakeModel())
+        assert self.add_required(tblobj, '$ghost') == '$ghost'

--- a/resources/common/th/th_view.py
+++ b/resources/common/th/th_view.py
@@ -13,8 +13,9 @@ from gnr.web.gnrwebstruct import struct_method
 from gnr.core.gnrdecorator import public_method,extract_kwargs,metadata
 from gnr.core.gnrdict import dictExtract
 from gnr.core.gnrbag import Bag
-from gnr.core.gnrstring import slugify
+from gnr.core.gnrstring import slugify, splitAndStrip
 from gnr.core.gnrdate import nextMonth
+from gnr.sql.gnrsql_exceptions import GnrSqlMissingColumn, GnrSqlMissingField
 
 
 class TableHandlerView(BaseComponent):
@@ -1146,18 +1147,28 @@ class TableHandlerView(BaseComponent):
     def _th_addRequiredColumns(self, tblobj, hiddencolumns):
         if not hiddencolumns:
             return hiddencolumns
-        columns = [c.strip() for c in hiddencolumns.split(',')]
+        columns = splitAndStrip(hiddencolumns)
         for col in list(columns):
-            colname = col.lstrip('$')
-            colobj = tblobj.model.column(colname)
+            colname = col.replace(' as ', ' AS ').split(' AS ', 1)[0].strip()
+            colname = colname.lstrip('$')
+            if not colname or colname[0] in ('(', '*'):
+                continue
+            try:
+                colobj = tblobj.model.column(colname)
+            except (GnrSqlMissingColumn, GnrSqlMissingField):
+                continue
             if colobj is None:
                 continue
             req = colobj.attributes.get('required_columns')
             if not req:
                 continue
-            for rc in req.split(','):
-                rc = rc.strip()
-                if rc and rc not in columns:
+            prefix = colname.rsplit('.', 1)[0] if colname.startswith('@') and '.' in colname else None
+            for rc in splitAndStrip(req):
+                if not rc:
+                    continue
+                if prefix:
+                    rc = '%s.%s' % (prefix, rc.lstrip('$'))
+                if rc not in columns:
                     columns.append(rc)
         return ','.join(columns)
 


### PR DESCRIPTION
## Problem

`_th_addRequiredColumns` (introduced in 00070ab90, #577/#579) breaks on `th_hiddencolumns` entries with an alias or a relation path: `@account_id.account_name as account_name` raises `Error code GNR-001: relation ... does not exist` and blocks the whole grid (#702).

## Root cause

The issue's premise needs one correction: `tblobj.model.column()` **does** resolve `@rel.col` paths. The `@` prefix is not the problem — only the alias suffix is. For `@account_id.account_name as account_name`, `_relatedColumn` hops to the related table and looks up `account_name as account_name`, finds nothing, and `column()` raises `GnrSqlMissingColumn` with the full string — byte-for-byte the reported error.

There is a second, silent half: a *non*-relational aliased entry (`$foo as bar`) does not raise, but its `required_columns` were silently dropped — i.e. #577 was still unfixed for aliased plain columns.

## Fix

- Strip the alias before resolving, with the same normalization the SQL compiler uses (`' as '` → `' AS '`, split once).
- Guard `model.column()` with `except (GnrSqlMissingColumn, GnrSqlMissingField)` so an unresolvable entry falls back to the pre-#579 passthrough instead of blocking the grid (note: both extend `GnrException` directly, not `GnrSqlException`).
- Re-root `required_columns` of relation columns onto their relation prefix (`@customer_id.score` with `required_columns='$account_name'` appends `@customer_id.account_name`), since they are expressed relative to the related table — same approach as `tpleditor`. Skipping `@` entries (as the issue suggested) would have left #577 unfixed for relational pyColumns.
- Use `splitAndStrip` instead of the hand-rolled split.

Original entries — aliases included — are preserved verbatim; only resolved required columns are appended. Bare names like `_h_count` still round-trip unchanged.

## Verification

- New unit tests: `gnrpy/tests/web/th_view_hiddencolumns_test.py` (10 cases: passthrough, plain/bare/aliased columns, the exact #702 repro, re-rooting, dedup, unknown column/relation). All pass.
- `flake8` clean on both touched files.
- Full suite: 1885 passed, 70 skipped, 1 failed — `tests/core/gnrlist_test.py::TestCsvReader::test_auto_dialect`, which fails identically on a clean `origin/develop` checkout (pre-existing, unrelated to this change).
