### PR TITLE
fix(th): tree_picker no longer hides the sibling sorting tool in hierarchical forms

### DIFF
--- a/resources/common/th/th_form.py
+++ b/resources/common/th/th_form.py
@@ -340,7 +340,8 @@ class TableHandlerForm(BaseComponent):
             treeslots = '2,left_placeholder,searchOn,*,treeSortingTool,right_placeholder,2'
             hviewPicker = tree_kwargs.get('picker')
             if hviewPicker:
-                treeslots = '2,left_placeholder,searchOn,*,treePicker,right_placeholder,2'
+                #keep treeSortingTool: it self-suppresses on tables without _row_count
+                treeslots = '2,left_placeholder,searchOn,*,treeSortingTool,treePicker,right_placeholder,2'
             tree_searchbar = bar.htreeSearchbar.slotToolbar(treeslots,searchOn=True,searchOn_searchCode=searchCode)
             tree_kwargs['searchCode'] = searchCode
             treeviewclass = tree_kwargs.get('_class')


### PR DESCRIPTION
## Problem

Using `tree_picker` in the `th_options` of a Form on a hierarchical table removes the ordering icon (sibling sorting tool) from the tree toolbar.

## Root cause

In `resources/common/th/th_form.py`, the tree toolbar slot string is **reassigned** instead of extended when a picker is configured:

```python
treeslots = '2,left_placeholder,searchOn,*,treeSortingTool,right_placeholder,2'
if hviewPicker:
    treeslots = '2,left_placeholder,searchOn,*,treePicker,right_placeholder,2'
```

The moment a picker exists, `treeSortingTool` is dropped from the toolbar entirely. It is a plain overwrite, not two widgets fighting for a slot.

## Fix

Keep both slots in the picker branch: `...,treeSortingTool,treePicker,...`. Safe for every table: `ht_slotbar_treeSortingTool` (`th_tree.py`) renders nothing unless the table has a `_row_count` column, so tables without `counter=True` are unaffected.

## Verification

- flake8 and compile check on the touched file; full pre-commit suite passes (1969 tests).
- Not verified live: no test page covers `tree_picker` (the test package has no hierarchical table at all). Manual steps: open the `adm.menu` form (Admin → Menu, hierarchical with `counter=True` and `tree_picker='page_id'`): before the fix the tree toolbar shows only the picker; after, both the sorting icon and the picker.

Fixes #75