### PR TITLE
fix(webpages): update pbl_root* callers to the struct_method page-root API

### DIFF
--- a/projects/gnrcore/packages/adm/webpages/preference.py
+++ b/projects/gnrcore/packages/adm/webpages/preference.py
@@ -20,4 +20,4 @@ class GnrCustomWebPage(object):
         return '!!Preference panel'
 
     def main(self, rootBC, **kwargs):
-        mainbc, top, bottom = self.pbl_rootBorderContainer(rootBC, '!!Preference')
+        rootBC.rootBorderContainer('!!Preference')

--- a/projects/gnrcore/packages/multidb/webpages/sync_status.py
+++ b/projects/gnrcore/packages/multidb/webpages/sync_status.py
@@ -23,7 +23,7 @@ class GnrCustomWebPage(object):
         per ogni grid abbiamo id, rowcaption operatore data e ora
         per modificati anche la modifica
         """
-        pane = self.pbl_rootContentPane(rootBC,title='!!Sync Status',datapath='syncstatus')
+        pane = rootBC.rootContentPane(title='!!Sync Status',datapath='syncstatus')
         frame = pane.framePane(frameCode='syncstatus')
         frame.includedView(storepath='.current')
         frame.dataRpc('.current','getCurrentStatus')

--- a/projects/gnrcore/packages/sys/webpages/memcached_stats.py
+++ b/projects/gnrcore/packages/sys/webpages/memcached_stats.py
@@ -32,9 +32,9 @@ class GnrCustomWebPage(object):
         return 'user'
 
     def main(self, root, **kwargs):
-        center, top, bottom = self.pbl_rootContentPane(root, title='!!Mem Stats')
-        center.dataRpc('root', 'getStats', _timing=45, _init=True)
-        center.tree(storepath='root')
+        frame = root.rootContentPane(title='!!Mem Stats')
+        frame.dataRpc('root', 'getStats', _timing=45, _init=True)
+        frame.tree(storepath='root')
 
     def rpc_getStats(self):
         result = Bag()

--- a/projects/gnrcore/packages/test15/webpages/components/advanced_form.py
+++ b/projects/gnrcore/packages/test15/webpages/components/advanced_form.py
@@ -6,7 +6,7 @@ class GnrCustomWebPage(object):
     py_requires = 'public'
 
     def main(self, rootBC, **kwargs):
-        center, top, bottom = self.pbl_rootBorderContainer(rootBC, title="!!Terapia", margin="1em", **kwargs)
+        center = rootBC.rootBorderContainer(title="!!Terapia", margin="1em", **kwargs)
 
         btPane = center.contentPane(region="bottom")
         buttons = btPane.div(width="100%")


### PR DESCRIPTION
## Problem

Four shipped webpages still call `self.pbl_rootContentPane(...)` / `self.pbl_rootBorderContainer(...)`, a page-method API that no longer exists. Building their structure raises `AttributeError`.

## Root cause

Commit `d9c60633` (2012-05-30) deleted the page-method page-root builders from `resources/common/public.py` (`_pbl_root`, `pbl_rootContentPane`, `pbl_rootStackContainer`, `pbl_rootTabContainer`, `pbl_rootBorderContainer`) and replaced them with `@struct_method`s dispatched on the struct node (`rootContentPane`, `rootBorderContainer`, `rootTabContainer`, `rootStackContainer`, all delegating to `_pbl_frameroot`). `GnrWebPage`/`GnrBaseWebPage` have no `__getattr__`, so any remaining `self.pbl_root*` call is a plain missing attribute — `AttributeError` during `main()`, not a lookup the framework can route.

**Four call sites on develop, not three.** The issue lists three and calls the fourth "already repaired" — that repair exists only on `origin/refactor/test15-example-migration-macro1` (commit `1fbf73ce2`), which **renames** `test15/webpages/components/advanced_form.py` to `test/webpages/components/advanced_form.py`. On `develop` the old path is still present and still broken:

| file | call |
|---|---|
| `projects/gnrcore/packages/adm/webpages/preference.py:23` | `self.pbl_rootBorderContainer(rootBC, '!!Preference')` |
| `projects/gnrcore/packages/sys/webpages/memcached_stats.py:35` | `self.pbl_rootContentPane(root, title='!!Mem Stats')` |
| `projects/gnrcore/packages/multidb/webpages/sync_status.py:26` | `self.pbl_rootContentPane(rootBC, title='!!Sync Status', datapath='syncstatus')` |
| `projects/gnrcore/packages/test15/webpages/components/advanced_form.py:9` | `self.pbl_rootBorderContainer(rootBC, title="!!Terapia", margin="1em", **kwargs)` |

These are the complete blast radius — every other method `d9c60633` removed (`pbl_topBar`, `pbl_bottomBar`, `pbl_bottom_default`, `pbl_bottom_message`, `pbl_batch_floating`, `pbl_canChangeWorkdate`, `pbl_preferenceAppTags`, `pbl_workdateManager`, `pbl_workdate_dialog`, `pbl_topBarLeft`, `mainLeftTop`, `pbl_rootStackContainer`) has zero remaining callers.

**"The frame's center is a plain slot, an explicit container is needed" is true only for `rootContentPane`.** `rootBorderContainer`/`rootTabContainer`/`rootStackContainer` already build the center as the right container via `center_widget` (`public.py:121,126,131` → `_pbl_frameroot` → `framePane(center_widget=...)`), so their return value can be used directly as that container.

**Reachability differs per page**, which is what the open decisions below turn on:
- `/adm/preference` is an orphan — `adm/menu.py` points at `/adm/user_preference` and `/adm/app_preference`, nothing references `/adm/preference` — and it's superseded by `app_preference.py` (same `maintable`, same window title). Its whole `main()` body is the one broken line.
- `sys/webpages/memcached_stats.py` is an orphan too (no menu entry, no reference), and its `rpc_getStats` needs a memcached-backed `shared_data` that no instance in this repo configures.
- `multidb/webpages/sync_status.py` **is** menu-linked (`multidb/menu.py`), but `rpc_getCurrentStatus` is `pass`, and no instance in `projects/*/instances/` mounts `multidb`.

## Change

Minimal repair at all four call sites — call the struct method directly on the root/rootBC node instead of `self`, and adjust the unpacking since the struct method returns the frame (or, for the border/tab/stack variants, the already-built center container) rather than a `(center, top, bottom)` tuple:

```diff
# adm/webpages/preference.py
-        mainbc, top, bottom = self.pbl_rootBorderContainer(rootBC, '!!Preference')
+        rootBC.rootBorderContainer('!!Preference')

# sys/webpages/memcached_stats.py
-        center, top, bottom = self.pbl_rootContentPane(root, title='!!Mem Stats')
-        center.dataRpc('root', 'getStats', _timing=45, _init=True)
-        center.tree(storepath='root')
+        frame = root.rootContentPane(title='!!Mem Stats')
+        frame.dataRpc('root', 'getStats', _timing=45, _init=True)
+        frame.tree(storepath='root')

# multidb/webpages/sync_status.py
-        pane = self.pbl_rootContentPane(rootBC,title='!!Sync Status',datapath='syncstatus')
+        pane = rootBC.rootContentPane(title='!!Sync Status',datapath='syncstatus')

# test15/webpages/components/advanced_form.py
-        center, top, bottom = self.pbl_rootBorderContainer(rootBC, title="!!Terapia", margin="1em", **kwargs)
+        center = rootBC.rootBorderContainer(title="!!Terapia", margin="1em", **kwargs)
```

Shape follows the direct-frame-children idiom already used elsewhere in the repo (`sys/webpages/process_manager.py:23-24`, `sys/webpages/package_editor.py:35-37`, `sys/webpages/system_dashboard.py:22-23`), not `frame.center.<widget>()` — an explicit `frame.center.<widget>()` child makes `gnrjs/gnr_d11/js/genro_components.js:864-868` take the `centerNode` branch and drop `centerPars` entirely, silently losing `center_class='pbl_root_center'` and `center_widget`.

No comments added — these are one-line API updates.

## Verification

- `python -m py_compile` on each touched file: clean.
- `flake8` on each touched file: zero errors.
- CI selection from repo root, `flake8 . --count --select=F401,E9,F63,F7,F82 --show-source --statistics`: `0`. Note this selection does **not** catch this class of defect — `self.pbl_root*` is a valid attribute access syntactically, not an undefined name, so this passing is not evidence the bug is gone.
- **Regression net**: `grep -rn "self\.pbl_root" projects/ resources/` → empty, both before (4 hits, matching the table above) and after (0 hits) the change.
- Full suite: `cd gnrpy && PYTHONPATH=$PWD python -m pytest tests/ -q --ignore=tests/sql` → 840 passed, 59 skipped, 0 failed. The pre-commit hook additionally ran the complete suite including `tests/sql` → 2011 passed, 69 skipped, 0 failed.
- **Not verified live.** This change was made in a git worktree; `~/.gnr/environment.xml` hardcodes `projects`/`resources` to the main checkout, so a served instance cannot see a worktree edit. Manual verification steps:
  - Instance `gnrdevelop` (`projects/gnrcore/instances/gnrdevelop/config/instanceconfig.xml`, sqlite, mounts `gnrcore:sys, adm, test15, docu, dev`; port 8080 per `~/.gnr/siteconfig/default.xml`).
  - `/test15/components/advanced_form` — live and menu-independent, check directly.
  - `/adm/preference` and `/sys/memcached_stats` — direct URL only, neither is in its package's `menu.py`.
  - Per page: POST the structure to the page URL and confirm the returned bag has **no error node**, and no server-error panel renders — status alone doesn't prove anything, the failure travels inside a 200.
  - `/multidb/sync_status` **cannot be reached locally**: no instance under `projects/*/instances/` mounts `multidb`. Verifying it needs `<gnrcore_multidb pkgcode="gnrcore:multidb"/>` added to an instanceconfig, or review-only acceptance on the strength of the `system_dashboard.py:22` precedent.
  - `memcached_stats` will still show an empty/failing tree without a memcached-backed `shared_data` — out of scope for this fix, not a regression from it.

## Related issue

Fixes #1108

## Design decisions

Moved to the issue, where they belong: https://github.com/genropy/genropy/issues/1108#issuecomment-5359353812. The diff implements the option marked **taken** for each; if the discussion lands elsewhere, this PR follows.

