### PR TITLE
feat(#1065): experimental per-page_id page class cache

### DIFF
--- a/gnrpy/gnr/web/gnrhtmlpage.py
+++ b/gnrpy/gnr/web/gnrhtmlpage.py
@@ -137,7 +137,7 @@ class GnrHtmlPage(GnrWebPage):
 
     def setCssRequires(self):
         css_import_statements_list=[]
-        css_requires = getattr(self, 'css_requires', [])
+        css_requires = list(getattr(self, 'css_requires', None) or [])
         css_requires.extend([k.split('.')[0] for k in list(self.envelope_css_requires.keys())])
         for css_require in css_requires:
              urls =self.getResourceExternalUriList(css_require,'css') or []
@@ -148,7 +148,7 @@ class GnrHtmlPage(GnrWebPage):
             self.builder.head.style(import_statements + ';\n', type="text/css")
 
     def setJsRequires(self):
-        js_requires = getattr(self, 'js_requires', [])
+        js_requires = list(getattr(self, 'js_requires', None) or [])
         js_requires.extend([k.split('.')[0] for k in list(self.envelope_js_requires.keys())])
         for js_require in js_requires:
              urls =self.getResourceExternalUriList(js_require,'js',add_mtime=True) or []

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -208,6 +208,13 @@ class GnrWebPage(GnrBaseWebPage):
         self.dojo_version = request_kwargs.pop('dojo_version', None) or getattr(self, 'dojo_version', None)
         self.envelope_js_requires= {}
         self.envelope_css_requires= {}
+        # ``css_requires``/``js_requires`` live on the page class, and both the
+        # runtime component mixins (BaseComponent.__onmixin__) and the root
+        # render append to them. Shadowing the class lists with per-instance
+        # copies keeps those appends inside the request, as they were when
+        # every request built its own class.
+        self.css_requires = list(getattr(self, 'css_requires', None) or [])
+        self.js_requires = list(getattr(self, 'js_requires', None) or [])
         self._avoid_module_cache = _avoid_module_cache
         self.debug_sql = boolean(request_kwargs.pop('debug_sql', None))
         debug_py = request_kwargs.pop('debug_py', None)
@@ -622,6 +629,7 @@ class GnrWebPage(GnrBaseWebPage):
         self._onEnd()
         if getattr(self,'_closed',False):
             self.site.register.drop_page(self.page_id, cascade=False)
+            self.site.resource_loader.drop_page_class_cache(self.page_id)
         return result
     
 

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -1426,6 +1426,7 @@ class GnrWsgiSite(object):
     def onClosedPage(self, page_id=None, **kwargs):
         "Drops page when closing"
         self.register.drop_page(page_id)
+        self.resource_loader.drop_page_class_cache(page_id)
 
     def cleanup(self):
         """clean up"""

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
@@ -83,6 +83,12 @@ class ResourceLoader(object):
                 self._page_class_cache.move_to_end(cache_key)
             return page_class
 
+    def page_class_cache_entries(self):
+        """A snapshot of the cache: (page_id, module_path, class_name) per entry."""
+        with self._page_class_cache_lock:
+            return [(page_id, module_path, page_class.__name__)
+                    for (page_id, module_path), page_class in self._page_class_cache.items()]
+        
     def store_page_class_cache(self, cache_key, page_class):
         """Deposit a freshly built class under its ``(page_id, module_path)``, LRU-bounded."""
         with self._page_class_cache_lock:

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
@@ -26,12 +26,16 @@ from gnr.core.gnrclasses import GnrMixinError,GnrMixinNotFound
 from gnr.core.gnrlang import uniquify
 from gnr.web import logger
 
-# Experimental per-page_id page-class cache (sys preference
+# Experimental page-class cache (sys preference
 # ``experimental.page_class_cache``): a page's class is a function of values
 # fixed at the page's birth (module, main package, plugin/custom mixins), so
-# the first build can serve every later request of the same page_id. The LRU
-# ceiling bounds memory without wiring into the page lifecycle; the preference
-# is re-read at most every PAGE_CLASS_CACHE_FLAG_TTL seconds because a
+# the first build can serve every later request of the same page. Entries are
+# keyed by ``(page_id, module_path)``: a page_id is validated against the
+# connection, never against the url it is posted to, so the module path keeps
+# a request that names another page's page_id from reading - or, worse, from
+# depositing - a class built for a different url. The cache is dropped on
+# page close and LRU-bounded for whatever escapes that; the preference is
+# re-read at most every PAGE_CLASS_CACHE_FLAG_TTL seconds because a
 # getPreference call deepcopies the whole preference bag.
 PAGE_CLASS_CACHE_MAXSIZE = 2000
 PAGE_CLASS_CACHE_FLAG_TTL = 10
@@ -53,29 +57,50 @@ class ResourceLoader(object):
         self._page_class_cache_flag = (False, 0.0)
 
     def page_class_cache_enabled(self):
-        """The experimental flag, read through a small TTL (kill switch stays live)."""
+        """The experimental flag, read through a small TTL (kill switch stays live).
+
+        ``getPreference`` resolves per dbstore: on a multidb instance the value
+        that holds for the next TTL is the one read by whichever store refreshed
+        it. That is fine for a kill switch - it is not a per-store setting.
+        Turning the flag off also drops what is already cached, so the switch
+        frees the classes instead of merely stopping new ones.
+        """
         value, read_ts = self._page_class_cache_flag
         now = time.time()
         if now - read_ts > PAGE_CLASS_CACHE_FLAG_TTL:
-            value = bool(self.site.getPreference('experimental.page_class_cache', pkg='sys'))
+            new_value = bool(self.site.getPreference('experimental.page_class_cache', pkg='sys'))
+            if value and not new_value:
+                self.clear_page_class_cache()
+            value = new_value
             self._page_class_cache_flag = (value, now)
         return value
 
-    def load_class_by_page_id(self, page_id):
+    def load_page_class_cache(self, cache_key):
         """The cached class of a live page, or None on a miss."""
         with self._page_class_cache_lock:
-            page_class = self._page_class_cache.get(page_id)
+            page_class = self._page_class_cache.get(cache_key)
             if page_class is not None:
-                self._page_class_cache.move_to_end(page_id)
+                self._page_class_cache.move_to_end(cache_key)
             return page_class
 
-    def store_class_by_page_id(self, page_id, page_class):
-        """Deposit a freshly built class under its page_id, LRU-bounded."""
+    def store_page_class_cache(self, cache_key, page_class):
+        """Deposit a freshly built class under its ``(page_id, module_path)``, LRU-bounded."""
         with self._page_class_cache_lock:
-            self._page_class_cache[page_id] = page_class
-            self._page_class_cache.move_to_end(page_id)
+            self._page_class_cache[cache_key] = page_class
+            self._page_class_cache.move_to_end(cache_key)
             while len(self._page_class_cache) > PAGE_CLASS_CACHE_MAXSIZE:
                 self._page_class_cache.popitem(last=False)
+
+    def drop_page_class_cache(self, page_id):
+        """Forget a closed page: every entry keyed on its page_id, whatever the url."""
+        with self._page_class_cache_lock:
+            for cache_key in [k for k in self._page_class_cache if k[0] == page_id]:
+                self._page_class_cache.pop(cache_key)
+
+    def clear_page_class_cache(self):
+        """Empty the cache (the flag going off, or an explicit reset)."""
+        with self._page_class_cache_lock:
+            self._page_class_cache.clear()
     
     @property
     def gnrapp(self):
@@ -152,21 +177,24 @@ class ResourceLoader(object):
         """Build the page class for a request — or serve the page's cached one.
 
         With the experimental ``page_class_cache`` preference on, a request
-        that names a ``page_id`` reuses the class built at that page's birth.
-        An explicit ``page_factory`` bypasses the cache (``instantiate_page``
-        forces ``GnrSimplePage``: a different base class under the same
-        page_id), and so does ``avoid_module_cache`` (the dev reload).
+        that names a ``page_id`` reuses the class built at that page's birth,
+        provided it asks for the same module: the key is the pair, because a
+        page_id is only ever validated against the connection. An explicit
+        ``page_factory`` bypasses the cache (``instantiate_page`` forces
+        ``GnrSimplePage``: a different base class under the same page_id), and
+        so does ``avoid_module_cache`` (the dev reload).
 
         :param path: TODO
         :param pkg: the :ref:`package <packages>` object"""
+        module_path = os.path.join(basepath,relpath)
         page_id = (request_kwargs or {}).get('page_id')
+        cache_key = (page_id, module_path)
         use_cache = (page_id and page_factory is None and not avoid_module_cache
                      and self.page_class_cache_enabled())
         if use_cache:
-            cached_class = self.load_class_by_page_id(page_id)
+            cached_class = self.load_page_class_cache(cache_key)
             if cached_class is not None:
                 return cached_class
-        module_path = os.path.join(basepath,relpath)
         page_module = gnrImport(module_path, avoidDup=True,silent=False,avoid_module_cache=avoid_module_cache)
         page_factory = page_factory or getattr(page_module, 'page_factory', GnrWebPage)
         custom_class = getattr(page_module, 'GnrCustomWebPage')
@@ -225,7 +253,7 @@ class ResourceLoader(object):
         self.page_class_custom_mixin(page_class, relpath, pkg=mainPkg)
         self.page_factories[module_path] = page_class
         if use_cache:
-            self.store_class_by_page_id(page_id, page_class)
+            self.store_page_class_cache(cache_key, page_class)
         return page_class
         
     def page_class_base_mixin(self, page_class, pkg=None):

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
@@ -10,6 +10,9 @@ import os
 
 import inspect
 import glob
+import time
+from collections import OrderedDict
+from threading import Lock
 
 from gnr.core.gnrbag import Bag, DirectoryResolver
 from gnr.core.gnrlang import gnrImport, classMixin, cloneClass,clonedClassMixin
@@ -23,6 +26,16 @@ from gnr.core.gnrclasses import GnrMixinError,GnrMixinNotFound
 from gnr.core.gnrlang import uniquify
 from gnr.web import logger
 
+# Experimental per-page_id page-class cache (sys preference
+# ``experimental.page_class_cache``): a page's class is a function of values
+# fixed at the page's birth (module, main package, plugin/custom mixins), so
+# the first build can serve every later request of the same page_id. The LRU
+# ceiling bounds memory without wiring into the page lifecycle; the preference
+# is re-read at most every PAGE_CLASS_CACHE_FLAG_TTL seconds because a
+# getPreference call deepcopies the whole preference bag.
+PAGE_CLASS_CACHE_MAXSIZE = 2000
+PAGE_CLASS_CACHE_FLAG_TTL = 10
+
 
 class ResourceLoader(object):
     """Base class to load :ref:`intro_resources`"""
@@ -35,6 +48,34 @@ class ResourceLoader(object):
         self.gnr_static_handler = self.site.getStatic('gnr')
         self.page_factories = {}
         self.default_path = self.site.default_page and self.site.default_page.split('/')
+        self._page_class_cache = OrderedDict()
+        self._page_class_cache_lock = Lock()
+        self._page_class_cache_flag = (False, 0.0)
+
+    def page_class_cache_enabled(self):
+        """The experimental flag, read through a small TTL (kill switch stays live)."""
+        value, read_ts = self._page_class_cache_flag
+        now = time.time()
+        if now - read_ts > PAGE_CLASS_CACHE_FLAG_TTL:
+            value = bool(self.site.getPreference('experimental.page_class_cache', pkg='sys'))
+            self._page_class_cache_flag = (value, now)
+        return value
+
+    def load_class_by_page_id(self, page_id):
+        """The cached class of a live page, or None on a miss."""
+        with self._page_class_cache_lock:
+            page_class = self._page_class_cache.get(page_id)
+            if page_class is not None:
+                self._page_class_cache.move_to_end(page_id)
+            return page_class
+
+    def store_class_by_page_id(self, page_id, page_class):
+        """Deposit a freshly built class under its page_id, LRU-bounded."""
+        with self._page_class_cache_lock:
+            self._page_class_cache[page_id] = page_class
+            self._page_class_cache.move_to_end(page_id)
+            while len(self._page_class_cache) > PAGE_CLASS_CACHE_MAXSIZE:
+                self._page_class_cache.popitem(last=False)
     
     @property
     def gnrapp(self):
@@ -108,11 +149,23 @@ class ResourceLoader(object):
 
 
     def get_page_class(self, basepath=None,relpath=None, pkg=None, plugin=None,avoid_module_cache=None,request_args=None,request_kwargs=None, page_factory=None):
-        """TODO
-        
+        """Build the page class for a request — or serve the page's cached one.
+
+        With the experimental ``page_class_cache`` preference on, a request
+        that names a ``page_id`` reuses the class built at that page's birth.
+        An explicit ``page_factory`` bypasses the cache (``instantiate_page``
+        forces ``GnrSimplePage``: a different base class under the same
+        page_id), and so does ``avoid_module_cache`` (the dev reload).
+
         :param path: TODO
         :param pkg: the :ref:`package <packages>` object"""
-
+        page_id = (request_kwargs or {}).get('page_id')
+        use_cache = (page_id and page_factory is None and not avoid_module_cache
+                     and self.page_class_cache_enabled())
+        if use_cache:
+            cached_class = self.load_class_by_page_id(page_id)
+            if cached_class is not None:
+                return cached_class
         module_path = os.path.join(basepath,relpath)
         page_module = gnrImport(module_path, avoidDup=True,silent=False,avoid_module_cache=avoid_module_cache)
         page_factory = page_factory or getattr(page_module, 'page_factory', GnrWebPage)
@@ -171,6 +224,8 @@ class ResourceLoader(object):
         self.page_class_plugin_mixin(page_class, plugin_webpage_classes)
         self.page_class_custom_mixin(page_class, relpath, pkg=mainPkg)
         self.page_factories[module_path] = page_class
+        if use_cache:
+            self.store_class_by_page_id(page_id, page_class)
         return page_class
         
     def page_class_base_mixin(self, page_class, pkg=None):

--- a/gnrpy/tests/web/gnrpageclasscache_test.py
+++ b/gnrpy/tests/web/gnrpageclasscache_test.py
@@ -1,0 +1,243 @@
+"""Unit tests for the experimental page-class cache (#1065).
+
+Three things are pinned here:
+
+- the cache helpers on ``ResourceLoader``: hit, miss, LRU eviction at the
+  ceiling, drop on page close, clear on the flag going off;
+- the TTL on the preference read, in both directions of the boundary;
+- the isolation of ``css_requires``/``js_requires``, which the cache turns
+  from per-request lists into class attributes shared by every request of
+  the same page.
+
+A full site is not built: ``ResourceLoader.__init__`` needs six values from
+its site and one static handler, so a stand-in supplies them and the code
+under test is the real one.
+"""
+
+import gnr.web.gnrwsgisite_proxy.gnrresourceloader as grl
+from gnr.web.gnrhtmlpage import GnrHtmlPage
+from gnr.web.gnrwsgisite_proxy.gnrresourceloader import ResourceLoader
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeStatic:
+    def path(self, *args):
+        return '/'.join(str(a) for a in args)
+
+
+class _FakeSite:
+    """The slice of GnrWsgiSite that ResourceLoader.__init__ touches."""
+
+    def __init__(self, preference=False):
+        self.site_path = '/tmp/site'
+        self.site_name = 'testsite'
+        self.gnr_config = {}
+        self.debug = False
+        self.default_page = None
+        self.preference = preference
+        self.preference_reads = 0
+
+    def getStatic(self, name):
+        return _FakeStatic()
+
+    def getPreference(self, path, pkg=None):
+        self.preference_reads += 1
+        return self.preference
+
+
+def _loader(preference=False):
+    site = _FakeSite(preference=preference)
+    return ResourceLoader(site=site), site
+
+
+class _PageA:
+    pass
+
+
+class _PageB:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+
+def test_store_then_load_is_a_hit():
+    loader, _site = _loader()
+    key = ('page-1', '/pkg/a.py')
+    loader.store_page_class_cache(key, _PageA)
+    assert loader.load_page_class_cache(key) is _PageA
+
+
+def test_load_of_an_unknown_key_is_a_miss():
+    loader, _site = _loader()
+    assert loader.load_page_class_cache(('page-1', '/pkg/a.py')) is None
+
+
+def test_same_page_id_on_another_module_does_not_hit():
+    """A page_id is validated against the connection, never against the url."""
+    loader, _site = _loader()
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    assert loader.load_page_class_cache(('page-1', '/pkg/b.py')) is None
+
+
+def test_same_module_on_another_page_id_does_not_hit():
+    loader, _site = _loader()
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    assert loader.load_page_class_cache(('page-2', '/pkg/a.py')) is None
+
+
+def test_two_pages_of_the_same_module_keep_their_own_class():
+    loader, _site = _loader()
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    loader.store_page_class_cache(('page-2', '/pkg/a.py'), _PageB)
+    assert loader.load_page_class_cache(('page-1', '/pkg/a.py')) is _PageA
+    assert loader.load_page_class_cache(('page-2', '/pkg/a.py')) is _PageB
+
+
+def test_eviction_at_the_ceiling_drops_the_least_recently_used(monkeypatch):
+    monkeypatch.setattr(grl, 'PAGE_CLASS_CACHE_MAXSIZE', 3)
+    loader, _site = _loader()
+    for i in range(4):
+        loader.store_page_class_cache(('page-%d' % i, '/pkg/a.py'), _PageA)
+    assert len(loader._page_class_cache) == 3
+    assert loader.load_page_class_cache(('page-0', '/pkg/a.py')) is None
+    assert loader.load_page_class_cache(('page-3', '/pkg/a.py')) is _PageA
+
+
+def test_a_read_refreshes_the_lru_position(monkeypatch):
+    monkeypatch.setattr(grl, 'PAGE_CLASS_CACHE_MAXSIZE', 2)
+    loader, _site = _loader()
+    loader.store_page_class_cache(('page-0', '/pkg/a.py'), _PageA)
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    loader.load_page_class_cache(('page-0', '/pkg/a.py'))
+    loader.store_page_class_cache(('page-2', '/pkg/a.py'), _PageA)
+    assert loader.load_page_class_cache(('page-0', '/pkg/a.py')) is _PageA
+    assert loader.load_page_class_cache(('page-1', '/pkg/a.py')) is None
+
+
+def test_drop_forgets_every_entry_of_a_closed_page():
+    loader, _site = _loader()
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    loader.store_page_class_cache(('page-1', '/pkg/b.py'), _PageB)
+    loader.store_page_class_cache(('page-2', '/pkg/a.py'), _PageA)
+    loader.drop_page_class_cache('page-1')
+    assert loader.load_page_class_cache(('page-1', '/pkg/a.py')) is None
+    assert loader.load_page_class_cache(('page-1', '/pkg/b.py')) is None
+    assert loader.load_page_class_cache(('page-2', '/pkg/a.py')) is _PageA
+
+
+def test_drop_of_an_unknown_page_is_harmless():
+    loader, _site = _loader()
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    loader.drop_page_class_cache('page-9')
+    assert loader.load_page_class_cache(('page-1', '/pkg/a.py')) is _PageA
+
+
+# ---------------------------------------------------------------------------
+# The flag and its TTL
+# ---------------------------------------------------------------------------
+
+
+def test_flag_is_read_once_within_the_ttl(monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
+    loader, site = _loader(preference=True)
+    assert loader.page_class_cache_enabled() is True
+    assert site.preference_reads == 1
+    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL - 1
+    assert loader.page_class_cache_enabled() is True
+    assert site.preference_reads == 1
+
+
+def test_flag_is_re_read_past_the_ttl(monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
+    loader, site = _loader(preference=True)
+    loader.page_class_cache_enabled()
+    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL + 1
+    site.preference = False
+    assert loader.page_class_cache_enabled() is False
+    assert site.preference_reads == 2
+
+
+def test_turning_the_flag_off_drops_what_is_already_cached(monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
+    loader, site = _loader(preference=True)
+    loader.page_class_cache_enabled()
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL + 1
+    site.preference = False
+    assert loader.page_class_cache_enabled() is False
+    assert len(loader._page_class_cache) == 0
+
+
+def test_turning_the_flag_on_leaves_the_cache_alone(monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
+    loader, site = _loader(preference=False)
+    loader.page_class_cache_enabled()
+    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
+    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL + 1
+    site.preference = True
+    assert loader.page_class_cache_enabled() is True
+    assert loader.load_page_class_cache(('page-1', '/pkg/a.py')) is _PageA
+
+
+# ---------------------------------------------------------------------------
+# css_requires / js_requires isolation
+# ---------------------------------------------------------------------------
+
+
+class _FakeHead:
+    def style(self, *args, **kwargs):
+        pass
+
+
+class _FakeBuilder:
+    head = _FakeHead()
+
+
+class _RenderStub:
+    """The slice of a page that setCssRequires/setJsRequires touch.
+
+    ``css_requires``/``js_requires`` are class attributes here exactly as
+    ``get_page_class`` builds them, so an in-place extend would show up on
+    the class and leak into the next render of a cached class.
+    """
+
+    css_requires = ['base.css']
+    js_requires = ['base.js']
+
+    def __init__(self):
+        self.envelope_css_requires = {'extra.css': '/extra.css'}
+        self.envelope_js_requires = {'extra.js': '/extra.js'}
+        self.builder = _FakeBuilder()
+
+    def getResourceExternalUriList(self, name, ext, add_mtime=None):
+        return []
+
+    def script(self, *args, **kwargs):
+        pass
+
+    body = property(lambda self: self)
+
+
+def test_root_render_does_not_extend_the_class_css_requires():
+    stub = _RenderStub()
+    GnrHtmlPage.setCssRequires(stub)
+    GnrHtmlPage.setCssRequires(stub)
+    assert _RenderStub.css_requires == ['base.css']
+
+
+def test_root_render_does_not_extend_the_class_js_requires():
+    stub = _RenderStub()
+    GnrHtmlPage.setJsRequires(stub)
+    GnrHtmlPage.setJsRequires(stub)
+    assert _RenderStub.js_requires == ['base.js']

--- a/projects/gnrcore/packages/sys/menu.py
+++ b/projects/gnrcore/packages/sys/menu.py
@@ -19,6 +19,7 @@ class Menu(object):
         system.webpage("Logging", tags="_DEV_", filepath="/sys/logging")
         system.webpage("Startup data manager", tags="_DEV_", filepath="/sys/startupdata_manager")
         system.webpage(u"Data retention", tags="_DEV_", filepath="/sys/dataretention")
+        system.webpage("Page Class Cache", tags="superadmin,_DEV_", filepath="/sys/page_class_cache")
         system.webpage("Package editor", tags="_DEV_", filepath="/sys/package_editor")
         system.webpage("Localization editor", tags="_DEV_,_TRD_,superadmin", filepath="/sys/localizationeditor")
         system.webpage("GnrIDE", tags="_DEV_", filepath="/sys/gnride")

--- a/projects/gnrcore/packages/sys/resources/preference.py
+++ b/projects/gnrcore/packages/sys/resources/preference.py
@@ -121,6 +121,7 @@ class AppPref(object):
         fb.comboBox(value='^.experimental.remoteForm',lbl='!![en]Remote forms',values='onEnter,delayed')
         fb.checkbox(value='^.experimental.wsk_disabled',lbl='!![en]WSK Disabled (kill switch)')
         fb.checkbox(value='^.experimental.no_mako',lbl='!![en]No Mako rootPage')
+        fb.checkbox(value='^.experimental.page_class_cache',lbl='!![en]Page class cache (per page_id)')
 
     def tablesConfiguration(self, pane):
         fb = pane.formbuilder(cols=1,border_spacing='3px',datapath='.tblconf')

--- a/projects/gnrcore/packages/sys/webpages/page_class_cache.py
+++ b/projects/gnrcore/packages/sys/webpages/page_class_cache.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env pythonw
+# -*- coding: utf-8 -*-
+#
+#  Copyright (c) 2026 Softwell.
+#
+
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrdecorator import public_method
+
+
+class GnrCustomWebPage(object):
+    py_requires = 'gnrcomponents/framegrid:FrameGrid'
+    auth_main = 'superadmin,_DEV_'
+
+    def windowTitle(self):
+        return '!!Page Class Cache'
+
+    def main(self, root, **kwargs):
+        bc = root.borderContainer(datapath='main')
+        frame = bc.frameGrid(region='center', frameCode='cacheEntries',
+                             datapath='cacheEntries',
+                             struct=self.cacheStruct,
+                             _class='pbl_roundedGroup', margin='2px')
+        frame.top.slotBar('2,vtitle,*,clearcache,5,refresh,2',
+                          vtitle='!!Page Class Cache',
+                          _class='pbl_roundedGroupLabel')
+        frame.top.bar.clearcache.button('!!Clear Cache', fire='.clearcache')
+        frame.top.bar.refresh.button('!!Refresh', fire='.refresh')
+        frame.grid.bagStore(storepath='cacheEntries.store',
+                            storeType='AttributesBagRows',
+                            sortedBy='=.grid.sorted',
+                            data='^cacheEntries.loaded_data',
+                            selfUpdate=True)
+        bc.dataRpc('cacheEntries.loaded_data', self.getCacheEntries,
+                   _onStart=True,
+                   _fired='^cacheEntries.refresh'
+                   )
+        bc.dataRpc('dummy', self.clearCacheEntries,
+                   _fired='^cacheEntries.clearcache',
+                   _onResult='FIRE cacheEntries.refresh;'
+                   )
+        
+    def cacheStruct(self, struct):
+        r = struct.view().rows()
+        r.cell('page_id', name='!!Page ID', width='20em')
+        r.cell('module_path', name='!!Module Path', width='40em')
+        r.cell('class_name', name='!!Class Name', width='20em')
+
+    @public_method
+    def clearCacheEntries(self):
+        self.site.resource_loader.clear_page_class_cache()
+
+    @public_method
+    def getCacheEntries(self):
+        result = Bag()
+        cache = self.site.resource_loader._page_class_cache
+        for i, ((page_id, module_path), page_class) in enumerate(cache.items()):
+            result.setItem(str(i), None,
+                        dict(
+                            page_id=page_id,
+                            module_path=module_path,
+                            class_name=page_class.__name__
+                        )
+                           )
+        return result

--- a/projects/gnrcore/packages/sys/webpages/page_class_cache.py
+++ b/projects/gnrcore/packages/sys/webpages/page_class_cache.py
@@ -53,13 +53,10 @@ class GnrCustomWebPage(object):
     @public_method
     def getCacheEntries(self):
         result = Bag()
-        cache = self.site.resource_loader._page_class_cache
-        for i, ((page_id, module_path), page_class) in enumerate(cache.items()):
-            result.setItem(str(i), None,
-                        dict(
-                            page_id=page_id,
-                            module_path=module_path,
-                            class_name=page_class.__name__
-                        )
+        for i, (page_id, module_path, class_name) in enumerate(
+                self.site.resource_loader.page_class_cache_entries()):
+            result.setItem(str(i), None, dict(page_id=page_id,
+                                              module_path=module_path,
+                                              class_name=class_name)
                            )
         return result


### PR DESCRIPTION
## What

An opt-in, LRU-bounded cache of the built page class, keyed by **page_id**, behind the sys preference **`experimental.page_class_cache`** (new checkbox in the existing experimental pane). Two files: the cache + hook in `ResourceLoader.get_page_class`, one line in the sys preference pane.

Full story, profile and benchmark tables in #1065. The short version: `classMixin` runs 138× per RPC (~40-45% of request CPU with a trivial query); the cache that once avoided this died in 2010 and its remains were deleted in 2014. **Measured capacity within 100ms doubles on both stacks** — 71 → 135 req/s (classic gunicorn + Pyro daemon), 128 → 238 req/s (daemonless single).

## Why per page_id is safe

- Each page reuses the class built at its own birth; no class is ever shared between pages, so the build-time mutations (`css_requires.extend`, per-request `getMainPackage`) cannot cross — the very reason the 2010 module-keyed cache had to die does not apply.
- Runtime component mixins go through `instanceMixin` (gnrlang.py:341) and never touch the class; table scripts are instantiated fresh per call (gnrresourceloader.py:520).
- An explicit `page_factory` bypasses the cache — `instantiate_page` forces `GnrSimplePage`, a different base class under the same page_id — and so does `avoid_module_cache` (dev reload).
- A request without a `page_id` builds exactly as today; RPCs (the hot path) always carry one.
- LRU ceiling (2000 classes) bounds memory with no lifecycle wiring: evicted pages just rebuild.

## The flag read

`getPreference` deepcopies the whole preference bag on every call, so the flag is re-read through a 10s TTL instead of per request: the preference remains a runtime kill switch (like `experimental.wsk_disabled`) with at most 10s of latency, at zero per-request cost.

## Verification

- 130-test regression suite of the daemonless bridge (boots this very site) green with the flag off AND on.
- Site exercised by hand with the flag on: login, table handlers, forms, chat.
- Benchmarks: single-row getSelection ramp 1..32 sessions and the 100-row workload, flag OFF vs ON on both stacks, zero errors — tables in #1065.

Ref #1065