### PR TITLE
feat(daemon): gate the gnr.web.daemon entry-point override on an explicit request

### DIFF
--- a/gnrpy/gnr/web/daemon/__init__.py
+++ b/gnrpy/gnr/web/daemon/__init__.py
@@ -1,9 +1,57 @@
-import importlib                                                                                                                      
-import importlib.metadata                                       
+"""Daemon package, optionally overridden by an alternative provider.
+
+An installed package can declare a ``gnr.web:daemon`` entry point to replace
+this whole namespace (``.handler``, ``.siteregister``, ``.processes``, ...).
+The override is *not* automatic: it happens only when the
+``GNR_DAEMON_PROVIDER`` environment variable names the provider, so the
+classic stack and an alternative provider can live in the same environment
+and be chosen per process instead of per virtualenv.
+
+With the variable unset this module is a plain package: no entry-point scan,
+no ``sys.modules`` surgery.
+"""
+import importlib
+import importlib.metadata
+import os
 import sys
 
-_eps = list(importlib.metadata.entry_points(group='gnr.web', name='daemon'))
-if _eps:
-    _mod = importlib.import_module(_eps[0].value)
+from gnr.web import logger
+
+DAEMON_PROVIDER_ENV = 'GNR_DAEMON_PROVIDER'
+DAEMON_ENTRY_POINT_GROUP = 'gnr.web'
+DAEMON_ENTRY_POINT_NAME = 'daemon'
+
+
+def _resolve_provider(provider, eps):
+    """Return the ``gnr.web:daemon`` entry point requested by *provider*.
+
+    *provider* is matched against both the entry-point value (the dotted
+    module path) and the name of the distribution declaring it. Raise
+    ``ImportError`` when nothing matches: an explicitly requested provider
+    that is not installed is a configuration error, not a reason to silently
+    fall back to the classic daemon. When more than one entry point matches,
+    warn and pick the first one instead of choosing silently.
+    """
+    matching = [ep for ep in eps
+                if provider in (ep.value, getattr(ep.dist, 'name', None))]
+    if not matching:
+        raise ImportError(
+            f'{DAEMON_PROVIDER_ENV}={provider!r}: no '
+            f'{DAEMON_ENTRY_POINT_GROUP}:{DAEMON_ENTRY_POINT_NAME} '
+            'entry point matches')
+    if len(matching) > 1:
+        logger.warning('%s=%r matches %d %s:%s entry points (%s): using %r',
+                       DAEMON_PROVIDER_ENV, provider, len(matching),
+                       DAEMON_ENTRY_POINT_GROUP, DAEMON_ENTRY_POINT_NAME,
+                       ', '.join(ep.value for ep in matching),
+                       matching[0].value)
+    return matching[0]
+
+
+_provider = os.environ.get(DAEMON_PROVIDER_ENV)
+if _provider:
+    _ep = _resolve_provider(_provider, importlib.metadata.entry_points(
+        group=DAEMON_ENTRY_POINT_GROUP, name=DAEMON_ENTRY_POINT_NAME))
+    _mod = importlib.import_module(_ep.value)
     _mod.__name__ = __name__
     sys.modules[__name__] = _mod

