### PR TITLE
added commodity methods to awsmanager's Route53, and mapped methods

### DIFF
--- a/gnrpy/gnr/utils/awsmanager.py
+++ b/gnrpy/gnr/utils/awsmanager.py
@@ -478,22 +478,84 @@ class Route53Manager(BaseAwsService):
             HostedZoneId=hosted_zone_id)['ResourceRecordSets']
         return dict([(r['Name'].lower(), record_to_dict(r)) for r in resource_records])
 
-    def update_record(self, hosted_zone_id=None, name=None, 
-        type=None, target=None, ttl=360):
+    def update_record(self, hosted_zone_id=None, name=None,
+        type=None, target=None, ttl=300):
         r53 = self.client
-        parameters = {'Comment': 'add %s -> %s' % (name, target),
-                    'Changes': [
-                            {
-                             'Action': 'UPSTERT',
-                             'ResourceRecordSet': {
-                                 'Name': name,
-                                 'Type': type,
-                                 'TTL': ttl,
-                                 'ResourceRecords': [{'Value': target}]
-                            }
-                        }]
-        }
-        r53.client.change_resource_record_sets(**parameters)
+        r53.change_resource_record_sets(
+            HostedZoneId=hosted_zone_id,
+            ChangeBatch={
+                'Comment': 'add %s -> %s' % (name, target),
+                'Changes': [{
+                    'Action': 'UPSERT',
+                    'ResourceRecordSet': {
+                        'Name': name,
+                        'Type': type,
+                        'TTL': ttl,
+                        'ResourceRecords': [{'Value': target}]
+                    }
+                }]
+            }
+        )
+
+    def find_managed_zone(self, name):
+        name = name.lower().rstrip('.')
+        hosted_zones = self.get_hosted_zones()
+        parts = name.split('.')
+        for i in range(len(parts) - 1):
+            candidate = '.'.join(parts[i:])
+            if candidate in hosted_zones:
+                return candidate, hosted_zones[candidate]
+        return None, None
+
+    def record_exists(self, name, hosted_zone_id=None):
+        name = name.lower().rstrip('.')
+        if not hosted_zone_id:
+            _, hosted_zone_id = self.find_managed_zone(name)
+            if not hosted_zone_id:
+                return None
+        records = self.get_resource_records(hosted_zone_id=hosted_zone_id)
+        return records.get(name + '.')
+
+    def verify_record(self, name, record_type, value, hosted_zone_id=None):
+        record = self.record_exists(name, hosted_zone_id=hosted_zone_id)
+        if not record:
+            return False
+        if record['type'].upper() != record_type.upper():
+            return False
+        return value in record['resource_records']
+
+    def ensure_cname_record(self, name, value, ttl=300, dryrun=False):
+        """Ensure a CNAME record exists in a managed Route53 zone.
+
+        Four possible outcomes:
+        - Name has no matching managed zone: raises ValueError.
+        - Record exists with the expected value: returns False (no-op).
+        - Record exists with a different value: raises ValueError.
+        - Record absent, dryrun=True: returns True without writing.
+        - Record absent, dryrun=False: creates the CNAME and returns True.
+
+        Call with dryrun=True to validate during setup, then call again
+        (dryrun=False, the default) after commit to perform the write.
+        """
+        name = name.lower().rstrip('.')
+        zone_name, hosted_zone_id = self.find_managed_zone(name)
+        if not hosted_zone_id:
+            raise ValueError('No managed Route53 zone found for %s' % name)
+        record = self.record_exists(name, hosted_zone_id=hosted_zone_id)
+        if record:
+            if value not in record['resource_records']:
+                raise ValueError('Record %s already exists with a different value: %s' % (name, record['resource_records']))
+            return False
+        if dryrun:
+            return True
+        self.update_record(
+            hosted_zone_id=hosted_zone_id,
+            name=name + '.',
+            type='CNAME',
+            target=value,
+            ttl=ttl
+        )
+        return True
 
 class CostExplorerManager(BaseAwsService):
     service_label='ce'

