### PR TITLE
fix(email): honor getBody in mail proxy payload

### DIFF
--- a/projects/gnrcore/packages/email/tests/conftest.py
+++ b/projects/gnrcore/packages/email/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *['..'] * 5))
+_GNRPY_DIR = os.path.join(_REPO_ROOT, 'gnrpy')
+
+for _path in (os.path.join(_GNRPY_DIR, 'tests'), _GNRPY_DIR):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)

--- a/projects/gnrcore/packages/email/tests/test_mailproxy_body.py
+++ b/projects/gnrcore/packages/email/tests/test_mailproxy_body.py
@@ -1,0 +1,132 @@
+import os
+import shutil
+import tempfile
+
+from gnr.app.gnrapp import GnrApp
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrlang import gnrImport
+from gnr.web.gnrdummysite import GnrDummySite
+
+from core.common import BaseGnrTest
+
+
+PACKAGE_MAIN = """from gnr.app.gnrdbo import GnrDboPackage
+
+
+class Package(GnrDboPackage):
+    def config_attributes(self):
+        return dict(name_short='Body compiler', name_long='Body compiler')
+
+    def config_db(self, pkg):
+        pass
+"""
+
+MESSAGE_EXTENSION = """class Table(object):
+    def getBody(self, message=None, **kwargs):
+        body = message['body'] if message else None
+        return body.replace('{{recipient}}', 'Ada') if body else None
+"""
+
+
+class ProxyClient:
+    tenant_id = 'test-tenant'
+
+    def add_messages(self, payload):
+        self.payload = payload
+        return {'queued': len(payload)}
+
+
+class TestMailProxyBody(BaseGnrTest):
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.temp_dir = tempfile.mkdtemp(prefix='gnr_email_proxy_')
+        cls._install_body_compiler()
+        bootstrap_app = GnrApp(cls.test_instance_name)
+        bootstrap_app.db.model.check(applyChanges=True)
+        bootstrap_app.db.commit()
+        bootstrap_app.db.closeConnection()
+        cls.site = GnrDummySite(cls.test_instance_name,
+                                site_name=cls.test_instance_name)
+        cls.app = cls.site.gnrapp
+        cls.db = cls.site.db
+        cls.message_tbl = cls.db.table('email.message')
+        cls.account_id = 'mailproxy-test-account'
+        cls.db.table('email.account').insert(dict(
+            id=cls.account_id,
+            account_name='Mail proxy test',
+            smtp_from_address='sender@example.com',
+        ))
+        cls.db.commit()
+        module_path = os.path.join(
+            cls.app.packages['email'].packageFolder,
+            'webpages', 'mailproxy', 'mp_endpoint.py',
+        )
+        module = gnrImport(module_path, avoidDup=True)
+        cls.page = module.GnrCustomWebPage()
+        cls.page.db = cls.db
+        cls.page.site = cls.site
+
+    @classmethod
+    def _install_body_compiler(cls):
+        packages_root = os.path.join(cls.temp_dir, 'packages')
+        package_root = os.path.join(packages_root, 'bodycompiler')
+        extension_root = os.path.join(package_root, 'model', '_packages', 'email')
+        os.makedirs(extension_root)
+        with open(os.path.join(package_root, 'main.py'), 'w', encoding='utf-8') as fp:
+            fp.write(PACKAGE_MAIN)
+        with open(os.path.join(extension_root, 'message.py'), 'w', encoding='utf-8') as fp:
+            fp.write(MESSAGE_EXTENSION)
+
+        config = Bag(cls.test_instance_config_path)
+        config.setItem('packages.gnrcore_email', None, pkgcode='gnrcore:email')
+        config.setItem('packages.bodycompiler', None,
+                       pkgcode='bodycompiler', path=packages_root)
+        config.toXml(cls.test_instance_config_path)
+
+    @classmethod
+    def teardown_class(cls):
+        if getattr(cls, 'db', None):
+            cls.db.closeConnection()
+        shutil.rmtree(getattr(cls, 'temp_dir', ''), ignore_errors=True)
+        super().teardown_class()
+
+    @classmethod
+    def _insert_message(cls, message_id, body=None, body_plain=None):
+        cls.message_tbl.insert(cls.message_tbl.newrecord(
+            id=message_id,
+            in_out='O',
+            account_id=cls.account_id,
+            to_address='recipient@example.com',
+            from_address='sender@example.com',
+            subject='Proxy body test',
+            body=body,
+            body_plain=body_plain,
+            html=bool(body),
+        ))
+        cls.db.commit()
+
+    def test_proxy_uses_compiled_body_and_plain_fallback(self):
+        compiled_id = 'mailproxy-compiled'
+        plain_id = 'mailproxy-plain'
+        placeholder = 'Hello {{recipient}}'
+        self._insert_message(compiled_id, body=placeholder)
+        self._insert_message(plain_id, body_plain='Plain fallback')
+
+        proxy_client = ProxyClient()
+        queued = self.page._add_messages_to_proxy_queue(
+            proxy_client, [compiled_id, plain_id])
+        self.db.commit()
+
+        payload = {message['id']: message for message in proxy_client.payload}
+        assert queued == 2
+        assert payload[compiled_id]['body'] == 'Hello Ada'
+        assert payload[plain_id]['body'] == 'Plain fallback'
+
+        compiled = self.message_tbl.record(compiled_id).output('dict')
+        plain = self.message_tbl.record(plain_id).output('dict')
+        assert compiled['body'] == placeholder
+        assert compiled['proxy_ts'] is not None
+        assert plain['proxy_ts'] is not None
+        assert self.db.table('email.message_to_send').query().count() == 0

--- a/projects/gnrcore/packages/email/webpages/mailproxy/mp_endpoint.py
+++ b/projects/gnrcore/packages/email/webpages/mailproxy/mp_endpoint.py
@@ -530,9 +530,8 @@ class GnrCustomWebPage(object):
         return result
 
     def _message_body(self, record):
-        if record.get('html') and record.get('body'):
-            return record['body']
-        return record.get('body') or record.get('body_plain') or ''
+        body = self.db.table('email.message').getBody(record)
+        return body or record.get('body_plain') or ''
 
 
     def _address_list(self, value):


### PR DESCRIPTION
## Problem

Mail proxy delivery sent the stored email body instead of the body produced by application customizations. Direct SMTP delivery already honored those customizations.

## Root cause

The proxy conversion path read email.message.body and body_plain directly. That bypassed the dynamic email.message.getBody() dispatch used by direct SMTP delivery.

## Change

Route proxy body generation through email.message.getBody() and retain body_plain as the fallback when the customized method returns no body.

Add an integration test using the real email package, a temporary SQLite database, and a headless Genro site. The test installs an application-level email.message extension and verifies the complete queue-to-proxy flow while replacing only the external proxy client.

## Verification

- flake8 on all modified Python files
- pytest projects/gnrcore/packages/email/tests/test_mailproxy_body.py -q: 1 passed
- pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql: 902 passed, 59 skipped
- pytest gnrpy/tests/sql -q: 1205 passed, 10 skipped
- git diff --check

A later pre-commit rerun encountered an already occupied daemon port (Errno 48) in gnrstoragehandler_test; the corresponding standalone non-SQL suite above had completed successfully before the concurrent port conflict.

## Related issue

Fixes #1122