--- a/gnrpy/gnr/web/daemon/__init__.py
+++ b/gnrpy/gnr/web/daemon/__init__.py
@@ -25,26 +25,28 @@ DAEMON_ENTRY_POINT_NAME = 'daemon'
 def _resolve_provider(provider, eps):
     """Return the ``gnr.web:daemon`` entry point requested by *provider*.
 
-    *provider* is matched against both the entry-point value (the dotted
-    module path) and the name of the distribution declaring it. Raise
-    ``ImportError`` when nothing matches: an explicitly requested provider
-    that is not installed is a configuration error, not a reason to silently
-    fall back to the classic daemon. When more than one entry point matches,
-    warn and pick the first one instead of choosing silently.
+    *provider* is matched against both the entry-point module and the name of
+    the distribution declaring it. The module is read from ``ep.module``
+    rather than ``ep.value``: the entry-point spec allows ``module:attr``,
+    which ``ep.value`` carries verbatim and no importable name ever equals.
+
+    Anything other than exactly one match raises ``ImportError``. An
+    explicitly requested provider is a configuration statement, so neither a
+    missing one nor an ambiguous one may degrade into running a daemon the
+    caller did not ask for.
     """
     matching = [ep for ep in eps
-                if provider in (ep.value, getattr(ep.dist, 'name', None))]
-    if not matching:
+                if provider in (ep.module, getattr(ep.dist, 'name', None))]
+    if len(matching) != 1:
+        installed = ', '.join(sorted(
+            f'{ep.module} ({getattr(ep.dist, "name", "unknown distribution")})'
+            for ep in eps)) or 'none'
         raise ImportError(
-            f'{DAEMON_PROVIDER_ENV}={provider!r}: no '
-            f'{DAEMON_ENTRY_POINT_GROUP}:{DAEMON_ENTRY_POINT_NAME} '
-            'entry point matches')
-    if len(matching) > 1:
-        logger.warning('%s=%r matches %d %s:%s entry points (%s): using %r',
-                       DAEMON_PROVIDER_ENV, provider, len(matching),
-                       DAEMON_ENTRY_POINT_GROUP, DAEMON_ENTRY_POINT_NAME,
-                       ', '.join(ep.value for ep in matching),
-                       matching[0].value)
+            f'{DAEMON_PROVIDER_ENV}={provider!r} matches {len(matching)} '
+            f'{DAEMON_ENTRY_POINT_GROUP}:{DAEMON_ENTRY_POINT_NAME} entry '
+            f'points; installed: {installed}')
+    logger.info('%s=%r resolved to %s', DAEMON_PROVIDER_ENV, provider,
+                matching[0].module)
     return matching[0]
 
 
@@ -52,6 +54,6 @@ _provider = os.environ.get(DAEMON_PROVIDER_ENV)
 if _provider:
     _ep = _resolve_provider(_provider, importlib.metadata.entry_points(
         group=DAEMON_ENTRY_POINT_GROUP, name=DAEMON_ENTRY_POINT_NAME))
-    _mod = importlib.import_module(_ep.value)
+    _mod = importlib.import_module(_ep.module)
     _mod.__name__ = __name__
     sys.modules[__name__] = _mod

--- a/gnrpy/tests/web/gnrdaemon.py
+++ b/gnrpy/tests/web/gnrdaemon.py
@@ -1,1 +1,0 @@
-import gnr.web.daemon  # noqa: F401

