### PR TITLE
feat(register): hold the parent -> children links on the register items

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -367,16 +367,24 @@ class ConnectionRegister(BaseRegister):
                 self.siteregister.drop_user(user)
 
     def user_connection_keys(self, user):
-        return [k for k, v in list(self.items()) if v['user'] == user]
+        # from the user item's link set; a list, so callers may drop while iterating
+        user_item = self.siteregister.user_register.registerItems.get(user)
+        if not user_item:
+            return []
+        return list(user_item['connections'])
 
     def user_connection_items(self, user):
-        return [(k, v) for k, v in list(self.items()) if v['user'] == user]
+        return [(k, self.registerItems[k]) for k in self.user_connection_keys(user)]
+
+    def user_connections(self, user):
+        return [self.registerItems[k] for k in self.user_connection_keys(user)]
 
     def connections(self, user=None, include_data=None):
-        connections = self.values(include_data=include_data)
-        if user:
-            connections = [v for v in connections if v['user'] == user]
-        return connections
+        if not user:
+            return self.values(include_data=include_data)
+        if include_data:
+            return [self.get_item(k, include_data=True) for k in self.user_connection_keys(user)]
+        return self.user_connections(user)
 
 
 class PageRegister(BaseRegister):
@@ -483,16 +491,35 @@ class PageRegister(BaseRegister):
         return [self.registerItems[k] for k in self.subscribed_table_page_keys(table)]
 
     def connection_page_keys(self, connection_id):
-        return [k for k, v in list(self.items()) if v['connection_id'] == connection_id]
+        # from the connection item's link set; a list, so callers may drop while iterating
+        connection_item = self.siteregister.connection_register.registerItems.get(connection_id)
+        if not connection_item:
+            return []
+        return list(connection_item['pages'])
 
     def connection_page_items(self, connection_id):
-        return [(k, v) for k, v in list(self.items()) if v['connection_id'] == connection_id]
+        return [(k, self.registerItems[k]) for k in self.connection_page_keys(connection_id)]
+
+    def connection_pages(self, connection_id):
+        return [self.registerItems[k] for k in self.connection_page_keys(connection_id)]
 
     def pages(self, connection_id=None, user=None, include_data=None, filters=None):
-        pages = self.values(include_data=include_data)
+        # walk the link sets rather than the whole registry: a connection knows its
+        # pages, a user knows its connections
+        page_ids = None
         if connection_id:
-            pages = [v for v in pages if v['connection_id'] == connection_id]
-        if user:
+            page_ids = self.connection_page_keys(connection_id)
+        elif user:
+            page_ids = [page_id
+                        for cid in self.siteregister.user_connection_keys(user)
+                        for page_id in self.connection_page_keys(cid)]
+        if page_ids is None:
+            pages = self.values(include_data=include_data)
+        elif include_data:
+            pages = [self.get_item(page_id, include_data=True) for page_id in page_ids]
+        else:
+            pages = [self.registerItems[page_id] for page_id in page_ids]
+        if connection_id and user:
             pages = [v for v in pages if v['user'] == user]
         if not filters or filters == '*':
             return pages

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -325,6 +325,7 @@ class UserRegister(BaseRegister):
             user_name=user_name,
             user_tags=user_tags,
             avatar_extra=avatar_extra,
+            connections=set(),
             register_name='user')
         self.addRegisterItem(register_item)
         return register_item
@@ -351,6 +352,7 @@ class ConnectionRegister(BaseRegister):
             user_agent=user_agent,
             electron_static=electron_static,
             browser_name=browser_name,
+            pages=set(),
             register_name='connection')
         self.addRegisterItem(register_item)
         return register_item
@@ -616,6 +618,34 @@ class SiteRegister(BaseRemoteObject):
         self.guest_connection_max_age = int(cleanup.get('guest_connection_max_age') or 40)
         self.connection_max_age = int(cleanup.get('connection_max_age') or 7200)
 
