### PR TITLE
fix(th): hdbSelect accepts the table kwarg instead of requiring the deprecated dbtable

### DIFF
--- a/projects/gnrcore/packages/test/webpages/inputfields/dbselect.py
+++ b/projects/gnrcore/packages/test/webpages/inputfields/dbselect.py
@@ -77,3 +77,11 @@ class GnrCustomWebPage(object):
                         selected_regione='.regione',
                         invalidItemCondition_message='troppo lungo',auxColumns='$regione')
         fb.div('^.regione')
+
+    def test_6_hdbselect(self,pane):
+        "hdbSelect on a hierarchical table: table= kwarg and the deprecated dbtable= spelling sharing a connectedMenu"
+        fb = pane.formbuilder(cols=1, border_spacing='4px')
+        fb.hdbSelect(value='^.tag_id',table='adm.htag',lbl='Tag',width='25em',
+                    caption_field='hierarchical_description',connectedMenu='htag_menu')
+        fb.hdbSelect(value='^.tag_id_2',dbtable='adm.htag',lbl='Tag (old spelling)',width='25em',
+                    caption_field='hierarchical_description',connectedMenu='htag_menu')

--- a/resources/common/gnrcomponents/htablehandler.py
+++ b/resources/common/gnrcomponents/htablehandler.py
@@ -184,12 +184,14 @@ class HTableHandlerBase(BaseComponent):
     def ht_hdbselect_old(self,pane,**kwargs):
         dbselect = pane.dbselect(**kwargs)
         attr = dbselect.attributes
+        dbtable = attr.get('dbtable') or attr.pop('table', None)
+        attr['dbtable'] = dbtable
         menupath = 'gnr.htablestores.%(dbtable)s' %attr
         attr['hasDownArrow'] = True
         dbselect_condition = attr.get('condition')
         dbselect_condition_kwargs = dictExtract(attr,'condition_')
         attr['condition'] = '$child_count=0' if not dbselect_condition else ' ( %s ) AND $child_count=0' %dbselect_condition