--- a/gnrpy/tests/utils/awsmanager_test.py
+++ b/gnrpy/tests/utils/awsmanager_test.py
@@ -1,0 +1,180 @@
+import pytest
+from unittest.mock import MagicMock
+
+from gnr.utils.awsmanager import Route53Manager
+
+
+ZONE_ID = '/hostedzone/Z1234567890'
+
+_HOSTED_ZONES_RESPONSE = {
+    'HostedZones': [{'Name': 'example.com.', 'Id': ZONE_ID}]
+}
+
+
+def _make_record(name, rtype, *values):
+    return {
+        'Name': name,
+        'Type': rtype,
+        'TTL': 300,
+        'ResourceRecords': [{'Value': v} for v in values],
+    }
+
+
+def _make_client(records=None, zones_response=None):
+    client = MagicMock()
+    client.list_hosted_zones.return_value = zones_response or _HOSTED_ZONES_RESPONSE
+    client.list_resource_record_sets.return_value = {
+        'ResourceRecordSets': records or []
+    }
+    return client
+
+
+def _make_manager(client=None):
+    mgr = Route53Manager(region_name='eu-south-1')
+    mgr.get_client = MagicMock(return_value=client or _make_client())
+    return mgr
+
+
+# ---------- find_managed_zone ----------
+
+def test_find_managed_zone_direct_match():
+    mgr = _make_manager()
+    zone_name, zone_id = mgr.find_managed_zone('example.com')
+    assert zone_name == 'example.com'
+    assert zone_id == ZONE_ID
+
+
+def test_find_managed_zone_subdomain():
+    mgr = _make_manager()
+    zone_name, zone_id = mgr.find_managed_zone('foo.example.com')
+    assert zone_name == 'example.com'
+    assert zone_id == ZONE_ID
+
+
+def test_find_managed_zone_deep_subdomain():
+    mgr = _make_manager()
+    zone_name, _ = mgr.find_managed_zone('a.b.example.com')
+    assert zone_name == 'example.com'
+
+
+def test_find_managed_zone_strips_trailing_dot():
+    mgr = _make_manager()
+    zone_name, zone_id = mgr.find_managed_zone('foo.example.com.')
+    assert zone_name == 'example.com'
+    assert zone_id == ZONE_ID
+
+
+def test_find_managed_zone_not_found():
+    mgr = _make_manager()
+    zone_name, zone_id = mgr.find_managed_zone('other.org')
+    assert zone_name is None
+    assert zone_id is None
+
+
+# ---------- record_exists ----------
+
+def test_record_exists_found():
+    record = _make_record('foo.example.com.', 'CNAME', 'bar.example.com')
+    mgr = _make_manager(_make_client(records=[record]))
+    result = mgr.record_exists('foo.example.com', hosted_zone_id=ZONE_ID)
+    assert result is not None
+    assert result['type'] == 'CNAME'
+    assert result['resource_records'] == ['bar.example.com']
+
+
+def test_record_exists_not_found():
+    mgr = _make_manager()
+    assert mgr.record_exists('missing.example.com', hosted_zone_id=ZONE_ID) is None
+
+
+def test_record_exists_auto_discovers_zone():
+    record = _make_record('foo.example.com.', 'CNAME', 'bar.example.com')
+    mgr = _make_manager(_make_client(records=[record]))
+    assert mgr.record_exists('foo.example.com') is not None
+
+
+def test_record_exists_returns_none_when_no_managed_zone():
+    mgr = _make_manager()
+    assert mgr.record_exists('foo.other.org') is None
+
+
+# ---------- verify_record ----------
+
+def test_verify_record_correct_type_and_value():
+    record = _make_record('foo.example.com.', 'CNAME', 'bar.example.com')
+    mgr = _make_manager(_make_client(records=[record]))
+    assert mgr.verify_record('foo.example.com', 'CNAME', 'bar.example.com',
+                             hosted_zone_id=ZONE_ID) is True
+
+
+def test_verify_record_wrong_type():
+    record = _make_record('foo.example.com.', 'A', '1.2.3.4')
+    mgr = _make_manager(_make_client(records=[record]))
+    assert mgr.verify_record('foo.example.com', 'CNAME', '1.2.3.4',
+                             hosted_zone_id=ZONE_ID) is False
+
+
+def test_verify_record_wrong_value():
+    record = _make_record('foo.example.com.', 'CNAME', 'bar.example.com')
+    mgr = _make_manager(_make_client(records=[record]))
+    assert mgr.verify_record('foo.example.com', 'CNAME', 'other.example.com',
+                             hosted_zone_id=ZONE_ID) is False
+
+
+def test_verify_record_missing():
+    mgr = _make_manager()
+    assert mgr.verify_record('missing.example.com', 'CNAME', 'x',
+                             hosted_zone_id=ZONE_ID) is False
+
+
+# ---------- ensure_cname_record ----------
+
+def test_ensure_cname_no_managed_zone():
+    mgr = _make_manager()
+    with pytest.raises(ValueError, match='No managed Route53 zone'):
+        mgr.ensure_cname_record('foo.other.org', 'bar.example.com')
+
+
+def test_ensure_cname_record_exists_correct_value():
+    record = _make_record('foo.example.com.', 'CNAME', 'bar.example.com')
+    client = _make_client(records=[record])
+    mgr = _make_manager(client)
+    assert mgr.ensure_cname_record('foo.example.com', 'bar.example.com') is False
+    client.change_resource_record_sets.assert_not_called()
+
+
+def test_ensure_cname_record_exists_wrong_value():
+    record = _make_record('foo.example.com.', 'CNAME', 'other.example.com')
+    mgr = _make_manager(_make_client(records=[record]))
+    with pytest.raises(ValueError, match='already exists with a different value'):
+        mgr.ensure_cname_record('foo.example.com', 'bar.example.com')
+
+
+def test_ensure_cname_absent_dryrun_skips_write():
+    client = _make_client()
+    mgr = _make_manager(client)
+    result = mgr.ensure_cname_record('foo.example.com', 'bar.example.com', dryrun=True)
+    assert result is True
+    client.change_resource_record_sets.assert_not_called()
+
+
+def test_ensure_cname_absent_creates_record():
+    client = _make_client()
+    mgr = _make_manager(client)
+    result = mgr.ensure_cname_record('foo.example.com', 'bar.example.com', ttl=300)
+    assert result is True
+    client.change_resource_record_sets.assert_called_once_with(
+        HostedZoneId=ZONE_ID,
+        ChangeBatch={
+            'Comment': 'add foo.example.com. -> bar.example.com',
+            'Changes': [{
+                'Action': 'UPSERT',
+                'ResourceRecordSet': {
+                    'Name': 'foo.example.com.',
+                    'Type': 'CNAME',
+                    'TTL': 300,
+                    'ResourceRecords': [{'Value': 'bar.example.com'}]
+                }
+            }]
+        }
+    )