+    def updateRegisterLink(self, register, parent_id, link_name, child_id, add=None):
+        """Add or drop *child_id* in a parent item's link set — the only writer of it.
+
+        A parent/child link in the register lives in two places: the child item
+        carries its parent id, the parent item carries the set of its children.
+        Every change goes through here so the two cannot drift into phantom
+        children or live children missing from the set.
+
+        ``registerItems`` rather than ``get_item``: linking a child must not
+        refresh the parent's timestamp, or a page being born would keep an
+        otherwise idle connection alive. Returns True when the set changed.
+        """
+        if not parent_id:
+            return False
+        parent_item = register.registerItems.get(parent_id)
+        if parent_item is None:
+            return False
+        children = parent_item.setdefault(link_name, set())
+        if add:
+            if child_id in children:
+                return False
+            children.add(child_id)
+            return True
+        if child_id not in children:
+            return False
+        children.discard(child_id)
+        return True
+
     def new_connection(self, connection_id, connection_name=None, user=None, user_id=None,
                        user_name=None, user_tags=None, user_ip=None, user_agent=None, browser_name=None,
                        avatar_extra=None, electron_static=None):
@@ -627,6 +657,7 @@ class SiteRegister(BaseRemoteObject):
             connection_id, connection_name=connection_name, user=user, user_id=user_id,
             user_name=user_name, user_tags=user_tags, user_ip=user_ip, user_agent=user_agent,
             browser_name=browser_name, electron_static=electron_static)
+        self.updateRegisterLink(self.user_register, user, 'connections', connection_id, add=True)
         return connection_item
 
     def drop_pages(self, connection_id):
@@ -634,6 +665,10 @@ class SiteRegister(BaseRemoteObject):
             self.drop_page(page_id)
 
     def drop_page(self, page_id, cascade=None):
+        page_item = self.page_register.registerItems.get(page_id)
+        if page_item:
+            self.updateRegisterLink(self.connection_register, page_item['connection_id'],
+                                    'pages', page_id)
         return self.page_register.drop(page_id, cascade=cascade)
 
     def drop_connections(self, user):
@@ -641,6 +676,10 @@ class SiteRegister(BaseRemoteObject):
             self.drop_connection(connection_id)
 
     def drop_connection(self, connection_id, cascade=None):
+        connection_item = self.connection_register.registerItems.get(connection_id)
+        if connection_item:
+            self.updateRegisterLink(self.user_register, connection_item['user'],
+                                    'connections', connection_id)
         self.connection_register.drop(connection_id, cascade=cascade)
 
     def drop_user(self, user):
@@ -669,6 +708,7 @@ class SiteRegister(BaseRemoteObject):
         page_item = self.page_register.create(page_id, pagename=pagename, connection_id=connection_id,
                                               user=user, user_ip=user_ip, user_agent=user_agent,
                                               relative_url=relative_url, data=data)
+        self.updateRegisterLink(self.connection_register, connection_id, 'pages', page_id, add=True)
         return page_item
 
     def new_user(self, user=None, user_tags=None, user_id=None, user_name=None, avatar_extra=None):

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -788,6 +788,10 @@ class SiteRegister(BaseRemoteObject):
         connection_item['user_name'] = user_name
         connection_item['user_id'] = user_id
         connection_item['avatar_extra'] = avatar_extra
+        # move the link before the drop_user guard below: it reads the old
+        # user's link set, which must no longer hold this connection
+        self.updateRegisterLink(self.user_register, olduser, 'connections', connection_id)
+        self.updateRegisterLink(self.user_register, user, 'connections', connection_id, add=True)
         for p in self.pages(connection_id=connection_id):
             p['user'] = user
         if not self.connection_register.connections(olduser):

--- a/gnrpy/tests/web/siteregister_links_test.py
+++ b/gnrpy/tests/web/siteregister_links_test.py
@@ -243,9 +243,39 @@ def test_both_directions_agree_through_a_full_lifecycle():
     assert _links_from_parents(reg) == _links_from_children(reg)
     reg.drop_connection('conn-2')
     assert _links_from_parents(reg) == _links_from_children(reg)
+    reg.change_connection_user('conn-1', user='bruno')
+    assert _links_from_parents(reg) == _links_from_children(reg)
     reg.drop_user('marco')
     assert _links_from_parents(reg) == _links_from_children(reg)
     reg.drop_page('page-1', cascade=True)
