### PR TITLE
multidb: honor do_update in createSysRecords on the rootstore

### DIFF
--- a/projects/gnrcore/packages/multidb/main.py
+++ b/projects/gnrcore/packages/multidb/main.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 
+from gnr.app import pkglog as logger
 from gnr.app.gnrdbo import GnrDboTable, GnrDboPackage
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrlang import instanceMixin
@@ -560,24 +561,18 @@ class MultidbTable(object):
                     result[k] = (v,store_record[k])
         return result
 
-    def createSysRecords(self,do_update=None):
+    def createSysRecords(self,do_update=False):
         if not self.db.usingRootstore():
+            #store-side runs are no-ops: sysRecords propagate from the rootstore
+            #through the standard multidb sync triggers
+            if do_update:
+                logger.warning('createSysRecords(do_update=True) skipped on store %s for table %s: '
+                                'run it on the rootstore, changes propagate through multidb sync',
+                                self.db.currentEnv.get('storename'),self.fullname)
             return
-        syscodes = []
-        for m in dir(self):
-            if m.startswith('sysRecord_') and m!='sysRecord_':
-                method = getattr(self,m)
-                if getattr(method,'mandatory',False):
-                    syscodes.append(m[10:])
-        commit = False
-        if syscodes:
-            f = self.query(where='$__syscode IN :codes',codes=syscodes).fetchAsDict('__syscode')
-            for syscode in syscodes:
-                if syscode not in f:
-                    self.sysRecord(syscode)
-                    commit = True
-        if commit:
-            self.db.commit()
+        #inserts and do_update changes propagate to the subscribed stores
+        #through trigger_onInserted_multidb/trigger_onUpdated_multidb
+        GnrDboTable.createSysRecords(self,do_update=do_update)
 
     def sysRecord(self,syscode):
         if not self.db.usingRootstore():

--- a/projects/gnrcore/packages/multidb/tests/test_createsysrecords.py
+++ b/projects/gnrcore/packages/multidb/tests/test_createsysrecords.py
@@ -1,0 +1,80 @@
+# encoding: utf-8
+"""Unit tests for MultidbTable.createSysRecords (no db required).
+
+The multidb override must delegate to GnrDboTable.createSysRecords on the
+rootstore (so do_update is honored and changes propagate to the stores through
+the standard multidb sync triggers) and stay a no-op on store-side runs,
+warning when do_update is requested there.
+"""
+
+import importlib.util
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gnr.core.gnrlang import instanceMixin
+
+MAIN_PY = Path(__file__).resolve().parents[1] / 'main.py'
+_spec = importlib.util.spec_from_file_location('multidb_main_under_test', MAIN_PY)
+multidb_main = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(multidb_main)
+
+
+class FakeTable(object):
+    fullname = 'fake.lookup'
+
+    def __init__(self, rootstore=True):
+        self.db = MagicMock()
+        self.db.usingRootstore.return_value = rootstore
+        self.db.currentEnv = {'storename': None if rootstore else 'store_1'}
+
+
+@pytest.fixture
+def base_calls(monkeypatch):
+    calls = []
+
+    def fake_base(self, do_update=False):
+        calls.append(dict(table=self, do_update=do_update))
+
+    monkeypatch.setattr(multidb_main.GnrDboTable, 'createSysRecords', fake_base)
+    return calls
+
+
+def mixined_table(rootstore=True):
+    tbl = FakeTable(rootstore=rootstore)
+    instanceMixin(tbl, multidb_main.MultidbTable)
+    return tbl
+
+
+def test_rootstore_delegates_to_base(base_calls):
+    tbl = mixined_table(rootstore=True)
+    tbl.createSysRecords()
+    assert base_calls == [dict(table=tbl, do_update=False)]
+
+
+def test_rootstore_forwards_do_update(base_calls):
+    tbl = mixined_table(rootstore=True)
+    tbl.createSysRecords(do_update=True)
+    assert base_calls == [dict(table=tbl, do_update=True)]
+
+
+def test_store_side_is_noop(base_calls, caplog):
+    tbl = mixined_table(rootstore=False)
+    with caplog.at_level(logging.WARNING, logger='gnr.pkg'):
+        tbl.createSysRecords()
+    assert base_calls == []
+    assert caplog.records == []
+
+
+def test_store_side_do_update_warns(base_calls, caplog):
+    tbl = mixined_table(rootstore=False)
+    with caplog.at_level(logging.WARNING, logger='gnr.pkg'):
+        tbl.createSysRecords(do_update=True)
+    assert base_calls == []
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert 'fake.lookup' in message
+    assert 'store_1' in message


### PR DESCRIPTION
## Problem

The `MultidbTable.createSysRecords` override (`projects/gnrcore/packages/multidb/main.py`) duplicated the insert-only part of `GnrDboTable.createSysRecords` and silently dropped the `do_update` argument:

- on the **rootstore**, `createSysRecords(do_update=True)` only inserted missing sysRecords and never realigned the existing ones — the caller got a no-op reported as success (this surfaced in a tms_leg upgrade on `ts_fatt.tipo_fattura`, which had to work around it with explicit `recordToUpdate` + `tempEnv(_multidbSync=True)`);
- on **store-side** runs it was a completely silent no-op.

The signature was also misaligned (`do_update=None` vs the base `do_update=False`).

## Fix

On the rootstore the override now delegates to `GnrDboTable.createSysRecords`, so `do_update` is honored. No new sync logic: inserts and updates propagate to the subscribed stores through the standard multidb triggers (`trigger_onInserted/onUpdated_multidb` → `onSubscriberTrigger` → `subscription.syncStore`), which already preserve store-local values for `multidb_onLocalWrite='merge'` tables; non-merge multidb tables reject local writes anyway, so realigning them to the master is the documented semantics.

Store-side runs stay no-ops (sysRecords arrive via sync) but now log a warning when `do_update=True` is requested, pointing the caller to the rootstore.

Note: the delegation is an explicit `GnrDboTable` call rather than `self.createSysRecords_` because `instanceMixin` keeps only one level of shadowed methods — going through the underscore chain would recurse on tables that define their own `createSysRecords` override (e.g. `adm.htag`). As today, the multidb mixin still shadows table-level overrides: unchanged behavior.

## Tests

New `projects/gnrcore/packages/multidb/tests/test_createsysrecords.py` (pure unit tests, no db):
- rootstore delegates to the base implementation, forwarding `do_update`;
- store-side is a no-op with no log noise;
- store-side with `do_update=True` emits the warning with store and table names.

Full gnrpy suite green (1904 passed, 67 skipped).