-        pane.dataRemote(menupath,self.ht_remoteTreeData,table=attr['dbtable'],
+        pane.dataRemote(menupath,self.ht_remoteTreeData,table=dbtable,
                         condition=dbselect_condition,
                         condition_kwargs=dbselect_condition_kwargs,cacheTime=30)
         dbselect.menu(storepath='%s._root_' %menupath,_class='smallmenu',modifiers='*',selected_pkey=attr['value'].replace('^',''))

--- a/resources/common/th/th_tree.py
+++ b/resources/common/th/th_tree.py
@@ -19,6 +19,8 @@ class HTableTree(BaseComponent):
     def ht_hdbselect(self,pane,caption_field=None,treeMode=None,folderSelectable=False,cacheTime=None,connectedMenu=None,tree_kwargs=None,**kwargs):
         dbselect = pane.dbselect(**kwargs)
         attr = dbselect.attributes
+        dbtable = attr.get('dbtable') or attr.pop('table', None)
+        attr['dbtable'] = dbtable
         dbselect_condition = attr.get('condition')
         dbselect_condition_kwargs = dictExtract(attr,'condition_',slice_prefix=False)
         dbselect_selected_kwargs = dictExtract(attr,'selected_',slice_prefix=False)
@@ -33,8 +35,8 @@ class HTableTree(BaseComponent):
         if connectedMenu not in currentHMenu:
             tree_kwargs['openOnClick'] = not folderSelectable
             tree_kwargs['selected_pkey'] = kwargs.get('value').replace('^','')
-            menupath = 'gnr.htablestores.%s_%s' %(attr['dbtable'],connectedMenu)
-            dbselect.treemenu(storepath=menupath,table=attr['dbtable'],condition=dbselect_condition,
+            menupath = 'gnr.htablestores.%s_%s' %(dbtable,connectedMenu)
+            dbselect.treemenu(storepath=menupath,table=dbtable,condition=dbselect_condition,
                                 condition_kwargs=dbselect_condition_kwargs,modifiers='*',
                                 caption_field=caption_field,cacheTime=cacheTime,
                                 menuId=connectedMenu,dbstore=kwargs.get('_storename'),**tree_kwargs)


### PR DESCRIPTION
## Problem

`hdbSelect(table=...)` raises `KeyError: 'dbtable'`, while `dbSelect(table=...)` works fine. The failure looks intermittent: it only happens the first time a given `connectedMenu` is built on a page.

## Root cause

`HTableTree.ht_hdbselect` (`resources/common/th/th_tree.py`) builds `dbselect = pane.dbselect(**kwargs)` and reads `attr = dbselect.attributes`, which is literally the raw kwargs the caller passed — there is no server-side normalization step that turns `table` into `dbtable` (that only happens client-side, in `objectExtract`/`objectPop` in `gnrjs/gnr_d11/js/genro_widgets.js`). Two lines inside the `if connectedMenu not in currentHMenu:` block then read `attr['dbtable']` directly, so a bare `table=` kwarg raises `KeyError`.

This is easy to miss because:
- `fb.field(..., tag='hdbselect')` gets `dbtable` injected automatically by the field builder (`gnrpy/gnr/web/gnrwebstruct/dojo11.py`), so only the explicit `fb.hdbSelect(table=...)` form hits it.
- a second `hdbSelect` sharing the same `connectedMenu` skips the branch entirely (menu already built), so the bug looks intermittent depending on call order.

The same bug shape exists in the legacy `HTableHandlerBase.ht_hdbselect_old` (`resources/common/gnrcomponents/htablehandler.py`), which builds its `menupath` via `%`-formatting on `attr` and also reads `attr['dbtable']` directly. It has no callers in the tree today, but the root cause is identical so it is fixed at the same time.

## Change

In both `ht_hdbselect` methods, right after reading `dbselect.attributes`:

```python
dbtable = attr.get('dbtable') or attr.pop('table', None)
attr['dbtable'] = dbtable
```

then use the local `dbtable` variable at the call sites that previously read `attr['dbtable']`. This mirrors the client-side resolver (fall back from `dbtable` to `table`, then remove `table`) and also avoids leaking a stray `table` attribute into the treemenu subtree that `dbselect.treemenu(...)` builds as a child node — node attributes are inherited down the struct, and `table` is an actively consulted inherited key elsewhere in the struct code.

Added a regression case to `projects/gnrcore/packages/test/webpages/inputfields/dbselect.py`: an `hdbSelect` on the hierarchical `adm.htag` table using `table=`, and a second one using the old `dbtable=` spelling with the same `connectedMenu`, so the test page exercises both spellings and the shared-menu branch (the one that previously skipped the fix entirely).

## Verification

- `flake8` on the three touched files: zero errors.
- `python -m py_compile` on the three touched files: clean.
- `pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql`: 787 passed, 57 skipped, no failures.
- `gnrpy/tests/sql` was not used as evidence (environmental: concurrent sessions on this machine share one postgres instance and their fixtures kill each other's connections).

**Not verified live.** Rendering the actual test page needs a running `gnrdevelop` instance against postgres, which I did not spin up. Manual steps to confirm:
1. Start the `gnrdevelop` instance (`projects/gnrcore/instances/gnrdevelop`), open `/test/inputfields/dbselect`.
2. Confirm the page renders with no traceback (pre-fix, the new `table=` field raises `KeyError: 'dbtable'`).
3. Click the new field's down-arrow, confirm the tree popup opens and lists the `adm.htag` hierarchy, pick a leaf, confirm the value is written.
4. Confirm the second field (old `dbtable=` spelling, same `connectedMenu`) still behaves, proving no regression on the old spelling and covering the shared-menu branch.

## Open point for @dgpaci

When neither `table` nor `dbtable` is passed, the call used to raise a `KeyError` right away and now silently degrades to `dbtable=None`, which will fail confusingly further downstream in `db.table(None)`. Worth raising an explicit, clearer error for that case — left out of scope here.

Fixes #931