### PR TITLE
docs(frameindex): correct the indexTab description, stale since the 2023 rewrite

### DIFF
--- a/docs/genro/components/components/frameindex.rst
+++ b/docs/genro/components/components/frameindex.rst
@@ -176,8 +176,12 @@ FrameIndex webpage variables
     * *index_url*: string. Allow to specify the url of your index page. For more information
       check the :ref:`fi_example_index_url`
     * *indexTab*: by default it is set to ``False``; you can write a string in place of
-      ``False`` to allow to see your index page (defined through the ``index_url`` attribute)
-      as a first button of the ``pages buttons`` in the :ref:`fi_topbar` of the FrameIndex page
+      ``False`` with the path (or URL) of a webpage, and it will be opened automatically as
+      an iframe tab and selected when the FrameIndex starts with no restored tabs and no
+      external windows. It is not the index page and is unrelated to the ``index_url``
+      attribute; prefer an absolute ``/package/page`` form. It is ignored whenever any
+      favorite or start page is restored, so for new code prefer the menu's ``openOnStart``
+      attribute instead
     * *hideLeftPlugins*: boolean. If ``True``, allow to start a page with the :ref:`fi_leftbar`
       hidden. By default it is ``False``
     * *preferenceTags*: TODO By default it is ``admin``


### PR DESCRIPTION
## Question asked

Issue #45: what does `indexTab = 'profilo'` do in `class GnrCustomWebPage`?

## Answer

`indexTab` is not a core `GnrWebPage` attribute. It is a class attribute of the
`frameindex` component (`FrameIndex`, in the `adm` package):

- `projects/gnrcore/packages/adm/resources/frameindex.py:33` — `indexTab = False` (the
  only definition).
- `frameindex.py:240` — the value is passed into a `dataController` as `indexTab=self.indexTab`.
- `frameindex.py:227-231` — the controller logic:
  ```js
  if(!data && !externalWindows){
      if(indexTab){
          genro.callAfter(function(){
              genro.framedIndexManager.selectIframePage({file:indexTab,url: indexTab});
          },1,this);
      }
  }
  ```

This runs on `_onStart` and on every `^refreshTablist`, but the `if(indexTab)` branch only
fires when `iframes` is empty **and** `externalWindows` is empty — i.e. a cold start with no
restored tabs.

`selectIframePage` reaches `createIframeRootPage` (`frameindex.js:73`), which calls
`finalizePageUrl` (`frameindex.js:376`), where:
```js
let baseurl = kw.webpage || kw.file || kw.filepath;
```
so the `file` value is used as the page URL (the `url:` kwarg passed alongside it is
overwritten by `finalizePageUrl` and never used). `genro.buildContextUrl`
(`gnrjs/gnr_d11/js/genro.js:1978`) prepends the dbstore/multidomain prefix only if the
string starts with `/`.

Net effect: on a genuinely cold start, `FrameIndex` opens `indexTab` as an already-open
iframe tab in the top tab bar and selects it, so the user lands there instead of on the
splash `indexpage` (`index_url`). It is unrelated to `index_url`.

Why a page class attribute like `indexTab = 'profilo'` actually takes effect: the resource
loader mixes the component's attributes first, then the page's own class last, with
`only_callables=False` (`gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py:161-162`),
which is what lets a non-callable attribute be overridden by the page.

`'profilo'` itself is application-specific — there is no `profilo` webpage or constant
anywhere in this repository, only `it="Profilo"` translations for the unrelated
`en_profile` string (`projects/gnrcore/packages/sys/localization.xml:457`,
`projects/gnrcore/packages/adm/localization.xml:659`). No page under `projects/gnrcore/**`
sets `indexTab`, so its only use is in downstream application code.

The mechanism is superseded in practice by the menu's `openOnStart` attribute
(`frameindex.js:722-729`, `checkStartPage`) and by the per-user favorite "Set as start
page" (`frameindex.py:207` -> `frameindex.js:636-655` -> `addToFavorite(..., start=True)`).
`indexTab` is the older, page-class-level, all-users variant, and it is silently skipped
whenever any favorite tab is restored.

## Why the existing text was wrong

The docs (`docs/genro/components/components/frameindex.rst:178-180`) described the
pre-2023 behaviour, when the string became the caption of a fake `indexpage` node injected
into the `iframes` bag, and tied it to `index_url`:

```diff
-  data.setItem('indexpage',null,{'fullname':indexTab,pageName:'indexpage',fullpath:'indexpage'});
-  this.setRelativeData("iframes",data);
+  genro.framedIndexManager.selectIframePage({file:indexTab,url: indexTab});
```

This is the diff from `ed10450840f3` ("frameindex indexTab ifxed", 2023-11-16), which
switched `indexTab` from being a display caption to being the URL of a real page to open.
The docs were never updated after that change, so they described a mechanism (fake caption
tab, tied to `index_url`) that no longer exists.

## Change

Rewrote the `indexTab` bullet in `docs/genro/components/components/frameindex.rst` to
describe the current mechanism: the string is the path/URL of a webpage opened
automatically as an iframe tab and selected when the FrameIndex starts with no restored
tabs and no external windows; it is not the index page and is unrelated to `index_url`;
an absolute `/package/page` form is preferred; it is ignored whenever a favorite or start
page is restored; new code should prefer the `openOnStart` menu attribute instead.

## Follow-up

`frameindex.py:31` also defines `index_page = False`, which is never read anywhere in the
repository (dead code, distinct from `index_url`). Left untouched as out of scope for this
documentation fix.
