### PR TITLE
fix(app): sort the user tags before joining them into a string

### DIFF
--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -1473,7 +1473,7 @@ class GnrApp(object):
             elif user_record_tags:
                 tags = tags.split(',')
                 tags.extend(user_record_tags.split(','))
-                tags = ','.join(list(set(tags)))
+                tags = ','.join(sorted(set(tags)))
             return self.makeAvatar(user=user, user_name=user_name, user_id=user_id, tags=tags,
                                    login_pwd=password, authenticate=authenticate,
                                    external_user=external_user,
@@ -1531,7 +1531,7 @@ class GnrApp(object):
         :param pwd: the password
         :param tags: TODO"""
         if defaultTags:
-            tags = ','.join(makeSet(defaultTags, tags or ''))
+            tags = ','.join(sorted(makeSet(defaultTags, tags or '')))
         if authenticate:
             valid = self.validatePassword(login_pwd, pwd)
             if valid and not self.checkAllowedIp(allowed_ip):

--- a/gnrpy/tests/app/gnrapp_test.py
+++ b/gnrpy/tests/app/gnrapp_test.py
@@ -184,3 +184,37 @@ class TestGnrApp(BaseGnrAppTest):
             assert p['sys.error']['extra_where_filter'] == None
             assert p['sys.task_execution']['extra_where_filter'] == None
        
+
+
+class TestUserTagsOrder(object):
+    """The user tags string must not depend on set iteration order (#1173).
+
+    Python randomises string hashing at every process start, so joining a set
+    gave a different order in every process. The value travels into the
+    connection register item, the avatar and the logs, where an order that
+    moves on its own makes two runs impossible to compare.
+    """
+
+    def _app(self):
+        """makeAvatar with authenticate=False touches nothing else on the app."""
+        return object.__new__(ga.GnrApp)
+
+    def test_make_avatar_sorts_the_default_tags(self):
+        avatar = self._app().makeAvatar('u', defaultTags='superadmin,_DEV_,admin')
+        assert avatar.user_tags == '_DEV_,admin,superadmin'
+
+    def test_make_avatar_sorts_across_both_sources(self):
+        """defaultTags and tags are merged, and the merge must sort too."""
+        avatar = self._app().makeAvatar('u', defaultTags='user,_SYSTEM_',
+                                        tags='level/green,_TRD_')
+        assert avatar.user_tags == '_SYSTEM_,_TRD_,level/green,user'
+
+    def test_make_avatar_drops_duplicates_and_blanks(self):
+        avatar = self._app().makeAvatar('u', defaultTags='admin,,user',
+                                        tags='user,admin')
+        assert avatar.user_tags == 'admin,user'
+
+    def test_make_avatar_without_default_tags_is_untouched(self):
+        """No defaultTags means the branch never runs: the string passes through."""
+        avatar = self._app().makeAvatar('u', tags='b,a')
+        assert avatar.user_tags == 'b,a'


### PR DESCRIPTION
## Problem

The user tags string is built by joining a Python `set`, so its order is whatever the hash table gives — and Python randomises string hashing at every process start. The same eight tags come out differently in every process:

```
_DEV_,superadmin,user,_SYSTEM_,admin,level/green,_DOC_,_TRD_
superadmin,_DEV_,user,_DOC_,_TRD_,admin,level/green,_SYSTEM_
_TRD_,_DOC_,_SYSTEM_,_DEV_,level/green,superadmin,user,admin
```

The value reaches the connection register item, the avatar and the logs. An order that moves on its own makes two runs impossible to compare — a diff of two servers reports a difference where the tags are identical — and it hides the change that matters: nobody notices a tag appearing or disappearing in a list whose order shifts anyway.

## Change

Two sites in `gnrpy/gnr/app/gnrapp.py`, both joining a set:

```diff
-                tags = ','.join(list(set(tags)))            # auth_py:1476
+                tags = ','.join(sorted(set(tags)))

-            tags = ','.join(makeSet(defaultTags, tags or ''))          # makeAvatar:1534
+            tags = ','.join(sorted(makeSet(defaultTags, tags or '')))
```

`makeSet` (`gnrpy/gnr/core/gnrstring.py:598-606`) returns a `set`, so the second one had the same problem through a helper. The redundant `list()` in the first goes with the change, since `sorted()` already returns a list.

## Left alone deliberately

`GnrAvatar.updateTags` (`gnrapp.py:2185`) builds its string from a list with an explicit `if not tag in t: t.append(tag)`. That order is already deterministic and reads as a precedence rather than an accident, so sorting it would change a meaning rather than remove a randomness. Worth a separate look if the team wants every tag list in the system to read the same way — not this PR's call to make.

## Nothing stored has to match

`user_tags` is never written to a database column: 27 occurrences under `gnr/`, none of them SQL, and the only mention in the `adm` models is a parameter of `updateGenericNotification` passed straight to `checkResourcePermission`. It lives in the register item and the avatar, both at runtime — so there is no persisted value that would stop matching a freshly sorted one.

## Tests

`gnrpy/tests/app/gnrapp_test.py::TestUserTagsOrder`, four cases: the sort on `defaultTags` alone, the sort across the merge of `defaultTags` and `tags`, the deduplication and blank-dropping `makeSet` already did, and the pass-through when no `defaultTags` is given so the branch never runs.

They exercise the real `makeAvatar` — with `authenticate=False` it touches nothing else on the app, so the instance can be built without `__init__` and the assertion reads the avatar's own `user_tags`.

**Honest note on the negative leg**: three of the four fail against the unsorted code, but *whether* they fail depends on the hash seed of that run — a three-element set can come out sorted by chance. On the sorted code they hold by construction, which is the property that matters; the failing run is a demonstration, not a guarantee.

## Verification

- `flake8` on both files: clean
- `pytest gnrpy/tests/app gnrpy/tests/core gnrpy/tests/web`: 877 passed, 76 skipped, with 2 pre-existing failures in `flatfiles_test.py` present on a clean `develop` and unrelated to this change

## Related issue

Fixes #1173