### PR TITLE
feat(#1158): carry _lastUserEventTs/_lastRpc on every RPC

### DIFF
--- a/gnrjs/gnr_d11/js/genro_rpc.js
+++ b/gnrjs/gnr_d11/js/genro_rpc.js
@@ -363,6 +363,8 @@ dojo.declare("gnr.GnrRpcHandler", null, {
         if(!sysrpc){
             genro._lastRpc = new Date();
         }
+        content._lastUserEventTs = genro.getServerLastTs();
+        content._lastRpc = genro.getServerLastRpc();
         if (genro.debugRpc) {
             this.debugRpc(kw);
         }


### PR DESCRIPTION
## Summary

`_lastUserEventTs` and `_lastRpc` were sent only in the ping payload
(`genro_rpc.js` `ping`). Between two beats a page could serve any number of
RPCs without its activity clocks moving, so `last_user_ts` and `last_rpc_ts`
on the register item were only ever as fresh as the last beat.

This PR is the "send only" half of #1158: two lines in `_serverCall`, the
single funnel every RPC goes through. No Python change.

The server already accepts the two keys on every call — `_rpcDispatcher`
pops them into `self._lastUserEventTs` / `self._lastRpc`
(`gnrwebpage.py:641-642`). Today those attributes are always `None` on a
non-ping RPC and nothing in the repo reads them. After this PR they carry a
value.

Position matters: the two lines sit **after** `genro._lastRpc = new Date()`.
A user-driven call reports its own timestamp; a sysrpc, which does not touch
`genro._lastRpc`, reports the last real RPC.

## Out of scope

Writing the clocks to the register on every RPC — that is the extra Pyro
round trip discussed in #1158, and the write policy stays a separate
decision. This PR leaves the daemon cost unchanged.

## Cost

~100 bytes per RPC (two `yyyy-MM-dd HH:mm:ss::DH` strings plus key names,
url-encoded) inside a POST that leaves anyway. No extra round trip, no extra
request, no daemon call added.

## Checks

- `node --check gnrjs/gnr_d11/js/genro_rpc.js` clean
- No client-side cache is keyed on the payload: `content.callcounter`
  already changes on every call (`register_call`)
- The other two routes of `_get_call_handler`, `_plugin` and external `rpc`,
  are not reachable from `_serverCall`: `pluginCommand` is client-side only
  and the `rpc` route is not generated by the JS
- `genro._lastUserEventTs` and `genro._lastRpc` are set in the `genro`
  constructor, before `genro.rpc` exists — no init-order hazard
- Cross-repo search on both keys: all hits are in this repo
- No test asserts on the RPC payload

## Test plan

- Open a page, run RPCs without waiting for a ping, verify the register item
  shows `last_user_ts` / `last_rpc_ts` advancing on the next beat rather than
  only at beat time
- Verify the ping still works: same two keys, unchanged path (`_ping`)
- Verify a sysrpc does not overwrite `last_rpc_ts` with its own timestamp