+    assert _links_from_parents(reg) == _links_from_children(reg)
+
+
+def test_change_connection_user_moves_the_link_between_users():
+    """The guest-to-authenticated shape: every login goes through here."""
+    reg = _register()
+    reg.new_connection('conn-1', user='guest_1')
+    _new_page(reg, 'page-1', 'conn-1', 'guest_1')
+    reg.change_connection_user('conn-1', user='anna')
+    # the connection now belongs to anna, link included
+    assert _connections_of(reg, 'anna') == {'conn-1'}
+    assert [c['register_item_id'] for c in reg.connections(user='anna')] == ['conn-1']
+    assert [p['register_item_id'] for p in reg.pages(user='anna')] == ['page-1']
+    # the guest, left with no connections, is gone with its links
+    assert not reg.user_register.exists('guest_1')
+    assert reg.connections(user='guest_1') == []
+    assert reg.pages(user='guest_1') == []
+    assert _links_from_parents(reg) == _links_from_children(reg)
+
+
+def test_change_connection_user_keeps_the_old_users_other_connections():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='anna')
+    reg.change_connection_user('conn-1', user='bruno')
+    assert _connections_of(reg, 'anna') == {'conn-2'}
+    assert _connections_of(reg, 'bruno') == {'conn-1'}
+    assert reg.user_register.exists('anna')
     assert _links_from_parents(reg) == _links_from_children(reg)
 
 

