### PR TITLE
fix(export): gridcall no longer crashes when the grid is empty

### DIFF
--- a/gnrpy/gnr/web/batch/btcexport.py
+++ b/gnrpy/gnr/web/batch/btcexport.py
@@ -37,7 +37,7 @@ class BaseResourceExport(BaseResourceBatch):
         self.batch_parameters = dict(export_mode=export_mode, filename=filename,localized_data=localized_data)
         self.batch_parameters.update(kwargs)
         self.prepareExportCols(data,struct=struct)
-        if not isinstance(data,Bag):
+        if data is not None and not isinstance(data,Bag):
             data = data.output('grid')
         self.data = self.rowFromValue(data) if datamode == 'bag' else self.rowFromAttr(data)
         self._pre_process()

--- a/gnrpy/tests/web/btcexport_test.py
+++ b/gnrpy/tests/web/btcexport_test.py
@@ -1,0 +1,122 @@
+"""Regression test for issue #1035: gridcall() must not crash on an empty grid.
+
+When the client-side grid selection is empty, genro_grid.js's
+mixin_serverAction sends data=None to the server (storebag() on an empty
+grid yields nothing), while struct is always sent. BaseResourceExport.
+gridcall() used to dereference data.output('grid') unconditionally,
+raising AttributeError: 'NoneType' object has no attribute 'output'.
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+import openpyxl
+
+from gnr.app.gnrapp import GnrApp
+from core.common import BaseGnrTest
+from gnr.core.gnrbag import Bag
+from gnr.web.batch.btcexport import BaseResourceExport
+
+
+def setup_module(module):
+    BaseGnrTest.setup_class()
+
+
+def teardown_module(module):
+    BaseGnrTest.teardown_class()
+
+
+class _FakeStorageNode(str):
+    """Minimal stand-in for a genropy StorageNode: a real filesystem path
+    string with the .url() accessor gridcall()'s post_process() expects.
+    """
+
+    def url(self):
+        return str(self)
+
+
+class _FakeSite:
+    """Provides just the slice of Site used by gridcall(): a storageNode()
+    that does real file I/O against a temporary directory, without booting
+    a full GnrWsgiSite/daemon (not exercised by the code path under test).
+    """
+
+    def __init__(self, base_dir):
+        self.base_dir = base_dir
+
+    def storageNode(self, storage, *parts, **kwargs):
+        path = os.path.join(self.base_dir, storage.replace(':', '_'), *parts)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        return _FakeStorageNode(path)
+
+
+class _FakePage:
+    """Narrowest real stand-in for a webpage. BaseResourceBatch.__init__()
+    only needs .db, .btc and .getUuid(); the gridcall() export path
+    additionally needs .locale and .site.storageNode(). Everything else
+    exercised by the test (self.db, prepareExportCols, rowFromAttr, the
+    writer, the Bag) is the genuine implementation.
+    """
+
+    def __init__(self, db, output_dir):
+        self.db = db
+        self.btc = object()
+        self.locale = 'en'
+        self.site = _FakeSite(output_dir)
+
+    def getUuid(self):
+        return 'test-uuid-0001'
+
+
+@pytest.fixture(scope='module')
+def sqlite_temp_dir():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        yield tmpdir
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture(scope='module')
+def sqlite_db(sqlite_temp_dir):
+    app = GnrApp('test_invoice', db_attrs=dict(
+        implementation='sqlite',
+        dbname=os.path.join(sqlite_temp_dir, 'testing'),
+    ))
+    app.db.model.check(applyChanges=True)
+    return app.db
+
+
+def _build_struct():
+    """A real struct Bag shaped as _prepareExportCols_struct() expects: it
+    pops 'info', then walks views -> rows -> cells reading the field/name/
+    dtype/hidden/columnset/caption_field/group_aggr cell attributes.
+    """
+    struct = Bag()
+    row = Bag()
+    row.setItem('description', None, field='description', name='Description', dtype='A')
+    row.setItem('amount', None, field='amount', name='Amount', dtype='N')
+    view = Bag()
+    view.setItem('row_0', row)
+    struct.setItem('view_0', view)
+    return struct
+
+
+def test_gridcall_empty_grid_exports_headers_only(sqlite_db, tmp_path):
+    """An empty grid (data=None) must produce a headers-only file instead
+    of raising AttributeError."""
+    page = _FakePage(sqlite_db, str(tmp_path))
+    resource = BaseResourceExport(page=page, resource_table=None)
+
+    fileurl = resource.gridcall(data=None, struct=_build_struct(),
+                                 export_mode='xls', filename='empty_grid_export')
+
+    assert fileurl
+    assert os.path.isfile(fileurl)
+
+    workbook = openpyxl.load_workbook(fileurl)
+    sheet = workbook.active
+    assert sheet.max_row == 1
+    assert [cell.value for cell in sheet[1]] == ['Description', 'Amount']


### PR DESCRIPTION
## Problem

Exporting an empty grid (e.g. after applying a filter that returns zero rows) via the grid menu's Export XLS crashes with:

```
AttributeError: 'NoneType' object has no attribute 'output'
```

## Root cause

`BaseResourceExport.gridcall()` in `gnrpy/gnr/web/batch/btcexport.py` unconditionally dereferenced `data` when it wasn't a `Bag`:

```python
self.prepareExportCols(data,struct=struct)
if not isinstance(data,Bag):
    data = data.output('grid')
```

The chain that produces `data=None`:

- `gnrjs/gnr_d11/js/genro_grid.js` (`mixin_serverAction`, around line 4267) always sends `kwargs['struct'] = this.structbag()`, but `kwargs['data'] = this.storebag()` yields nothing on an empty grid, so `data` arrives at the server as `None`.
- `gnrpy/gnr/web/gnrwebpage_proxy/apphandler/export.py`, `includedViewAction()` (lines ~381-390) only reassigns `data` when `selectionName` is set, or when `selectedPkeys` and `columns` are both truthy. On an empty grid neither condition holds, so the client's `None` is passed straight through to `gridcall()`.

The empty-selection case was already handled one level below: `rowFromAttr()` and `rowFromValue()` (lines ~45-55) both guard with `if data:`, with the comment "prevents eror if there is no selection added by JBE 2012-01-23". `gridcall()` was simply missing the equivalent guard before its own dereference.

## Change

```python
if data is not None and not isinstance(data,Bag):
    data = data.output('grid')
```

This is sufficient because `struct` always travels from the client, so `prepareExportCols()` takes the `_prepareExportCols_struct(struct)` branch and never touches `data`. `rowFromAttr(None)` then yields an empty generator, and `_pre_process()`'s `if not self.data:` check is `False` (a generator object is always truthy), so the export proceeds and produces a file with headers only, no data rows.

## Verification

- `flake8` on the modified file: zero errors.
- Added a real regression test at `gnrpy/tests/web/btcexport_test.py`: it builds a genuine `struct` `Bag` shaped the way `_prepareExportCols_struct()` expects (views -> rows -> cells with `field`/`name`/`dtype` attributes), constructs a real `GnrSqlDb` against a temporary SQLite `test_invoice` instance, and drives `BaseResourceExport.gridcall(data=None, struct=...)` through a minimal page/site stand-in (only `.db`, `.btc`, `.getUuid()`, `.locale`, `.site.storageNode()` are provided; storage I/O is real, written to a temp directory). The test asserts `gridcall()` returns a file url instead of raising, and that the produced `.xlsx` file has the expected header row and no data rows. Confirmed the test fails with the old code (`AttributeError`) and passes with the fix.
- `python -m pytest gnrpy/tests/ -q -k "export or batch"`: 6 passed.
- `python -m pytest gnrpy/tests/web/ -q`: 137 passed, 57 skipped (skips are the daemon-backed tests, which need a running `gnr web daemon` and are unrelated to this change).
- Manual check (not verified in this session, no running instance available): open any table handler with a filter that returns zero rows, then Export XLS from the grid menu — expected to download a headers-only file instead of erroring.

## Follow-up

`prepareExportCols()` has a latent, unrelated crash risk: if `struct` were ever absent while `data` is `None`, it would fall into `_prepareExportCols_selection(None)`, which dereferences `.columns` on `None`. Not fixed here since no current caller reaches this path — the client always sends `struct` alongside `data`. Flagging it for awareness only.

Fixes #1035