### PR TITLE
fix(docu): keep example modules in sync with the documentation lifecycle

### DIFF
--- a/gnrpy/tests/app/test_docu_examples_sync.py
+++ b/gnrpy/tests/app/test_docu_examples_sync.py
@@ -1,0 +1,183 @@
+"""Tests for the example-module synchronization of docu.documentation.
+
+The .py example files served from site:webpages/docu_examples must follow
+the record lifecycle: written when the sourcebag changes, relocated when
+the record is renamed or moved in the hierarchy (keeping the folders of
+the children records intact), removed when the record is deleted, and
+regenerable in bulk from the sourcebag since the site folder is
+disposable. The rst links pointing to a renamed record must be rewritten
+in the docbag of the other records.
+
+The tests run against a real database (gnrdevelop instance on a temporary
+sqlite file) and a real local storage service backed by a temporary
+directory: records go through the actual table triggers and assertions
+read the actual filesystem.
+"""
+import shutil
+import tempfile
+from types import SimpleNamespace
+
+from gnr.core.gnrbag import Bag
+from gnr.lib.services.storage import BaseLocalService, StorageNode
+
+from common import BaseGnrAppTest
+
+
+class StorageSiteStub:
+    """Minimal site wiring exposing a real local storage service to the model."""
+
+    def __init__(self, services_dirs):
+        self.currentPage = SimpleNamespace(isMobile=False, user=None)
+        self.services = {}
+        for name, base_path in services_dirs.items():
+            service = BaseLocalService(parent=self, base_path=base_path)
+            service.service_name = name
+            self.services[name] = service
+
+    def storageNode(self, fullpath, *parts):
+        if parts:
+            fullpath = '/'.join([fullpath] + list(parts))
+        service_name, path = fullpath.split(':', 1)
+        return StorageNode(parent=self, path=path, service=self.services[service_name])
+
+
+def sourceBag(*versions):
+    result = Bag()
+    for version, source in versions:
+        result.setItem(version, Bag(dict(version=version, source=source)))
+    return result
+
+
+class TestDocuExamplesSync(BaseGnrAppTest):
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.db = cls.app.db
+        cls.db.model.check(applyChanges=True)
+        cls.doctbl = cls.db.table('docu.documentation')
+        cls.site_dir = tempfile.mkdtemp(prefix='gnr_docu_site_')
+        cls.app.site = StorageSiteStub({'site': cls.site_dir})
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.site_dir, ignore_errors=True)
+        super().teardown_class()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def examplesNode(self, hierarchical_name):
+        return self.app.site.storageNode('site:webpages/docu_examples/%s'
+                                         % hierarchical_name)
+
+    def exampleFiles(self, hierarchical_name):
+        """Sorted example file names, or None if the folder is missing."""
+        node = self.examplesNode(hierarchical_name)
+        if not node.exists:
+            return None
+        return sorted(n.basename for n in node.children() if not n.isdir)
+
+    def exampleSource(self, hierarchical_name, filename):
+        with self.examplesNode(hierarchical_name).child(filename).open('r') as f:
+            return f.read()
+
+    def addDoc(self, name, parent_id=None, sourcebag=None, docbag=None):
+        record = dict(name=name, parent_id=parent_id)
+        self.doctbl.insert(record)
+        if sourcebag is not None or docbag is not None:
+            with self.doctbl.recordToUpdate(record['id']) as rec:
+                if sourcebag is not None:
+                    rec['sourcebag'] = sourcebag
+                if docbag is not None:
+                    rec['docbag'] = docbag
+        self.db.commit()
+        return record['id']
+
+    def updateDoc(self, pkey, **values):
+        with self.doctbl.recordToUpdate(pkey) as rec:
+            rec.update(values)
+        self.db.commit()
+
+    # ------------------------------------------------------------------
+    # sourcebag lifecycle
+    # ------------------------------------------------------------------
+
+    def test_write_on_sourcebag_update(self):
+        self.addDoc('intro', sourcebag=sourceBag(('v000', "print('first')"),
+                                                 ('v010', "print('second')")))
+        assert self.exampleFiles('intro') == ['v000.py', 'v010.py']
+        assert self.exampleSource('intro', 'v000.py') == "print('first')"
+
+    def test_rename_relocates_files(self):
+        pkey = self.addDoc('old_page', sourcebag=sourceBag(('v000', "print('x')")))
+        assert self.exampleFiles('old_page') == ['v000.py']
+        self.updateDoc(pkey, name='new_page')
+        assert self.exampleFiles('old_page') is None
+        assert self.exampleFiles('new_page') == ['v000.py']
+
+    def test_move_relocates_files(self):
+        shelf_id = self.addDoc('shelf')
+        pkey = self.addDoc('orphan', sourcebag=sourceBag(('v000', "print('x')")))
+        self.updateDoc(pkey, parent_id=shelf_id)
+        assert self.exampleFiles('orphan') is None
+        assert self.exampleFiles('shelf/orphan') == ['v000.py']
+
+    def test_parent_rewrite_keeps_children_files(self):
+        guide_id = self.addDoc('guide', sourcebag=sourceBag(('v000', "print('guide')")))
+        self.addDoc('step', parent_id=guide_id,
+                    sourcebag=sourceBag(('v000', "print('step')")))
+        self.updateDoc(guide_id, sourcebag=sourceBag(('v000', "print('guide!')"),
+                                                     ('v010', "print('more')")))
+        assert self.exampleFiles('guide') == ['v000.py', 'v010.py']
+        assert self.exampleSource('guide', 'v000.py') == "print('guide!')"
+        assert self.exampleFiles('guide/step') == ['v000.py']
+
+    def test_rename_parent_cascades_to_children(self):
+        book_id = self.addDoc('book', sourcebag=sourceBag(('v000', "print('book')")))
+        self.addDoc('chapter', parent_id=book_id,
+                    sourcebag=sourceBag(('v000', "print('chapter')")))
+        self.updateDoc(book_id, name='volume')
+        assert self.examplesNode('book').exists is False
+        assert self.exampleFiles('volume') == ['v000.py']
+        assert self.exampleFiles('volume/chapter') == ['v000.py']
+
+    def test_delete_removes_files(self):
+        pkey = self.addDoc('trash', sourcebag=sourceBag(('v000', "print('x')")))
+        assert self.exampleFiles('trash') == ['v000.py']
+        record = self.doctbl.record(pkey, for_update=True).output('dict')
+        self.doctbl.delete(record)
+        self.db.commit()
+        assert self.exampleFiles('trash') is None
+
+    # ------------------------------------------------------------------
+    # docbag links rewriting on rename
+    # ------------------------------------------------------------------
+
+    def test_rename_updates_links(self):
+        processor_name = self.doctbl.pkg.htmlProcessorName()
+        target_id = self.addDoc('link_target_v1')
+        docbag = Bag()
+        docbag['en.title'] = 'Linking page'
+        docbag['en.rst'] = '`See also <%s/link_target_v1>`_' % processor_name
+        linking_id = self.addDoc('linking_page', docbag=docbag)
+        self.updateDoc(target_id, name='link_target_v2')
+        updated_docbag = Bag(self.doctbl.record(linking_id).output('dict')['docbag'])
+        assert '<%s/link_target_v2>' % processor_name in updated_docbag['en.rst']
+        assert 'link_target_v1' not in updated_docbag['en.rst']
+
+    # ------------------------------------------------------------------
+    # bulk regeneration (the contract used by the export_to_sphinx batch)
+    # ------------------------------------------------------------------
+
+    def test_regenerate_after_site_loss(self):
+        pkey = self.addDoc('survivor', sourcebag=sourceBag(('v000', "print('keep')")))
+        self.app.site.storageNode('site:webpages').delete()
+        assert self.exampleFiles('survivor') is None
+        record = self.doctbl.record(pkey).output('dict')
+        self.doctbl.writeModulesFromSourceBag(dict(
+            hierarchical_name=record['hierarchical_name'],
+            sourcebag=Bag(record['sourcebag'])))
+        assert self.exampleFiles('survivor') == ['v000.py']
+        assert self.exampleSource('survivor', 'v000.py') == "print('keep')"

