### PR TITLE
fix(web): stop re-adding the thread-local currentDomain entry after cleanup

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1162,7 +1162,13 @@ class GnrWsgiSite(object):
             return exc(environ, start_response)
         finally:
             self.cleanup()
-            self.currentDomain = self.rootDomain
+            # Do not re-set currentDomain here: cleanup() already reset it
+            # to None, which pops this thread's entry from the underlying
+            # ThreadedDict. Assigning rootDomain again would re-add a
+            # {tid: '_main_'} entry that is never removed, i.e. the same
+            # unbounded thread-local growth fixed for currentRequest/
+            # currentPage in #379. The currentDomain getter already falls
+            # back to rootDomain when unset, so no re-assignment is needed.
 
     def raiseIfDeveloper(self, exception=None):
         page = self.currentPage

--- a/gnrpy/tests/core/gnrlang_test.py
+++ b/gnrpy/tests/core/gnrlang_test.py
@@ -277,3 +277,62 @@ def test_gnrImport_concurrent_single_module_identity(tmp_path):
     assert len(modules) == 8
     assert all(m is modules[0] for m in modules)
     assert modules[0].Service is not None
+
+
+# ---------------------------------------------------------------------------
+# ThreadedDict
+# ---------------------------------------------------------------------------
+
+
+def test_threaded_dict_get_default_is_none():
+    td = gl.ThreadedDict()
+    assert td.get() is None
+
+
+def test_threaded_dict_set_then_get_roundtrip():
+    td = gl.ThreadedDict()
+    td.set('value')
+    assert td.get() == 'value'
+
+
+def test_threaded_dict_set_none_pops_entry():
+    """Assigning None removes the current thread's entry instead of
+    storing it, so the backing dict does not keep a live-but-empty slot
+    for every thread that ever called set()."""
+    td = gl.ThreadedDict()
+    td.set('value')
+    assert len(td._data) == 1
+    td.set(None)
+    assert td.get() is None
+    assert len(td._data) == 0
+
+
+def test_threaded_dict_isolated_across_threads():
+    """Each thread sees only the value it set, keyed by its own ident.
+
+    A thread that exits without explicitly resetting to None leaves its
+    entry behind: ThreadedDict itself does no bookkeeping on thread exit,
+    so callers (e.g. GnrWsgiSite.cleanup()) are responsible for popping
+    their slot with set(None) before the thread ends. Skipping that step
+    is exactly the unbounded per-thread growth fixed by #379/#380.
+    """
+    td = gl.ThreadedDict()
+    results = {}
+
+    def worker(name):
+        td.set(name)
+        results[name] = td.get()
+        td.set(None)  # mirrors the app's own cleanup-on-exit responsibility
+
+    threads = [threading.Thread(target=worker, args=(name,))
+               for name in ('thread_a', 'thread_b', 'thread_c')]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results == {'thread_a': 'thread_a',
+                        'thread_b': 'thread_b',
+                        'thread_c': 'thread_c'}
+    # each worker popped its own entry before exiting: nothing left behind
+    assert len(td._data) == 0

