### PR TITLE
hotfix: docker build definition not to be overwritten with current repo data

### DIFF
--- a/gnrpy/gnr/dev/builder.py
+++ b/gnrpy/gnr/dev/builder.py
@@ -119,7 +119,9 @@ class GnrProjectBuilder(object):
             'description': self.instance_name,
             'subfolder': None
             }
-        _repos[main_repo_url] = code_repo
+        
+        if main_repo_url not in _repos:
+            _repos[main_repo_url] = code_repo
         git_repositories = list(_repos.values())
         logger.debug("Found git repositories: %s", git_repositories)
         return git_repositories


### PR DESCRIPTION
hotfix: if a build definition defines the same repository we are building from,
don't overwrite its configuration, but use the one defined in the build definition.
Some projects may have a subfolder, information needed to correctly build the package.