### PR TITLE
fix: keep gnr migrate -u going on upgrade failures and report them per store

### DIFF
--- a/gnrpy/gnr/db/cli/gnrmigrate.py
+++ b/gnrpy/gnr/db/cli/gnrmigrate.py
@@ -206,55 +206,68 @@ def main():
     else:
         stores = [storename]
     for storename in stores:
+        storelabel = storename or 'main'
         app.db.use_store(storename)
-        if options.upgrade_only:
-            logger.info(f'#### UPGRADE SCRIPTS IN STORE {storename} ####')
-            app.pkgBroadcast('onDbUpgrade,onDbUpgrade_*')
-            app.db.table('sys.upgrade').runUpgrades()
-            app.db.commit()
-            app.db.closeConnection()
-            continue
-        extensions = app.db.application.config['db?extensions']
-        migrator = SqlMigrator(app.db, extensions=extensions,
-                               ignore_constraint_name=True,
-                               excludeReadOnly=True,
-                               removeDisabled=True,
-                               force=options.force,
-                               backup=options.backup)
-        migrator.prepareMigrationCommands()
+        try:
+            if options.upgrade_only:
+                logger.info(f'#### UPGRADE SCRIPTS IN STORE {storename} ####')
+                app.pkgBroadcast('onDbUpgrade,onDbUpgrade_*')
+                upgrade_errors = app.db.table('sys.upgrade').runUpgrades()
+                app.db.commit()
+                errordb.extend((storelabel, f'{codekey}: {error}')
+                               for codekey, error in upgrade_errors)
+                continue
+            extensions = app.db.application.config['db?extensions']
+            migrator = SqlMigrator(app.db, extensions=extensions,
+                                   ignore_constraint_name=True,
+                                   excludeReadOnly=True,
+                                   removeDisabled=True,
+                                   force=options.force,
+                                   backup=options.backup)
+            migrator.prepareMigrationCommands()
 
-        if options.extensions:
-            # we only need the needed extensions
-            # as defined in the application.
-            needed_extensions = migrator.ormExtractor.get_json_struct().get('root', {}).get('extensions', {})
-            if options.extensions == 'json':
-                print(json.dumps(needed_extensions))
-            if options.extensions == 'sql':
-                print("\n".join([f"CREATE EXTENSION IF NOT EXISTS {x};" for x in needed_extensions]))
-            if options.extensions == 'txt':
-                print(",".join(needed_extensions))
-            sys.exit(1)
-            
-        if options.check:
-            check_db(migrator, options)
-        elif options.import_file:
-            import_db(options.import_file, options)
-        elif options.inspect:
-            inspect(migrator, options)
-        else:
-            changes = check_db(migrator, options)
-            if changes:
-                logger.info('APPLYING CHANGES TO DATABASE...')
-                migrator.applyChanges()
-                logger.info('CHANGES APPLIED TO DATABASE')
-        app.pkgBroadcast('onDbSetup,onDbSetup_*')
-        if options.upgrade:
-            app.pkgBroadcast('onDbUpgrade,onDbUpgrade_*')
-            app.db.table('sys.upgrade').runUpgrades()
-            app.db.commit()
-        app.db.closeConnection()
+            if options.extensions:
+                # we only need the needed extensions
+                # as defined in the application.
+                needed_extensions = migrator.ormExtractor.get_json_struct().get('root', {}).get('extensions', {})
+                if options.extensions == 'json':
+                    print(json.dumps(needed_extensions))
+                if options.extensions == 'sql':
+                    print("\n".join([f"CREATE EXTENSION IF NOT EXISTS {x};" for x in needed_extensions]))
+                if options.extensions == 'txt':
+                    print(",".join(needed_extensions))
+                sys.exit(1)
+                
+            if options.check:
+                check_db(migrator, options)
+            elif options.import_file:
+                import_db(options.import_file, options)
+            elif options.inspect:
+                inspect(migrator, options)
+            else:
+                changes = check_db(migrator, options)
+                if changes:
+                    logger.info('APPLYING CHANGES TO DATABASE...')
+                    migrator.applyChanges()
+                    logger.info('CHANGES APPLIED TO DATABASE')
+            app.pkgBroadcast('onDbSetup,onDbSetup_*')
+            if options.upgrade:
+                app.pkgBroadcast('onDbUpgrade,onDbUpgrade_*')
+                upgrade_errors = app.db.table('sys.upgrade').runUpgrades()
+                app.db.commit()
+                errordb.extend((storelabel, f'{codekey}: {error}')
+                               for codekey, error in upgrade_errors)
+        except Exception as e:
+            logger.error(f'store {storelabel}: {e}')
+            errordb.append((storelabel, str(e)))
+        finally:
+            app.db.closeConnection()
     if errordb:
-        logger.error(f'db: {errordb}')
+        failed_stores = sorted(set(storelabel for storelabel, _ in errordb))
+        logger.error(f"Migration completed with errors on {len(failed_stores)} store(s): {', '.join(failed_stores)}")
+        for storelabel, error in errordb:
+            logger.error(f' - {storelabel}: {error}')
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/gnrpy/gnr/sql/gnrsql/transactions.py
+++ b/gnrpy/gnr/sql/gnrsql/transactions.py
@@ -253,6 +253,29 @@ class TransactionMixin(GnrSqlDbBaseMixin):
         """Roll back the current connection's transaction."""
         self.connection.rollback()
 
