### PR TITLE
fix(widgets): keep the SVG data-URI intact when reading the placeholder css variable

### DIFF
--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -5424,7 +5424,7 @@ dojo.declare("gnr.widgets.uploadable", gnr.widgets.baseHtml, {
             crop = objectUpdate({text_align:'center',overflow:'hidden'},crop);
             var innerImage=objectExtract(attr,'src,src_back,placeholder,height,width,edit,upload_maxsize,upload_folder,upload_filename,upload_ext,zoomWindow,format,mask,border,takePicture,nodeId,capture');
             if (innerImage.placeholder===true){
-                innerImage.placeholder = getComputedStyle(document.documentElement).getPropertyValue('--icon-placeholder-img').trim().slice(4, -1).replace(/["']/g, '')
+                innerImage.placeholder = getComputedStyle(document.documentElement).getPropertyValue('--icon-placeholder-img').trim().slice(4, -1).replace(/^["']|["']$/g, '')
             }
             innerImage.cr_width=crop.width;
             innerImage.cr_height=crop.height;


### PR DESCRIPTION
Refs #1000

## Problem

`placeholder=True` on an `uploadable` field in crop mode renders an empty box instead of the grey placeholder graphic.

## Root cause

`gnrjs/gnr_d11/js/genro_widgets.js:5427`, in `gnr.widgets.uploadable.onBuilding` (crop branch):

```js
innerImage.placeholder = getComputedStyle(document.documentElement).getPropertyValue('--icon-placeholder-img').trim().slice(4, -1).replace(/["']/g, '')
```

The variable is defined once, `gnrjs/gnr_d11/css/gnrbase_css/01_gnr_variables.css:478`, as `url("data:image/svg+xml,%3Csvg xmlns='…' viewBox='0 0 120 90'…")` — double quotes outside, literal single quotes inside for every SVG attribute. `.slice(4, -1)` correctly strips `url(`…`)`, but `.replace(/["']/g, '')` then strips the boundary double quotes **and every inner single quote**, producing unquoted XML attributes. The browser cannot decode that as SVG, so nothing renders.

Before/after on the real CSS value:

```
CURRENT: data:image/svg+xml,%3Csvg xmlns=http://www.w3.org/2000/svg viewBox=0 0 120 90%3E…
FIXED  : data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 90'%3E…
```

The rest of the path is transparent to this string once it's assembled: `img` is a plain `htmlNS` tag (`gnrpy/gnr/web/gnrwebstruct/dojo11.py:38`), `creating` (`genro_widgets.js:5716-5722`) assigns `attributes.src` after `decodeUrl`, `currentFromDatasource` (`gnrdomsource.js:585`) returns the string untouched (`isPointerPath`, `gnrdomsource.js:634`, only reacts to a leading `^`/`=`), and `setSrc` (`genro_widgets.js:5884`) short-circuits on `data:`. None of them touch quoting.

Regression introduced by 7683c9123 ("feat(#671): style modernization"), which replaced a plain `.png` placeholder path with this CSS-var extraction.

## Change

Boundary-only strip at line 5427:

```diff
-innerImage.placeholder = getComputedStyle(document.documentElement).getPropertyValue('--icon-placeholder-img').trim().slice(4, -1).replace(/["']/g, '')
+innerImage.placeholder = getComputedStyle(document.documentElement).getPropertyValue('--icon-placeholder-img').trim().slice(4, -1).replace(/^["']|["']$/g, '')
```

Scope: line 5427 only.

## The twin at line 1122

The identical expression is copy-pasted verbatim at `genro_widgets.js:1122` (`--icon-download-file`, in `gnr.widgets.iframe.initContentHtml`), from the same commit. It is not touched by this PR, and it is a harder fix:

- The stripped URI is injected **unquoted** into a CSS `url(...)` at line 1123, and the data URI contains literal spaces, so even a correct boundary-only strip leaves an invalid CSS url-token. Fixing it needs a second edit at 1123 (quote the `url(...)`, or `%27`-escape the apostrophes instead of stripping them).
- The parent document's `var()` is not reachable there anyway in the general case — `initContentHtml` targets a separate `contentWindow.document` (an iframe), so `getComputedStyle(document.documentElement)` only works when that document inherits the same stylesheet.
- There is no test page exercising this branch: `html/iframe.py` never uses a `src` whose extension falls outside `_default_ext`, so it's currently dead code in practice.

## Scope decision required

How to handle the twin — not settled by this PR:

- **(a)** Fix line 5427 only (this PR as-is).
- **(b)** Fix both 5427 and 1122/1123 — closes both `7683c9123` regressions in one PR, but 1122/1123 needs its own quoting/escaping decision and has no test coverage to verify against.
- **(c)** Extract a shared helper, e.g. `genro.dom.cssUrlValue(varname)` in `genro_dom.js`, used by both call sites — consistent with "fix the shared function," but there is no shared function today, so it turns a bugfix into a small refactor, and 1123 still needs its own escaping fix on top. Precedent for this kind of DOM/CSS helper: `genro.dom.cssRulesToBag` / `cssRulesToText` (`genro_dom.js:722` / `:2015`).

## Verification

**Not verified live.** `node --check` passes on the modified file, and the exact before/after data-URI transformation was reproduced against the real CSS value in a standalone script, matching the description above byte-for-byte. Spinning up a running instance turned out to require creating a new database-backed site (`gnrmksite`/`gnr dev mksite`, wired to a package, backed by the local Postgres) rather than pointing an existing one at this branch, which was more than this verification pass should take on unattended.

Manual steps to verify:

1. Point `static/js/gnr_11` at this branch's checkout (e.g. via an isolated `GENRO_GNRFOLDER` config copy, or just building/serving from this branch directly).
2. Open `/test/html/img` (`gnrcomponents/testhandler:TestHandlerFull`, from `projects/gnrcore/packages/test/webpages/html/img.py`).
3. `test_1_uploadImage`, `test_2_uploadCamera`, `test_3_uploadCameraWithCapture`, `test_5_dataUrl` are crop-mode + `placeholder=True`: today a blank box, after this fix the grey placeholder SVG should render.
4. `test_4_uploadImageAndRemove` uses `placeholder='<url>'` (string form) as a non-regression check — unaffected by this change, should look the same before and after.

## Follow-up (not part of this fix)

`placeholder=True` **without** `crop_*` was never supported — the `===true` → path conversion only ever existed in the crop branch, so outside of it `creating` (`genro_widgets.js:5720`) sets `src="true"` literally. This predates `7683c9123` and is unrelated to this regression.