--- a/gnrpy/tests/web/gnrwsgisite_dispatcher_cleanup_test.py
+++ b/gnrpy/tests/web/gnrwsgisite_dispatcher_cleanup_test.py
@@ -1,0 +1,109 @@
+"""Regression test for the thread-local cleanup at the end of
+``GnrWsgiSite.dispatcher()`` (#379/#380).
+
+``dispatcher()`` sets ``currentRequest``/``currentDomain`` for the
+serving thread and, in its ``finally`` block, calls ``cleanup()`` to pop
+every thread-local slot again. The real properties involved
+(``currentPage``, ``currentRequest``, ``currentAuxInstanceName``,
+``currentDomain``) are backed by ``gnr.core.gnrlang.ThreadedDict``,
+where assigning ``None`` pops the current thread's entry. The fake site
+below reuses those exact property/method objects from ``GnrWsgiSite``
+so the test exercises the real pop semantics, not a mock of them; only
+the pieces external to this mechanism (``_dispatcher``, ``errorHandler``,
+``db``) are faked.
+"""
+
+import gnr.web.gnrwsgisite as gws
+from gnr.core.gnrlang import ThreadedDict
+from werkzeug.test import EnvironBuilder
+
+
+class _FakeDb:
+    def closeConnection(self):
+        pass
+
+
+class _FakeSite:
+    """Reuses the real thread-local properties and cleanup()/
+    raiseIfDeveloper() from GnrWsgiSite, so dispatcher() (called unbound)
+    exercises the actual pop-on-None behaviour instead of a mock of it.
+    """
+
+    currentPage = gws.GnrWsgiSite.currentPage
+    currentRequest = gws.GnrWsgiSite.currentRequest
+    currentAuxInstanceName = gws.GnrWsgiSite.currentAuxInstanceName
+    currentDomain = gws.GnrWsgiSite.currentDomain
+    cleanup = gws.GnrWsgiSite.cleanup
+    raiseIfDeveloper = gws.GnrWsgiSite.raiseIfDeveloper
+
+    def __init__(self, dispatcher_exc=None):
+        self._currentPages = ThreadedDict()
+        self._currentRequests = ThreadedDict()
+        self._currentAuxInstanceNames = ThreadedDict()
+        self._currentDomains = ThreadedDict()
+        self.rootDomain = '_main_'
+        self.debug = False
+        self.db = _FakeDb()
+        self.errorHandler_calls = []
+        self._dispatcher_exc = dispatcher_exc
+
+    def _dispatcher(self, environ, start_response):
+        if self._dispatcher_exc is not None:
+            raise self._dispatcher_exc
+        return [b'ok']
+
+    def errorHandler(self, exception=None, traceback=None):
+        self.errorHandler_calls.append(exception)
+
+
+def _wsgi_environ():
+    return EnvironBuilder(path='/some/page').get_environ()
+
+
+def _start_response(status, headers):
+    pass
+
+
+def test_dispatcher_success_leaves_no_thread_local_residue():
+    """Happy path: cleanup() still pops every slot after a normal
+    return, no thread-local entry survives the request."""
+    site = _FakeSite()
+    environ = _wsgi_environ()
+
+    gws.GnrWsgiSite.dispatcher(site, environ, _start_response)
+
+    assert site._currentRequests._data == {}
+    assert site._currentDomains._data == {}
+    assert site._currentPages._data == {}
+    assert site._currentAuxInstanceNames._data == {}
+
+
+def test_dispatcher_exception_leaves_no_thread_local_residue():
+    """Error path: _dispatcher raises, the except branch builds a 500
+    response, and the finally block must still leave every thread-local
+    slot empty. Before the #380 fix this passed too because cleanup()
+    already popped currentDomain; the residual line then re-added a
+    never-removed {tid: '_main_'} entry, which this test would catch if
+    that line came back."""
+    site = _FakeSite(dispatcher_exc=RuntimeError('boom'))
+    environ = _wsgi_environ()
+
+    gws.GnrWsgiSite.dispatcher(site, environ, _start_response)
+
+    assert len(site.errorHandler_calls) == 1
+    assert site._currentRequests._data == {}
+    assert site._currentDomains._data == {}
+    assert site._currentPages._data == {}
+    assert site._currentAuxInstanceNames._data == {}
+
+
+def test_dispatcher_currentdomain_falls_back_to_rootdomain_after_cleanup():
+    """After the request is done, reading currentDomain again (e.g. from
+    another request on the same thread) must still see rootDomain via
+    the property's fallback, not a stale per-thread value."""
+    site = _FakeSite(dispatcher_exc=RuntimeError('boom'))
+    environ = _wsgi_environ()
+
+    gws.GnrWsgiSite.dispatcher(site, environ, _start_response)
+
+    assert site.currentDomain == site.rootDomain


### PR DESCRIPTION
## Problem

Issue #380 asks to add a `try/finally` around `GnrWsgiSite.dispatcher()` that resets `currentRequest` and calls `cleanup()`, so thread-local state does not leak to the next request served on the same thread when `_dispatcher()` raises.

