### PR TITLE
fix(datastore): react to an attribute-only trigger carrying more than one attribute

### DIFF
--- a/gnrjs/gnr_d11/js/genro_frm.js
+++ b/gnrjs/gnr_d11/js/genro_frm.js
@@ -1778,12 +1778,17 @@ dojo.declare("gnr.GnrFrmHandler", null, {
             allowed = !this._protectedNode(kw.node);
         }
         if( kw.value==kw.oldvalue  || (isNullOrBlank(kw.value) && isNullOrBlank(kw.oldvalue))){
-            if(kw.updattr && kw.changedAttr && kw.changedAttr!='_displayedValue'){
-                var cattr = kw.changedAttr;
+            var cattrs = kw.updattr?triggerChangedAttrs(kw):[];
+            var logged = false;
+            var changes = cattrs.length?this.getChangesLogger():null;
+            for(var i=0;i<cattrs.length;i++){
+                var cattr = cattrs[i];
+                if(cattr[0]=='_'){
+                    continue; //internal attributes are not user changes: they would dirty a clean form
+                }
                 var oldvalue = kw.oldattr[cattr];
                 var newvalue = kw.node.attr[cattr];
                 var changekey = this.getChangeKey(kw.node) + cattr;
-                var changes = this.getChangesLogger();
                 var n = changes.getNode(changekey);
                 if(n){
                     if(n.attr.from == newvalue){
@@ -1794,6 +1799,9 @@ dojo.declare("gnr.GnrFrmHandler", null, {
                 }else{
                     changes.setItem(changekey,null,{_valuelabel:kw.reason.getElementLabel?kw.reason.getElementLabel():cattr,from:oldvalue,to:newvalue,allowed:allowed});
                 }
+                logged = true;
+            }
+            if(logged){
                 this.updateStatus();
             }
             return;

--- a/gnrjs/gnr_d11/js/gnrbag.js
+++ b/gnrjs/gnr_d11/js/gnrbag.js
@@ -465,12 +465,7 @@ dojo.declare("gnr.GnrBagNode", null, {
             this.attr = attr;
         }
         if (doTrigger) {
-            var changedAttributes = {};
-            for(var k in this.attr){
-                if(!(k in oldattr) || oldattr[k]!==this.attr[k]){
-                    changedAttributes[k] = true;
-                }
-            }
+            var changedAttributes = changedAttrKeys(oldattr, attr, updateAttr);
             if (this._parentbag && this._parentbag._backref) {
                 this._parentbag.onNodeTrigger({'evt':'upd','node':this, 'pathlist':[this.label],
                     'oldattr':oldattr,'updattr':true, reason:doTrigger,

--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -1393,7 +1393,17 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
             return;
         }
         else if (attr == '_class') {
-            var oldvalue = ('oldvalue' in kw) ? kw.oldvalue : kw.changedAttr ? kw.oldattr[kw.changedAttr] : null;
+            var oldvalue = null;
+            if ('oldvalue' in kw) {
+                oldvalue = kw.oldvalue;
+            } else {
+                //the old class lives under the attribute this node is bound to, not under
+                //whichever attribute the trigger happens to name
+                var boundattr = (this.attr._class || '').split('?')[1];
+                if (boundattr && boundattr[0] != '=' && triggerChangedAttrs(kw).indexOf(boundattr) >= 0) {
+                    oldvalue = kw.oldattr[boundattr];
+                }
+            }
 
             var domnode;
             if (this.widget) {

--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -1396,12 +1396,12 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
             var oldvalue = null;
             if ('oldvalue' in kw) {
                 oldvalue = kw.oldvalue;
-            } else {
-                //the old class lives under the attribute this node is bound to, not under
-                //whichever attribute the trigger happens to name
+            } else if (trigger_reason == 'node') {
                 var boundattr = (this.attr._class || '').split('?')[1];
-                if (boundattr && boundattr[0] != '=' && triggerChangedAttrs(kw).indexOf(boundattr) >= 0) {
+                if (boundattr && boundattr[0] != '=') {
                     oldvalue = kw.oldattr[boundattr];
+                } else if (kw.changedAttr) {
+                    oldvalue = kw.oldattr[kw.changedAttr];
                 }
             }
 
@@ -2254,4 +2254,3 @@ dojo.declare("gnr.GnrDomSource", gnr.GnrStructData, {
         return node;
     }
 });
-

--- a/gnrjs/gnr_d11/js/gnrdomsource.js
+++ b/gnrjs/gnr_d11/js/gnrdomsource.js
@@ -1399,9 +1399,9 @@ dojo.declare("gnr.GnrDomSourceNode", gnr.GnrBagNode, {
             } else if (trigger_reason == 'node') {
                 var boundattr = (this.attr._class || '').split('?')[1];
                 if (boundattr && boundattr[0] != '=') {
-                    oldvalue = kw.oldattr[boundattr];
+                    oldvalue = (kw.oldattr || {})[boundattr];
                 } else if (kw.changedAttr) {
-                    oldvalue = kw.oldattr[kw.changedAttr];
+                    oldvalue = (kw.oldattr || {})[kw.changedAttr];
                 }
             }
 

--- a/gnrjs/gnr_d11/js/gnrlang.js
+++ b/gnrjs/gnr_d11/js/gnrlang.js
@@ -572,6 +572,13 @@ function changedAttrKeys(currattr, newattr, updattr) {
     return changed;
 }
 
+function triggerChangedAttrs(kw) {
+    if (kw.changedAttr) {
+        return [kw.changedAttr]; //a single changed attribute is named: callers may read its absence
+    }
+    return kw.changedAttributes || [];
+}
+
 function isNullOrBlank(elem){
     return elem === null || elem===undefined || elem === '';
 }

--- a/gnrjs/gnr_d11/js/gnrlang.js
+++ b/gnrjs/gnr_d11/js/gnrlang.js
@@ -573,10 +573,13 @@ function changedAttrKeys(currattr, newattr, updattr) {
 }
 
 function triggerChangedAttrs(kw) {
-    if (kw.changedAttr) {
-        return [kw.changedAttr]; //a single changed attribute is named: callers may read its absence
+    if (kw.changedAttributes && kw.changedAttributes.length) {
+        return kw.changedAttributes;
     }
-    return kw.changedAttributes || [];
+    if (kw.changedAttr) {
+        return [kw.changedAttr];
+    }
+    return [];
 }
 
 function isNullOrBlank(elem){

--- a/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
+++ b/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
@@ -71,6 +71,37 @@ class GnrCustomWebPage(object):
             """genro.setData(this.absDatapath('.target?tag'), 'bypath_'+genro.getCounter(),
                           {other:'other_'+genro.getCounter()});""")
 
+    def test_2_more_than_one_attribute(self, pane):
+        """Two attributes changed by a single set. Every consumer that branches on the changed
+        name must still react: 'changedAttr' stays empty because no single attribute can be
+        named, so the list is the only road. The _class bound to '?style' must drop its previous
+        class even when 'tag' travels with it, and the last button deletes 'tag' while writing
+        'style': a removed attribute is a change of its own path"""
+        box = pane.div(datapath='.t2')
+        box.data('.target', 'A', tag='first', style='testclass_a')
+        box.data('.attr_triggers', 0)
+        fb = box.formbuilder(cols=2, border_spacing='3px')
+        fb.div('^.attr_triggers', lbl='tag attribute triggers')
+        fb.div('^.target?tag', lbl='tag attribute')
+        fb.div('^.target?style', lbl='style attribute')
+        fb.div('^.changed_attr', lbl='changedAttr (empty when more than one)')
+        fb.div('^.changed_attrs', lbl='changedAttrs list')
+        fb.div('Bound to ?style', _class='^.target?style', lbl='node with _class on an attribute')
+        box.dataController("""SET .attr_triggers = n+1;
+                              SET .changed_attr = _triggerpars.kw.changedAttr;
+                              SET .changed_attrs = triggerChangedAttrs(_triggerpars.kw).join(',');""",
+                           target_tag='^.target?tag', n='=.attr_triggers')
+        bar = box.div(margin='5px')
+        bar.button('Change tag and style together').dataController(
+            """var c = genro.getCounter();
+               genro.getDataNode(this.absDatapath('.target')).updAttributes(
+                   {tag:'tag_'+c, style:'testclass_'+c}, true);""")
+        bar.button('Change style only').dataController(
+            """genro.setData(this.absDatapath('.target?style'), 'testclass_'+genro.getCounter());""")
+        bar.button('Drop tag, write style').dataController(
+            """genro.setData(this.absDatapath('.target'), 'A',
+                          {tag:null, style:'testclass_'+genro.getCounter()});""")
+
     def gridStruct(self, struct):
         r = struct.view().rows()
         r.cell('name', name='Name', width='12em', edit=True)

--- a/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
+++ b/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
@@ -80,7 +80,7 @@ class GnrCustomWebPage(object):
         class even when 'tag' travels with it, and the last button deletes 'tag' while writing
         'style': a removed attribute is a change of its own path"""
         box = pane.div(datapath='.t2')
-        box.data('.target', 'A', style='testclass_a')
+        box.data('.target', 'A', tag='first', style='testclass_a')
         box.data('.attr_triggers', 0)
         fb = box.formbuilder(cols=2, border_spacing='3px')
         fb.div('^.attr_triggers', lbl='tag attribute triggers')

--- a/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
+++ b/projects/gnrcore/packages/test/webpages/datastore/attribute_trigger.py
@@ -57,8 +57,10 @@ class GnrCustomWebPage(object):
         fb.div('^.target', lbl='value')
         fb.div('^.target?tag', lbl='tag attribute')
         fb.div('^.target?other', lbl='other attribute')
+        fb.div('^.changed_attrs', lbl='changedAttrs list')
         box.dataController("SET .value_triggers = n+1;", target='^.target', n='=.value_triggers')
-        box.dataController("SET .attr_triggers = n+1;",
+        box.dataController("""SET .attr_triggers = n+1;
+                              SET .changed_attrs = triggerChangedAttrs(_triggerpars.kw).join(',');""",
                            target_tag='^.target?tag', n='=.attr_triggers')
         bar = box.div(margin='5px')
         bar.button('Same value, same tag').dataController(
@@ -78,7 +80,7 @@ class GnrCustomWebPage(object):
         class even when 'tag' travels with it, and the last button deletes 'tag' while writing
         'style': a removed attribute is a change of its own path"""
         box = pane.div(datapath='.t2')
-        box.data('.target', 'A', tag='first', style='testclass_a')
+        box.data('.target', 'A', style='testclass_a')
         box.data('.attr_triggers', 0)
         fb = box.formbuilder(cols=2, border_spacing='3px')
         fb.div('^.attr_triggers', lbl='tag attribute triggers')

--- a/resources/common/gnrcomponents/framegrid.py
+++ b/resources/common/gnrcomponents/framegrid.py
@@ -705,8 +705,8 @@ class EvaluationGrid(BaseComponent):
     def _evlg_saver(self,frame,value):
         frame.dataController(
             """
-            let changedAttr = _triggerpars.kw.changedAttr;
-             if(!changedAttr){
+            let changedAttrs = triggerChangedAttrs(_triggerpars.kw);
+             if(!changedAttrs.length){
                 return
              }
              let newvalue = null;
@@ -727,7 +727,7 @@ class EvaluationGrid(BaseComponent):
                     cbcells[kw.original_field] = kw;
                 }
              }
-             if(!(changedAttr in cbcells)){
+             if(!changedAttrs.some(function(n){return n in cbcells;})){
                 return;
              }
              let currentAttributes = _node.attr;
@@ -777,7 +777,7 @@ class EvaluationGrid(BaseComponent):
 
     def _evlg_loader(self,frame,value):
         frame.dataController("""
-            if(_triggerpars.kw.changedAttr){
+            if(triggerChangedAttrs(_triggerpars.kw).length){
                 return;
             }
             if(_triggerpars.kw.reason=='evlg_saver'){

--- a/resources/common/gnrcomponents/framegrid.py
+++ b/resources/common/gnrcomponents/framegrid.py
@@ -777,7 +777,7 @@ class EvaluationGrid(BaseComponent):
 
     def _evlg_loader(self,frame,value):
         frame.dataController("""
-            if(triggerChangedAttrs(_triggerpars.kw).length){
+            if(_triggerpars.kw.updattr && !_triggerpars.kw.updvalue){
                 return;
             }
             if(_triggerpars.kw.reason=='evlg_saver'){
@@ -813,4 +813,3 @@ class EvaluationGrid(BaseComponent):
                 n.updAttributes(updattr,false);
             });
         """,value=value,store='^.store',grid=frame.grid.js_widget)
-

--- a/resources/common/gnrcomponents/tag_matrix_grid.py
+++ b/resources/common/gnrcomponents/tag_matrix_grid.py
@@ -208,43 +208,43 @@ class TagMatrixGrid(BaseComponent):
                 return;
             }
             const kw = _triggerpars.kw;
-            if(kw.reason == 'tmg_multiselect' || !kw.changedAttr){
+            const changedTags = triggerChangedAttrs(kw).filter(function(n){return n.startsWith('tag_');});
+            if(kw.reason == 'tmg_multiselect' || !changedTags.length){
                 return;
             }
-            const changedAttr = kw.changedAttr;
-            if(!changedAttr.startsWith('tag_')){
-                return;
-            }
-            const tagId = changedAttr.substring(4);
             const clickedPkey = _node.attr._pkey;
-            const checked = _node.attr[changedAttr];
 
             // Get selected pkeys from grid
             const selectedPkeys = grid.getSelectedPkeys() || [];
-            let sourceIds = [];
             const storebag = grid.storebag();
+            const multiSelection = selectedPkeys.length > 1 && selectedPkeys.includes(clickedPkey);
+            const selectedRowsIdx = multiSelection? (grid.getSelectedRowidx() || []) : [];
 
-            if(selectedPkeys.length > 1 && selectedPkeys.includes(clickedPkey)){
-                // Multiple selection - apply to all selected rows
-                sourceIds = selectedPkeys;
-                const selectedRowsIdx = grid.getSelectedRowidx() || [];
-                selectedRowsIdx.forEach(function(rowIdx){
-                    const rowPath = '#' + grid.absIndex(rowIdx);
-                    const sep = grid.datamode=='bag'? '.':'?';
-                    // Update store for all selected rows with reason to avoid re-trigger
-                    storebag.setItem(rowPath + sep + changedAttr, checked, null, {doTrigger:'tmg_multiselect'});
+            changedTags.forEach(function(changedAttr){
+                const tagId = changedAttr.substring(4);
+                const checked = _node.attr[changedAttr];
+                let sourceIds = [];
+                if(multiSelection){
+                    // Multiple selection - apply to all selected rows
+                    sourceIds = selectedPkeys;
+                    selectedRowsIdx.forEach(function(rowIdx){
+                        const rowPath = '#' + grid.absIndex(rowIdx);
+                        const sep = grid.datamode=='bag'? '.':'?';
+                        // Update store for all selected rows with reason to avoid re-trigger
+                        storebag.setItem(rowPath + sep + changedAttr, checked, null, {doTrigger:'tmg_multiselect'});
+                    });
+                } else {
+                    // Single row
+                    sourceIds.push(clickedPkey);
+                }
+
+                // Save to server
+                genro.serverCall(rpcmethod, {
+                    source: source,
+                    source_ids: sourceIds,
+                    tag_id: tagId,
+                    checked: checked
                 });
-            } else {
-                // Single row
-                sourceIds.push(clickedPkey);
-            }
-
-            // Save to server
-            genro.serverCall(rpcmethod, {
-                source: source,
-                source_ids: sourceIds,
-                tag_id: tagId,
-                checked: checked
             });
         """, store='^.store', source=source, grid=frame.grid.js_widget,
             rpcmethod=self.tmg_saveChanges)


### PR DESCRIPTION
Stacked on #1145 (`fix/1144-selectedid-trigger`), whose `changedAttrKeys()` helper and `test/datastore/attribute_trigger` page this builds on. Review that one first; GitHub will retarget this to `develop` when it merges.

## Problem

`setAttr()` names `changedAttr` only when exactly one attribute changed (`gnrjs/gnr_d11/js/gnrbag.js`). As soon as two travel together the field is null, and every consumer that branches on it goes blind:

- the form changes logger (`genro_frm.js`) skips the row, so the change is never logged and the form stays clean
- a `_class` bound to an attribute (`gnrdomsource.js`) keeps its previous class
- `_evlg_saver` (`framegrid.py`) returns immediately, so an `expressionListGrid` checkbox is not saved
- the tag matrix (`tag_matrix_grid.py`) saves nothing

Two corrections to the issue's own diagnosis, both verified in code:

1. **It is not new with #1145.** `setAttr()` receives `changedAttr` only from `setAttribute()`; `updAttributes()` and `replaceAttr()` always pass it undefined, and multi-key `updAttributes(dict, true)` calls exist on `develop` today (`genro_components.js:7691` external-selection row refresh, `:3566`, `:7239`, `genro_grid.js:3561`, `gnrbag.js:1482`).
2. **The `_class` consumer was already reading the wrong attribute**, not merely losing `oldvalue`: `getTriggerReason()` strips `?attr` from the bound path without checking which attribute changed, so `kw.oldattr[kw.changedAttr]` returned a sibling's old value whenever the sibling was the one written. A fallback on the list alone would have papered over that.

`_evlg_loader` is also affected, not just a constraint: it returns on the *presence* of `changedAttr`, meaning "an attribute-only change is the saver's business". With two attributes it runs and reloads the store when it should stand down.

## Change

- `changedAttributes` now comes from `changedAttrKeys()` instead of a hand-rolled loop over the surviving keys, so it also reports an attribute **deleted** by `removeNulls` — invisible to the previous comparison. It had no consumer in the repo, so its shape is free to become the list every consumer needs.
- new `triggerChangedAttrs(kw)` in `gnrlang.js`: the single name when present, the list otherwise. `changedAttr` itself is left untouched, because `_evlg_loader` reads its absence and defaulting it would change that meaning.
- `dataChangeLogger` loops the names, one logged change each, `updateStatus()` once, skipping the internal `_`-prefixed ones. Without that filter an external selection refresh would register `_loadedValue`, `_customClass_*` and `_pkey` as user changes and mark a clean form dirty.
- the `_class` branch takes the attribute from its own bound expression, falling back to today's behaviour for `?=` formula attributes.
- `_evlg_saver` runs when any changed name is a checkbox cell; `_evlg_loader` stands down whenever an attribute changed.
- the tag matrix saves every changed `tag_` attribute, one `serverCall` each, with the multi-selection propagation computed once.

## Verification

`test/datastore/attribute_trigger` grows a third case: two attributes changed by one set, with the `changedAttr`/`changedAttrs` readout side by side, a node with `_class` bound to `?style`, and a button that drops `tag` while writing `style` to cover the deletion path.

The Python suite is green (2100 passed, 69 skipped) and flake8 is clean on the three touched Python files. The four JS files pass `node --check`, and the JS embedded in the `dataController` strings was extracted and parsed too — a malformed snippet inside a Python string is caught by no linter otherwise.

**Not verified: the browser pass.** There is no JS test runner (`gnrpy/tests/browser/` is empty), so the manual run on the test page and the regression sweep — inline grid editing, `_class`-bound sourceNodes, `expressionListGrid` checkbox cells, tag matrix — are still to be done.

## Related issue

Fixes #1169

Note: with the base on a feature branch GitHub does not register the closing reference; it should appear once this is retargeted to `develop`.
