### PR TITLE
fix(deps): replace watchgod with watchfiles to lift the anyio<4 ceiling

### DIFF
--- a/gnrpy/gnr/web/cli/gnrtaskscheduler.py
+++ b/gnrpy/gnr/web/cli/gnrtaskscheduler.py
@@ -4,7 +4,7 @@
 import sys
 import os.path
 import asyncio
-from watchgod import awatch
+from watchfiles import awatch
 from multiprocessing import Process
 import importlib
 

--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 	     "tzlocal",
 	     "unidecode",
 	     "vobject",
-	     "watchgod", # used in asyncio for autoreload
+	     "watchfiles", # used in asyncio for autoreload
 	     "weasyprint",
 	     "werkzeug>=2.3.8,!=3.1.4",
 	     "xlrd",


### PR DESCRIPTION
## Problem

`gnrpy/pyproject.toml` declares `watchgod` as a dependency. `watchgod` itself requires `anyio<4,>=3.0.0`. In any environment that also runs a modern ASGI stack (`httpcore>=1` needs `anyio>=4` for its asyncio extra), this silently downgrades `anyio` to 3.7.1 and the environment fails `pip check`.

## Root cause

`watchgod` is imported in exactly one place in the shipped tree: `gnrpy/gnr/web/cli/gnrtaskscheduler.py`, where `awatch()` is used only as an edge trigger to restart a child process on code changes — the yielded change set is discarded, so no call-site behavior depends on the specific library. `watchfiles` is the maintained successor by the same author, exposes the same `awatch(path)` signature, and declares `anyio>=3.0.0` with no upper bound, removing the conflicting ceiling.

## Change

- `gnrpy/pyproject.toml`: `watchgod` -> `watchfiles` in `dependencies` (alphabetical position preserved)
- `gnrpy/gnr/web/cli/gnrtaskscheduler.py`: `from watchgod import awatch` -> `from watchfiles import awatch`

Considered and rejected: pinning an explicit `anyio` floor in `pyproject.toml`. The dependency list is overwhelmingly unpinned (only `chardet`, `smart_open` and `werkzeug` carry specifiers), and the `watchfiles` swap already removes the conflicting constraint, so an extra pin would be unnecessary.

## Verification

- `flake8` on the touched Python file: clean.
- Import check: `gnr.web.cli.gnrtaskscheduler` imports cleanly with `watchfiles`, confirmed resolving from this branch's checkout (not a stray editable install elsewhere).
- Full test suite: `pytest gnrpy/tests/` — 1958 passed, 67 skipped, 0 failed (includes `tests/sql`, `gnrasync_test.py`, `gnrasync_session_test.py`).
- Not verified: the autoreload loop itself was not exercised live, since it requires a site configured for the async task manager. Manual steps to verify: run `gnrtaskscheduler <sitename> --autoreload` against such a site, `touch` a `.py` file under `gnrpy`, and confirm the `Detected code changes, restarting...` log line together with a new child process PID; repeat once to confirm the watch loop survives past the first yield.

Fixes #1078