--- a/projects/gnrcore/packages/docu/model/documentation.py
+++ b/projects/gnrcore/packages/docu/model/documentation.py
@@ -91,31 +91,48 @@ class Table(object):
     def trigger_onUpdated(self,record,old_record):
         if record['hierarchical_name'] != old_record['hierarchical_name']:
             self.updateLink(record, old_record)
-            if record['sourcebag'] and record['sourcebag']==old_record['sourcebag']:
-                self.tutorialRecordNode(old_record).move(self.tutorialRecordNode(record))
-        if record['sourcebag'] != old_record['sourcebag']:
+            self.deleteSourceBagModules(old_record)
+            self.writeModulesFromSourceBag(record)
+        elif record['sourcebag'] != old_record['sourcebag']:
             self.writeModulesFromSourceBag(record)
 
+    def trigger_onDeleted(self,record):
+        self.deleteSourceBagModules(record)
+
     def updateLink(self, record, old_record):
-        old_link = '&lt;%s/%s&gt;' %(self.pkg.htmlProcessorName(),old_record['hierarchical_name'])
-        new_link = '&lt;%s/%s&gt;' %(self.pkg.htmlProcessorName(),record['hierarchical_name'])
-        
+        processor_name = self.pkg.htmlProcessorName()
+        old_link = '&lt;%s/%s&gt;' % (processor_name, old_record['hierarchical_name'])
+        new_link = '&lt;%s/%s&gt;' % (processor_name, record['hierarchical_name'])
+
         def cb(row):