--- a/gnrpy/tests/web/gnrdaemon_test.py
+++ b/gnrpy/tests/web/gnrdaemon_test.py
@@ -8,7 +8,6 @@ looked up.
 """
 import importlib
 import importlib.metadata
-import logging
 import os
 import subprocess
 import sys
@@ -25,8 +24,16 @@ FAKE_PROVIDER_DIST = 'gnr-daemon-test-provider'
 
 
 def _entry_point(value, dist_name):
-    """Stub with the attributes ``_resolve_provider`` actually reads."""
-    return SimpleNamespace(value=value, dist=SimpleNamespace(name=dist_name))
+    """A real ``EntryPoint``, so ``.module`` is derived and not asserted.
+
+    The distinction matters here: ``.module`` strips the ``:attr`` suffix the
+    spec allows, and a stub declaring both fields by hand would agree with
+    whatever the code under test happens to read.
+    """
+    ep = importlib.metadata.EntryPoint(name='daemon',
+                                       value=value, group='gnr.web')
+    object.__setattr__(ep, 'dist', SimpleNamespace(name=dist_name))
+    return ep
 
 
 def _daemon_modules():
@@ -70,8 +77,14 @@ def test_import_smoke():
 
 # --- _resolve_provider, pure unit tests -----------------------------------
 
-def test_resolve_provider_matches_entry_point_value():
+def test_resolve_provider_matches_entry_point_module():
     eps = [_entry_point(FAKE_PROVIDER_MODULE, FAKE_PROVIDER_DIST)]
+    assert gnr.web.daemon._resolve_provider(FAKE_PROVIDER_MODULE, eps) is eps[0]
+
+
+def test_resolve_provider_matches_module_of_a_module_attr_value():
+    """``module:attr`` is a legal entry-point value; only the module imports."""
+    eps = [_entry_point(f'{FAKE_PROVIDER_MODULE}:provider', FAKE_PROVIDER_DIST)]
     assert gnr.web.daemon._resolve_provider(FAKE_PROVIDER_MODULE, eps) is eps[0]
 
 
@@ -87,6 +100,8 @@ def test_resolve_provider_ignores_unrelated_entry_points():
         gnr.web.daemon._resolve_provider(FAKE_PROVIDER_MODULE, eps)
     assert PROVIDER_ENV in str(excinfo.value)
     assert FAKE_PROVIDER_MODULE in str(excinfo.value)
+    assert 'other.provider' in str(excinfo.value)
+    assert 'other-dist' in str(excinfo.value)
 
 
 def test_resolve_provider_raises_without_entry_points():
@@ -94,14 +109,14 @@ def test_resolve_provider_raises_without_entry_points():
         gnr.web.daemon._resolve_provider(FAKE_PROVIDER_MODULE, [])
 
 
-def test_resolve_provider_warns_on_multiple_matches(caplog):
-    """Today's ``_eps[0]`` picks an undefined winner silently."""
+def test_resolve_provider_raises_on_multiple_matches():
+    """An ambiguous request is a configuration error, not a coin toss."""
     eps = [_entry_point('first.provider', FAKE_PROVIDER_DIST),
            _entry_point('second.provider', FAKE_PROVIDER_DIST)]
-    with caplog.at_level(logging.WARNING, logger='gnr.web'):
-        assert gnr.web.daemon._resolve_provider(FAKE_PROVIDER_DIST, eps) is eps[0]
-    assert 'first.provider' in caplog.text
-    assert 'second.provider' in caplog.text
+    with pytest.raises(ImportError) as excinfo:
+        gnr.web.daemon._resolve_provider(FAKE_PROVIDER_DIST, eps)
+    assert 'first.provider' in str(excinfo.value)
+    assert 'second.provider' in str(excinfo.value)
 
 
 # --- the gate itself, on a real import ------------------------------------

