### PR TITLE
dataRemote: do not leave _sourceNode in the data node attributes

### DIFF
--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -493,7 +493,12 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
                 var resolvedValue = this._resolvedValue;
                 var resolver = genro.rpc.remoteResolver(method, attributes, {'cacheTime':cacheTime,
                     'isGetter':isGetter});
-                dataNode.setValue(resolver, true, attributes);
+                // the resolver keeps its own copy of the parameters, so _sourceNode must not
+                // be left in the attributes assigned to the data node: a GnrDomSourceNode in
+                // node.attr breaks any serialization of that node (e.g. a record cluster).
+                var nodeAttributes = objectUpdate({}, attributes);
+                delete nodeAttributes['_sourceNode'];
+                dataNode.setValue(resolver, true, nodeAttributes);
                 if(resolvedValue){
                     dataNode._status = 'loaded';
                     dataNode.setValue(resolvedValue,'resolver');

--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -493,12 +493,10 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
                 var resolvedValue = this._resolvedValue;
                 var resolver = genro.rpc.remoteResolver(method, attributes, {'cacheTime':cacheTime,
                     'isGetter':isGetter});
-                // the resolver keeps its own copy of the parameters, so _sourceNode must not
-                // be left in the attributes assigned to the data node: a GnrDomSourceNode in
-                // node.attr breaks any serialization of that node (e.g. a record cluster).
-                var nodeAttributes = objectUpdate({}, attributes);
-                delete nodeAttributes['_sourceNode'];
-                dataNode.setValue(resolver, true, nodeAttributes);
+                // the resolver already took its own copy of the parameters: a GnrDomSourceNode
+                // left in node.attr breaks any serialization of that node (e.g. a record cluster).
+                objectExtract(attributes, '_*');
+                dataNode.setValue(resolver, true, attributes);
                 if(resolvedValue){
                     dataNode._status = 'loaded';
                     dataNode.setValue(resolvedValue,'resolver');


### PR DESCRIPTION
## Symptom

Saving a form whose record contains a `dataRemote` node kills the client **before** the request is sent: the POST never leaves the browser, nothing reaches the server, and the console shows

```
Uncaught RangeError: Maximum call stack size exceeded
    at isBag (gnrlang.js)
    at guessDtype (gnrlang.js)
    at toTypedJSON (gnrlang.js)
    at convertToText (gnrlang.js)
    at asTypedTxt (gnrlang.js)
    at toTypedJSON (gnrlang.js)
    ... forever
```

Reproduced on a `dynamicform` characteristic configured with a **Data getter** (`table`, `column`, `where id=^.iban_c`): while the getter is unresolved the form saves; as soon as it resolves, the record can no longer be saved.

## Cause

1. `_df_handleGetter` (`dynamicform.py:643`) installs the getter as `fb.dataRemote('.<code>', ...)`, and the dynamic-fields `fb` has its datapath on the record's Bag column — so the destination is a data node *inside the record*, which is serialized on save. That part is intended: the characteristic must be persisted.

2. `setDataNodeValueDo`, `dataRemote` branch (`gnrdomsource.js:492`), sets `attributes['_sourceNode'] = this` and then passes the **same** object to `dataNode.setValue(resolver, true, attributes)`. `setValue` with a resolver reaches `setAttr` without `updateAttr`, which assigns the object verbatim (`gnrbag.js:465`, `this.attr = attr`). From then on `node.attr._sourceNode` is a `GnrDomSourceNode`.

3. On save, `_getRecordCluster` copies the column Bag with nodes **and attributes** (`genro_frm.js:1715`), `serializeParameters` calls `asTypedTxt` on the cluster (`genro_rpc.js:778`), and `_toXmlBlock` → `xml_buildTag` → `objectAsXmlAttributes` (`gnrlang.js:800`) calls `asTypedTxt` on every non-string attribute (line 810).

4. `asTypedTxt` on a node never terminates: `guessDtype` returns `BAGNODE`, which is not `AR`/`SET`/`OBJ` nor in `['L','N','NN','B']`, so `toTypedJSON` returns `JSON.stringify(asTypedTxt(value))` (line 1508); `asTypedTxt` → `convertToText`, where the value is not a string/boolean/number/date and a **node** exposes no `toXml` (only `Bag` does), so it falls into `else if (t == 'object') { result = ['JS', toTypedJSON(value)]; }` (line 1481) — with the same value. The two call each other until the stack ends.

The `datarpc` branch a few lines above already does the right thing: it strips the technical keys (`objectExtract(kwargs, '_*')`) and passes `kwargs['_sourceNode'] = this` only to `remoteCall` (line 449), never writing it on a data node. `dataRemote` was the only branch carrying it onto the node.

## Fix

Pass a cleaned copy of the attributes to the data node. Safe because `remoteResolver` does not retain the object it receives — it copies it (`var kwargs = objectUpdate({'sync':true}, params);`, `genro_rpc.js:697`) — so the resolver keeps its own `_sourceNode` and keeps working; only the data node stops carrying it into serialization.

## Verification

- Every step of the chain above was checked line by line on `develop` at the time of writing.
- `_sourceNode` is never read back from a data node's `attr`: all consumers take it from the resolver/call kwargs (`genro_rpc.js:58-80`, `311`). `genro_widgets.js:4827` follows a similar pattern but installs the resolver via `setResolver`, so no node attribute is polluted there.
- Not exercised in a browser here: the crash reproduces only on the reporter's instance. The change is a strict removal of a key that nothing downstream reads.

## Left out on purpose

The structural defect in `convertToText` survives this patch: **any** value whose `guessDtype` is an unhandled dtype and which has no `toXml` produces the same stack overflow, wherever it ends up — `FILE` being the realistic case (a `File` in an attribute or value, from drag&drop or an uploader). Guarding the `t == 'object'` branch so it does not re-enter `toTypedJSON` on the same value belongs in its own PR.

Reported by Andrea Busanelli (icond project).
