### PR TITLE
fix(tests): temp conf dirs no longer leak into the source tree on setup failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,6 @@ projects/test_invoice/test_invoice_db.zip
 projects/test_invoice/data/invoice_data.zip
 projects/test_invoice/data/export/invoice.csv
 projects/test_invoice/data/export/invoice_row.csv
-gnrpy/tests/core/*/gnr/environment.xml
-gnrpy/tests/core/*/gnr/instanceconfig/default.xml
-gnrpy/tests/core/*/gnr/siteconfig/default.xml
-gnrpy/tests/core/*/gnrtest/instances/gnrtest/config/instanceconfig.xml
-gnrpy/tests/core/*/gnrtest/instances/gnrtest/root.py
+gnrpy/tests/core/tmp_*/
 /temp/
 .gnr/

--- a/gnrpy/tests/core/common.py
+++ b/gnrpy/tests/core/common.py
@@ -1,6 +1,7 @@
 """
 Common objects for gnr.app testing, mostly custom Genropy environment
 """
+import atexit
 import os
 import os.path
 import tempfile
@@ -16,11 +17,26 @@ class BaseGnrTest:
     """
     @classmethod
     def setup_class(cls):
-        """ 
-        Setup the testing environment 
+        """
+        Setup the testing environment
         """
         cls.local_dir = os.path.dirname(__file__)
-        cls.tmp_conf_dir = tempfile.mkdtemp(prefix=f"{cls.local_dir}/")
+        cls.tmp_conf_dir = tempfile.mkdtemp(prefix=f"{cls.local_dir}/tmp_")
+        # teardown_class is skipped by pytest when any setup_class in the
+        # chain raises (pytest.skip included); this backstop reaps the dir
+        # at interpreter exit and is a no-op after a normal teardown
+        atexit.register(cls._reap_tmp_conf_dir)
+        try:
+            cls._build_test_env()
+        except BaseException:
+            # pytest skips teardown_class when setup_class raises (including
+            # pytest.skip, which is a BaseException): clean up here or the
+            # temp dir leaks into the source tree
+            cls.teardown_class()
+            raise
+
+    @classmethod
+    def _build_test_env(cls):
         fconf = os.path.join(cls.tmp_conf_dir, "gnr")
         os.mkdir(fconf)
         cls.conf_dir = fconf
@@ -104,28 +120,42 @@ class BaseGnrTest:
                     cls.test_instance_config_path)
         
     @classmethod
+    def _reap_tmp_conf_dir(cls):
+        """Idempotent removal of the temp conf dir (teardown and atexit backstop)"""
+        tmp_conf_dir = getattr(cls, "tmp_conf_dir", None)
+        if tmp_conf_dir and os.path.isdir(tmp_conf_dir):
+            shutil.rmtree(tmp_conf_dir, ignore_errors=True)
+        cls.tmp_conf_dir = None
+
+    @classmethod
     def teardown_class(cls):
-        """Teardown testing environment"""
-        shutil.rmtree(cls.tmp_conf_dir)
+        """Teardown testing environment (idempotent: also called on setup failure)"""
+        cls._reap_tmp_conf_dir()
         os.environ.pop("GENRO_GNRFOLDER", None)
 
 class BaseGnrAppTest(BaseGnrTest):
     app_name = 'gnrdevelop'
-    
+
     @classmethod
     def setup_class(cls):
         super().setup_class()
         cls._tempdir = tempfile.mkdtemp()
-        cls.app = ga.GnrApp(cls.app_name, db_attrs=dict(
-            implementation='sqlite',
-            dbname=os.path.join(cls._tempdir, 'testing'),
-        ))
+        try:
+            cls.app = ga.GnrApp(cls.app_name, db_attrs=dict(
+                implementation='sqlite',
+                dbname=os.path.join(cls._tempdir, 'testing'),
+            ))
+        except BaseException:
+            cls.teardown_class()
+            raise
 
     @classmethod
     def teardown_class(cls):
+        tempdir = getattr(cls, "_tempdir", None)
+        if tempdir and os.path.isdir(tempdir):
+            shutil.rmtree(tempdir, ignore_errors=True)
+        cls._tempdir = None
         super().teardown_class()
