### PR TITLE
fix(web): escape dotted usernames in the remaining Bag-label keyed registries

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister_client.py
+++ b/gnrpy/gnr/web/daemon/siteregister_client.py
@@ -449,7 +449,8 @@ class RegisterResolver(BagResolver):
             item['info'] = Bag(item_user)
             item['data'] = data
             item.setItem('connections', RegisterResolver(user=user), cacheTime=3)
-            result.setItem(user, item, user=user)
+            label = user.replace('.', '_').replace('@', '_')
+            result.setItem(label, item, user=user)
         return result
 
     def list_connections(self, user):
@@ -459,7 +460,7 @@ class RegisterResolver(BagResolver):
             delta = (datetime.now() - connection['start_ts']).seconds
             user = connection['user'] or 'Anonymous'
             connection_name = connection['connection_name']
-            itemlabel = '%s (%i)' % (connection_name, delta)
+            itemlabel = ('%s (%i)' % (connection_name, delta)).replace('.', '_').replace('@', '_')
             item = Bag()
             data = connection.pop('data', None)
             item['info'] = Bag(connection)
@@ -474,7 +475,7 @@ class RegisterResolver(BagResolver):
         for page_id, page in list(pagesDict.items()):
             delta = (datetime.now() - page['start_ts']).seconds
             pagename = page['pagename'].replace('.py', '')
-            itemlabel = '%s (%i)' % (pagename, delta)
+            itemlabel = ('%s (%i)' % (pagename, delta)).replace('.', '_').replace('@', '_')
             item = Bag()
             data = page.pop('data', None)
             item['info'] = Bag(page)

--- a/gnrpy/gnr/web/gnrasync.py
+++ b/gnrpy/gnr/web/gnrasync.py
@@ -370,15 +370,23 @@ class SharedStatus(SharedObject):
     def sharedObjects(self):
         return self.data['sharedObjects']
 
+    @staticmethod
+    def _userkey(user):
+        """Bag labels split on '.', so a dotted username must be escaped
+        before it can key the users tree; the real username still rides in
+        the node's 'user' attribute/value."""
+        return user.replace('.', '_').replace('@', '_')
+
     def registerPage(self, page):
         page_item = page.page_item
         users = self.users
         page_id = page.page_id
