### PR TITLE
fix(datastore): trigger a set with attributes only on a real change

### DIFF
--- a/gnrjs/gnr_d11/js/genro.js
+++ b/gnrjs/gnr_d11/js/genro.js
@@ -1581,7 +1581,7 @@ dojo.declare('gnr.GenroClient', null, {
                     var inner=dpath.slice(registered_path.length);
                     if(!inner || inner[0]=='.'){
                         genro._serverstore_changes = genro._serverstore_changes || {};
-                        genro._serverstore_changes[genro._serverstore_paths[registered_path]+inner] = asTypedTxt(kw.value);
+                        genro._serverstore_changes[genro._serverstore_paths[registered_path]+inner] = asTypedTxt(kw.node._value);
                         break;
                     }
                 }

--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -889,7 +889,7 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
         sourceNode.subscribe('updatedSelectedRow',function(){
             var selectedIndex = this.widget.selection.selectedIndex;
             this.widget.sourceNode.setAttributeInDatasource('selectedId', this.widget.rowIdByIndex(selectedIndex), 
-                                                                null, this.widget.rowByIndex(selectedIndex), true);
+                                                                null, this.widget.rowByIndex(selectedIndex));
         });
         sourceNode.subscribe('configuratorPalette',function(){
             this.widget.configuratorPalette();
@@ -1504,7 +1504,7 @@ dojo.declare("gnr.widgets.DojoGrid", gnr.widgets.baseDojo, {
                             selNodes, {'count':selNodes?selNodes.len():0});
         }
         if(this.sourceNode.attr.selectedId) {
-            this.sourceNode.setAttributeInDatasource('selectedId', selectedId, null, row, true);
+            this.sourceNode.setAttributeInDatasource('selectedId', selectedId, null, row);
         }
         if(this.sourceNode.attr.selectedRowData){
             var rowDataBag = new gnr.GnrBag(row);

--- a/gnrjs/gnr_d11/js/gnrbag.js
+++ b/gnrjs/gnr_d11/js/gnrbag.js
@@ -1747,11 +1747,11 @@ dojo.declare("gnr.GnrBag", null, {
                     label = splittedlabel[0];
                     var attr = splittedlabel[1];
                     var node = obj.getNode(label, false, true);
-                    if(kwargs.lazySet && isEqual(node.attr[attr],value)){  
-                        return;
-                    }
-                    var auxattr = {};
+                    var auxattr = objectUpdate({}, _attributes);
                     auxattr[attr] = value;
+                    if(kwargs.lazySet && !changedAttrKeys(node.attr,auxattr,'*').length){
+                        return node;
+                    }
                     var _doTrigger = true;
                     if ('doTrigger' in kwargs) {
                         _doTrigger = kwargs.doTrigger;
@@ -1816,11 +1816,15 @@ dojo.declare("gnr.GnrBag", null, {
                 node.setResolver(resolver);
             }
             if(kwargs.lazySet && isEqual(node._value,value)){
-                if(attrIsUnchanged(node.attr,_attributes,_updattr)){
+                var changedAttrs = changedAttrKeys(node.attr,_attributes,_updattr);
+                if(!changedAttrs.length){
                     return node;
                 }
-                //same value, changed attributes: only the attribute listeners have to be notified
-                node.setAttr(_attributes, _doTrigger, _updattr);
+                //same value, changed attributes: only the attribute listeners have to be notified.
+                //changedAttr comes from here because setAttr cannot default it without changing the
+                //callers that read its absence as a whole-attribute change
+                node.setAttr(_attributes, _doTrigger, _updattr,
+                             changedAttrs.length==1?changedAttrs[0]:null);
                 return node;
             }
             node.setValue(value, _doTrigger, _attributes, _updattr,kwargs.fired);

--- a/gnrjs/gnr_d11/js/gnrbag.js
+++ b/gnrjs/gnr_d11/js/gnrbag.js
@@ -1815,10 +1815,13 @@ dojo.declare("gnr.GnrBag", null, {
             if (resolver) {
                 node.setResolver(resolver);
             }
-            if(kwargs.lazySet){
-                if(isEqual(node._value,value)){
+            if(kwargs.lazySet && isEqual(node._value,value)){
+                if(attrIsUnchanged(node.attr,_attributes,_updattr)){
                     return node;
                 }
+                //same value, changed attributes: only the attribute listeners have to be notified
+                node.setAttr(_attributes, _doTrigger, _updattr);
+                return node;
             }
             node.setValue(value, _doTrigger, _attributes, _updattr,kwargs.fired);
             return node;

--- a/gnrjs/gnr_d11/js/gnrbag.js
+++ b/gnrjs/gnr_d11/js/gnrbag.js
@@ -1749,14 +1749,15 @@ dojo.declare("gnr.GnrBag", null, {
                     var node = obj.getNode(label, false, true);
                     var auxattr = objectUpdate({}, _attributes);
                     auxattr[attr] = value;
-                    if(kwargs.lazySet && !changedAttrKeys(node.attr,auxattr,'*').length){
+                    var changedAttrs = changedAttrKeys(node.attr,auxattr,'*');
+                    if(kwargs.lazySet && !changedAttrs.length){
                         return node;
                     }
                     var _doTrigger = true;
                     if ('doTrigger' in kwargs) {
                         _doTrigger = kwargs.doTrigger;
                     }
-                    node.setAttr(auxattr, _doTrigger, '*', attr);
+                    node.setAttr(auxattr, _doTrigger, '*', changedAttrs.length>1 ? null : attr);
                     return node;
                 }
                 else {

--- a/gnrjs/gnr_d11/js/gnrbag.js
+++ b/gnrjs/gnr_d11/js/gnrbag.js
@@ -1757,7 +1757,8 @@ dojo.declare("gnr.GnrBag", null, {
                     if ('doTrigger' in kwargs) {
                         _doTrigger = kwargs.doTrigger;
                     }
-                    node.setAttr(auxattr, _doTrigger, '*', changedAttrs.length>1 ? null : attr);
+                    node.setAttr(auxattr, _doTrigger, '*',
+                                 changedAttrs.length>1 ? null : (changedAttrs.length ? changedAttrs[0] : attr));
                     return node;
                 }
                 else {

--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -510,13 +510,26 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
     setAttributeInDatasource: function(attrname, value, doTrigger, attributes) {
         doTrigger = (doTrigger == null) ? this:doTrigger;
         var path = this.attrDatapath(attrname);
-        if (path == null || (value == null && !attributes && !genro._data.getNode(path))) {
+        if (isBag(attributes)) {
+            attributes = attributes.asDict();
+        }
+        if (path == null || (value == null && !objectNotEmpty(attributes) && !genro._data.getNode(path))) {
             return; //nothing to publish: an attribute never set needs no datanode
         }
-        if (attributes) {
-            // attributes can be a live store row: without a copy the datastore node
-            // would alias it and no comparison could ever detect a change
-            attributes = objectUpdate({}, attributes);
+        if (objectNotEmpty(attributes)) {
+            // attributes can be a live store row: without a copy of its container values too
+            // the datastore node would alias them and no comparison could detect a change
+            var snapshot = {};
+            for (var k in attributes) {
+                var v = attributes[k];
+                if (isBag(v)) {
+                    v = v.deepCopy();
+                } else if (v != null && v.constructor === Object) {
+                    v = objectUpdate({}, v);
+                }
+                snapshot[k] = v;
+            }
+            attributes = snapshot;
         }
         genro._data.setItem(path, value, attributes, {'doTrigger':doTrigger,'lazySet':true});
     },

--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -507,16 +507,18 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
         }
         
     },
-    setAttributeInDatasource: function(attrname, value, doTrigger, attributes, forceChanges) {
+    setAttributeInDatasource: function(attrname, value, doTrigger, attributes) {
         doTrigger = (doTrigger == null) ? this:doTrigger;
         var path = this.attrDatapath(attrname);
-        var old_value = genro._data.getItem(path);
-        //if (forceChanges){
-        //    genro._data.setItem(path,v,null,{'doTrigger':false});
-        //}
-        if (!isEqual(value,old_value) || (forceChanges && value != null)) {
-            genro._data.setItem(path, value, attributes, {'doTrigger':doTrigger});
+        if (path == null || (value == null && !attributes && !genro._data.getNode(path))) {
+            return; //nothing to publish: an attribute never set needs no datanode
         }
+        if (attributes) {
+            // attributes can be a live store row: without a copy the datastore node
+            // would alias it and no comparison could ever detect a change
+            attributes = objectUpdate({}, attributes);
+        }
+        genro._data.setItem(path, value, attributes, {'doTrigger':doTrigger,'lazySet':true});
     },
     defineForm: function(formId, formDatapath, controllerPath, pkeyPath,kw) {
         this.form = new gnr.GnrFrmHandler(this, formId, formDatapath, controllerPath, pkeyPath,kw);

--- a/gnrjs/gnr_d11/js/gnrlang.js
+++ b/gnrjs/gnr_d11/js/gnrlang.js
@@ -547,24 +547,29 @@ function objectIsEqual(obj1, obj2) {
     }
 }
 
-function attrIsUnchanged(currattr, newattr, updattr) {
+function changedAttrKeys(currattr, newattr, updattr) {
     if (newattr == null) {
-        return true; //a setter without attributes leaves them untouched
+        return []; //a setter without attributes leaves them untouched
     }
     currattr = currattr || {};
+    var changed = [];
     for (var k in newattr) {
-        if (!isEqual(newattr[k], currattr[k])) {
-            return false;
+        if (updattr == '*' && newattr[k] == null) {
+            if (k in currattr) {
+                changed.push(k); //update with '*': a null deletes the attribute
+            }
+        } else if (!(k in currattr) || !isEqual(newattr[k], currattr[k])) {
+            changed.push(k);
         }
     }
     if (!updattr) {
         for (var k in currattr) {
             if (!(k in newattr)) {
-                return false;
+                changed.push(k); //replace semantics: a dropped attribute changes its own path
             }
         }
     }
-    return true;
+    return changed;
 }
 
 function isNullOrBlank(elem){

--- a/gnrjs/gnr_d11/js/gnrlang.js
+++ b/gnrjs/gnr_d11/js/gnrlang.js
@@ -547,6 +547,26 @@ function objectIsEqual(obj1, obj2) {
     }
 }
 
+function attrIsUnchanged(currattr, newattr, updattr) {
+    if (newattr == null) {
+        return true; //a setter without attributes leaves them untouched
+    }
+    currattr = currattr || {};
+    for (var k in newattr) {
+        if (!isEqual(newattr[k], currattr[k])) {
+            return false;
+        }
+    }
+    if (!updattr) {
+        for (var k in currattr) {
+            if (!(k in newattr)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 function isNullOrBlank(elem){
     return elem === null || elem===undefined || elem === '';
 }

--- a/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
+++ b/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
@@ -11,8 +11,9 @@ class GnrCustomWebPage(object):
     def test_0_grid_selected_id(self, pane):
         """Grid selectedId. Click a row: both counters step. Click the same row again: nothing
         moves. 'Republish selection' writes the same id with the same row data and must move
-        nothing. 'Rename selected row' changes the row data, so the id stays and only the
-        attributes counter steps"""
+        nothing. 'Rename selected row' changes the row data, so the id stays, only the attributes
+        counter steps and 'changedAttr' must read name: the consumers that branch on that field
+        (the form changes logger, a _class bound to an attribute) are blind without it"""
         box = pane.div(datapath='.t0')
         box.data('.store', self.gridStore())
         box.data('.id_triggers', 0)
@@ -25,9 +26,10 @@ class GnrCustomWebPage(object):
         fb.div('^.attr_triggers', lbl='selectedId?name triggers')
         fb.div('^.grid.selectedId', lbl='selectedId')
         fb.div('^.grid.selectedId?name', lbl='name from attributes')
+        fb.div('^.changed_attr', lbl='changedAttr of the last trigger')
         box.dataController("SET .id_triggers = n+1;",
                            selectedId='^.grid.selectedId', n='=.id_triggers')
-        box.dataController("SET .attr_triggers = n+1;",
+        box.dataController("SET .attr_triggers = n+1; SET .changed_attr = _triggerpars.kw.changedAttr;",
                            rowname='^.grid.selectedId?name', n='=.attr_triggers')
         bar = box.div(margin='5px')
         bar.button('Republish selection').dataController(
@@ -44,7 +46,8 @@ class GnrCustomWebPage(object):
     def test_1_setdata_with_attributes(self, pane):
         """genro.setData carrying attributes. Same value and same attributes: no trigger at all.
         Same value with a changed attribute: only the attribute listener steps. Changed value:
-        both step"""
+        both step. The last button writes an attribute by path and carries a second one: both
+        have to land, the '?attr' road obeys the same rule as the value one"""
         box = pane.div(datapath='.t1')
         box.data('.value_triggers', 0)
         box.data('.attr_triggers', 0)
@@ -53,6 +56,7 @@ class GnrCustomWebPage(object):
         fb.div('^.attr_triggers', lbl='attribute triggers')
         fb.div('^.target', lbl='value')
         fb.div('^.target?tag', lbl='tag attribute')
+        fb.div('^.target?other', lbl='other attribute')
         box.dataController("SET .value_triggers = n+1;", target='^.target', n='=.value_triggers')
         box.dataController("SET .attr_triggers = n+1;",
                            target_tag='^.target?tag', n='=.attr_triggers')
@@ -63,6 +67,9 @@ class GnrCustomWebPage(object):
             "genro.setData(this.absDatapath('.target'),'A',{tag:'tag_'+genro.getCounter()});")
         bar.button('New value').dataController(
             "genro.setData(this.absDatapath('.target'),'B_'+genro.getCounter(),{tag:'first'});")
+        bar.button('Tag by path, carrying another attribute').dataController(
+            """genro.setData(this.absDatapath('.target?tag'), 'bypath_'+genro.getCounter(),
+                          {other:'other_'+genro.getCounter()});""")
 
     def gridStruct(self, struct):
         r = struct.view().rows()

--- a/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
+++ b/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+"""Triggers of a set carrying attributes"""
+
+from gnr.core.gnrbag import Bag
+
+
+class GnrCustomWebPage(object):
+    py_requires = "gnrcomponents/testhandler:TestHandlerFull,gnrcomponents/framegrid:FrameGrid"
+
+    def test_0_grid_selected_id(self, pane):
+        """Grid selectedId. Click a row: both counters step. Click the same row again: nothing
+        moves. 'Republish selection' writes the same id with the same row data and must move
+        nothing. 'Rename selected row' changes the row data, so the id stays and only the
+        attributes counter steps"""
+        box = pane.div(datapath='.t0')
+        box.data('.store', self.gridStore())
+        box.data('.id_triggers', 0)
+        box.data('.attr_triggers', 0)
+        box.bagGrid(frameCode='t0_grid', storepath='.store', struct=self.gridStruct,
+                    grid_nodeId='t0_selgrid', height='180px',
+                    addrow=False, delrow=False, batchAssign=False)
+        fb = box.formbuilder(cols=2, border_spacing='3px')
+        fb.div('^.id_triggers', lbl='selectedId triggers')
+        fb.div('^.attr_triggers', lbl='selectedId?name triggers')
+        fb.div('^.grid.selectedId', lbl='selectedId')
+        fb.div('^.grid.selectedId?name', lbl='name from attributes')
+        box.dataController("SET .id_triggers = n+1;",
+                           selectedId='^.grid.selectedId', n='=.id_triggers')
+        box.dataController("SET .attr_triggers = n+1;",
+                           rowname='^.grid.selectedId?name', n='=.attr_triggers')
+        bar = box.div(margin='5px')
+        bar.button('Republish selection').dataController(
+            "genro.nodeById('t0_selgrid').publish('updatedSelectedRow');")
+        bar.button('Rename selected row').dataController("""
+            if(!selectedId){
+                return;
+            }
+            genro.setData(this.absDatapath('.store.'+selectedId+'.name'),
+                          'renamed_'+genro.getCounter());
+            genro.nodeById('t0_selgrid').publish('updatedSelectedRow');""",
+            selectedId='=.grid.selectedId')
+
+    def test_1_setdata_with_attributes(self, pane):
+        """genro.setData carrying attributes. Same value and same attributes: no trigger at all.
+        Same value with a changed attribute: only the attribute listener steps. Changed value:
+        both step"""
+        box = pane.div(datapath='.t1')
+        box.data('.value_triggers', 0)
+        box.data('.attr_triggers', 0)
+        fb = box.formbuilder(cols=2, border_spacing='3px')
+        fb.div('^.value_triggers', lbl='value triggers')
+        fb.div('^.attr_triggers', lbl='attribute triggers')
+        fb.div('^.target', lbl='value')
+        fb.div('^.target?tag', lbl='tag attribute')
+        box.dataController("SET .value_triggers = n+1;", target='^.target', n='=.value_triggers')
+        box.dataController("SET .attr_triggers = n+1;",
+                           target_tag='^.target?tag', n='=.attr_triggers')
+        bar = box.div(margin='5px')
+        bar.button('Same value, same tag').dataController(
+            "genro.setData(this.absDatapath('.target'),'A',{tag:'first'});")
+        bar.button('Same value, new tag').dataController(
+            "genro.setData(this.absDatapath('.target'),'A',{tag:'tag_'+genro.getCounter()});")
+        bar.button('New value').dataController(
+            "genro.setData(this.absDatapath('.target'),'B_'+genro.getCounter(),{tag:'first'});")
+
+    def gridStruct(self, struct):
+        r = struct.view().rows()
+        r.cell('name', name='Name', width='12em', edit=True)
+        r.cell('city', name='City', width='12em', edit=True)
+
+    def gridStore(self):
+        result = Bag()
+        for i, (name, city) in enumerate([('Anna', 'Milano'), ('Bruno', 'Roma'), ('Carla', 'Napoli')]):
+            row = Bag()
+            row['name'] = name
+            row['city'] = city
+            result.setItem('r_%i' % i, row)
+        return result


### PR DESCRIPTION
Fixes #1144

## What was wrong

`selectedId` is published with the whole row as node attributes, so `^grid.selectedId?field` works. `setAttributeInDatasource()` compared the value alone, so the only way to keep those attributes fresh was `forceChanges`, which wrote (and triggered) unconditionally: clicking the already selected row, or any re-publication of the same selection, re-ran every controller bound to that path.

The same value-only comparison hurt in the opposite direction everywhere else: `genro.setData()`, `setRelativeData()` and `setItem(..., {lazySet:true})` skipped the write when the value was equal, silently **dropping** an attribute-only change and its trigger.

## The rule now implemented

A set carrying attributes has exactly three outcomes:

| value | attributes | result |
|---|---|---|
| same | same | nothing written, no trigger |
| same | changed | attributes updated, only the attribute listeners notified (`^path?attr`) |
| changed | any | value and attributes updated, everybody notified |

The middle row is what the annoying case needed: after an inline edit of the selected row the attribute watchers get the fresh row, while a form bound to `^grid.selectedId` does not reload for an id that never changed.

## Changes

- `gnrlang.js`: `attrIsUnchanged(currattr, newattr, updattr)` — tells whether applying `newattr` would change anything, honouring both the replace and the update semantics of `setAttr()`, and comparing values with `isEqual` (Date and Bag included).
- `gnrbag.js` — `GnrBag.set()`: the `lazySet` comparison covers the attributes; same value with changed attributes goes through `setAttr()`, which notifies the attribute listeners without faking a value change.
- `gnrdomsource.js` — `setAttributeInDatasource()`: `forceChanges` is gone, the write is lazy, and the attributes are copied before being stored, because a grid can hand out the live store row (`node.attr`) and an aliased object makes any comparison blind. An attribute that was never published no longer materializes an empty datanode.
- `genro_grid.js`: the two `selectedId` publications drop the `forceChanges` argument.

## Test case

New test page `test/datastore/attribute_trigger` (no database needed):

- **test_0** — a `bagGrid` with `selectedId`, two counters (`^...selectedId` and `^...selectedId?name`), plus buttons that republish the very same selection and that rename the selected row.
- **test_1** — `genro.setData()` with attributes: same value/same attribute, same value/new attribute, new value.

Verified on a running instance:

| action | value triggers | attribute triggers |
|---|---|---|
| first click on a row | 1 | 1 |
| same row clicked again / selection republished | 1 | 1 |
| selected row renamed, then republished | 1 | 2 |
| `setData` same value same tag (twice) | 1 | 1 |
| `setData` same value new tag | 1 | 2 |
| `setData` new value | 2 | 3 |

Regression pass on the same instance: `plainTableHandler` and `borderTableHandler` (selection loads the form, switching rows loads the related rows), inline editing on a `bagGrid`, formatted/masked values in `dojo/displayed_value`. `pytest core web sql app xtnd`: 2159 passed, 10 skipped.


**On the test counts across runs.** Nothing in this diff touches Python, so the executed/skipped split follows whichever services are up when the suite runs, not the diff: `2159 passed, 10 skipped` and `2100 passed, 69 skipped` have the same total and differ by 59 tests moving from executed to skipped. Neither is a regression against the other.