--- a/gnrpy/tests/web/siteregister_links_test.py
+++ b/gnrpy/tests/web/siteregister_links_test.py
@@ -1,0 +1,249 @@
+"""Tests for the parent -> children links in the site register.
+
+A register item carries its parent id (a page knows its connection, a connection
+knows its user), but the other direction had no structure: every walk down the
+hierarchy scanned the whole registry. The user item now holds a ``connections``
+set and the connection item a ``pages`` set, both written exclusively through
+``SiteRegister.updateRegisterLink`` so the two directions of a link cannot drift.
+
+``SiteRegister`` is built directly with a stand-in server: the only thing its
+constructor needs is ``server.daemon.register`` for the remote-bag handler.
+"""
+
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _register():
+    return SiteRegister(_FakeServer(), sitename='testsite')
+
+
+def _connections_of(reg, user):
+    return reg.user_register.registerItems[user]['connections']
+
+
+def _pages_of(reg, connection_id):
+    return reg.connection_register.registerItems[connection_id]['pages']
+
+
+def _new_page(reg, page_id, connection_id, user):
+    return reg.new_page(page_id, pagename='p', connection_id=connection_id, user=user)
+
+
+# ---------------------------------------------------------------------------
+# the sets get filled
+# ---------------------------------------------------------------------------
+
+
+def test_a_fresh_user_starts_with_no_connections():
+    reg = _register()
+    reg.new_user(user='anna')
+    assert _connections_of(reg, 'anna') == set()
+
+
+def test_a_fresh_connection_starts_with_no_pages():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    assert _pages_of(reg, 'conn-1') == set()
+
+
+def test_a_new_connection_lands_in_its_user_set():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    assert _connections_of(reg, 'anna') == {'conn-1'}
+
+
+def test_the_user_is_created_implicitly_and_still_gets_the_link():
+    """new_connection creates the user when missing; the link must not be lost."""
+    reg = _register()
+    assert not reg.user_register.exists('anna')
+    reg.new_connection('conn-1', user='anna')
+    assert _connections_of(reg, 'anna') == {'conn-1'}
+
+
+def test_a_new_page_lands_in_its_connection_set():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    assert _pages_of(reg, 'conn-1') == {'page-1'}
+
+
+def test_several_children_accumulate():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    assert _connections_of(reg, 'anna') == {'conn-1', 'conn-2'}
+    assert _pages_of(reg, 'conn-1') == {'page-1', 'page-2'}
+    assert _pages_of(reg, 'conn-2') == set()
+
+
+def test_two_users_do_not_share_connections():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='marco')
+    assert _connections_of(reg, 'anna') == {'conn-1'}
+    assert _connections_of(reg, 'marco') == {'conn-2'}
+
+
+# ---------------------------------------------------------------------------
+# the sets get emptied
+# ---------------------------------------------------------------------------
+
+
+def test_dropping_a_page_removes_it_from_its_connection():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    reg.drop_page('page-1')
+    assert _pages_of(reg, 'conn-1') == {'page-2'}
+
+
+def test_dropping_a_connection_removes_it_from_its_user():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='anna')
+    reg.drop_connection('conn-1')
+    assert _connections_of(reg, 'anna') == {'conn-2'}
+
+
+def test_dropping_a_connection_drops_its_pages_and_empties_the_set():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    reg.drop_connection('conn-1')
+    assert not reg.connection_register.exists('conn-1')
+    assert not reg.page_register.exists('page-1')
+    assert not reg.page_register.exists('page-2')
+
+
+def test_dropping_a_user_cascades_through_both_levels():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    reg.drop_user('anna')
+    assert not reg.user_register.exists('anna')
+    assert not reg.connection_register.exists('conn-1')
+    assert not reg.page_register.exists('page-1')
+
+
+def test_the_last_page_leaving_cascades_the_connection_away():
+    """PageRegister.drop(cascade=True) drops the connection when no page is left."""
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    reg.drop_page('page-1', cascade=True)
+    assert not reg.page_register.exists('page-1')
+    assert not reg.connection_register.exists('conn-1')
+
+
+def test_a_surviving_sibling_keeps_the_connection_alive():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    reg.drop_page('page-1', cascade=True)
+    assert reg.connection_register.exists('conn-1')
+    assert _pages_of(reg, 'conn-1') == {'page-2'}
+
+
+# ---------------------------------------------------------------------------
+# the single writer
+# ---------------------------------------------------------------------------
+
+
+def test_link_reports_whether_the_set_changed():
+    reg = _register()
+    reg.new_user(user='anna')
+    ur = reg.user_register
+    assert reg.updateRegisterLink(ur, 'anna', 'connections', 'conn-1', add=True) is True
+    assert reg.updateRegisterLink(ur, 'anna', 'connections', 'conn-1', add=True) is False
+    assert reg.updateRegisterLink(ur, 'anna', 'connections', 'conn-1') is True
+    assert reg.updateRegisterLink(ur, 'anna', 'connections', 'conn-1') is False
+
+
+def test_linking_under_a_missing_parent_is_refused():
+    reg = _register()
+    assert reg.updateRegisterLink(reg.user_register, 'ghost', 'connections', 'c', add=True) is False
+
+
+def test_linking_under_no_parent_at_all_is_refused():
+    """A page may be registered with no connection_id; nothing to link then."""
+    reg = _register()
+    assert reg.updateRegisterLink(reg.connection_register, None, 'pages', 'p', add=True) is False
+
+
+def test_a_page_with_no_connection_does_not_raise():
+    reg = _register()
+    _new_page(reg, 'page-1', None, 'anna')
+    assert reg.page_register.exists('page-1')
+    reg.drop_page('page-1')
+    assert not reg.page_register.exists('page-1')
+
+
+def test_linking_does_not_refresh_the_parent_timestamp():
+    """A child being born must not keep an otherwise idle parent alive."""
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    before = dict(reg.connection_register.itemsTS)
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    assert reg.connection_register.itemsTS == before
+
+
+# ---------------------------------------------------------------------------
+# the invariant: both directions of every link agree
+# ---------------------------------------------------------------------------
+
+
+def _links_from_children(reg):
+    """Rebuild both link sets from the children, the way a scan would."""
+    connections = {}
+    for user in reg.user_register.registerItems:
+        connections[user] = {k for k, v in reg.connection_register.registerItems.items()
+                             if v['user'] == user}
+    pages = {}
+    for connection_id in reg.connection_register.registerItems:
+        pages[connection_id] = {k for k, v in reg.page_register.registerItems.items()
+                                if v['connection_id'] == connection_id}
+    return connections, pages
+
+
+def _links_from_parents(reg):
+    connections = {k: set(v['connections'])
+                   for k, v in reg.user_register.registerItems.items()}
+    pages = {k: set(v['pages'])
+             for k, v in reg.connection_register.registerItems.items()}
+    return connections, pages
+
+
+def test_both_directions_agree_through_a_full_lifecycle():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='anna')
+    reg.new_connection('conn-3', user='marco')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    _new_page(reg, 'page-3', 'conn-2', 'anna')
+    _new_page(reg, 'page-4', 'conn-3', 'marco')
+    assert _links_from_parents(reg) == _links_from_children(reg)
+    reg.drop_page('page-2')
+    assert _links_from_parents(reg) == _links_from_children(reg)
+    reg.drop_connection('conn-2')
+    assert _links_from_parents(reg) == _links_from_children(reg)
+    reg.drop_user('marco')
+    assert _links_from_parents(reg) == _links_from_children(reg)
+    reg.drop_page('page-1', cascade=True)
+    assert _links_from_parents(reg) == _links_from_children(reg)

--- a/gnrpy/tests/web/siteregister_links_test.py
+++ b/gnrpy/tests/web/siteregister_links_test.py
@@ -247,3 +247,119 @@ def test_both_directions_agree_through_a_full_lifecycle():
     assert _links_from_parents(reg) == _links_from_children(reg)
     reg.drop_page('page-1', cascade=True)
     assert _links_from_parents(reg) == _links_from_children(reg)