-        if page.user not in users:
-            users[page.user] = Bag(dict(
+        userkey = self._userkey(page.user)
+        if userkey not in users:
+            users[userkey] = Bag(dict(
                 start_ts=page_item['start_ts'], user=page.user, connections=Bag(),
             ))
-        userbag = users[page.user]
+        userbag = users[userkey]
         connection_id = page.connection_id
         if connection_id not in userbag['connections']:
             userbag['connections'][connection_id] = Bag(dict(
@@ -397,7 +405,8 @@ class SharedStatus(SharedObject):
 
     def unregisterPage(self, page):
         users = self.users
-        userbag = users[page.user]
+        userkey = self._userkey(page.user)
+        userbag = users[userkey]
         connection_id = page.connection_id
         userconnections = userbag['connections']
         connection_pages = userconnections[connection_id]['pages']
@@ -405,13 +414,13 @@ class SharedStatus(SharedObject):
         if not connection_pages:
             userconnections.popNode(connection_id)
             if not userconnections:
-                users.popNode(page.user)
+                users.popNode(userkey)
 
     def onPing(self, page_id, lastEventAge):
         page = self.server.pages.get(page_id)
         if not page:
             return
-        userdata = self.users[page.user]
+        userdata = self.users[self._userkey(page.user)]
         conndata = userdata['connections'][page.connection_id]
         pagedata = conndata['pages'][page_id]
         pagedata['lastEventAge'] = lastEventAge
@@ -426,7 +435,7 @@ class SharedStatus(SharedObject):
         page = self.server.pages.get(page_id)
         if not page:
             return
-        pagedata = self.users[page.user]['connections'][page.connection_id]['pages'][page_id]
+        pagedata = self.users[self._userkey(page.user)]['connections'][page.connection_id]['pages'][page_id]
         old_targetId = pagedata['evt_targetId']
         for k, v in list(event.items()):
             pagedata['evt_%s' % k] = v

--- a/gnrpy/tests/web/gnrasync_test.py
+++ b/gnrpy/tests/web/gnrasync_test.py
@@ -186,6 +186,51 @@ async def test_unix_sockets_created(tmp_path):
         await run_task
 
 
+def _fake_page(page_id, user, connection_id):
+    page = MagicMock()
+    page.page_id = page_id
+    page.user = user
+    page.userTags = 'admin'
+    page.connection_id = connection_id
+    page.page_item = {
+        'start_ts': 'ts', 'user_ip': '127.0.0.1', 'user_agent': 'pytest',
+        'pagename': 'p', 'relative_url': '/',
+    }
+    return page
+
+
+def test_dotted_username_does_not_clobber_bag_label(tmp_path):
+    """Bag labels split on '.', so a raw dotted username used as a label
+    collides with a plain-username sibling (e.g. 'amelia' vs
+    'amelia.martin'). SharedStatus must escape the label while keeping the
+    real username in the node's 'user' value."""
+    server, _ = _build_server(tmp_path, PORT_BASE + 5)
+    sharedStatus = server.sharedStatus
+
+    dotted_page = _fake_page('pg_dotted', 'amelia.martin', 'c_dotted')
+    plain_page = _fake_page('pg_plain', 'amelia', 'c_plain')
+    server.pages['pg_dotted'] = dotted_page
+    server.pages['pg_plain'] = plain_page
+
+    sharedStatus.registerPage(dotted_page)
+    assert list(sharedStatus.users.keys()) == ['amelia_martin']
+    assert sharedStatus.users['amelia_martin']['user'] == 'amelia.martin'
+
+    sharedStatus.registerPage(plain_page)
+    assert sorted(sharedStatus.users.keys()) == ['amelia', 'amelia_martin']
+    assert sharedStatus.users['amelia_martin']['user'] == 'amelia.martin'
+    assert sharedStatus.users['amelia']['user'] == 'amelia'
+
+    sharedStatus.onPing('pg_dotted', 0)
+    sharedStatus.onPing('pg_plain', 0)
+    assert sharedStatus.users['amelia_martin']['user'] == 'amelia.martin'
+    assert sharedStatus.users['amelia']['user'] == 'amelia'
+
+    sharedStatus.unregisterPage(dotted_page)
+    assert list(sharedStatus.users.keys()) == ['amelia']
+    assert sharedStatus.users['amelia']['user'] == 'amelia'
+
+
 @pytest.mark.asyncio
 async def test_no_tornado_import():
     """The migration deletes the tornado dependency entirely."""

--- a/projects/gnrcore/packages/test15/webpages/tools/newregisterexplorer.py
+++ b/projects/gnrcore/packages/test15/webpages/tools/newregisterexplorer.py
@@ -200,7 +200,8 @@ class GnrCustomWebPage(object):
             item.pop('datachanges', None)
             if child_name is None:
                 self.maintenance_cellServerProfile(item)
-            result.setItem(key, None, _customClasses=' '.join(_customClasses), **item)
+            result.setItem(key.replace('.', '_').replace('@', '_'), None,
+                           _customClasses=' '.join(_customClasses), **item)
         return result
 
 


### PR DESCRIPTION
## Problem

Issue #1062: usernames containing a dot (or `@`) break any GenroPy feature that keys a Bag by the raw username, because Bag labels split on `.` in both the Python `Bag` and the JS `GnrBag`. PR #1063 fixed the chat half. This PR is the audit-driven fix for the remaining sites.

## Root cause

`Bag.__setitem__` / `__getitem__` treat `.` as the path separator, so `bag['amelia.martin']` is really `bag['amelia']['martin']`. Any code that does `bag.setItem(user, ...)` (or `bag[user] = ...`) with a raw, dotted username silently nests instead of creating a sibling. If a plain `amelia` user also exists, whichever write happens second clobbers the other's subtree, and lookups for the dotted user return `None`.

## Change

Audited sites from the issue, and what was done with each:

| Site | Status | Notes |
|---|---|---|
| `gnrpy/gnr/web/gnrwebpage_proxy/connection.py:205` | already fixed (#1063) | established the convention this PR extends |
| `gnrpy/gnr/web/daemon/siteregister_client.py` (`RegisterResolver.list_users`, `list_connections`, `list_pages`) | **fixed here** | escaped the label at all three `setItem` calls (`:452`, `:468`, `:482`); the `user=user` attribute was already carried, readers keep it |
| `gnrpy/gnr/web/gnrasync.py` (`SharedStatus`) | **fixed here** | added a `_userkey()` helper used at all 7 label call sites (`registerPage`, `unregisterPage`, `onPing`, `onUserEvent`); verified failure before the fix: `users['amelia'] = Bag(...)` then `users['amelia.martin']` returned `None`, so `onPing`/`onUserEvent` raised `TypeError` on `None['connections']`, and `popNode(page.user)` could leave an orphan node |
| `projects/gnrcore/packages/sys/webpages/asyncdashboard.py` | no change needed (consumer) | its `dataController` paths concatenate the grid's *selected label*, which is now the escaped label — label and path stay in agreement |
| `projects/gnrcore/packages/test15/webpages/tools/newregisterexplorer.py` (`_maintenance_get_items`) | **fixed here** | escaped the label exactly as `packages/sys/webpages/onering.py:266` already does; `item['_pkey']` keeps the real key |

Three conventions coexist in-tree for this class of problem, found during the audit:
- dot/`@`-escaping (the one used by #1063 and by this PR)
- numeric re-keying in `maintenance.py:356-359`, from the 2019 fix `4808b8084`
- raw labels (the bug this PR removes at the sites above)

## Verification

- `flake8 <touched files> --select=F401,E9,F63,F7,F82` — clean.
- `PYTHONPATH=<worktree>/gnrpy pytest gnrpy/tests/web/gnrasync_test.py -q` — 7 passed, including a new test that registers a page for `amelia.martin`, asserts the `SharedStatus.users` tree has exactly one top-level node whose `user` value is the full dotted name, registers a second page for `amelia` and asserts neither clobbers the other, calls `onPing` for both without raising, then unregisters the dotted page and asserts no orphan node remains.
- `PYTHONPATH=<worktree>/gnrpy pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql` — 803 passed, 57 skipped.
- `asyncdashboard.py` behavior verified by reading, not by running the page in a browser (no change made; left manual/visual verification to the reviewer if desired).
- `newregisterexplorer.py` and `siteregister_client.py` changes verified by code inspection against the working `onering.py`/`connection.py` precedents; not exercised through a live register-explorer page in this session.

## Open decision — @genro

The systemic alternative to boundary-escaping is a literal-label form for `setItem`/`getItem` (i.e. stop splitting on `.` when the path is escaped upstream). Python's `smartsplit` already honours backslash-escaped separators, but the JS twin (`gnrlang.js:224-237`) is a broken Rhino-era leftover — `new java.lang.Character(1)` throws a `ReferenceError` the moment a path contains `\.` in a browser. So the systemic option requires fixing JS `smartsplit` first. This PR deliberately keeps extending the boundary-escaping convention instead, to close the known holes without touching that shared code path. Worth deciding whether the systemic fix is wanted for the future or whether escaping-at-the-boundary is the accepted long-term pattern.

## Follow-up (out of scope here)

`siteregister.py:457` does an unanchored `re.match(fltval, value)`, and `filters='user:%s' % user'` is built at `gnrwebpage.py:2347` and `chat_component.py:176`. This means a filter for `user:anna` also matches `anna.bianchi`. Not fixed in this PR; flagging as a candidate follow-up.

Fixes #1062
