### PR TITLE
fix(grid): support selectedId in legacy included views

### DIFF
--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -1578,8 +1578,8 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
                 selection.select(idx);
             }
         }
-        if(scrollTo===true && typeof(idx)=='number' && idx>=0){
-            scrollTo = idx;
+        if(scrollTo===true){
+            scrollTo = (typeof(idx)=='number' && idx>=0) ? idx : false;
         }
         if(scrollTo){
             this.scrollToRow(scrollTo);

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -2893,7 +2893,9 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
         }
         this.restoreSelectedRows();
         if(this.sourceNode.attr.selectedId && this.sourceNode.attr.selectedId.startsWith('^')){
-            this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
+            if(this.setSelectedId){
+                this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
+            }
         }
         this.fillServerTotalize();
     },

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -3868,6 +3868,20 @@ dojo.declare("gnr.widgets.IncludedView", gnr.widgets.VirtualStaticGrid, {
         }
         return savedAttrs;
     },
+
+    mixin_setSelectedId: function(pkey) {
+        var nrow = this.rowCount;
+        if (nrow == 0 || isNullOrBlank(pkey)) {
+            this.selection.unselectAll();
+        } else {
+            var idx = this.indexByRowAttr(this.rowIdentifier(), pkey);
+            if (idx >= nrow) {
+                idx = nrow - 1;
+            }
+            this.selection.select(idx);
+            this.scrollToRow(idx);
+        }
+    },
     
     mixin_setEditableColumns:function(){
         var cellmap = this.cellmap;

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -2879,6 +2879,14 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
         )
     },
 
