### PR TITLE
fix(#1062): chat with dotted usernames — escape Bag labels, real name in the user attribute

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -2319,12 +2319,13 @@ class GnrWebPage(GnrBaseWebPage):
         path = 'gnr.chat.msg.%s' % roomId
         priority = priority or 'H'
         if not users:
-            # the label travels dot-escaped (Bag labels split on dots);
+            # the label travels escaped ([.@] -> _, the connected_users_bag rule:
+            # dots split Bag paths, @ comes with email-style usernames);
             # the real username rides in the node's `user` attribute
             users = Bag()
             if from_user!='SYSTEM':
-                users.setItem(from_user.replace('.','_'),None,user_name=from_user,user=from_user)
-            users.setItem(user.replace('.','_'),None,user_name=user,user=user)
+                users.setItem(from_user.replace('.','_').replace('@','_'),None,user_name=from_user,user=from_user)
+            users.setItem(user.replace('.','_').replace('@','_'),None,user_name=user,user=user)
         ts = self.toText(datetime.datetime.now(), format='HH:mm:ss')
         with self.userStore(user) as store:
             if disconnect and (user == from_user):

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -2319,10 +2319,12 @@ class GnrWebPage(GnrBaseWebPage):
         path = 'gnr.chat.msg.%s' % roomId
         priority = priority or 'H'
         if not users:
+            # the label travels dot-escaped (Bag labels split on dots);
+            # the real username rides in the node's `user` attribute
             users = Bag()
             if from_user!='SYSTEM':
-                users.setItem(from_user,None,user_name=from_user,user=from_user)
-            users.setItem(user,None,user_name=user,user=user)
+                users.setItem(from_user.replace('.','_'),None,user_name=from_user,user=from_user)
+            users.setItem(user.replace('.','_'),None,user_name=user,user=user)
         ts = self.toText(datetime.datetime.now(), format='HH:mm:ss')
         with self.userStore(user) as store:
             if disconnect and (user == from_user):

--- a/resources/common/gnrcomponents/chat_component/chat_component.js
+++ b/resources/common/gnrcomponents/chat_component/chat_component.js
@@ -36,9 +36,10 @@ ct_chat_utils.fill_title = function(roombag) {
     roombag.setItem('title', title);
 };
 ct_chat_utils.escape_user = function(user){
-    // usernames may contain dots, which Bag labels read as path separators:
-    // the label travels escaped, the real name rides in the `user` attribute
-    return user.replace(/\./g, '_');
+    // usernames may contain dots (Bag path separators) or @ (email-style):
+    // the label travels escaped — the same [.@] -> _ rule connected_users_bag
+    // uses — and the real name rides in the `user` attribute
+    return user.replace(/[.@]/g, '_');
 };
 ct_chat_utils.key_from_users = function(users){
     var user = ct_chat_utils.escape_user(genro._('gnr.avatar.user'));

--- a/resources/common/gnrcomponents/chat_component/chat_component.js
+++ b/resources/common/gnrcomponents/chat_component/chat_component.js
@@ -35,8 +35,13 @@ ct_chat_utils.fill_title = function(roombag) {
     }
     roombag.setItem('title', title);
 };
+ct_chat_utils.escape_user = function(user){
+    // usernames may contain dots, which Bag labels read as path separators:
+    // the label travels escaped, the real name rides in the `user` attribute
+    return user.replace(/\./g, '_');
+};
 ct_chat_utils.key_from_users = function(users){
-    var user = genro._('gnr.avatar.user');
+    var user = ct_chat_utils.escape_user(genro._('gnr.avatar.user'));
     var user_list = users.digest('#k').sort();
     var idx = dojo.indexOf(user_list,user);
     if(idx>=0){
@@ -51,7 +56,7 @@ ct_chat_utils.open_chat = function(roomId, users,roomtitle) {
     var user_name = genro._('gnr.avatar.user_name') || user;
     var roomsNode = genro.nodeById('ct_chat_rooms');
     var user_name_list = users.digest('#a.user_name').sort();
-    users.setItem(user, null, {user_name:user_name,user:user});
+    users.setItem(ct_chat_utils.escape_user(user), null, {user_name:user_name,user:user});
     var roompath = 'gnr.chat.rooms.' + roomId;
     var roombag = new gnr.GnrBag({'users':users,user_name:user_name,user:user,roomtitle:roomtitle});
     ct_chat_utils.fill_title(roombag);
@@ -116,7 +121,7 @@ ct_chat_utils.read_msg = function(msgbag) {
     genro.fireEvent('gnr.chat.calc_unread');
     users = roombag.getItem('users');
     if (disconnect) {
-        users.popNode(from_user);
+        users.popNode(ct_chat_utils.escape_user(from_user));
     }
     ct_chat_utils.fill_title(roombag);
     roomNode.updAttributes({'user_room_key':this.key_from_users(users)});
@@ -176,8 +181,8 @@ ct_chat_utils.prepare_usersbag = function(userstring){
     var n;
     var users = new gnr.GnrBag();
     dojo.forEach(userlist,function(username){
-        n = connectedUsers.getNode(username);
-        users.setItem(n.attr.user,null,{user_name:n.attr.user_name,user:n.attr.user});
+        n = connectedUsers.getNode(ct_chat_utils.escape_user(username));
+        users.setItem(ct_chat_utils.escape_user(n.attr.user),null,{user_name:n.attr.user_name,user:n.attr.user});
     });
     return users;
 };

--- a/resources/common/gnrcomponents/chat_component/chat_component.py
+++ b/resources/common/gnrcomponents/chat_component/chat_component.py
@@ -142,7 +142,7 @@ class ChatComponent(BaseComponent):
                             var rows = grid.getSelectedNodes();
                             var users =new gnr.GnrBag();
                             dojo.forEach(rows,function(n){
-                                users.setItem(n.attr.user,null,{user_name:n.attr.user_name,user:n.attr.user});
+                                users.setItem(ct_chat_utils.escape_user(n.attr.user),null,{user_name:n.attr.user_name,user:n.attr.user});
                             });
                             var roomId= 'cr_'+new Date().getTime();
                             ct_chat_utils.open_chat(roomId,users);
@@ -160,7 +160,9 @@ class ChatComponent(BaseComponent):
             msg = '<i>User %s left the room</i>' % self.user
         path = 'gnr.chat.msg.%s' % roomId
         for userNode in users:
-            user = userNode.label
+            # the label travels dot-escaped (Bag labels split on dots);
+            # the real username rides in the node's `user` attribute
+            user = userNode.attr.get('user') or userNode.label
             with self.userStore(user) as store:
                 if disconnect and (user == self.user):
                     store.drop_datachanges(path)


### PR DESCRIPTION
## What

Usernames containing dots (`name.surname`) broke the chat: Bag labels split on dots in both the Python `Bag` and the JS `GnrBag`, so the room's `users` bag nested (`amelia.martin` → `amelia` → `martin`), `ct_send_message` iterated the truncated top-level labels and wrote the messages to the stores of non-existent users, and the room title digested the attribute-less intermediate nodes (showing `,`). The `room_alert` still fired through the loose `user:` filter match, masking the lost messages behind a working notification sound.

## How

The convention `connected_users_bag` already uses, applied consistently:

- **the label travels dot-escaped** — `ct_chat_utils.escape_user` (JS) at every point a username becomes a Bag label (`open_chat`, `prepare_usersbag`, the connected-users grid controller, `key_from_users`, the disconnect `popNode`); `replace('.','_')` in `chatMessageToUser` server-side;
- **the real username always rides in the node's `user` attribute** (it already did);
- **`ct_send_message` reads the attribute, not the label**: `user = userNode.attr.get('user') or userNode.label` — the fallback keeps old callers passing flat undotted bags working.

## Verification

Exercised live with two dotted-username users (`amelia.martin`, `alexander.king`) on the daemonless single: sender echo, recipient delivery and room titles all correct, in both directions, wire captures checked (`change_fired`, single leaf per write).

Issue #1062 asks the broader question — whether other subsystems key Bags by username; this PR fixes the chat surface (the confirmed breakage) and leaves the audit open.

Ref #1062