### PR TITLE
fix(app): honour the instanceconfig package path in the dependency check

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -1054,10 +1054,7 @@ class GnrApp(object):
         if pkgid in self.packages:
             return 
         attrs = pkgattrs or {}
-        if not attrs.get('path'):
-            attrs['path'] = self.pkg_name_to_path(pkgid,project)
-        if not os.path.isabs(attrs['path']):
-            attrs['path'] = self.realPath(attrs['path'])
+        attrs['path'] = self.pkg_path_from_attrs(pkgid, attrs, project=project)
         apppkg = GnrPackage(pkgid, self, **attrs)
         apppkg.content = pkgcontent or Bag()
         readOnlyAttrs = {'readOnly':True} if attrs.get('readOnly') else dict()
@@ -1076,8 +1073,9 @@ class GnrApp(object):
             else:
                 project = None
                 
-            packageFolder = self.pkg_name_to_path(package, project)
-            requirements_file = os.path.join(packageFolder, package, "requirements.txt")
+            packageFolder = self.pkg_path_from_attrs(package, pkgattrs, project=project)
+            filename = (pkgattrs or {}).get('filename') or package
+            requirements_file = os.path.join(packageFolder, filename, "requirements.txt")
             if os.path.isfile(requirements_file):
                 with open(requirements_file) as fp:
                     for line in fp:
@@ -1238,7 +1236,22 @@ class GnrApp(object):
         else:
             raise Exception(
                     'Error: package %s not found' % pkgid)
-        
+
+    def pkg_path_from_attrs(self, pkgid, pkgattrs=None, project=None):
+        """Return the folder containing the :ref:`package <packages>` folder.
+
+        The instanceconfig can declare an explicit ``path`` attribute, pointing
+        anywhere on the filesystem: only when it is missing the package is
+        looked up in the known packages roots.
+
+        :param pkgid: the id of the :ref:`package <packages>`
+        :param pkgattrs: the instanceconfig attributes of the package
+        :param project: the project owning the package, if any"""
+        path = (pkgattrs or {}).get('path') or self.pkg_name_to_path(pkgid, project)
+        if not os.path.isabs(path):
+            path = self.realPath(path)
+        return path
+
     def project_path(self, project):
         """TODO
         

--- a/gnrpy/tests/app/test_package_path_attr.py
+++ b/gnrpy/tests/app/test_package_path_attr.py
@@ -1,0 +1,114 @@
+"""Tests for packages declared with an explicit path in the instanceconfig.
+
+InstanceMaker writes a path attribute for every package passed as a
+(package, path) pair. Such a package can live anywhere on the filesystem,
+outside the project packages folder and outside every packages root declared
+in environment.xml, so the attribute is the only way to resolve it.
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from gnr.app.gnrapp import GnrApp
+from gnr.core.gnrbag import Bag
+from gnr.dev.makers.instance import InstanceMaker
+
+from core.common import BaseGnrTest
+
+EXTERNAL_PACKAGE_MAIN = """from gnr.app.gnrdbo import GnrDboTable, GnrDboPackage
+
+
+class Package(GnrDboPackage):
+    def config_attributes(self):
+        return dict(comment='external package', sqlschema='extpkg', sqlprefix=True,
+                    name_short='Ext', name_long='External', name_full='External package')
+
+    def config_db(self, pkg):
+        pass
+
+
+class Table(GnrDboTable):
+    pass
+"""
+
+# a distribution genropy itself depends on: the dependency check must find it
+# through the declared path, and must not report it as missing
+EXTERNAL_PACKAGE_REQUIREMENTS = "packaging\n"
+
+
+class TestExternalPackagePath(BaseGnrTest):
+    """A package reachable only through the path attribute of its instanceconfig"""
+
+    package_id = 'extpkg'
+    abs_instance_name = 'extpkg_abs'
+    rel_instance_name = 'extpkg_rel'
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.tempdir = tempfile.mkdtemp()
+        cls.external_packages_path = os.path.join(cls.tempdir, 'external_packages')
+        package_path = os.path.join(cls.external_packages_path, cls.package_id)
+        os.makedirs(package_path)
+        with open(os.path.join(package_path, 'main.py'), 'w', encoding='utf-8') as fp:
+            fp.write(EXTERNAL_PACKAGE_MAIN)
+        with open(os.path.join(package_path, 'requirements.txt'), 'w', encoding='utf-8') as fp:
+            fp.write(EXTERNAL_PACKAGE_REQUIREMENTS)
+        cls.makeInstance(cls.abs_instance_name, cls.external_packages_path)
+        rel_config_path = os.path.join(cls.test_instance_path, cls.rel_instance_name, 'config')
+        cls.makeInstance(cls.rel_instance_name,
+                         os.path.relpath(cls.external_packages_path, rel_config_path))
+
+    @classmethod
+    def teardown_class(cls):
+        super().teardown_class()
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    @classmethod
+    def makeInstance(cls, instance_name, packages_path):
+        """Create an instance declaring the external package at packages_path"""
+        InstanceMaker(instance_name, base_path=cls.test_instance_path,
+                      packages=[(cls.package_id, packages_path)],
+                      authentication=False).do()
+
+    def loadApp(self, instance_name):
+        return GnrApp(instance_name, db_attrs=dict(
+            implementation='sqlite',
+            dbname=os.path.join(self.tempdir, instance_name)))
+
+    def expectedPackageFolder(self):
+        return os.path.realpath(os.path.join(self.external_packages_path, self.package_id))
+
+    def test_instancemaker_declares_path(self):
+        """InstanceMaker writes the path attribute the instance depends on"""
+        config = Bag(os.path.join(self.test_instance_path, self.abs_instance_name,
+                                  'config', 'instanceconfig.xml'))
+        assert config['packages.%s?path' % self.package_id] == self.external_packages_path
+
+    def test_package_is_not_in_packages_roots(self):
+        """Without the declared path there would be no way to find the package"""
+        app = self.loadApp(self.abs_instance_name)
+        with pytest.raises(Exception, match='not found'):
+            app.pkg_name_to_path(self.package_id)
+
+    def test_app_boots_with_absolute_path(self):
+        app = self.loadApp(self.abs_instance_name)
+        assert self.package_id in app.packages
+        assert os.path.realpath(
+            app.packages[self.package_id].packageFolder) == self.expectedPackageFolder()
+
+    def test_app_boots_with_relative_path(self):
+        """A relative path is resolved against the instance folder"""
+        app = self.loadApp(self.rel_instance_name)
+        assert os.path.realpath(
+            app.packages[self.package_id].packageFolder) == self.expectedPackageFolder()
+
+    def test_dependencies_found_through_declared_path(self):
+        """The requirements of the external package are collected at boot"""
+        app = self.loadApp(self.abs_instance_name)
+        assert app.instance_packages_dependencies['packaging'] == [self.package_id]
+        missing, wrong = app.check_package_missing_dependencies()
+        assert missing == []