+    mixin_setSelectedId: function(pkey) {
+        if (this.rowCount == 0 || isNullOrBlank(pkey)) {
+            this.selection.unselectAll();
+        } else {
+            this.selectByRowAttr(this.rowIdentifier(), pkey, null, true);
+        }
+    },
+
     mixin_newDataStore:function() {
         this.updateRowCount(0);
         this.resetFilter();
@@ -2893,9 +2901,7 @@ dojo.declare("gnr.widgets.VirtualStaticGrid", gnr.widgets.DojoGrid, {
         }
         this.restoreSelectedRows();
         if(this.sourceNode.attr.selectedId && this.sourceNode.attr.selectedId.startsWith('^')){
-            if(this.setSelectedId){
-                this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
-            }
+            this.setSelectedId(this.sourceNode.getAttributeFromDatasource('selectedId'));
         }
         this.fillServerTotalize();
     },
@@ -3869,20 +3875,6 @@ dojo.declare("gnr.widgets.IncludedView", gnr.widgets.VirtualStaticGrid, {
             attributes.excludeListCb = funcCreate(attributes.excludeListCb);
         }
         return savedAttrs;
-    },
-
-    mixin_setSelectedId: function(pkey) {
-        var nrow = this.rowCount;
-        if (nrow == 0 || isNullOrBlank(pkey)) {
-            this.selection.unselectAll();
-        } else {
-            var idx = this.indexByRowAttr(this.rowIdentifier(), pkey);
-            if (idx >= nrow) {
-                idx = nrow - 1;
-            }
-            this.selection.select(idx);
-            this.scrollToRow(idx);
-        }
     },
     
     mixin_setEditableColumns:function(){

--- a/projects/gnrcore/packages/test15/webpages/gnrwdg/includedview_bagstore.py
+++ b/projects/gnrcore/packages/test15/webpages/gnrwdg/includedview_bagstore.py
@@ -44,6 +44,8 @@ class GnrCustomWebPage(object):
             seed='=.seed')
         toolbar.button('Select last').dataController(
             "SET .legacy.selectedId = 'row_039'; SET .new.grid.selectedId = 'row_039';")
+        toolbar.button('Select missing').dataController(
+            "SET .legacy.selectedId = 'row_999'; SET .new.grid.selectedId = 'row_999';")
         toolbar.button('Clear selection').dataController(
             'SET .legacy.selectedId = null; SET .new.grid.selectedId = null;')
         toolbar.textbox(value='^.legacy.selectedId', lbl='Legacy selected id', readOnly=True)

--- a/projects/gnrcore/packages/test15/webpages/gnrwdg/includedview_bagstore.py
+++ b/projects/gnrcore/packages/test15/webpages/gnrwdg/includedview_bagstore.py
@@ -30,7 +30,55 @@ class GnrCustomWebPage(object):
         gridEditor.textbox(gridcell='name')
         gridEditor.numbertextbox(gridcell='age')
         gridEditor.textbox(gridcell='work')
-        
+
+    def test_1_selected_id_on_store_replacement(self, pane):
+        "Legacy selectedId parity on store replacement and NewIncludedView smoke"
+        root = pane.borderContainer(height='480px', datapath='.selected_id_test')
+        root.data('.seed', self.selected_id_data())
+        root.dataFormula('.legacy.rows', 'new gnr.GnrBag()', _onStart=True)
+        root.dataFormula('.new.rows', 'new gnr.GnrBag()', _onStart=True)
+
+        toolbar = root.contentPane(region='top', height='32px')
+        toolbar.button('Load rows').dataController(
+            'SET .legacy.rows = seed.deepCopy(); SET .new.rows = seed.deepCopy();',
+            seed='=.seed')
+        toolbar.button('Select last').dataController(
+            "SET .legacy.selectedId = 'row_039'; SET .new.grid.selectedId = 'row_039';")
+        toolbar.button('Clear selection').dataController(
+            'SET .legacy.selectedId = null; SET .new.grid.selectedId = null;')
+        toolbar.textbox(value='^.legacy.selectedId', lbl='Legacy selected id', readOnly=True)
+        toolbar.textbox(value='^.new.grid.selectedId', lbl='New selected id', readOnly=True)
+
+        grids = root.borderContainer(region='center')
+        legacy = grids.borderContainer(region='left', width='50%', splitter=True)
+        self.includedViewBox(legacy, nodeId='selected_id_legacy',
+                             label='Legacy IncludedView', datapath='.legacy',
+                             storepath='.rows', struct=self.selected_id_struct,
+                             datamode='bag', autoWidth=True)
+
+        grids.bagGrid(region='center', frameCode='selected_id_new_frame',
+                      datapath='.new', storepath='.rows',
+                      title='NewIncludedView smoke', struct=self.selected_id_struct,
+                      grid_nodeId='selected_id_new', grid_selectedId='^.selectedId',
+                      store__identifier='_pkey', gridEditor=False,
+                      addrow=False, delrow=False, batchAssign=False)
+
+    def selected_id_data(self):
+        result = Bag()
+        for i in range(40):
+            pkey = 'row_%03i' % i
+            result.setItem(pkey, Bag(dict(nome='Locality %02i' % i,
+                                          cap='%05i' % (20000 + i),
+                                          codice_istat='%06i' % i)),
+                           _pkey=pkey)
+        return result
+
+    def selected_id_struct(self, struct):
+        r = struct.view().rows()
+        r.cell('nome', name='Name', width='16em')
+        r.cell('cap', name='Postal code', width='8em')
+        r.cell('codice_istat', name='ISTAT code', width='8em')
+
     def common_data(self):
         result = Bag()
         for i in range(5):
@@ -42,4 +90,3 @@ class GnrCustomWebPage(object):
         r.cell('name',name='Name',width='10em')
         r.cell('age',name='Age',dtype='I',width='5em')
         r.cell('work',name='Work',width='10em')
-        


### PR DESCRIPTION
## Problem

Legacy grids created by `includedViewBox` fail while installing a replacement datastore because their subscribed `selectedId` invokes a method the widget does not implement. The exception leaves the grid empty.

## Root cause

`VirtualStaticGrid.mixin_newDataStore` applies subscribed `selectedId` values through `setSelectedId`, but no class in that branch of the hierarchy implements it: `NewIncludedView` provides its own through `collectionStore()`, while legacy `IncludedView` — and `VirtualStaticGrid` itself, which is exported as a widget in its own right (`gnrpy/gnr/web/gnrwebstruct/dojo11.py:59`) — inherit the caller without an implementation.

## Change

- Implement `mixin_setSelectedId` on `gnr.widgets.VirtualStaticGrid`, the class that owns the only caller. Every class that can reach the call inherits from it, so one hunk covers legacy `IncludedView`, `VirtualStaticGrid` used standalone, and anything else below.
- Build it on the existing `selectByRowAttr` (`genro_grid.js:1557`), which already resolves the row by attribute, guards a missing row and scrolls only to a real one.
- Fix `selectByRowAttrDo` so a `scrollTo` passed as `true` cannot leak the boolean into `scrollToRow`. The old guard reassigned only on success, so a row that was not found left `scrollTo === true` and `scrollToRow(true)` scrolled to row 1. `formhandler` already hits this: it passes `frm.store.loadedIndex == -1` as `scrollTo` (`resources/common/gnrcomponents/formhandler.py:220`).
- Preserve the optimized `NewIncludedView` override unchanged.
- Add a mounted `test15` testhandler covering store replacement, pkey selection and scroll, a pkey absent from the new store, and `null` clearing.

## Why not a capability guard

An earlier revision of this branch took a different route: `if(this.setSelectedId)` around the call, plus a hand-rolled copy of the method on `IncludedView`. Both are gone.

The guard was only needed because the method sat one class too low. And the hand-rolled index lookup had a hole: `indexByRowAttr` returns `-1` for a pkey absent from the store (`indexByCb`, `genro_grid.js:1531`), and `selection.select(-1)` reaches `grid.onSelected(-1)` → `_gnrUpdateSelect(-1)` (`genro_grid.js:1455`), which writes `null` back into the subscribed `selectedId` path and silently discards the caller's value. That is the ordinary case on a whole-store replacement, when the subscribed id still holds a pkey from the previous store — exactly the scenario this PR is about. `selectByRowAttr` guards it.

The `idx >= rowCount → rowCount - 1` clamp went with it: `indexByCb` only ever returns `0..rowCount-1`, so it was unreachable in the copied version. It is meaningful only in `NewIncludedView`, where `getIdxFromPkey` reads a stored `rowidx`.

## Why the grid stays empty

The `TypeError` is not merely noisy. `mixin_setStorepath` raises `_updatingIncludedView` on entry and lowers it on the last line of the branch (`genro_grid.js:2944` and `:3001` on `develop`). `newDataStore()` is called at `:2962`, in between, and the throw at `:2896` escapes before the reset — so the flag stays `true` and the guard at `:2934` discards **every subsequent store update** with no error anywhere. The rows visible at first paint come from `updateRowCount('*')`, a few lines above the throw; what is lost is everything after.

## Related issue

Fixes #1127
Fixes #1103

## Two reports, one defect

#1103 and #1127 are the same bug seen from two angles by the same reporter two days apart. The repro page of #1103, `projects/gnrcore/packages/test15/webpages/components/drop_uploader.py`, builds its grids with `includedViewBox` (lines 101 and 109) — the same widget #1127 names. This PR closes both, and supersedes #1110, which carried the guard hunk alone.

## Verification

- `node --check gnrjs/gnr_d11/js/genro_grid.js`
- `flake8` on the modified Python file, with the repository config
- Repository suite (`core web app sql xtnd`): 2076 passed, 69 skipped
- Live browser test on the testhandler `/test15/gnrwdg/includedview_bagstore/1`, reading the grid state and the datastore after each action:

| action | legacy `IncludedView` | `NewIncludedView` |
|---|---|---|
| Load rows (whole-store replacement) | 40 rows, no selection | 40 rows, no selection |
| Select last (`row_039`) | row 39 selected, scrolled to it | row 39 selected, scrolled to it |
| Select missing (`row_999`) | selection kept, no scroll, **`selectedId` still `row_999`** | selection cleared, **`selectedId` overwritten with `null`** |
| Clear selection (`null`) | selection cleared, rows kept | selection cleared, rows kept |
| Load rows again | 40 rows, no error | 40 rows, no error |

No console errors and no failed local requests at any step.

The third row is the defect described above, still live in `NewIncludedView` through its own `getIdxFromPkey` path — the new test page makes it observable side by side. It is out of scope here and tracked in #1162.
