### PR TITLE
fix(#1077): version the test_invoice_pg site so a fresh clone can start it

### DIFF
--- a/projects/test_invoice/sites/test_invoice_pg/root.py
+++ b/projects/test_invoice/sites/test_invoice_pg/root.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python2.6
+import sys
+sys.stdout = sys.stderr
+from gnr.web.gnrwsgisite import GnrWsgiSite
+site = GnrWsgiSite(__file__)
+
+def application(environ,start_response):
+    return site(environ,start_response)
+
+if __name__ == '__main__':
+    from gnr.web.server import NewServer
+    server=NewServer(__file__)
+    server.run()

--- a/projects/test_invoice/sites/test_invoice_pg/siteconfig.xml
+++ b/projects/test_invoice/sites/test_invoice_pg/siteconfig.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<GenRoBag>
+	<wsgi mainpackage="invc"/>
+
+	<connection_timeout/>
+
+	<connection_refresh/>
+
+	<dojo version="11"/>
+</GenRoBag>


### PR DESCRIPTION
Closes #1077.

Only `instanceconfig.xml` was tracked for the `test_invoice_pg` instance, so on a clean checkout neither route of `PathResolver.entity_name_to_path` (`gnrpy/gnr/app/pathresolver.py:68-76`) could resolve the site:

1. `<projects>/*/sites/test_invoice_pg/` did not exist;
2. the instance fallback needs a `root.py` under `instances/test_invoice_pg/`, which was not tracked either.

`gnrasgiserve test_invoice_pg` therefore exited with `EntityNotFoundException`, and 77 of the 132 tests in the genropy-asgi suite self-skipped with `cannot build the test_invoice_pg site`.

## What changes

Two files, both byte-identical to their `invoice_demo` siblings:

- `projects/test_invoice/sites/test_invoice_pg/root.py`
- `projects/test_invoice/sites/test_invoice_pg/siteconfig.xml`

Copied verbatim on purpose, the py2.6 shebang included: the two sites of this project stay uniform rather than half-modernised. Modernising `root.py` is a separate change that should touch both.

## Verified

On genropy `develop` @ `fef1037bb` with genro-asgi `51de991` and genropy-asgi `a465c47`, Python 3.13.2, PostgreSQL 16.8:

- genropy suite: 2015 passed, 10 skipped
- genropy-asgi suite: 132 passed, 0 skipped (was 55 passed, 77 skipped)
- `gnrasgiserve test_invoice_pg -p 8098 --nodebug` → `/index` 200, `/metrics` 200
- same with `--workers 2`: two workers announced on the hub, both endpoints 200