+    def rollbackAll(self) -> None:
+        """Roll back every uncommitted connection of the current thread.
+
+        This is the counterpart of :meth:`commit`, which walks *all* the
+        thread's connections whose ``connectionName`` matches the active
+        one: triggers may have written to other stores' connections (e.g.
+        a dbstore trigger updating the root store), and :meth:`rollback`
+        alone would leave those writes pending, silently flushed by the
+        next :meth:`commit`.
+
+        Deferred-callback queues and pending exceptions accumulated for
+        the rolled-back connections are discarded as well.
+        """
+        trconns = self._connections.get(_thread.get_ident(), {})
+        for connection in list(trconns.values()):
+            if connection.committed or connection.connectionName != self.currentConnectionName:
+                continue
+            connection.rollback()
+            with self.tempEnv(storename=connection.storename):
+                for queue in (self.QUEUE_DEFER_TO_COMMIT, self.QUEUE_DEFER_AFTER_COMMIT):
+                    self.currentEnv.pop(f"{queue}_{self.connectionKey()}", None)
+        self.currentEnv.pop('_pendingExceptions', None)
+
     def listen(self, *args: Any, **kwargs: Any) -> None:
         """Start listening for a database notification channel (Postgres).
 

--- a/projects/gnrcore/packages/sys/model/upgrade.py
+++ b/projects/gnrcore/packages/sys/model/upgrade.py
@@ -19,6 +19,9 @@ class Table(object):
         
 
     def runUpgrades(self):
+        """Run all pending upgrades and return the failed ones as a list
+        of ``(codekey, error)`` tuples (empty list if all succeeded)."""
+        errors = []
         alreadyRun= self.query(where='$error IS NULL').fetchAsDict('codekey')
         for pkg,pkgobj in list(self.db.application.packages.items()):
             upgradefolder = os.path.join(pkgobj.packageFolder,'lib','upgrades') 
@@ -31,7 +34,10 @@ class Table(object):
                 upgradekey = '%s|%s' %(pkg,filename)
                 if upgradekey not in alreadyRun:
                     print('upgrade',upgradekey)
-                    self.runUpgrade(upgradekey)
+                    error = self.runUpgrade(upgradekey)
+                    if error:
+                        errors.append((upgradekey,error))
+        return errors
     
     def runUpgrade(self,codekey):
         pkg,filename = codekey.split('|')
@@ -40,8 +46,14 @@ class Table(object):
         try:
             m = gnrImport(filepath)
             error = m.main(self.db)
+            # commit inside the try: deferred constraints and writes queued
+            # on other connections by triggers only surface here, and they
+            # must be recorded as this upgrade's error, not kill the caller
+            self.db.commit()
         except Exception as e:
-            self.db.rollback()
+            # rollbackAll, not rollback: triggers may have written to other
+            # connections (e.g. the root store during a dbstore upgrade)
+            self.db.rollbackAll()
             error = str(e)
         with self.recordToUpdate(codekey,insertMissing=True) as r:
             r['error'] = error
@@ -50,6 +62,7 @@ class Table(object):
         if error:
             print('ERROR',codekey,error)
         self.db.commit()
+        return error
 
     def use_dbstores(self,**kwargs):
         return True


### PR DESCRIPTION
Fixes #1023

A failing upgrade script in one store no longer aborts the whole migration; failures are accumulated and reported at the end, per store, with their reason.

## Changes

**`projects/gnrcore/packages/sys/model/upgrade.py`**
- `runUpgrade` commits the upgrade's work *inside* its `try`: failures that only surface at commit time (deferred FK constraints, deferred-to-commit callables) are now recorded as the upgrade's error like any other exception, instead of escaping and killing the caller. Returns the error.
- On error it calls the new `rollbackAll()` instead of `rollback()` (see below).
- `runUpgrades` returns the list of `(codekey, error)` failures.

**`gnrpy/gnr/sql/gnrsql/transactions.py`**
- New `GnrSqlDb.rollbackAll()`, the counterpart of `commit()`: rolls back every uncommitted connection of the current thread (same `connectionName` selection as `commit()`) and discards the associated deferred-callback queues and pending exceptions. `rollback()` alone only covers the current connection, so writes done by triggers on *other* connections — e.g. a dbstore trigger updating the root store — survived the rollback and were silently flushed, or exploded, at the next `commit()`. That was the crash in #1023.

**`gnrpy/gnr/db/cli/gnrmigrate.py`**
- Each store iteration is wrapped in `try/except/finally`: connections are always closed, a hard failure on one store is logged and accumulated instead of stopping the loop.
- Upgrade failures returned by `runUpgrades` are accumulated in `errordb` (previously declared but never populated).
- Final summary listing the failing stores and the reason for each, exiting non-zero:

```
ERROR ... Migration completed with errors on 2 store(s): main, store_b
ERROR ...  - main: erpy_xxx|0008_yyy: !!You cannot update this record in a synced store ...
ERROR ...  - store_b: erpy_xxx|0005_zzz: object of type 'NoneType' has no len()
```

## Testing

- Full `gnrpy` test suite green (1912 passed, 67 skipped).
- `rollbackAll()` exercised against a live sqlite `GnrSqlDb`: pending writes discarded, deferred-to-commit callables dropped, subsequent commits clean, committed work untouched.