### PR TITLE
fix(grid): do not select an unresolved pkey in NewIncludedView

### DIFF
--- a/gnrjs/gnr_d11/js/genro_grid.js
+++ b/gnrjs/gnr_d11/js/genro_grid.js
@@ -4454,8 +4454,10 @@ dojo.declare("gnr.widgets.NewIncludedView", gnr.widgets.IncludedView, {
             if (idx >= nrow) {
                 idx = nrow - 1;
             }
-            this.selection.select(idx);
-            this.scrollToRow(idx);
+            if (idx >= 0) {
+                this.selection.select(idx);
+                this.scrollToRow(idx);
+            }
         }
     },
 


### PR DESCRIPTION
Fixes #1162

## Problem

`NewIncludedView.mixin_setSelectedId` resolves the row with `collectionStore().getIdxFromPkey(pkey)` and guards only the upper bound. `getIdxFromPkey` returns **-1** when the pkey is not in the store (`genro_components.js:6895` and `:8094`), and `selection.select(-1)` is not inert: `addToSelection(-1)` finds `onCanSelect` returning `true` unconditionally, so it fires `grid.onSelected(-1)` → `_gnrUpdateSelect(-1)` (`genro_grid.js:1455`), where `selectedId` is computed as `null` and written back to the datastore.

A grid subscribed with `selectedId='^.selectedId'` therefore **overwrites the caller's value with `null`** whenever the pkey it was handed does not resolve. Silently: no exception, no log. `scrollToRow(-1)` runs too.

`mixin_newDataStore` applies the subscribed `selectedId` on every whole-store replacement, and at that moment the subscribed value still holds a pkey from the *previous* store — so any replacement with different keys walks into it.

## Change

Keep the optimized `getIdxFromPkey` lookup and skip the selection when it resolves to nothing, which is what `selectByRowAttr` already does on the `VirtualStaticGrid` side. Four lines, one class, no other behaviour touched.

## What is deliberately left out

`NewIncludedView.mixin_selectByRowAttr` does not resolve immediately: it waits on `pendingStore` until `collectionStore()` reports neither `runningQuery` nor `loadingData` (`genro_grid.js:4814`). `setSelectedId` has no such wait, so on a store that is still loading `getIdxFromPkey` returns -1 for a **valid** pkey as well.

This patch changes that case from "the subscribed value is destroyed" to "the selection is not applied", which is strictly better but not complete. Adding the wait means sharing the `pendingStore` block between the two methods, and it is a different defect from the one #1162 reports — I have not reproduced it live, so I am not folding an unverified change into this one. Worth its own issue if someone hits it.

## Verification

- `node --check gnrjs/gnr_d11/js/genro_grid.js`
- Repository suite (`core web app sql xtnd`): 2076 passed, 69 skipped
- Live browser test on the testhandler `/test15/gnrwdg/includedview_bagstore/1`, reading widget state and datastore after each action. That page comes from #1130, so the run was done on `develop` + this patch + #1130 applied locally — i.e. the state both branches produce once merged:

| action | legacy `IncludedView` | `NewIncludedView` |
|---|---|---|
| Load rows (whole-store replacement) | 40 rows, no selection | 40 rows, no selection |
| Select last (`row_039`) | row 39 selected, scrolled to it | row 39 selected, scrolled to it |
| Select missing (`row_999`) | selection kept, `selectedId` still `row_999` | selection kept, `selectedId` still `row_999` |
| Clear selection (`null`) | selection cleared, rows kept | selection cleared, rows kept |
| Load rows again | 40 rows, no error | 40 rows, no error |

Before the patch the third row read *selection cleared, `selectedId` overwritten with `null`* for `NewIncludedView`. The two columns are now identical at every step.

168 local requests, all 200, `_ping` included. No console errors from the application (the only console entries are refused Google Fonts stylesheets, external network being unavailable in this environment).

## Note on #1130

Independent of #1130 and mergeable in either order — that PR touches `VirtualStaticGrid` and `selectByRowAttrDo`, this one only the `NewIncludedView` override. They touch the same file, so whichever lands second may need a trivial rebase.
