### PR TITLE
fix(js): guard setSelectedId on grids whose class does not implement it

### DIFF
--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -2893,7 +2893,9 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
         }
         this.restoreSelectedRows();
         if(this.sourceNode.attr.selectedId && this.sourceNode.attr.selectedId.startsWith('^')){
-            this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
+            if(this.setSelectedId){
+                this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
+            }
         }
         this.fillServerTotalize();
     },


### PR DESCRIPTION
## Problem

Legacy `includedview`-tag grids throw `TypeError: this.setSelectedId is not a function` when their datastore is (re)loaded, and the crash prevents `fillServerTotalize()` from ever running afterwards.

## Root cause

The crashing call is `gnrjs/gnr_d11/js/genro_grid.js:2896`, inside `mixin_newDataStore`, defined on `dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {...})`:

```js
this.restoreSelectedRows();
if(this.sourceNode.attr.selectedId && this.sourceNode.attr.selectedId.startsWith('^')){
    this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
}
this.fillServerTotalize();
```

`mixin_setSelectedId` is defined **only** on `gnr.widgets.NewIncludedView` (a `VirtualStaticGrid` subclass, via `IncludedView`), and depends on `this.collectionStore()`, a `NewIncludedView`-only abstraction.

The `mixin_` prefix is a real runtime rewrite, not a naming convention: `gnr.wdg.doMixin` (`genro_wdg.js:571-609`) walks `for (var prop in handler)` and copies every `mixin_*` method onto the live widget instance under its unprefixed name. Because `for...in` walks the prototype chain, which methods land on a given widget depends entirely on the class the widget's tag resolves to:

- tag `includedview` → `IncludedView → VirtualStaticGrid → DojoGrid` chain → `setSelectedId` is **never created** on the instance.
- tag `newincludedview` → chain includes `NewIncludedView` → `setSelectedId` exists and the call works.

`mixin_newDataStore` lives on the shared `VirtualStaticGrid` base, so it is copied onto both — hence the crash is specific to legacy-tag grids.

**Exposure is broad, not an edge case.** `resources/common/foundation/includedview.py`: `includedGrid` (`:697`) hardcodes `gridattr['tag'] = 'includedview'`, and `includedViewBox` (`:184-185`) defaults **every** grid to a live `'^.selectedId'` binding when the caller doesn't set one — which is exactly the condition that triggers the call at `:2896`. `includedViewBox`/`includedGrid` are used pervasively: `resources/common/gnrcomponents/drop_uploader.py` (`dropFileGrid`), `flib/item_picker.py`, `sys/webpages/external_token.py`, `sys/webpages/register_explorer.py`, `foundation/selectionhandler.py`, `gnrcomponents/htablehandler.py`.

**Correction to the issue's own repro page**: `projects/gnrcore/packages/test/webpages/components/drop_uploader.py` (package `gnrcore:test`) only calls `pane.dropUploader(...)` — a plain drop target `<div>`, no grid involved — and `gnrcore:test` is not mounted by any instance in this repo. The page that actually reproduces the crash is the sibling `test15` package, method `test_3_dropFileGridXLS`, the only `drop_uploader` test method that renders an `includedViewBox` grid (via `dropFileGrid`).

Also, "mixed into a different target" is an imprecise way to describe the bug: both `mixin_newDataStore` and `mixin_setSelectedId` are copied onto the **same** target object by the same `doMixin` call. The actual defect is that the capability is implemented only on the most-derived subclass while the call site lives in the shared base class.

## Change

One-line guard, matching the file's own established idiom for optional `NewIncludedView`-only capabilities (see `mixin_getAllPkeys`, `genro_grid.js:1631-1641`, which guards `this.collectionStore` the same way):

```diff
         this.restoreSelectedRows();
         if(this.sourceNode.attr.selectedId && this.sourceNode.attr.selectedId.startsWith('^')){
-            this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
+            if(this.setSelectedId){
+                this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
+            }
         }
         this.fillServerTotalize();
```

Behaviour is unchanged where it already works (`newincludedview`-tag grids keep re-selecting on datastore reload); the crash stops where the capability was never implemented in the first place — that call has never once succeeded for legacy grids.

## Verification

- `node --check gnrjs/gnr_d11/js/genro_grid.js` passes on the modified file.
- **Verified live** (2026-08-20), before/after on the same page and flow:
  - *before* — `gnrdevelop`-equivalent instance serving develop's `genro_grid.js`, `/test15/components/drop_uploader` with the `test_3_dropFileGridXLS` card: console shows `this.setSelectedId is not a function` on the grid's first datastore load, no interaction needed;
  - *after* — same page served from this branch (`gnrdevelop`, gnrjs pointed at the branch checkout, guard confirmed present in the served `/_gnr/11/js/genro_grid.js`): page renders fully, all three grids populate, **zero console errors, zero failed requests**.
  - The regression leg on `newincludedview` grids is by construction: the guard only skips the call where `setSelectedId` is undefined; on `NewIncludedView` the mixin exists, so that path is byte-identical. Not exercised separately.

## Related issue

Fixes #1103

## Open decision

@dgpaci — two ways to close this, and I took the narrower one:

- **Guard-only (taken in this PR)**: pure crash fix, zero behavioural risk, but legacy `includedview` grids then silently no-op instead of re-selecting on reload — a capability that, per the analysis above, has never actually worked for them.
- **Full parity**: build a fallback usable by legacy grids too, from the generic primitives already in the file (`selectByRowAttr`, `genro_grid.js:1553-1571`, `rowIdentifier()`, `rowIdByIndex`), mirroring how `mixin_getAllPkeys` falls back instead of no-op'ing. This would restore real behaviour but is a larger, untested change that deserves its own review cycle rather than riding along with a crash fix.

Worth naming separately: `resources/common/foundation/includedview.py:184-185` defaults **every** `includedViewBox` to a live `'^.selectedId'` binding, which is what makes this crash path universal rather than opt-in. Tightening that default is a separate, python-side design decision outside the scope of this JS fix.

