### PR TITLE
fix(#1160): anchor the save_failed controller to #FORM so nested forms show the refused-save message

### DIFF
--- a/resources/common/th/th_form.py
+++ b/resources/common/th/th_form.py
@@ -236,7 +236,7 @@ class TableHandlerForm(BaseComponent):
 
         form.dataController(""" if(reason=='nochange'){return;}
                                 genro.dlg.alert(msg+' '+this.form.getRecordCaption()+': '+(reason=='invalid'?invalid:nochange),titledialog);""",
-                            reason="^.controller.save_failed",_if='reason',
+                            reason="^#FORM.controller.save_failed",_if='reason',
                             titledialog='!!Save failed',
                             msg='!!You cannot save',
                             invalid='!!Invalid record',


### PR DESCRIPTION
## Problem / Root cause

`th_form` declares on the form node a dataController that alerts the user when a save is refused, watching `^.controller.save_failed` — a relative path (`resources/common/th/th_form.py:239`).

At build time `FrameForm.createContent` re-parents the children declared on the form node into the FramePane center content node (`gnrjs/gnr_d11/js/genro_components.js`, `content.concat(children)` in `gnrwdg._beforeCreation`, then again in `FramePane.createContent` which returns the center node's bag). When the form resource builds its center with the `form.record` idiom — a contentPane with `datapath='.record'` (`gnrpy/gnr/web/gnrwebstruct/base.py:318`), the typical shape of sub-forms on related tables — the relative path gains a `.record` segment and resolves to `<form>.record.controller.save_failed`.

The form handler however fires the flag at `<form>.controller.save_failed` (`gnrjs/gnr_d11/js/genro_frm.js:1523-1531`, `getControllerData` resolves `.controller` against the node `defineForm` was called on). The controller never triggers: a refused save (invalid record, no change) gives no feedback and the record silently stays unsaved.

The discriminating axis is the resource layout, not root vs nested as such: root forms usually place a borderContainer (no datapath) at center, so the relative path happens to resolve correctly there — which is why the defect surfaces on nested/sub-forms.

## Change

One line: anchor the watch to the form — `reason="^#FORM.controller.save_failed"`. `#FORM` resolves against the ancestor node owning `formId` (`gnrjs/gnr_d11/js/genro.js`, `nodeById`), the same base `fireControllerData` writes to, so the path is correct in every layout. Same idiom already used a few lines above in the same function (`_fired='^#FORM.controller.loaded'`, `th_form.py:183`). Where the relative path happened to work the resolved path is unchanged, so no regression.

The alternative fix — keeping declared controllers outside the `.record` content node in the FrameForm/FramePane re-parenting — would touch the core widget building for every form and was discarded as riskier.

## Verification

- flake8 on the touched file: clean.
- `pytest gnrpy/tests/ --ignore=gnrpy/tests/sql`: 2102 passed, 69 skipped.
- Path resolution verified statically against the resolver: `#FORM` → `attributeOwnerNode('formId')` → `absDatapath('.controller.save_failed')` matches the write base of `fireControllerData('save_failed', ...)`. Not verified on a live page in this session: the repo test packages carry no nested-form th page reproducing the issue's setup.

## Related issue

Fixes #1160