### PR TITLE
fix(web): make directory creation idempotent to close the makedirs race

### DIFF
--- a/gnrpy/gnr/web/_gnrbasewebpage.py
+++ b/gnrpy/gnr/web/_gnrbasewebpage.py
@@ -185,8 +185,7 @@ class GnrBaseWebPage(GnrObject):
         :param page_id: TODO"""
         page_id = page_id or self.page_id
         folder = os.path.join(self.connectionFolder, page_id)
-        if not os.path.isdir(folder):
-            os.makedirs(folder)
+        os.makedirs(folder, exist_ok=True)
         return os.path.join(folder, docname)
         
     def freezeSelection(self, selection, name,**kwargs):
@@ -811,8 +810,7 @@ class GnrBaseWebPage(GnrObject):
         if args:
             path = os.path.join(self.siteFolder, 'data', *args)
             dirname = os.path.dirname(path)
-            if not os.path.exists(dirname):
-                os.makedirs(dirname)
+            os.makedirs(dirname, exist_ok=True)
             outfile = open(path, 'w')
             return outfile
             
@@ -821,8 +819,7 @@ class GnrBaseWebPage(GnrObject):
         if args:
             path = os.path.join(self.siteFolder, 'pages', 'static', *args)
             dirname = os.path.dirname(path)
-            if not os.path.exists(dirname):
-                os.makedirs(dirname)
+            os.makedirs(dirname, exist_ok=True)
             outfile = open(path, 'w')
             return outfile
             
@@ -830,14 +827,12 @@ class GnrBaseWebPage(GnrObject):
         """TODO"""
         if args:
             path = os.path.join(self.siteFolder, 'data', *args)
-            if not os.path.exists(path):
-                os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
             return path
             
     def createFolderInStatic(self, *args):
         """TODO"""
         if args:
             path = os.path.join(self.siteFolder, 'pages', 'static', *args)
-            if not os.path.exists(path):
-                os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
             return path

--- a/gnrpy/gnr/web/daemon/handler.py
+++ b/gnrpy/gnr/web/daemon/handler.py
@@ -57,8 +57,7 @@ def getFullOptions(options=None):
     if env_options.get('sockets'):
         if env_options['sockets'].lower() in ('t','true','y') :
             env_options['sockets']=os.path.join(gnr_path,'sockets')
-        if not os.path.isdir(env_options['sockets']):
-            os.makedirs(env_options['sockets'])
+        os.makedirs(env_options['sockets'], exist_ok=True)
         env_options['socket']=env_options.get('socket') or os.path.join(env_options['sockets'],'gnrdaemon.sock')
     assert env_options,"Missing gnrdaemon configuration."
     for k,v in list(options.items()):

--- a/gnrpy/gnr/web/daemon/siteregister_client.py
+++ b/gnrpy/gnr/web/daemon/siteregister_client.py
@@ -152,8 +152,7 @@ class SiteRegisterClient(object):
         if 'sockets' in daemonconfig:
             if daemonconfig['sockets'].lower() in ('t', 'true', 'y'):
                 daemonconfig['sockets'] = os.path.join(gnrConfigPath(), 'sockets')
-            if not os.path.isdir(daemonconfig['sockets']):
-                os.makedirs(daemonconfig['sockets'])
+            os.makedirs(daemonconfig['sockets'], exist_ok=True)
             daemonconfig['socket'] = daemonconfig.get('socket') or os.path.join(daemonconfig['sockets'], 'gnrdaemon.sock')
         if daemonconfig.get('socket'):
             daemon_uri = 'PYRO:GnrDaemon@./u:%(socket)s' % daemonconfig

--- a/gnrpy/gnr/web/gnrasync.py
+++ b/gnrpy/gnr/web/gnrasync.py
@@ -958,8 +958,7 @@ class GnrBaseAsyncServer:
                 os.path.basename(self.gnrsite.instance_path),
                 'gnr_sock',
             )
-        if not os.path.exists(sockets_dir):
-            os.makedirs(sockets_dir)
+        os.makedirs(sockets_dir, exist_ok=True)
         return sockets_dir
 
     async def _run(self):

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -2890,16 +2890,14 @@ class GnrWebPage(GnrBaseWebPage):
         """TODO"""
         filepath = os.path.join(self.connectionFolder, self.page_id, *args)
         folder = os.path.dirname(filepath)
-        if not os.path.isdir(folder):
-            os.makedirs(folder)
+        os.makedirs(folder, exist_ok=True)
         return filepath
         
     def userDocument(self, *args):
         """TODO"""
         filepath = os.path.join(self.userFolder, *args)
         folder = os.path.dirname(filepath)
-        if not os.path.isdir(folder):
-            os.makedirs(folder)
+        os.makedirs(folder, exist_ok=True)
         return filepath
         
     def connectionDocumentUrl(self, *args, **kwargs):

--- a/gnrpy/gnr/web/gnrwebpage_proxy/developer.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/developer.py
@@ -175,8 +175,7 @@ class GnrWebDeveloper(GnrBaseProxy):
         moverpath = self.page.site.getStaticPath('user:temp','mover')
         indexpath = os.path.join(moverpath,'index.xml')
         indexbag = Bag()
-        if not os.path.isdir(moverpath):
-            os.makedirs(moverpath)
+        os.makedirs(moverpath, exist_ok=True)
         for movercode,table,pkeys,reftable,objtype in data.digest('#k,#a.table,#a.pkeys,#a.reftable,#a.objtype'):
             pkeys = list(pkeys.keys())
             databag = self.db.table(table).toXml(pkeys=pkeys,rowcaption=True,

--- a/gnrpy/gnr/web/gnrwebpage_proxy/jstools.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/jstools.py
@@ -36,9 +36,8 @@ class GnrWebJSTools(GnrBaseProxy):
             rebuild = False
         if rebuild:
             path = site.getStatic('site').path('_static', '_jslib')
-            if not os.path.exists(path):
-                os.makedirs(path)
-                
+            os.makedirs(path, exist_ok=True)
+
             outfile_handle, outfile_path = tempfile.mkstemp(prefix='gnrcompress',suffix='.js')
             with os.fdopen(outfile_handle, "w") as cpf:
                 cpf.write('// %s\n' % ts)

--- a/gnrpy/gnr/web/gnrwebpage_proxy/utils.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/utils.py
@@ -164,8 +164,7 @@ class GnrWebUtils(GnrBaseProxy):
         result = Bag()
         path = os.path.normpath(path)
         path = path.rstrip('/')
-        if not os.path.exists(path):
-            os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
         result[os.path.basename(path)] = DirectoryResolver(path, include=include, exclude=exclude, dropext=True,
                                                            ext=ext)
         return result

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -826,8 +826,7 @@ class GnrWsgiSite(object):
             else:
                 autocreate_args = args
             dest_dir = static_handler.path(*autocreate_args)
-            if not os.path.exists(dest_dir):
-                os.makedirs(dest_dir)
+            os.makedirs(dest_dir, exist_ok=True)
         dest_path = static_handler.path(*args)
         return dest_path
 

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrwebsockethandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrwebsockethandler.py
@@ -76,8 +76,7 @@ class WsgiWebSocketHandler(WebSocketHandler):
         sockets_dir = os.path.join(site.site_path, 'sockets')
         if len(sockets_dir)>90:
             sockets_dir = os.path.join('/tmp', os.path.basename(site.instance_path), 'gnr_sock')
-        if not os.path.exists(sockets_dir):
-            os.makedirs(sockets_dir)
+        os.makedirs(sockets_dir, exist_ok=True)
         self.socket_path = os.path.join(sockets_dir, 'async.sock')
         self.proxyurl='/wsproxy'
     

--- a/gnrpy/tests/web/_gnrbasewebpage_test.py
+++ b/gnrpy/tests/web/_gnrbasewebpage_test.py
@@ -1,0 +1,74 @@
+"""Regression tests for the makedirs race in ``pageLocalDocument`` (#1033).
+
+``pageLocalDocument`` used to check ``os.path.isdir(folder)`` and then call
+``os.makedirs(folder)``: a classic check-then-act race. Two concurrent
+requests belonging to the same page could both pass the ``isdir`` check and
+the second one would blow up with ``FileExistsError``. The fix makes the
+call idempotent with ``os.makedirs(folder, exist_ok=True)``.
+
+``pageLocalDocument`` only touches ``self.connectionFolder`` and
+``self.page_id``/``page_id``, so it is exercised unbound against a minimal
+fake, following the precedent in ``gnrwsgisite_folder_cleanup_test.py``.
+"""
+
+import os
+import threading
+
+from gnr.web._gnrbasewebpage import GnrBaseWebPage
+
+
+class _FakePage:
+    """Bag of attributes accessed by ``pageLocalDocument``. The method is
+    invoked unbound: ``GnrBaseWebPage.pageLocalDocument(_FakePage(...), ...)``."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+def test_pagelocaldocument_creates_folder(tmp_path):
+    """First call creates the per-page folder and returns the doc path."""
+    page = _FakePage(connectionFolder=str(tmp_path), page_id='page1')
+
+    result = GnrBaseWebPage.pageLocalDocument(page, 'selection.xml')
+
+    assert result == os.path.join(str(tmp_path), 'page1', 'selection.xml')
+    assert os.path.isdir(os.path.join(str(tmp_path), 'page1'))
+
+
+def test_pagelocaldocument_repeated_call_does_not_raise(tmp_path):
+    """Calling it twice for the same page (folder already exists) must not
+    raise FileExistsError: this is the exact sequence the TOCTOU bug hit."""
+    page = _FakePage(connectionFolder=str(tmp_path), page_id='page1')
+
+    first = GnrBaseWebPage.pageLocalDocument(page, 'selection.xml')
+    second = GnrBaseWebPage.pageLocalDocument(page, 'selection.xml')
+
+    assert first == second
+    assert os.path.isdir(os.path.join(str(tmp_path), 'page1'))
+
+
+def test_pagelocaldocument_concurrent_calls_do_not_raise(tmp_path):
+    """Two threads racing to create the same page folder must not raise:
+    this reproduces the production FileExistsError from concurrent
+    requests hitting checkFreezedSelection -> unfreezeSelection ->
+    pageLocalDocument for the same page."""
+    page = _FakePage(connectionFolder=str(tmp_path), page_id='page1')
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def _call():
+        try:
+            barrier.wait(timeout=5)
+            GnrBaseWebPage.pageLocalDocument(page, 'selection.xml')
+        except Exception as exc:  # noqa: BLE001 - we want to see any failure
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_call) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert errors == [], f"pageLocalDocument raised under concurrency: {errors}"
+    assert os.path.isdir(os.path.join(str(tmp_path), 'page1'))