## Root cause

That protection already exists on `develop`. What remained was a one-line residue: right after `cleanup()` popped the per-thread `currentDomain` entry, `dispatcher()`'s `finally` block re-set it to `rootDomain`, silently re-adding a `{tid: '_main_'}` entry to the underlying `ThreadedDict` that is never removed again. Every thread ident that ever served one request keeps that entry forever — the same unbounded thread-local growth issue #379 fixed for `currentRequest`/`currentPage`, just left in place for `currentDomain`.

## Why #380 is already implemented

- The `try/finally` requested by #380 was added by commit `f77dddcf7` ("fix: improve error handling for non-developer users and file uploads"). `dispatcher()`'s `finally` block already calls `self.cleanup()`.
- `cleanup()` (`gnrpy/gnr/web/gnrwsgisite.py`) already resets `currentPage`, `currentRequest`, `currentAuxInstanceName` and `currentDomain` to `None`.
- The sibling issue #379 was closed by PR #396, which turned these four into `ThreadedDict`-backed properties: assigning `None` pops the current thread's entry instead of storing it, so `cleanup()`'s resets are real pops, not leaks.
- `_currentDomains` is only ever touched through the `currentDomain` property (`self._currentDomains.get()/.set()`); no code in the repo inspects the backing dict directly. The getter (`return self._currentDomains.get() or self.rootDomain`) can never return `None`, since `rootDomain` is a fixed non-empty string (`'_main_'`) set once in `__init__` and never reassigned. Re-setting `currentDomain` after `cleanup()` was therefore both redundant and the one remaining leak of the #379 class.

Given this, #380's ask is functionally done on `develop` already; this PR only removes the residual line that was quietly re-opening the leak #379 closed.

## Change

One line removed from `dispatcher()`'s `finally` block, with a comment explaining why it must stay removed:

```python
finally:
    self.cleanup()
    # Do not re-set currentDomain here: cleanup() already reset it
    # to None, which pops this thread's entry from the underlying
    # ThreadedDict. Assigning rootDomain again would re-add a
    # {tid: '_main_'} entry that is never removed, i.e. the same
    # unbounded thread-local growth fixed for currentRequest/
    # currentPage in #379. The currentDomain getter already falls
    # back to rootDomain when unset, so no re-assignment is needed.
```

Also added:
- `gnrpy/tests/web/gnrwsgisite_dispatcher_cleanup_test.py`: calls `GnrWsgiSite.dispatcher()` unbound on a fake site that reuses the real `currentPage`/`currentRequest`/`currentAuxInstanceName`/`currentDomain` properties and `cleanup()`/`raiseIfDeveloper()`, backed by real `ThreadedDict` instances — no mocking of the thread-local mechanism itself. Covers the success path, the exception path, and the fallback-to-`rootDomain` behavior after cleanup. Verified this test fails (catches the regression) when the removed line is temporarily reintroduced.
- `gnrpy/tests/core/gnrlang_test.py`: `ThreadedDict` had no dedicated test anywhere; added coverage for the default-`None` get, set/get roundtrip, pop-on-`None`, and isolation across real `threading.Thread`s — the load-bearing piece of the #379 fix.

## Verification

- `flake8` on all touched files: zero errors.
- `python -m pytest gnrpy/tests/web/ -q`: 143 passed, 57 skipped (skips are pre-existing, daemon/Postgres not available in this environment — unrelated to this change).
- Full suite via the repository's pre-commit hook: 1926 passed, 67 skipped, 0 failed.
- Confirmed by temporarily reintroducing the removed line that the new dispatcher test fails, proving it actually exercises the leak.

## Follow-up (not in this PR)

Same leak class, still open elsewhere: `site.currentPage = page … = None` without a `try/finally` at `gnrpy/gnr/web/daemon/processes.py:317` and `:325`, `gnrpy/gnr/web/gnrtask.py:137`, and `gnrpy/gnr/web/gnrtask_new.py:668`.

---

Given the above, should #380 be closed as already implemented on `develop`, with this PR credited as the residual fix?