+
+
+# ---------------------------------------------------------------------------
+# the readers, now walking the links instead of the registry
+# ---------------------------------------------------------------------------
+
+
+def _populate(reg):
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='anna')
+    reg.new_connection('conn-3', user='marco')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    _new_page(reg, 'page-3', 'conn-2', 'anna')
+    _new_page(reg, 'page-4', 'conn-3', 'marco')
+    return reg
+
+
+def test_user_connection_keys_walks_the_user_set():
+    reg = _populate(_register())
+    assert sorted(reg.user_connection_keys('anna')) == ['conn-1', 'conn-2']
+    assert reg.user_connection_keys('marco') == ['conn-3']
+    assert reg.user_connection_keys('ghost') == []
+
+
+def test_user_connection_items_and_connections_return_the_real_items():
+    reg = _populate(_register())
+    items = dict(reg.user_connection_items('marco'))
+    assert list(items) == ['conn-3']
+    assert items['conn-3'] is reg.connection_register.registerItems['conn-3']
+    assert reg.user_connections('marco') == [reg.connection_register.registerItems['conn-3']]
+
+
+def test_connection_page_keys_walks_the_connection_set():
+    reg = _populate(_register())
+    assert sorted(reg.connection_page_keys('conn-1')) == ['page-1', 'page-2']
+    assert reg.connection_page_keys('conn-3') == ['page-4']
+    assert reg.connection_page_keys('ghost') == []
+
+
+def test_pages_of_a_connection():
+    reg = _populate(_register())
+    got = sorted(p['register_item_id'] for p in reg.pages(connection_id='conn-1'))
+    assert got == ['page-1', 'page-2']
+
+
+def test_pages_of_a_user_walks_user_then_connections():
+    reg = _populate(_register())
+    got = sorted(p['register_item_id'] for p in reg.pages(user='anna'))
+    assert got == ['page-1', 'page-2', 'page-3']
+
+
+def test_pages_with_no_argument_still_returns_everything():
+    reg = _populate(_register())
+    got = sorted(p['register_item_id'] for p in reg.pages())
+    assert got == ['page-1', 'page-2', 'page-3', 'page-4']
+
+
+def test_pages_with_a_mismatched_connection_and_user_returns_nothing():
+    """conn-3 belongs to marco, so asking for anna's pages on it is empty."""
+    reg = _populate(_register())
+    assert reg.pages(connection_id='conn-3', user='anna') == []
+
+
+def test_pages_of_an_unknown_parent_is_empty():
+    reg = _populate(_register())
+    assert reg.pages(connection_id='ghost') == []
+    assert reg.pages(user='ghost') == []
+
+
+def test_connections_of_a_user_and_of_nobody():
+    reg = _populate(_register())
+    got = sorted(c['register_item_id'] for c in reg.connection_register.connections(user='anna'))
+    assert got == ['conn-1', 'conn-2']
+    got_all = sorted(c['register_item_id']
+                     for c in reg.connection_register.connections())
+    assert got_all == ['conn-1', 'conn-2', 'conn-3']
+
+
+def test_the_readers_agree_with_a_scan_of_the_whole_registry():
+    """The conversion must not change what the readers answer, only how."""
+    reg = _populate(_register())
+    for connection_id in ['conn-1', 'conn-2', 'conn-3']:
+        scanned = sorted(k for k, v in reg.page_register.registerItems.items()
+                         if v['connection_id'] == connection_id)
+        assert sorted(reg.connection_page_keys(connection_id)) == scanned
+    for user in ['anna', 'marco']:
+        scanned = sorted(k for k, v in reg.connection_register.registerItems.items()
+                         if v['user'] == user)
+        assert sorted(reg.user_connection_keys(user)) == scanned
+        scanned_pages = sorted(k for k, v in reg.page_register.registerItems.items()
+                               if v['user'] == user)
+        assert sorted(p['register_item_id'] for p in reg.pages(user=user)) == scanned_pages
+
+
+def test_readers_do_not_refresh_timestamps():
+    reg = _populate(_register())
+    before_pages = dict(reg.page_register.itemsTS)
+    before_conns = dict(reg.connection_register.itemsTS)
+    reg.pages(user='anna')
+    reg.pages(connection_id='conn-1')
+    reg.user_connection_items('anna')
+    reg.connection_page_items('conn-1')
+    assert reg.page_register.itemsTS == before_pages
+    assert reg.connection_register.itemsTS == before_conns
+
+
+def test_dropping_while_iterating_the_walk_is_safe():
+    """drop_pages and drop_connections iterate what the readers return."""
+    reg = _populate(_register())
+    reg.drop_pages('conn-1')
+    assert reg.connection_page_keys('conn-1') == []
+    reg.drop_connections('anna')
+    assert reg.user_connection_keys('anna') == []
+    assert not reg.connection_register.exists('conn-2')
+    assert not reg.page_register.exists('page-3')


