### PR TITLE
Restore legacy BaseComponent proxy compatibility

### DIFF
--- a/gnrpy/gnr/core/gnrlang.py
+++ b/gnrpy/gnr/core/gnrlang.py
@@ -426,6 +426,10 @@ def classMixin(target_class, source_class, methods=None, only_callables=True,
     if exclude:
         mlist = [item for item in mlist if item not in FilterList(exclude)]
     proxy_name = getattr(source_class, 'proxy_name', None)
+    if not proxy_name:
+        proxy_name = getattr(source_class, 'proxy', None)
+        if proxy_name is True:
+            proxy_name = source_class.__name__.lower()
     if proxy_name:
         keyproxy = '{proxy_name}_proxyclass'.format(proxy_name=proxy_name)
         proxy_class =  getattr(target_class, keyproxy, None)

--- a/gnrpy/tests/core/gnrlang_test.py
+++ b/gnrpy/tests/core/gnrlang_test.py
@@ -189,6 +189,83 @@ class TestGnrLang():
             assert 1000 in fl
         assert "d" not in fl
 
+
+class TestClassMixinProxy():
+    def test_legacy_true_uses_lowercase_class_name(self):
+        class Target(object):
+            pass
+
+        class Proxy_test(object):
+            proxy = True
+
+            def ping(self):
+                return 'pong'
+
+        gl.classMixin(Target, Proxy_test)
+
+        assert hasattr(Target, 'proxy_test_proxyclass')
+        assert Target.proxy_test_proxyclass.ping.proxy_name == 'proxy_test'
+
+    def test_legacy_named_proxy_composes_components(self):
+        class Target(object):
+            pass
+
+        class FirstComponent(object):
+            proxy = 'shared'
+
+            def first(self):
+                return 'first'
+
+        class SecondComponent(object):
+            proxy = 'shared'
+
+            def second(self):
+                return 'second'
+
+        gl.classMixin(Target, FirstComponent)
+        gl.classMixin(Target, SecondComponent)
+
+        page = Target()
+        page.shared = Target.shared_proxyclass(page)
+        assert page.shared.first() == 'first'
+        assert page.shared.second() == 'second'
+
+    def test_proxy_name_precedes_legacy_proxy(self):
+        class Target(object):
+            pass
+
+        class Component(object):
+            proxy = 'legacy'
+            proxy_name = 'modern'
+
+            def ping(self):
+                return 'pong'
+
+        gl.classMixin(Target, Component)
+
+        assert hasattr(Target, 'modern_proxyclass')
+        assert not hasattr(Target, 'legacy_proxyclass')
+        assert Target.modern_proxyclass.ping.proxy_name == 'modern'
+
+    def test_proxy_instantiation_preserves_serialized_rpc_name(self):
+        class Target(object):
+            pass
+
+        class Component(object):
+            proxy = 'shared'
+
+            def rpc_ping(self):
+                return 'pong'
+
+        gl.classMixin(Target, Component)
+
+        page = Target()
+        page.shared = Target.shared_proxyclass(page)
+        assert page.shared.main is page
+        assert page.shared.rpc_ping() == 'pong'
+        assert gl.serializedFuncName(page.shared.rpc_ping) == 'shared.ping'
+
+
 class TestGnrLang_getEncoding():
     def _get_data_path(self, filename):
         return os.path.join(os.path.dirname(__file__), 'data', filename)


### PR DESCRIPTION
## Summary

- restore the legacy BaseComponent proxy=True and named proxy contracts in classMixin
- preserve proxy_name precedence for page_proxy and Class AS alias consumers
- cover implicit naming, shared proxy composition, modern precedence, instantiation, and RPC serialization

## Verification

- flake8 on the changed source and test files
- targeted classMixin proxy tests: 4 passed
- full gnrpy test suite: 2111 passed, 69 skipped
- local testhandler /test15/components/proxy_tester: page construction, server-side proxy access, and RPC all passed with no console or server errors
- git diff --check

Fixes #1102