--- a/gnrpy/tests/web/gnrdaemon_test.py
+++ b/gnrpy/tests/web/gnrdaemon_test.py
@@ -1,0 +1,177 @@
+"""Coverage for the ``gnr.web.daemon`` entry-point override gate.
+
+The scenario numbering in the test names follows the table in issue #1067.
+Note that rows 1 (no provider installed) and 3 (provider installed, variable
+unset) are the same code path: genropy declares no ``gnr.web:daemon`` entry
+point of its own, so with the variable unset the entry points are never even
+looked up.
+"""
+import importlib
+import importlib.metadata
+import logging
+import os
+import subprocess
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import gnr.web.daemon  # noqa: F401
+
+DAEMON_PKG = 'gnr.web.daemon'
+PROVIDER_ENV = 'GNR_DAEMON_PROVIDER'
+FAKE_PROVIDER_MODULE = 'gnrdaemon_test_fake_provider'
+FAKE_PROVIDER_DIST = 'gnr-daemon-test-provider'
+
+
+def _entry_point(value, dist_name):
+    """Stub with the attributes ``_resolve_provider`` actually reads."""
+    return SimpleNamespace(value=value, dist=SimpleNamespace(name=dist_name))
+
+
+def _daemon_modules():
+    return [name for name in list(sys.modules)
+            if name == DAEMON_PKG or name.startswith(f'{DAEMON_PKG}.')]
+
+
+@pytest.fixture
+def daemon_sandbox(monkeypatch):
+    """Allow re-importing ``gnr.web.daemon`` without poisoning the suite.
+
+    ``gnr.web.gnrwsgisite`` imports the package at module level, so by the
+    time this test module runs the real package and some of its submodules
+    are already in ``sys.modules``: they must be put back verbatim, otherwise
+    every sibling test inherits a half-imported daemon package.
+    """
+    saved = {name: sys.modules[name] for name in _daemon_modules()}
+    provider = ModuleType(FAKE_PROVIDER_MODULE)
+    provider.MARKER = 'fake provider'
+    monkeypatch.setitem(sys.modules, FAKE_PROVIDER_MODULE, provider)
+    for name in saved:
+        del sys.modules[name]
+    yield provider
+    for name in _daemon_modules():
+        del sys.modules[name]
+    sys.modules.update(saved)
+
+
+def _patch_entry_points(monkeypatch, eps):
+    def fake_entry_points(**kwargs):
+        if (kwargs.get('group'), kwargs.get('name')) == ('gnr.web', 'daemon'):
+            return list(eps)
+        return []
+    monkeypatch.setattr(importlib.metadata, 'entry_points', fake_entry_points)
+
+
+def test_import_smoke():
+    """The import smoke test #688 replaced its unit tests with."""
+    assert sys.modules[DAEMON_PKG] is gnr.web.daemon
+
+
+# --- _resolve_provider, pure unit tests -----------------------------------
+
+def test_resolve_provider_matches_entry_point_value():
+    eps = [_entry_point(FAKE_PROVIDER_MODULE, FAKE_PROVIDER_DIST)]
+    assert gnr.web.daemon._resolve_provider(FAKE_PROVIDER_MODULE, eps) is eps[0]
+
+
+def test_resolve_provider_matches_distribution_name():
+    eps = [_entry_point(FAKE_PROVIDER_MODULE, FAKE_PROVIDER_DIST)]
+    assert gnr.web.daemon._resolve_provider(FAKE_PROVIDER_DIST, eps) is eps[0]
+
+
+def test_resolve_provider_ignores_unrelated_entry_points():
+    """Row 5: the variable names a provider that is not installed."""
+    eps = [_entry_point('other.provider', 'other-dist')]
+    with pytest.raises(ImportError) as excinfo:
+        gnr.web.daemon._resolve_provider(FAKE_PROVIDER_MODULE, eps)
+    assert PROVIDER_ENV in str(excinfo.value)
+    assert FAKE_PROVIDER_MODULE in str(excinfo.value)
+
+
+def test_resolve_provider_raises_without_entry_points():
+    with pytest.raises(ImportError):
+        gnr.web.daemon._resolve_provider(FAKE_PROVIDER_MODULE, [])
+
+
+def test_resolve_provider_warns_on_multiple_matches(caplog):
+    """Today's ``_eps[0]`` picks an undefined winner silently."""
+    eps = [_entry_point('first.provider', FAKE_PROVIDER_DIST),
+           _entry_point('second.provider', FAKE_PROVIDER_DIST)]
+    with caplog.at_level(logging.WARNING, logger='gnr.web'):
+        assert gnr.web.daemon._resolve_provider(FAKE_PROVIDER_DIST, eps) is eps[0]
+    assert 'first.provider' in caplog.text
+    assert 'second.provider' in caplog.text
+
+
+# --- the gate itself, on a real import ------------------------------------
+
+def test_provider_installed_but_variable_unset(daemon_sandbox, monkeypatch):
+    """Rows 1 and 3: the classic package, entry point or no entry point."""
+    monkeypatch.delenv(PROVIDER_ENV, raising=False)
+    _patch_entry_points(monkeypatch,
+                        [_entry_point(FAKE_PROVIDER_MODULE, FAKE_PROVIDER_DIST)])
+    daemon = importlib.import_module(DAEMON_PKG)
+    assert daemon is not daemon_sandbox
+    assert daemon.__file__.endswith(os.path.join('gnr', 'web', 'daemon', '__init__.py'))
+    assert importlib.import_module(f'{DAEMON_PKG}.handler').__package__ == DAEMON_PKG
+
+
+def test_provider_installed_and_requested(daemon_sandbox, monkeypatch):
+    """Row 4: the whole namespace is replaced by the provider package."""
+    monkeypatch.setenv(PROVIDER_ENV, FAKE_PROVIDER_MODULE)
+    _patch_entry_points(monkeypatch,
+                        [_entry_point(FAKE_PROVIDER_MODULE, FAKE_PROVIDER_DIST)])
+    daemon = importlib.import_module(DAEMON_PKG)
+    assert daemon is daemon_sandbox
+    assert daemon.MARKER == 'fake provider'
+    assert sys.modules[DAEMON_PKG] is daemon_sandbox
+
+
+def test_requested_provider_not_installed(daemon_sandbox, monkeypatch):
+    """Row 5 end to end: the import fails instead of falling back."""
+    monkeypatch.setenv(PROVIDER_ENV, FAKE_PROVIDER_MODULE)
+    _patch_entry_points(monkeypatch, [])
+    with pytest.raises(ImportError):
+        importlib.import_module(DAEMON_PKG)
+
+
+# --- out of process -------------------------------------------------------
+
+def _run_python(code, **env_overrides):
+    env = os.environ.copy()
+    env.pop(PROVIDER_ENV, None)
+    for key, value in env_overrides.items():
+        env[key] = value
+    return subprocess.run([sys.executable, '-c', code], env=env,
+                          capture_output=True, text=True)
+
+
+def test_pyro4_is_imported_by_the_handler_not_by_the_package():
+    """The package import alone is Pyro4-free; ``.handler`` is not.
+
+    Cannot be asserted in process: Pyro4 is already in ``sys.modules`` by the
+    time this module runs.
+    """
+    pytest.importorskip('Pyro4')
+    result = _run_python(
+        'import sys\n'
+        'import gnr.web.daemon\n'
+        'print("package:", "Pyro4" in sys.modules)\n'
+        'import gnr.web.daemon.handler\n'
+        'print("handler:", "Pyro4" in sys.modules)\n')
+    assert result.returncode == 0, result.stderr
+    assert 'package: False' in result.stdout
+    assert 'handler: True' in result.stdout
+
+
+def test_the_gate_is_per_process():
+    """Same interpreter, same installation, two processes, two outcomes."""
+    code = 'import gnr.web.daemon; print("imported")'
+    classic = _run_python(code)
+    assert classic.returncode == 0, classic.stderr
+    assert 'imported' in classic.stdout
+    overridden = _run_python(code, **{PROVIDER_ENV: FAKE_PROVIDER_MODULE})
+    assert overridden.returncode != 0
+    assert 'ImportError' in overridden.stderr
+    assert PROVIDER_ENV in overridden.stderr