### PR DESCRIPTION
## Problem

Intermittent HTTP 500 while loading a table handler page. Observed 4 times over two months in production, affecting 3 different users, always on the page with the largest grid (the one using frozen selections):

```
File "gnr/web/gnrwebpage_proxy/apphandler/misc.py", line 649, in checkFreezedSelection
  selection = self.page.unfreezeSelection(dbtable=table, name=selectionName)
File "gnr/web/_gnrbasewebpage.py", line 214, in unfreezeSelection
  selection = self.db.unfreezeSelection(self.pageLocalDocument(name, page_id=page_id))
File "gnr/web/_gnrbasewebpage.py", line 189, in pageLocalDocument
  os.makedirs(folder)
FileExistsError: [Errno 17] File exists: '.../site/data/_connections/<conn_id>/<page_id>'
```

## Root cause

`pageLocalDocument` in `gnrpy/gnr/web/_gnrbasewebpage.py` is a check-then-act race:

```python
folder = os.path.join(self.connectionFolder, page_id)
if not os.path.isdir(folder):
    os.makedirs(folder)
```

Two concurrent requests belonging to the same page can both pass the `isdir` check; the second one fails in `makedirs`. The window is short, which is why it is rare, but it is hit regularly on busy pages and more easily with `liveUpdate` enabled.