-            row['docbag'] = row['docbag'].replace(old_link,new_link)
-        
-        self.batchUpdate(cb,where='$docbag ILIKE :old_link_query OR $docbag ILIKE :old_link_query',
-                            old_link_query='%%%s%%',_raw_update=True,bagFields=True)
+            #the LIKE pattern is not escaped so it may overmatch: the exact check is here
+            if not row['docbag'] or old_link not in row['docbag']:
+                return False
+            row['docbag'] = row['docbag'].replace(old_link, new_link)
+
+        self.batchUpdate(cb, where='$docbag ILIKE :old_link_query',
+                         old_link_query='%%%s%%' % old_link,
+                         _raw_update=True, bagFields=True)
     
     def tutorialRecordNode(self,record):
         return self.db.application.site.storageNode('site:webpages','docu_examples',record['hierarchical_name'])
 
-    def writeModulesFromSourceBag(self,record):
+    def deleteSourceBagModules(self,record):
+        """Delete only the example files: the node of a parent record
+           also contains the subfolders of its children records"""
         tutorial_record_node = self.tutorialRecordNode(record)
-        if tutorial_record_node.exists:
-            for n in tutorial_record_node.children():
-                if n.exists and not n.isdir:
-                    tutorial_record_node.delete()
+        if not tutorial_record_node.exists:
+            return
+        for n in tutorial_record_node.children() or []:
+            if n.exists and not n.isdir:
+                n.delete()
+        if not tutorial_record_node.children():
+            tutorial_record_node.delete()
+
+    def writeModulesFromSourceBag(self,record):
+        self.deleteSourceBagModules(record)
         if record['sourcebag']:
+            tutorial_record_node = self.tutorialRecordNode(record)
             for source_version in record['sourcebag'].values():
                 with tutorial_record_node.child('%(version)s.py' %source_version).open('w') as f:
                     f.write(source_version['source'])

--- a/projects/gnrcore/packages/docu/resources/tables/handbook/action/export_to_sphinx.py
+++ b/projects/gnrcore/packages/docu/resources/tables/handbook/action/export_to_sphinx.py
@@ -260,6 +260,10 @@ class Main(BaseResourceBatch):
             docbag = Bag(record['docbag'])
             self.curr_sourcebag = Bag(record['sourcebag'])
             self.hierarchical_name = record['hierarchical_name']
+            if self.curr_sourcebag:
+                #regenerate the served example modules: the site folder is disposable
+                self.doctable.writeModulesFromSourceBag(dict(hierarchical_name=self.hierarchical_name,
+                                                             sourcebag=self.curr_sourcebag))
             lbag=docbag[self.handbook_record['language']] or Bag()
             rst = lbag['rst'] or ''
             df_rst = self.doctable.dfAsRstTable(record['id'], language=self.handbook_record['language'])

--- a/projects/gnrcore/packages/docu/tests/test_examples_sync.py
+++ b/projects/gnrcore/packages/docu/tests/test_examples_sync.py
@@ -8,19 +8,19 @@ regenerable in bulk from the sourcebag since the site folder is
 disposable. The rst links pointing to a renamed record must be rewritten
 in the docbag of the other records.
 