### PR DESCRIPTION
**Draft** — the diff is a starting point for the discussion, not a decision. See **Open decisions** at the bottom: @genro and @cgabriel, none of those points has been silently picked, and every one of them can change the shape of this patch.

Fixes #1067

## Motivation

@genro needs the classic daemon stack and an alternative provider in the **same** environment, choosing between them **per process** rather than per virtualenv. Today that is impossible: the switch fires on installation alone, so as soon as any installed package declares a `gnr.web:daemon` entry point, every site in that interpreter gets the override and going back to the classic daemon means building a separate virtualenv.

## Current mechanism

`gnrpy/gnr/web/daemon/__init__.py` was, in its entirety, these nine lines — added whole by `6a320d0fc` "Transitory refactoring of daemon package and modules (#688)":

```python
import importlib
import importlib.metadata
import sys

_eps = list(importlib.metadata.entry_points(group='gnr.web', name='daemon'))
if _eps:
    _mod = importlib.import_module(_eps[0].value)
    _mod.__name__ = __name__
    sys.modules[__name__] = _mod
```

Four precisions worth stating, all verified against the tree:

- **The baseline is genuinely a no-op.** genropy declares no `gnr.web:daemon` entry point of its own — `gnrpy/pyproject.toml:87-95` has only `[project.scripts]` — so `_eps` is empty unless a third party ships one. Rows 1 and 3 of the table in #1067 are therefore *the same code path*, which is exactly why the gate cannot regress anyone running the classic stack.
- **The override swaps the package, not a module.** Replacing `sys.modules['gnr.web.daemon']` means `.handler`, `.siteregister`, `.siteregister_client`, `.processes` and `.service` all resolve through the provider's `__path__`; the classic modules become unreachable by name.
- **`_eps[0]` picks an undefined winner** when two providers are installed — entry-point ordering is not a contract.
- **`_mod.__name__ = __name__` mutates the provider module object globally.** The provider also stays in `sys.modules` under its real name, now with a lying `__name__`.