--- a/projects/gnrcore/packages/sys/resources/services/cloudmanager/awsmanager.py
+++ b/projects/gnrcore/packages/sys/resources/services/cloudmanager/awsmanager.py
@@ -59,6 +59,17 @@ class Service(CloudManager):
     def get_hosted_zones(self):
         return self.aws_manager.Route53.get_hosted_zones()
 
+    def route53_record_exists(self, name, hosted_zone_id=None):
+        return self.aws_manager.Route53.record_exists(name=name, hosted_zone_id=hosted_zone_id)
+
+    def route53_verify_record(self, name, record_type, value, hosted_zone_id=None):
+        return self.aws_manager.Route53.verify_record(name=name, record_type=record_type,
+            value=value, hosted_zone_id=hosted_zone_id)
+
+    def route53_ensure_cname_record(self, name, value, ttl=300, dryrun=False):
+        return self.aws_manager.Route53.ensure_cname_record(name=name, value=value,
+            ttl=ttl, dryrun=dryrun)
+
     # ECS Methods
     def list_ecs_clusters(self):
         return self.aws_manager.ECS.list_clusters()


### PR DESCRIPTION
added commodity methods to awsmanager's Route53, and mapped methods in the cloudmanager/awsmanager service accordingly.

The methods allows simple low-level operations on route53, and higher logic method are added, like ensure_cname_record. This method will be used in a deployer context, when the user enters the requested FQDN for the applicatio, it can:

1/ check if the zone is managed - if not, just report the matter, leaving to the user update the non-manager zone accordingly
2/ check if the record already exists - if so, reports an error, to avoid disruption
 with existing services
3/ create the record with the provided value (the ingress/endpoint server, up to the caller)

The method supports dryrun to verify all the above during a wizard, and then execute the change at commit time.

Added relevant tests using mocked boto3