### PR TITLE
fix(#1153): skip register freshness check for services not configured in db

### DIFF
--- a/gnrpy/gnr/lib/services/__init__.py
+++ b/gnrpy/gnr/lib/services/__init__.py
@@ -89,7 +89,10 @@ class BaseServiceType(object):
         self._implementations_lock = threading.RLock()
 
     def addService(self, service_name=None, **kwargs):
-        service_conf = kwargs or self.getConfiguration(service_name)
+        db_conf = self.getServiceConfigurationFromDb(service_name)
+        service_conf = kwargs or db_conf or \
+                self.getServiceConfigurationFromSiteConfig(service_name) or \
+                self.getServiceConfigurationFromSelf(service_name)
         if not service_conf:
             return
         implementation = service_conf.pop('implementation',None) or service_conf.pop('resource',None) #resource is the oldname for implementation
@@ -103,6 +106,7 @@ class BaseServiceType(object):
         service.service_type = self.service_type
         service.service_implementation = implementation
         service._service_creation_ts = datetime.now()
+        service._config_from_db = db_conf is not None
         self.service_instances[service_name] = service
         return service
 
@@ -229,6 +233,11 @@ class BaseServiceType(object):
     def __call__(self, service_name=None, **kwargs):
         service_name = service_name or self.default_service_name
         service = self.service_instances.get(service_name)
+        if service is not None and not service._config_from_db:
+            # The expiration timestamp is written only by the sys.service table
+            # triggers: a service whose configuration was not resolved from the
+            # database can never expire, so skip the register read entirely.
+            return service
         gs = self.site.register.globalStore()
         cache_key = 'globalServices_lastChangedConfigTS.%s_%s' % (self.service_type, service_name)
         lastChangedConfigurationTS = gs.getItem(cache_key)

--- a/gnrpy/gnr/web/daemon/siteregister_client.py
+++ b/gnrpy/gnr/web/daemon/siteregister_client.py
@@ -393,8 +393,10 @@ class ServerStore(object):
 
     @property
     def data(self):
-        if self.register_item:
-            return self.register_item['data']
+        # register_item is a remote call: evaluate it once
+        register_item = self.register_item
+        if register_item:
+            return register_item['data']
 
     @property
     def datachanges(self):

--- a/gnrpy/tests/core/gnrservices_test.py
+++ b/gnrpy/tests/core/gnrservices_test.py
@@ -24,10 +24,15 @@ class FakeResourceLoader(object):
         return result
 
 
+class FakeApp(object):
+    packages = {}
+
+
 class FakeSite(object):
     def __init__(self, resources_dirs):
         self.resources_dirs = resources_dirs
         self.resource_loader = FakeResourceLoader()
+        self.gnrapp = FakeApp()
 
 
 @pytest.fixture
@@ -101,3 +106,42 @@ def test_concurrent_first_access_is_atomic(service_type):
     assert len(build_calls) == 1
     assert len(factories) == 8
     assert all(f is factories[0] and callable(f) for f in factories)
+
+
+class FakeGlobalStore(object):
+    def __init__(self):
+        self.getitem_calls = 0
+
+    def getItem(self, key):
+        self.getitem_calls += 1
+        return None
+
+
+class FakeRegister(object):
+    def __init__(self):
+        self.global_store = FakeGlobalStore()
+
+    def globalStore(self, triggered=False):
+        return self.global_store
+
+
+def test_cached_non_db_service_skips_register(service_type):
+    service_type.site.register = FakeRegister()
+    service = service_type('one', implementation='alpha')
+    assert service._config_from_db is False
+    # creation path reads the register once
+    assert service_type.site.register.global_store.getitem_calls == 1
+    # cached non-db service: no further register reads
+    assert service_type('one') is service
+    assert service_type('one') is service
+    assert service_type.site.register.global_store.getitem_calls == 1
+
+
+def test_cached_db_service_keeps_freshness_check(service_type):
+    service_type.site.register = FakeRegister()
+    service_type.getServiceConfigurationFromDb = lambda service_name: {'implementation': 'alpha'}
+    service = service_type('one')
+    assert service._config_from_db is True
+    assert service_type('one') is service
+    # db-configured service: the register is read on every call
+    assert service_type.site.register.global_store.getitem_calls == 2

--- a/gnrpy/tests/core/services_addservice_test.py
+++ b/gnrpy/tests/core/services_addservice_test.py
@@ -34,6 +34,7 @@ def make_site():
         debug=False,
         getStatic=lambda name: None,
         default_page=None,
+        gnrapp=SimpleNamespace(packages={}),
     )
     site.resource_loader = ResourceLoader(site)
     site.resources_dirs = [COMMON_RESOURCES]


### PR DESCRIPTION
## Problem

`BaseServiceType.__call__` caches service instances in-process but re-read
`globalServices_lastChangedConfigTS.<type>_<name>` from the register global store on
every call, to detect configuration changes made in other processes.

Measured on a legacy stack (gunicorn + separate sitedaemon over Pyro), a single login
performed 384 register calls / 386 wire round-trips / 175 ms inside the register.
242 of those calls (63%, 112.7 ms) came from this single freshness check:
121 service requests × 2 round-trips each.

Two distinct defects:

1. **`ServerStore.data` evaluated `register_item` twice** (`if self.register_item:`
   followed by `self.register_item['data']`). Each evaluation is a Pyro round-trip,
   so every `getItem` on any store cost 2 round-trips instead of 1.
2. **The freshness check was unconditional.** The timestamp key is written only by the
   `sys.service` table triggers. Services whose configuration is resolved from
   `conf_<name>` methods, `DEFAULT_STORAGE_CONFIGS` or explicit kwargs without a
   `sys.service` record (e.g. storage `rsrc`, `gnr`, `dojo`, `_raw_`) never get the
   key written: the check read `None` forever. In the measured login those were
   118 of the 121 service requests.

## Fix

- `ServerStore.data` evaluates `register_item` once (242 → 121 round-trips).
- `addService` resolves the database configuration first and marks the instance with
  `_config_from_db`; `__call__` returns a cached instance immediately when its
  configuration was not resolved from `sys.service` — the timestamp can never
  concern it.

Combined effect on the measured login: register round-trips for the freshness check
drop from 242 to 3.

## Trade-off

Creating a **new** `sys.service` record that overrides a name previously resolved from
built-in configuration (e.g. redefining storage `dojo`) is no longer picked up by
running workers holding the cached instance: it requires a restart. Overriding a
built-in volume is a deploy-time operation, so the restart is considered implicit.
Updates to services that already have a `sys.service` record keep the current
behavior: the freshness check still runs for them on every call.

## Tests

- `tests/core/gnrservices_test.py`: two new tests — a cached non-db service performs
  no register reads; a db-configured service keeps the per-call freshness check.
- Test site facades gained a `gnrapp.packages` attribute, now always traversed by
  `addService`.
- flake8 clean on modified files; full suite green except pre-existing failures
  (`flatfiles_test`, `test_gnrbaseadapter`).

Ref #1153