Minor factual correction to the table in the issue: `import gnr.web.daemon` alone does **not** import Pyro4. Pyro4 enters at `gnr/web/daemon/handler.py:15` and `gnr/web/daemon/siteregister.py:24`. There is a test for this below.

## Change

~40 lines in `gnrpy/gnr/web/daemon/__init__.py`, following @genro's PoC:

- read `GNR_DAEMON_PROVIDER` and **return early with the namespace untouched when it is unset** — no entry-point scan at all, so the classic path is provably identical to today's (and marginally cheaper);
- when it is set, filter the `gnr.web:daemon` entry points on `ep.value` / `ep.dist.name`;
- raise `ImportError` with an explicit message when nothing matches.

Two additions beyond the PoC, both cheap:

- the selection is extracted into a pure `_resolve_provider(provider, eps)`, so the interesting cases become plain unit tests with no `sys.modules` surgery;
- `logger.warning` (via `from gnr.web import logger`, `gnr/web/__init__.py:2`) when the variable is set and more than one entry point matches, instead of today's silent `_eps[0]`.

Conventions this follows, since #688 is the only precedent in the tree and there is not much of one:

- `GNR_DAEMON_*` is already a live family: `GNR_DAEMON_PORT` at `gnr/web/gnrk8s.py:100`, `GNR_DAEMON_HOST` at `gnrk8s.py:188,293`. `GNR_DAEMON_PROVIDER` sits inside the existing namespace.
- Import-time `os.environ.get` at module level is the established idiom — `gnr/web/gnrwebpage.py:43`, `gnr/web/gnrtask_new.py:47-49`, `gnr/core/gnrenv.py:13-21`.
- A presence-only gate, if the on/off variant is preferred instead, has its own precedent: `gnr/core/cli/gnr.py:159`, `if "GNR_AUTOCOMPLETE" in os.environ:`.
- There is **no** generic env-switch helper to reuse. `getEnvironmentItem` (`gnr/core/gnrconfig.py:219`) reads `environment.xml`, which is per-installation — precisely the granularity @genro wants to escape — and the daemon's `getFullOptions` (`gnr/web/daemon/handler.py:53-66`) runs long after import. An environment variable is the only lever available at import time.
- `importlib.metadata.entry_points` occurs **exactly once in the whole tree**: this file. There is no entry-point-selection convention to match and no other entry-point namespace override anywhere, so whatever lands here becomes the precedent — which is part of why this is a draft.
- `requires-python = ">=3.11"` (`gnrpy/pyproject.toml:18`), so `entry_points(group=, name=)` selection and a populated `ep.dist` are both safe.

One line added to `gnrpy/RELEASE_NOTES.rst`, the only place `GNR_*` variables are documented today (cf. the `GNR_LOGLEVEL` mention).

Who imports the package, which is what makes the `ImportError` question below a real one: `gnr/web/gnrwsgisite.py:45-46` **top level**, `gnr/web/gnrwsgisite_proxy/gnrsiteregister.py:5,12` top level, `gnr/web/cli/gnrdaemon.py:5` (the `gnrdaemon` console script, also reached via `gnr web daemon`), `gnr/app/gnrapp.py:1942` lazy.

