### PR TITLE
chore(github): cover gnrpy and add a catch-all rule to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,10 @@
+# The last matching pattern wins, so the catch-all must stay first:
+# anything the rules below do not cover falls back to it instead of
+# opening with no code owner and no reviewer at all.
+*               @fporcari @genro
+
+gnrpy/          @fporcari @genro
 gnrjs/          @fporcari @genro
-resources/      @fporcari @genro 
-projects/       @fporcari @genro 
+resources/      @fporcari @genro
+projects/       @fporcari @genro
 *.js            @fporcari

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@ gnrpy/          @fporcari @genro
 gnrjs/          @fporcari @genro
 resources/      @fporcari @genro
 projects/       @fporcari @genro
-*.js            @fporcari
+*.js            @fporcari @genro


### PR DESCRIPTION
## Problem

`.github/CODEOWNERS` covered `gnrjs/`, `resources/`, `projects/` and `*.js`. Every other directory matched no rule at all — including `gnrpy/`, which holds the framework itself.

A pull request whose diff touches only uncovered paths gets no code owner. GitHub has nobody to request a review from, so it opens with an empty `reviewRequests`, nobody is notified, and it sits in `REVIEW_REQUIRED` with a green CI until somebody happens to look at the list.

## How it surfaced

Triaging the open pull requests, five of them had no reviewer at all, and the pattern was exact:

| PR | Paths touched | Reviewer requested on open |
|---|---|---|
| #1091, #1090, #1089, #1087, #1084 | only `gnrpy/**` | none |
| #1086 | `projects/gnrcore/...` | `@genro`, from CODEOWNERS |

Nothing distinguished those five except the directory they happen to live in.

There is a second half to it. `develop` is protected, so the missing rule only delays a merge there — `required_approving_review_count` is still 1. On a pull request stacked on a feature branch the protection does not apply at all: #1083 targets `fix/1082-siteregister-pyro-retry`, matches no CODEOWNERS rule, and reports `mergeStateStatus: CLEAN` with zero submitted reviews. Green, mergeable, never read.

## Change

- `gnrpy/` gets an explicit rule.
- A `*` catch-all is added so a directory created tomorrow is covered the day it appears, rather than reopening the same hole.
- `*.js` gains `@genro` as a second owner.
- Trailing whitespace removed from two existing lines.

The catch-all is placed **first** on purpose. In CODEOWNERS the *last* matching pattern takes precedence, so a `*` at the bottom would shadow every specific rule above it, `*.js @fporcari` included. First, it only applies where nothing else matches.

Two consequences of the catch-all are worth stating rather than leaving to be discovered:

**`.github/` becomes code-owned, CODEOWNERS itself included**, along with any workflow added later. Until now anyone with write access could rewrite the ownership rules without an owner reading the change. That is a hardening in its own right, not a side effect of covering `gnrpy/`.

**`*.js` needed a second owner.** It is the last line, so it wins over `gnrjs/` for JavaScript files, and its sole owner was also the most frequent author on them — nobody approves their own pull request, so a PR touching only `.js` files had no reachable code owner review. #1046 is the live case: two `.css` files under `gnrjs/` (owned by both of us) plus `genro_toast.js`, owned by me alone.

## Open decision

`develop` has `require_code_owner_reviews` enabled, so making every file code-owned also narrows who can satisfy the requirement. On the paths that previously had no rule, any collaborator with write access could approve; after this change it has to be `@fporcari` or `@genro`.

That is a policy change, not just a notification fix, and it is worth a deliberate answer:

- keep it as proposed, and accept `@fporcari`/`@genro` as the gate on everything;
- or point the catch-all at a GitHub team, so the set of people who can approve is managed by team membership instead of by editing this file on every change.

@genro @cgabriel — the second option is the one I would pick if the two-person gate looks too narrow in practice.

## Verification

No code change, nothing to test. The rule ordering was checked against GitHub's documented "last matching pattern wins" semantics; the coverage gap was verified by diffing the existing rules against the top-level directories on `develop` and against the touched paths of the open pull requests listed above.