## Change

The reported line is one instance of a pattern repeated across `gnr/web/`, so the fix is the pattern, not the single call site. Every occurrence of the guard-then-`makedirs` shape under `gnrpy/gnr/web/` becomes `os.makedirs(path, exist_ok=True)` with the now-redundant guard dropped — 15 sites in 10 files:

| file | sites |
|---|---|
| `_gnrbasewebpage.py` | 5 (incl. the reported one at :189) |
| `gnrwebpage.py` | 2 |
| `gnrwsgisite.py` | 1 |
| `gnrasync.py` | 1 |
| `gnrwsgisite_proxy/gnrwebsockethandler.py` | 1 |
| `gnrwebpage_proxy/jstools.py` | 1 |
| `gnrwebpage_proxy/developer.py` | 1 |
| `gnrwebpage_proxy/utils.py` | 1 |
| `daemon/handler.py` | 1 |
| `daemon/siteregister_client.py` | 1 |

Every guard was read before being removed and confirmed to exist solely to protect its `os.makedirs` call: none had a side effect worth preserving, none relies on `FileExistsError` being raised. No site was left alone within scope.

## Verification

- New regression test `gnrpy/tests/web/_gnrbasewebpage_test.py`: exercises `pageLocalDocument` unbound against a real `tmp_path`, with a two-thread concurrent case. `os.makedirs` is not mocked. The concurrent test reproduces the exact `FileExistsError: [Errno 17]` against the pre-fix code and passes against the fix — both directions confirmed.
- `flake8` (F, E9) on all touched files: zero errors introduced. Pre-existing `F841`/`F811` warnings at shifted line numbers were diffed against the base and confirmed identical.
- `python -m pytest gnrpy/tests/web/ -q`: 143 passed, 57 skipped (pre-existing skips, daemon not available in this environment).
- Full suite via the pre-commit hook: 1922 passed, 67 skipped.

## Follow-up (not in this PR)

The same check-then-act pattern exists outside `gnrpy/gnr/web/`, e.g. under `gnr/lib/` and `gnr/core/`. Left out of scope deliberately to keep this diff reviewable.

Fixes #1033