## Verification

Side finding first: **existing coverage was zero, and it had silently regressed.** `gnrpy/tests/web/gnrdaemon.py` — the smoke test #688 added in place of the two test modules it deleted — matches neither `test_*.py` nor `*_test.py`, and there is no `python_files` override (`gnrpy/pyproject.toml:196-200` sets only `testpaths` / `pythonpath` / asyncio scope). It has therefore never been collected since #688. This PR `git mv`s it to `gnrpy/tests/web/gnrdaemon_test.py`, keeping its import smoke test, which restores that lost coverage.

That file now carries 11 tests:

- **`_resolve_provider`, pure unit tests** — match by `ep.value`, match by `ep.dist.name`, no match → `ImportError` (row 5), empty entry-point list → `ImportError`, two matches → warning and first (feeding `SimpleNamespace(value=..., dist=SimpleNamespace(name=...))` stubs; no `importlib.metadata` monkeypatching needed once the function is extracted).
- **the gate on a real import** — synthetic provider pre-registered in `sys.modules`, `importlib.metadata.entry_points` faked, `gnr.web.daemon` and its already-imported submodules popped, then re-imported: variable unset → the classic package (`__file__` under `gnr/web/daemon/`, and `.handler` still resolves there) which is rows 1 and 3; variable set and matching → `sys.modules['gnr.web.daemon']` **is** the provider object, row 4; variable set and absent → `ImportError`, row 5 end to end. A fixture restores the original modules — `gnrwsgisite` has already imported the real package by then, so teardown is not optional.
- **out of process** — the "Pyro4 imported" column cannot be asserted in-process (Pyro4 is already in `sys.modules` from earlier tests), so it runs as a subprocess printing `'Pyro4' in sys.modules` after `import gnr.web.daemon` (False) and after `import gnr.web.daemon.handler` (True). A second subprocess pair — same interpreter, same installation, variable unset vs. variable set — is the per-process proof the issue is actually asking for.

Ran: `flake8` on both touched files, clean; `pytest gnrpy/tests/web/gnrdaemon_test.py` → 11 passed; `pytest gnrpy/tests/web/` → 177 passed, 57 skipped (checking the `sys.modules` surgery does not poison siblings); `pytest gnrpy/tests/ --ignore=gnrpy/tests/sql` → 798 passed, 57 skipped. `gnrpy/tests/sql/` was not run — `initdb` fails in this environment for reasons unrelated to the change.

Not verified: no run against a real installed third-party provider package, and no run of an actual daemon process under an override. The provider is synthetic in every test here.

## Open decisions

@genro, @cgabriel — #688 is @cgabriel's and declared transitory there, so the shape is his call. Nothing below has been decided; the diff picks one option per line only so that there is something concrete to react to.

- **Env-var name**: `GNR_DAEMON_PROVIDER` (fits the existing `GNR_DAEMON_HOST` / `GNR_DAEMON_PORT` family), or something else?
- **Named provider vs. plain on/off switch** in the style of `GNR_AUTOCOMPLETE` (`gnr/core/cli/gnr.py:159`), which @genro says would already cover his case?
- **Match key when named**: `ep.value`, `ep.dist.name`, or both as in the PoC (what this diff does)?
- **Variable set but nothing matches**: `ImportError` at import time — which, because `gnrwsgisite.py:45` imports at top level, takes down every site in that process, not just the daemon — or `logger.warning` plus classic fallback?
- **Two or more matching entry points**: silent `_eps[0]` as today, warn-and-pick-first (what this diff does), or hard error?
- **Also expose the choice as a CLI flag** on `gnr web daemon` / `gnrdaemon`, or environment-only?
- **Keep the `_mod.__name__ = __name__` mutation?** And should the classic package stay reachable under an alias, so a provider can delegate to it?
- **Does #688's "transitory" status mean the mechanism is to be replaced outright**, which would make this gate moot?