-The tests run against a real database (gnrdevelop instance on a temporary
-sqlite file) and a real local storage service backed by a temporary
-directory: records go through the actual table triggers and assertions
-read the actual filesystem.
+The tests need no running site nor a shared database: they build a
+throwaway application on a temporary sqlite file and expose a real local
+storage service on a temporary directory, so the records go through the
+actual table triggers and the assertions read the actual filesystem.
 """
+import os
 import shutil
 import tempfile
 from types import SimpleNamespace
 
+from gnr.app.gnrapp import GnrApp
 from gnr.core.gnrbag import Bag
 from gnr.lib.services.storage import BaseLocalService, StorageNode
-
-from common import BaseGnrAppTest
 
 
 class StorageSiteStub:
@@ -48,11 +48,15 @@ def sourceBag(*versions):
     return result
 
 
-class TestDocuExamplesSync(BaseGnrAppTest):
+class TestDocuExamplesSync(object):
 
     @classmethod
     def setup_class(cls):
-        super().setup_class()
+        cls.instance_name = os.environ.get('GNR_TESTING_INSTANCE_NAME') or 'gnrdevelop'
+        cls.temp_dir = tempfile.mkdtemp(prefix='gnr_docu_examples_')
+        cls.app = GnrApp(cls.instance_name, db_attrs=dict(
+            implementation='sqlite',
+            dbname=os.path.join(cls.temp_dir, 'testing')))
         cls.db = cls.app.db
         cls.db.model.check(applyChanges=True)
         cls.doctbl = cls.db.table('docu.documentation')
@@ -61,8 +65,9 @@ class TestDocuExamplesSync(BaseGnrAppTest):
 
     @classmethod
     def teardown_class(cls):
-        shutil.rmtree(cls.site_dir, ignore_errors=True)
-        super().teardown_class()
+        cls.db.closeConnection()
+        for folder in (cls.site_dir, cls.temp_dir):
+            shutil.rmtree(folder, ignore_errors=True)
 
     # ------------------------------------------------------------------
     # helpers


### PR DESCRIPTION
## Motivation

The `.py` example modules served from `site:webpages/docu_examples` are written by the `docu.documentation` triggers, but they fell out of sync with the record lifecycle in several cases:

- **Rename/move left the old folder orphaned.** `trigger_onUpdating` always rewrites the `url` attributes inside the sourcebag with the new `hierarchical_name`, so in `trigger_onUpdated` the equality check `record['sourcebag']==old_record['sourcebag']` guarding the folder move could never be true: the files were written at the new location and the old folder stayed behind.
- **Delete left the folder behind.** There was no `trigger_onDeleted` at all.
- **Rewriting a parent's sourcebag wiped the descendants' examples.** The cleanup loop in `writeModulesFromSourceBag` deleted the whole `tutorialRecordNode` as soon as it found a file child, but with hierarchical names the folder of a parent record contains the subfolders of its children records.
- **The export could not rebuild a lost site folder.** The `site` folder is disposable by definition, but the only code paths regenerating the example files were the update trigger and the per-record `checkSourceBagModules`.
- **`updateLink` fetched and rewrote almost the whole table on every rename.** The LIKE pattern was never interpolated with the searched link (`old_link_query='%%%s%%'` reached the database as a literal pattern, i.e. "any docbag containing an *s*"), the condition was duplicated in the where clause, and `batchUpdate` rewrites every fetched row, locking them with `SELECT FOR UPDATE`.

## Changes

- `trigger_onUpdated`: on a `hierarchical_name` change the old node files are deleted and the modules rewritten at the new location. The hierarchical cascade updates every descendant through full triggered updates, so each child record relocates its own folder.
- New `trigger_onDeleted` removes the example files of the deleted record.
- New `deleteSourceBagModules` deletes only the **file** children of the record node, keeping the subfolders of the children records intact; the folder itself is removed only when empty. `writeModulesFromSourceBag` now delegates the cleanup to it.
- `export_to_sphinx.prepare()` calls `writeModulesFromSourceBag` for every exported document with a sourcebag, so a full export regenerates `site:webpages/docu_examples` from scratch.
- `updateLink` builds the LIKE pattern from the actual old link and the callback returns `False` for rows that do not contain it, so only the linking records are rewritten. The pattern is intentionally not wildcard-escaped: the sqlite adapter translates `ILIKE` to a plain `LIKE` with no `ESCAPE` clause, so escaping would break matching there; the exact check in the callback makes the SQL pattern a pure pre-filter.

## Test cases

`projects/gnrcore/packages/docu/tests/test_examples_sync.py` (8 tests), run with:

```
gnr dev tests <instance> docu
```

The tests are self-contained: they build a throwaway application on a temporary sqlite file and a real local storage service on a temporary directory, so records go through the actual table triggers and assertions read the actual filesystem — no running site nor shared instance database needed.

- sourcebag update writes the module files with the right content
- rename relocates the files and removes the old folder
- move under another parent relocates the files
- rewriting a parent's sourcebag keeps the children's files intact (regression for the folder wipe)
- renaming a parent cascades: both the parent and the children folders are relocated
- delete removes the files
- rename rewrites the rst links inside the docbag of the linking records (names with underscores, guarding the LIKE pattern against escaping regressions)
- bulk regeneration after the loss of the site folder, through the same call the export batch uses

Framework suites unaffected: `tests/app` 163 passed, `tests/sql` 1202 passed, `tests/core` 428 passed with 2 pre-existing failures in `flatfiles_test.py` (present on a clean develop checkout as well, unrelated).

flake8 clean on all touched files.

Note: running the package tests through the `DbBasedTest`/`PackageTester` base currently fails on a fresh checkout because the committed `gnrdevelop` instance databases are not aligned with the current models (`no such table: adm.adm_preference` while booting `GnrWsgiSite`) — the `sys` package tests hit the same wall. These tests avoid that dependency on purpose; the stale instance data deserves a separate issue.