### PR DESCRIPTION
## Purpose

Make looking up a user's pages fast and solid. Today it is a full scan of the registry, and it is on the path of every request.

## Problem

A register item carries only its parent id: a page knows its connection, a connection knows its user. The other direction has no structure, so every walk down the hierarchy scans everything — `user_connection_keys` over all connections, `connection_page_keys` over all pages, `pages(user=...)` over all pages comparing the user field, and the cascade drops scanning again on their way down.

## Change

Two commits, deliberately separate so the plumbing and the behaviour can be read apart.

**`ab09e5f07` — the links.** The user item holds a `connections` set, the connection item a `pages` set. Both are written exclusively through `SiteRegister.updateRegisterLink(register, parent_id, link_name, child_id, add=None)`.

Two directions of one link would otherwise be maintained in as many places as there are lifecycle events — `new_connection`, `new_page`, `drop_page`, `drop_connection`, `drop_user` — and drift into phantom children or live children missing from their parent's set. One writer is one place to keep them in step.

Two details worth the review:

- The parent item is reached through `registerItems` rather than `get_item`, because `get_item` refreshes the item timestamp and a page being born must not keep an otherwise idle connection alive.
- The unlink happens **before** the child is dropped. `PageRegister.drop(cascade=True)` asks whether any page is left before deciding to drop the connection; unlinking afterwards would have that check still see the page it is dropping.

**`0ac990ae1` — the readers.** `connection_page_keys` and `user_connection_keys` read the sets; `connection_page_items`, `connection_pages`, `user_connection_items`, `user_connections` and `connections(user=...)` build on them; `pages()` starts from the links — by connection directly, by user through its connections — and still returns the whole registry when given neither.

Both key readers return a list, so `drop_pages` and `drop_connections` keep iterating what they were given while the underlying set shrinks under them.

Preserved deliberately: items are reached through `registerItems`, not `get_item`, so listing a connection's pages does not refresh their timestamps — only the `include_data` path goes through `get_item`, as before. And asking for a connection and a user that do not match still returns nothing, which the previous chain of two filters gave for free.

## What this lights up

`gnrwebpage_proxy/connection.py:72` already prefers `connection_item['pages']` and falls back to a register scan. Until now the key never existed, so the fallback always ran. `validate_page_id` is on the path of every request, so it stops scanning the registry.

Serpent round-trips a non-empty set as a set and an empty one as an empty tuple — both falsy when empty, both supporting `in` — so the membership test holds over Pyro either way. Checked, since this is a page-validation path.

## Not in scope

`PageRegister.pages()` filters with an unanchored `re.match(fltval, value)` while the same function compares with `==` two lines above, so `filters='user:anna'` also matches `anna.bianchi`. That is a separate matter being settled on #1100, where it was first flagged. Worth noting here only because once `pages(user=...)` is a link walk, the chat no longer needs the `filters` path at all.

## Tests

`gnrpy/tests/web/siteregister_links_test.py`, 31 tests.

The links: sets filling and emptying across all five lifecycle methods; the implicit user creation inside `new_connection` still linking; the cascade when the last page leaves and the sibling that prevents it; a page with no connection at all; linking not refreshing the parent timestamp; and both directions of every link compared against a rebuild from the children through a full lifecycle.

The readers: every converted method; the mismatched connection/user pair; unknown parents; timestamps untouched; dropping while iterating a walk; and each reader compared against a scan of the whole registry, so the conversion is shown to change how the answer is found and not what it is.

## Verification

- `flake8` on both files: clean
- `pytest gnrpy/tests/web/siteregister_links_test.py`: 31 passed
- `pytest gnrpy/tests`: 2042 passed, with 2 pre-existing failures in `flatfiles_test.py` and 8 pre-existing errors in `tests/sql` from missing pg/mysql drivers, all present on a clean develop
- Not verified: no live run against a real daemon with several connections and pages. The classic register is exercised only through these unit tests, and the ASGI provider replaces this register entirely, so it is unaffected.