### PR DESCRIPTION
## Problem

`GnrApp.check_package_dependencies()` resolved every package through `pkg_name_to_path()`, ignoring the `path` attribute that `addPackage()` honours.

`pkg_name_to_path()` only knows the project packages folder and the `<packages>` roots of `environment.xml`: for a package declared with an explicit `path` it raises `Exception('Error: package %s not found')`. Since the check runs before any package is loaded, such an instance dies at boot.

`InstanceMaker` writes exactly those attributes for every package passed as a `(package, path)` pair, so any instance created that way was unbootable. No instance under `projects/` uses `path=`, which is why nothing failed in CI.

## Fix

Both call sites now share `pkg_path_from_attrs()`:

- the declared `path` wins, `pkg_name_to_path()` is the fallback when it is absent;
- relative paths are resolved against the instance folder through `realPath()`, as `addPackage()` already did.

The requirements lookup also honours the `filename` attribute, the same way `GnrPackage` builds its package folder from `path` + `filename`.

## Tests

`gnrpy/tests/app/test_package_path_attr.py`, on `BaseGnrTest`: a minimal package (`main.py` + `requirements.txt`) is created in a temporary folder outside every packages root, and two instances are built with `InstanceMaker`, one declaring an absolute path and one a relative path. The tests check that the instanceconfig carries the `path` attribute, that the package is indeed unreachable via `pkg_name_to_path()`, that the app boots with `packageFolder` pointing at the external folder in both cases, and that the external requirements are collected without being reported as missing.

Four of the five tests fail on `develop` with `Exception: Error: package extpkg not found`.

Full suite: 1924 passed, 67 skipped.

## Context

Follow-up 1 of #1058 (issue #1006), deliberately left out of that PR.