-        if cls._tempdir and os.path.exists(cls._tempdir):
-            shutil.rmtree(cls._tempdir)
 
 def checkInstance(instance_name):
     """Attempt to load a Genropy instance.

--- a/gnrpy/tests/web/webcommon.py
+++ b/gnrpy/tests/web/webcommon.py
@@ -30,11 +30,11 @@ class BaseGnrDaemonTest(BaseGnrTest):
     """
     @classmethod
     def setup_class(cls):
-        super().setup_class()
         if shutil.which("gnr") is None:
+            # skip before super().setup_class(): nothing to clean up yet
             pytest.skip("gnr CLI not available in PATH")
+        super().setup_class()
         cls.external = ExternalProcess(['gnr','web','daemon'], cwd=None)
-
         try:
             cls.external.start()
             cls.site_name = 'gnrdevelop'
@@ -42,15 +42,19 @@ class BaseGnrDaemonTest(BaseGnrTest):
             cls.client = WSGITestClient(cls.site)
             cls.services_handler = cls.site.services_handler
         except Exception as e:
-            # re-raise to take care of the problem, but ensuring the external
-            # process is being terminated.
-            pytest.skip(f"Daemon not available: {e}")
+            # pytest.skip raises, so teardown_class would never run:
+            # clean up the daemon and the temp conf dir first
             cls.teardown_class()
-        
-        
+            pytest.skip(f"Daemon not available: {e}")
+
     @classmethod
     def teardown_class(cls):
-        cls.external.stop()
+        external = getattr(cls, "external", None)
+        if external is not None:
+            try:
+                external.stop()
+            finally:
+                cls.external = None
         super().teardown_class()
 
 


### PR DESCRIPTION
## Problem

`gnrpy/tests/core/` accumulates orphan temp directories (261 on a long-lived checkout). They were invisible because `.gitignore` whitelisted exactly the five files each one contains.

Closes the question raised in the issue thread: failures and KeyboardInterrupt do **not** leak (teardown runs fine there, as reported). The leak happens when `setup_class` itself raises **after** `mkdtemp`.

## Root cause

pytest wires `setup_class`/`teardown_class` as a single generator fixture (`_pytest/python.py`, `xunit_setup_class_fixture`): if `setup_class` raises before `yield`, `teardown_class` never runs. `pytest.skip()` raises `Skipped`, which is a `BaseException`, so it propagates the same way.

The dominant path is `BaseGnrDaemonTest.setup_class` (`gnrpy/tests/web/webcommon.py`): it calls `super().setup_class()` (which builds the temp environment) and *then* skips if the `gnr` CLI is missing or the daemon does not come up. Every `tests/web` run on a machine without a working daemon leaked 2 fully populated directories — the orphans on disk match this signature exactly (populated, in pairs ~10s apart, matching the daemon retry loop). The original cleanup call after `pytest.skip(...)` was unreachable dead code.

## Fix

- `BaseGnrTest.setup_class` builds the environment inside `try/except BaseException`, cleaning up before re-raising; an `atexit` backstop reaps the tracked dir even when a *subclass* `setup_class` fails after `super()` returned. Teardown is idempotent and safe on partial setup.
- `BaseGnrAppTest` guards `GnrApp` creation the same way and removes its own sqlite tempdir before delegating.
- `BaseGnrDaemonTest` checks for the `gnr` CLI **before** building the environment, cleans up before skipping when the daemon is unavailable, and its teardown tolerates a missing external process.
- Temp dirs now use a `tmp_` prefix; the five whitelisting `.gitignore` patterns are replaced by a single `gnrpy/tests/core/tmp_*/` entry, so any future leak shows up as one ignored directory instead of being masked file-by-file.

Pre-existing orphans are untracked local debris and can be swept with `rm -rf gnrpy/tests/core/*/` (nothing under them is in git).

## Verification

Performed in this branch:

- Probe class raising / `pytest.skip`-ing inside `setup_class` after `super()`: **+2 leaked dirs before the fix, +0 after** (probe not committed).
- Full `core`, `app` and `web` suites pass (576 + 197), including the real daemon path, with no `atexit` noise.
- Full pre-commit suite: 1969 passed, 10 skipped.
- flake8 clean on touched files.

The daemon-unavailable real-world path (skip at `webcommon.py`) is exercised by the probe's identical mechanism; reproducing it live requires a machine where the daemon cannot start — reproduce with `setup_class` broken, not with a failing test.

Fixes #701