### PR TITLE
hotfix(adm): align notification audience on both paths, with static/dynamic lists

### DIFF
--- a/gnrpy/tests/core/gnrbag_test.py
+++ b/gnrpy/tests/core/gnrbag_test.py
@@ -27,8 +27,8 @@ class TestBasicBag(object):
         assert b == self.mybag
         
     def test_fillFromUrl(self):
-        b = Bag('https://www.genropy.org/feed/')
-        assert b['rss.channel.title'] == 'Genropy'
+        b = Bag('https://www.genropy.org/sitemap.xml')
+        assert b['urlset.url']
 
     def test_fillFromXml(self):
         b = Bag("<name>John</name>")

--- a/projects/gnrcore/packages/adm/localization.xml
+++ b/projects/gnrcore/packages/adm/localization.xml
@@ -204,6 +204,12 @@
 				<en_for_all_users fr="Pour tous les utilisateurs" de="Für alle Benutzer" en="For all users" it="Per tutti gli utenti" base="For all users"/>
 				<en_letterhead fr="Tête" de="Briefkopf" en="Letterhead" it="Carta intestata" base="Letterhead" zh="信头"/>
 				<en_linked_query base="Linked query" it="Query collegata" en="Linked query" zh="关联查询"/>
+				<en_dynamic_list base="Dynamic list" en="Dynamic list" it="Lista dinamica"/>
+				<en_dynamic base="Dynamic" en="Dynamic" it="Dinamica"/>
+				<en_confirmed_users base="Confirmed users" en="Confirmed users" it="Utenti confermati"/>
+				<en_conf_users base="Conf.users" en="Conf.users" it="Utenti conf."/>
+				<en_pending_users base="Pending users" en="Pending users" it="Utenti da confermare"/>
+				<en_pend_users base="Pend.users" en="Pend.users" it="Utenti pend."/>
 		</notification>
 		<pkginfo path="model/pkginfo.py" ext="py">
 			<en_package_info base="Package info" en="Package info" it="Informazioni sul pacchetto"/>

--- a/projects/gnrcore/packages/adm/model/notification.py
+++ b/projects/gnrcore/packages/adm/model/notification.py
@@ -16,31 +16,78 @@ class Table(object):
         tbl.column('all_users','B',name_long='!!For all users')
         tbl.column('letterhead_id',size='22',group='_',name_long='!!Letterhead').relation('htmltemplate.id',relation_name='notifications',mode='foreignkey')
         tbl.column('linked_query', dtype='X', name_long='!![en]Linked query',_sendback=True)
+        # Dynamic by default: this is how notifications behaved before the
+        # column existed, so the rows that predate it (NULL) and the new ones
+        # (True) keep enrolling users at login. Static is an explicit opt-out.
+        tbl.column('dynamic_list','B',default=True,
+                   name_long='!!Dynamic list', name_short='!!Dynamic')
+        tbl.column('start_date','D',name_long='!!Start date')
+        tbl.column('end_date','D',name_long='!!End date')
         
         tbl.formulaColumn('existing_for_current_user',"""
                 (EXISTS(SELECT * FROM adm.adm_user_notification AS un WHERE un.user_id=:env_user_id AND un.notification_id=#THIS.id))
             """,dtype='B')
 
+        tbl.formulaColumn('confirmed_count',select=dict(table='adm.user_notification',
+                                                        columns='COUNT(*)',
+                                                        where='$notification_id=#THIS.id AND $confirmed IS TRUE'),
+                                            dtype='L',name_long='!!Confirmed users',
+                                            name_short='!!Conf.users')
+
+        tbl.formulaColumn('pending_count',select=dict(table='adm.user_notification',
+                                                      columns='COUNT(*)',
+                                                      where='$notification_id=#THIS.id AND $confirmed IS NOT TRUE'),
+                                          dtype='L',name_long='!!Pending users',
+                                          name_short='!!Pend.users')
+
     def trigger_onInserting(self, record):
-        if not record['linked_query']:
+        if self._hasNoAudienceRule(record):
             record['all_users'] = True
-    
+
     def trigger_onInserted(self, record):
-        if record['linked_query']:
-            self.updateUserNotificationsFromQuery(record)
-            
+        # The audience is photographed as soon as the notification is saved:
+        # for a static list this snapshot *is* the list, and a dynamic one
+        # still has to reach the users matching right now. With `all_users`
+        # that means one adm.user_notification row per user, written inside
+        # the insert transaction: saving a notification costs one insert per
+        # user of the installation. That is the intended price of a snapshot.
+        self.updateUserNotificationsFromQuery(record)
+
     def trigger_onUpdating(self, record, old_record=None):
-        if not record['linked_query']:
+        if self._hasNoAudienceRule(record):
             record['all_users'] = True
-            
+
     def trigger_onUpdated(self, record, old_record=None):
-        if record['linked_query'] and self.fieldsChanged('linked_query,tag_rule,all_users,group_code', record, old_record):
+        # Only a change to the audience criteria re-photographs the list: the
+        # snapshot drops the pending rows and rebuilds membership from the
+        # current population, so firing it on `dynamic_list` or on the date
+        # window would silently re-photograph a static list -- extending the
+        # window of a static notification would enrol exactly the newcomers
+        # it is meant to exclude, and drop the users who no longer match.
+        if self.fieldsChanged('linked_query,tag_rule,all_users,group_code', record, old_record):
             self.updateUserNotificationsFromQuery(record)
-            
-    def updateUserNotificationsFromQuery(self, notification_record):
+
+    def _hasNoAudienceRule(self, record):
+        # all_users is implied only when no explicit audience criterion is set
+        return not (record['linked_query'] or record['tag_rule'] or record['group_code'])
+
+    def audienceWhere(self, notification_record):
+        """Build the (where, kwargs) pre-selecting the adm.user rows that are
+        candidates for this notification audience.
+
+        Only the criteria SQL can express live here, `group_code` and
+        `linked_query`. The tag rule is applied by `tagRuleMatches` on the
+        candidate rows instead: it is a permission-engine expression (exact
+        tags, `%` wildcards, `AND`/`NOT`, `;`) that a LIKE cannot reproduce.
+        Callers must therefore pair this pre-selection with the tag check --
+        `audienceUserIds` and `userMatchesAudience` are the two entry points
+        that do, and that is what keeps the bulk snapshot and the per-user
+        login alignment on one single rule.
+
+        Returns (None, {}) when the notification targets all users."""
+        if notification_record['all_users']:
+            return None, {}
         where = []
-        user_tbl = self.db.table('adm.user')
-        user_notification_tbl = self.db.table('adm.user_notification')
         selection_kwargs = {}
 
         # Check if user has at least one of the specified groups
@@ -53,22 +100,65 @@ class Table(object):
                     selection_kwargs[f'group_{i}'] = f'%{g}%'
                 where.append('(' + ' OR '.join(group_conditions) + ')')
 
-        # Check if user has at least one of the specified tags
-        if notification_record.get('tag_rule'):
-            tags = [t.strip() for t in notification_record['tag_rule'].split(',') if t.strip()]
-            if tags:
-                tag_conditions = []
-                for i, t in enumerate(tags):
-                    tag_conditions.append(f"$auth_tags LIKE :tag_{i}")
-                    selection_kwargs[f'tag_{i}'] = f'%{t}%'
-                where.append('(' + ' OR '.join(tag_conditions) + ')')
-
         # Add linked query condition
-        wherebag = Bag(notification_record['linked_query'])['query.where']
-        condition, selection_kwargs = self.db.table('adm.user').sqlWhereFromBag(
-                                wherebag, selection_kwargs)
-        where.append(condition)
-        users = user_tbl.query(where=' AND '.join(where),**selection_kwargs).selection().output('pkeylist')
+        if notification_record.get('linked_query'):
+            wherebag = Bag(notification_record['linked_query'])['query.where']
+            condition, selection_kwargs = self.db.table('adm.user').sqlWhereFromBag(
+                                    wherebag, selection_kwargs)
+            where.append(condition)
+        return (' AND '.join(where) if where else None), selection_kwargs
+
+    def audienceTagRule(self, notification_record):
+        """The tag rule in force for this notification, if any.
+        `all_users` wins over every other criterion, the tag rule included."""
+        if notification_record['all_users']:
+            return None
+        return notification_record['tag_rule']
+
+    def tagRuleMatches(self, tag_rule, user_tags):
+        """Evaluate a notification tag rule against a user's effective tags.
+
+        Delegated to the permission engine, the same one that gates every
+        other tagged resource of the framework: `$auth_tags LIKE '%admin%'`
+        would also match a user tagged `superadmin`, and would honor none of
+        the rule syntax the engine understands."""
+        if not tag_rule:
+            return True
+        return self.db.application.checkResourcePermission(tag_rule, user_tags)
+
+    def audienceUserIds(self, notification_record):
+        """Return the pkeys of the adm.user rows matching this notification."""
+        user_tbl = self.db.table('adm.user')
+        where, selection_kwargs = self.audienceWhere(notification_record)
+        tag_rule = self.audienceTagRule(notification_record)
+        if not tag_rule:
+            return user_tbl.query(where=where, **selection_kwargs).selection().output('pkeylist')
+        # $all_tags is the column adm authentication reads to build the avatar
+        # tags, so the rule is evaluated against the tags the user actually
+        # logs in with: their own plus the ones inherited from their group.
+        # Being a pyColumn it costs a query per candidate, paid only when a
+        # tag rule has to be evaluated -- and the snapshot that calls this is
+        # already one insert per user anyway.
+        rows = user_tbl.query(where=where, columns='*,$all_tags', **selection_kwargs).fetch()
+        return [r['id'] for r in rows if self.tagRuleMatches(tag_rule, r['all_tags'])]
+
+    def userMatchesAudience(self, notification_record, user_id):
+        """Return True if the given user matches the notification audience.
+        Used for the dynamic per-user alignment at login."""
+        where, selection_kwargs = self.audienceWhere(notification_record)
+        user_where = '$id=:__audience_uid'
+        if where:
+            user_where = f'({where}) AND {user_where}'
+        selection_kwargs['__audience_uid'] = user_id
+        rows = self.db.table('adm.user').query(where=user_where, columns='*,$all_tags',
+                                               **selection_kwargs).fetch()
+        if not rows:
+            return False
+        return self.tagRuleMatches(self.audienceTagRule(notification_record), rows[0]['all_tags'])
+
+    def updateUserNotificationsFromQuery(self, notification_record):
+        user_notification_tbl = self.db.table('adm.user_notification')
+        users = self.audienceUserIds(notification_record)
 
         # Delete previous unconfirmed notifications for this notification_id
         user_notification_tbl.deleteSelection(where='$notification_id=:notif_id AND $confirmed IS NOT TRUE',

--- a/projects/gnrcore/packages/adm/model/notification.py
+++ b/projects/gnrcore/packages/adm/model/notification.py
@@ -90,14 +90,18 @@ class Table(object):
         where = []
         selection_kwargs = {}
 
-        # Check if user has at least one of the specified groups
+        # Check if user has at least one of the specified groups. $all_groups is a
+        # comma-join with no delimiter at the string boundaries, so the match is made
+        # on delimited codes: a bare LIKE '%admin%' would also reach a user in
+        # `superadmin`, `admin_ro` or `nonadmin` -- a false positive, i.e. a
+        # group-restricted notification delivered outside its audience.
         if notification_record.get('group_code'):
             groups = [g.strip() for g in notification_record['group_code'].split(',') if g.strip()]
             if groups:
                 group_conditions = []
                 for i, g in enumerate(groups):
-                    group_conditions.append(f"$all_groups LIKE :group_{i}")
-                    selection_kwargs[f'group_{i}'] = f'%{g}%'
+                    group_conditions.append(f"',' || $all_groups || ',' LIKE :group_{i}")
+                    selection_kwargs[f'group_{i}'] = f'%,{g},%'
                 where.append('(' + ' OR '.join(group_conditions) + ')')
 
         # Add linked query condition

--- a/projects/gnrcore/packages/adm/model/user_notification.py
+++ b/projects/gnrcore/packages/adm/model/user_notification.py
@@ -46,19 +46,38 @@ class Table(object):
         return self.nextUserNotification(rec['user_id'])
 
     def nextUserNotification(self,user_id=None):
-        f = self.query(where='$user_id=:uid AND $confirmed IS NOT TRUE',uid=user_id,limit=1,order_by='$__ins_ts asc').fetch()
+        f = self.query(where="""$user_id=:uid AND $confirmed IS NOT TRUE
+                                AND (@notification_id.start_date IS NULL OR @notification_id.start_date<=:today)
+                                AND (@notification_id.end_date IS NULL OR @notification_id.end_date>=:today)""",
+                       uid=user_id,today=self.db.workdate,limit=1,order_by='$__ins_ts asc').fetch()
         user_notification_id = f[0]['id'] if f else None
         if user_notification_id:
             return user_notification_id
-        
 
-    def updateGenericNotification(self,user_id=None,user_tags=None):
-        generic_notification = self.db.table('adm.notification').query(where="""($all_users IS TRUE OR $tag_rule IS NOT NULL )
-                                                                                AND NOT $existing_for_current_user
-                                                                                """,env_user_id=user_id).fetch()
+
+    def updateGenericNotification(self,user_id=None,**kwargs):
+        """Enrol a user that just logged in into the dynamic notifications
+        they match.
+
+        Only dynamic notifications gain new users over time, and only while
+        they are inside their active date window: a static list is frozen at
+        the snapshot taken when the notification was saved. The test is
+        `IS NOT FALSE` so that a NULL keeps meaning dynamic: the rows that
+        predate the column were delivered by this very incremental alignment,
+        and nothing stops being delivered after the upgrade.
+
+        `**kwargs` absorbs the avatar tags older callers still pass: the tag
+        rule is now evaluated on the user record, through the same
+        `audienceWhere` + `tagRuleMatches` pair the bulk snapshot uses."""
+        notification_tbl = self.db.table('adm.notification')
+        dynamic_notification = notification_tbl.query(where="""$dynamic_list IS NOT FALSE
+                                                               AND NOT $existing_for_current_user
+                                                               AND ($start_date IS NULL OR $start_date<=:today)
+                                                               AND ($end_date IS NULL OR $end_date>=:today)""",
+                                                      env_user_id=user_id,today=self.db.workdate).fetch()
         commit = False
-        for n in generic_notification:
-            if n['all_users'] or self.db.application.checkResourcePermission(n['tag_rule'],user_tags):
+        for n in dynamic_notification:
+            if notification_tbl.userMatchesAudience(n,user_id):
                 if not self.checkDuplicate(user_id=user_id,notification_id=n['id']):
                     commit = True
                     self.insert(dict(user_id=user_id,notification_id=n['id']))

--- a/projects/gnrcore/packages/adm/resources/frameindex.py
+++ b/projects/gnrcore/packages/adm/resources/frameindex.py
@@ -97,7 +97,7 @@ class FrameIndex(BaseComponent):
             if pageAuth:
                 if self.avatar and self.avatar.user != self.avatar.user_id:
                     usernotification_tbl = self.db.table('adm.user_notification')
-                    usernotification_tbl.updateGenericNotification(self.avatar.user_id,user_tags=self.avatar.user_tags)
+                    usernotification_tbl.updateGenericNotification(self.avatar.user_id)
                     notification_id = usernotification_tbl.nextUserNotification(user_id=self.avatar.user_id) if self.avatar.user_id else None
                     self.pageSource().dataController('loginManager.notificationManager(notification_id);',notification_id=notification_id or False,_onStart=1,_if='notification_id')
                 if custom_index and custom_index!='*':

--- a/projects/gnrcore/packages/adm/resources/tables/notification/th_notification.py
+++ b/projects/gnrcore/packages/adm/resources/tables/notification/th_notification.py
@@ -8,10 +8,14 @@ class View(BaseComponent):
 
     def th_struct(self,struct):
         r = struct.view().rows()
-        r.fieldcell('title')
-        r.fieldcell('letterhead_id')
-        r.fieldcell('tag_rule', width='20em')
+        r.fieldcell('title', width='20em')
+        r.fieldcell('tag_rule', width='15em')
         r.fieldcell('group_code', width='10em')
+        r.fieldcell('dynamic_list', width='6em')
+        r.fieldcell('start_date', width='6em')
+        r.fieldcell('end_date', width='6em')
+        r.fieldcell('confirmed_count', width='7em')
+        r.fieldcell('pending_count', width='7em')
 
     def th_order(self):
         return 'title'
@@ -25,14 +29,17 @@ class Form(BaseComponent):
 
     def th_form(self, form):
         bc = form.center.borderContainer()
-        top = bc.borderContainer(region='top',datapath='.record', height='120px')
-        
+        top = bc.borderContainer(region='top',datapath='.record', height='160px')
+
         fb = top.contentPane(region='center').formbuilder(cols=2, border_spacing='4px', fld_width='100%')
         fb.field('title', colspan=2)
         fb.field('tag_rule', tag='checkboxtext', table='adm.htag', popup=True, cols=4, colspan=2)
         fb.field('group_code', tag='checkboxtext', table='adm.group', popup=True, cols=4, colspan=2)
-        fb.field('confirm_label',width='20em')
+        fb.field('confirm_label',width='20em', colspan=2)
         fb.field('letterhead_id')
+        fb.field('dynamic_list')
+        fb.field('start_date')
+        fb.field('end_date')
         
         self.linkedQueryPane(top.roundedGroup(region='right',width='400px', 
                                 title='!![en]Restriction query'))
@@ -135,7 +142,10 @@ class FormEmbed(Form):
         fb.field('group_code', tag='checkboxtext', table='adm.group', popup=True, cols=4)
         fb.field('confirm_label',width='20em')
         fb.field('letterhead_id')
-        
+        fb.field('dynamic_list')
+        fb.field('start_date')
+        fb.field('end_date')
+
         self.linkedQueryPane(left.roundedGroup(region='center', title='!![en]Restriction query'))
 
         sc = bc.stackContainer(region='center')

--- a/projects/gnrcore/packages/adm/tests/test_notification_audience.py
+++ b/projects/gnrcore/packages/adm/tests/test_notification_audience.py
@@ -28,6 +28,11 @@ WORKDATE = datetime.date(2026, 6, 30)
 TAG_ADMIN = 'ZZADMIN'
 TAG_SUPERADMIN = 'SUPERZZADMIN'
 TAG_OTHER = 'ZZOTHER'
+# Same trick for the groups: GROUP_ADMIN is a substring of GROUP_SUPERADMIN, and
+# $all_groups is a comma-join with no delimiter at the string boundaries.
+GROUP_ADMIN = 'ZZADMG'
+GROUP_SUPERADMIN = 'SUPERZZADMG'
+GROUP_OTHER = 'ZZOTHERG'
 
 
 class TestNotificationAudience(object):
@@ -88,6 +93,14 @@ class TestNotificationAudience(object):
             tbl.insert(rec)
             self.db.commit()
         return code
+
+    def _add_extra_group(self, user_id, code):
+        """A group beyond the user's own group_code: $all_groups aggregates it
+        through adm.user_group, comma-joined with the others."""
+        tbl = self.db.table('adm.user_group')
+        rec = tbl.newrecord(user_id=user_id, group_code=self._insert_group(code))
+        tbl.insert(rec)
+        self.db.commit()
 
     def _tagged_user(self, username, tags):
         user_id = self._insert_user(username)
@@ -250,6 +263,55 @@ class TestNotificationAudience(object):
 
     def test_tag_rule_does_not_imply_all_users(self):
         notif_id = self._insert_notification(title='only tag rule', tag_rule=TAG_ADMIN)
+        rec = self.notif_tbl.record(pkey=notif_id).output('dict')
+        assert not rec['all_users'], "an explicit audience rule must not force all_users"
+
+    # --- group_code --------------------------------------------------------
+
+    def test_group_code_audience_coherent_on_both_paths(self):
+        member = self._insert_user('notif_group_member',
+                                   group_code=self._insert_group(GROUP_ADMIN))
+        other = self._insert_user('notif_group_other',
+                                  group_code=self._insert_group(GROUP_OTHER))
+
+        notif_id = self._insert_notification(title='group dynamic',
+                                             group_code=GROUP_ADMIN, dynamic_list=True)
+        linked = self._linked_users(notif_id)
+        assert member in linked
+        assert other not in linked
+
+        newcomer = self._insert_user('notif_group_new', group_code=GROUP_ADMIN)
+        self._login(newcomer)
+        assert newcomer in self._linked_users(notif_id)
+
+    def test_group_code_does_not_match_by_substring(self):
+        """A notification restricted to ZZADMG must not reach a user in
+        SUPERZZADMG: an unanchored LIKE '%code%' delivers it outside its
+        audience, which is the unsafe direction of the error."""
+        superadmin = self._insert_user('notif_group_superadmin',
+                                       group_code=self._insert_group(GROUP_SUPERADMIN))
+        notif_id = self._insert_notification(title='group substring',
+                                             group_code=GROUP_ADMIN, dynamic_list=True)
+        assert superadmin not in self._linked_users(notif_id)
+
+        newcomer = self._insert_user('notif_group_superadmin_new',
+                                     group_code=GROUP_SUPERADMIN)
+        self._login(newcomer)
+        assert newcomer not in self._linked_users(notif_id)
+
+    def test_group_code_matches_a_secondary_group(self):
+        """The delimited match must still see a group the user holds beyond their
+        own group_code, which reaches $all_groups through the comma-join."""
+        member = self._insert_user('notif_group_secondary',
+                                   group_code=self._insert_group(GROUP_OTHER))
+        self._add_extra_group(member, GROUP_ADMIN)
+        notif_id = self._insert_notification(title='group secondary',
+                                             group_code=GROUP_ADMIN, dynamic_list=True)
+        assert member in self._linked_users(notif_id)
+
+    def test_group_code_does_not_imply_all_users(self):
+        notif_id = self._insert_notification(title='only group code',
+                                             group_code=GROUP_ADMIN)
         rec = self.notif_tbl.record(pkey=notif_id).output('dict')
         assert not rec['all_users'], "an explicit audience rule must not force all_users"
 

--- a/projects/gnrcore/packages/adm/tests/test_notification_audience.py
+++ b/projects/gnrcore/packages/adm/tests/test_notification_audience.py
@@ -1,0 +1,309 @@
+"""Tests for the audience alignment of adm.notification.
+
+Both paths that align a notification with its audience are exercised
+against a real database:
+ - the bulk snapshot taken by the notification triggers
+   (``updateUserNotificationsFromQuery`` -> ``audienceUserIds``)
+ - the per-user incremental alignment at login
+   (``updateGenericNotification`` -> ``userMatchesAudience``)
+
+so that the two stay coherent, and the static/dynamic behaviour, the tag
+rule semantics and the start/end date window gating are all verified.
+
+The tests need no running site nor a shared database: they build a
+throwaway application on a temporary sqlite file, so users, tags and
+notifications go through the actual table triggers.
+"""
+import datetime
+import os
+import shutil
+import tempfile
+
+from gnr.app.gnrapp import GnrApp
+
+
+WORKDATE = datetime.date(2026, 6, 30)
+# Tags unique to this module. TAG_ADMIN is a substring of TAG_SUPERADMIN on
+# purpose: that pair is what tells a permission-engine match from a LIKE one.
+TAG_ADMIN = 'ZZADMIN'
+TAG_SUPERADMIN = 'SUPERZZADMIN'
+TAG_OTHER = 'ZZOTHER'
+
+
+class TestNotificationAudience(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.instance_name = os.environ.get('GNR_TESTING_INSTANCE_NAME') or 'gnrdevelop'
+        cls.temp_dir = tempfile.mkdtemp(prefix='gnr_notification_audience_')
+        cls.app = GnrApp(cls.instance_name, db_attrs=dict(
+            implementation='sqlite',
+            dbname=os.path.join(cls.temp_dir, 'testing')))
+        cls.db = cls.app.db
+        cls.db.model.check(applyChanges=True)
+        cls.db.updateEnv(workdate=WORKDATE)
+        cls.notif_tbl = cls.db.table('adm.notification')
+        cls.usernotif_tbl = cls.db.table('adm.user_notification')
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.closeConnection()
+        shutil.rmtree(cls.temp_dir, ignore_errors=True)
+
+    # --- fixtures ----------------------------------------------------------
+
+    def _insert_user(self, username, group_code=None):
+        tbl = self.db.table('adm.user')
+        rec = tbl.newrecord(username=username, email='%s@test.local' % username,
+                            firstname='Test', lastname='Aud', group_code=group_code)
+        tbl.insert(rec)
+        self.db.commit()
+        return rec['id']
+
+    def _tag_id(self, code):
+        """The pkey of an adm.htag, created on first use."""
+        tbl = self.db.table('adm.htag')
+        existing = tbl.query(where='$code=:c', c=code, columns='$id').fetch()
+        if existing:
+            return existing[0]['id']
+        rec = tbl.newrecord(code=code, description=code)
+        tbl.insert(rec)
+        self.db.commit()
+        return rec['id']
+
+    def _assign_tag(self, code, user_id=None, group_code=None):
+        """Tag a user, or a whole group, the way the framework does: through
+        adm.user_tag, which is what feeds the $all_tags column the audience is
+        evaluated against."""
+        tbl = self.db.table('adm.user_tag')
+        rec = tbl.newrecord(tag_id=self._tag_id(code), user_id=user_id,
+                            group_code=group_code)
+        tbl.insert(rec)
+        self.db.commit()
+
+    def _insert_group(self, code):
+        tbl = self.db.table('adm.group')
+        if not tbl.query(where='$code=:c', c=code, columns='$code').fetch():
+            rec = tbl.newrecord(code=code, description=code)
+            tbl.insert(rec)
+            self.db.commit()
+        return code
+
+    def _tagged_user(self, username, tags):
+        user_id = self._insert_user(username)
+        for tag in tags:
+            self._assign_tag(tag, user_id=user_id)
+        return user_id
+
+    def _insert_notification(self, **kwargs):
+        rec = self.notif_tbl.newrecord(**kwargs)
+        self.notif_tbl.insert(rec)
+        self.db.commit()
+        return rec['id']
+
+    def _linked_users(self, notification_id):
+        rows = self.usernotif_tbl.query(where='$notification_id=:nid',
+                                        nid=notification_id,
+                                        columns='$user_id').fetch()
+        return {r['user_id'] for r in rows}
+
+    def _login(self, user_id):
+        self.usernotif_tbl.updateGenericNotification(user_id)
+
+    # --- static vs dynamic -------------------------------------------------
+
+    def test_static_all_users_snapshot_is_frozen(self):
+        existing = self._insert_user('notif_static_existing')
+        notif_id = self._insert_notification(title='static all-users',
+                                             dynamic_list=False)
+
+        assert existing in self._linked_users(notif_id), \
+            "the snapshot must link the users present at save time"
+
+        # A user created after the snapshot must NOT be added to a static list.
+        newcomer = self._insert_user('notif_static_newcomer')
+        self._login(newcomer)
+        assert newcomer not in self._linked_users(notif_id)
+
+    def test_dynamic_all_users_grows_at_login(self):
+        notif_id = self._insert_notification(title='dynamic all-users',
+                                             dynamic_list=True)
+        newcomer = self._insert_user('notif_dynamic_newcomer')
+        self._login(newcomer)
+        assert newcomer in self._linked_users(notif_id)
+
+    def test_dynamic_list_is_the_default(self):
+        notif_id = self._insert_notification(title='default audience mode')
+        rec = self.notif_tbl.record(pkey=notif_id).output('dict')
+        assert rec['dynamic_list'], "a new notification must be dynamic unless opted out"
+
+    def test_notification_predating_the_column_still_enrols(self):
+        """A row saved before dynamic_list existed has it NULL and no snapshot
+        of its own: it used to be delivered by the incremental alignment at
+        login, and it must keep being delivered after the upgrade."""
+        notif_id = self._insert_notification(title='legacy notification',
+                                             dynamic_list=None)
+        rec = self.notif_tbl.record(pkey=notif_id).output('dict')
+        assert rec['dynamic_list'] is None, "the legacy case is a NULL, not a False"
+
+        newcomer = self._insert_user('notif_legacy_newcomer')
+        self._login(newcomer)
+        assert newcomer in self._linked_users(notif_id)
+
+    # --- tag rule ----------------------------------------------------------
+
+    def test_tag_rule_audience_coherent_on_both_paths(self):
+        matching = self._tagged_user('notif_tag_match', [TAG_ADMIN])
+        other = self._tagged_user('notif_tag_other', [TAG_OTHER])
+
+        notif_id = self._insert_notification(title='tag dynamic',
+                                             tag_rule=TAG_ADMIN, dynamic_list=True)
+
+        # Snapshot path: only the matching user is linked.
+        linked = self._linked_users(notif_id)
+        assert matching in linked
+        assert other not in linked
+
+        # Login path must use the same audience rule: a new matching user is
+        # linked, a new non-matching user is not.
+        new_match = self._tagged_user('notif_tag_new_match', [TAG_ADMIN])
+        new_nomatch = self._tagged_user('notif_tag_new_nomatch', [TAG_OTHER])
+        self._login(new_match)
+        self._login(new_nomatch)
+
+        linked = self._linked_users(notif_id)
+        assert new_match in linked
+        assert new_nomatch not in linked
+
+    def test_tag_rule_does_not_match_by_substring(self):
+        """A rule on ZZADMIN must not reach a user tagged SUPERZZADMIN: that
+        is exactly what a bare LIKE '%tag%' does, on either path."""
+        superadmin = self._tagged_user('notif_tag_superadmin', [TAG_SUPERADMIN])
+        notif_id = self._insert_notification(title='tag substring',
+                                             tag_rule=TAG_ADMIN, dynamic_list=True)
+        assert superadmin not in self._linked_users(notif_id)
+
+        newcomer = self._tagged_user('notif_tag_superadmin_new', [TAG_SUPERADMIN])
+        self._login(newcomer)
+        assert newcomer not in self._linked_users(notif_id)
+
+    def test_tag_rule_honors_wildcards(self):
+        admin = self._tagged_user('notif_tag_wildcard_in', [TAG_ADMIN])
+        other = self._tagged_user('notif_tag_wildcard_out', [TAG_OTHER])
+        notif_id = self._insert_notification(title='tag wildcard',
+                                             tag_rule='ZZADM%', dynamic_list=True)
+        linked = self._linked_users(notif_id)
+        assert admin in linked
+        assert other not in linked
+
+        newcomer = self._tagged_user('notif_tag_wildcard_new', [TAG_ADMIN])
+        self._login(newcomer)
+        assert newcomer in self._linked_users(notif_id)
+
+    def test_tag_rule_honors_exclusions(self):
+        only_admin = self._tagged_user('notif_tag_not_in', [TAG_ADMIN])
+        both = self._tagged_user('notif_tag_not_out', [TAG_ADMIN, TAG_OTHER])
+        notif_id = self._insert_notification(title='tag exclusion',
+                                             tag_rule='%s NOT %s' % (TAG_ADMIN, TAG_OTHER),
+                                             dynamic_list=True)
+        linked = self._linked_users(notif_id)
+        assert only_admin in linked
+        assert both not in linked
+
+        new_excluded = self._tagged_user('notif_tag_not_new', [TAG_ADMIN, TAG_OTHER])
+        self._login(new_excluded)
+        assert new_excluded not in self._linked_users(notif_id)
+
+    def test_tag_rule_honors_alternative_rules(self):
+        """`;` separates alternative rules: matching either one is enough."""
+        second_rule = self._tagged_user('notif_tag_alt_in', [TAG_SUPERADMIN])
+        neither = self._tagged_user('notif_tag_alt_out', [TAG_ADMIN])
+        notif_id = self._insert_notification(title='tag alternatives',
+                                             tag_rule='%s;%s' % (TAG_OTHER, TAG_SUPERADMIN),
+                                             dynamic_list=True)
+        linked = self._linked_users(notif_id)
+        assert second_rule in linked
+        assert neither not in linked
+
+    def test_tag_rule_matches_tags_inherited_from_group(self):
+        """The rule is evaluated on $all_tags, the very column the login reads
+        to build the avatar tags, so a tag granted through the group counts."""
+        group_code = self._insert_group('ZZGRP')
+        self._assign_tag(TAG_ADMIN, group_code=group_code)
+        in_group = self._insert_user('notif_tag_group_member', group_code=group_code)
+        outsider = self._insert_user('notif_tag_group_outsider')
+
+        notif_id = self._insert_notification(title='tag from group',
+                                             tag_rule=TAG_ADMIN, dynamic_list=True)
+        linked = self._linked_users(notif_id)
+        assert in_group in linked
+        assert outsider not in linked
+
+        newcomer = self._insert_user('notif_tag_group_new', group_code=group_code)
+        self._login(newcomer)
+        assert newcomer in self._linked_users(notif_id)
+
+    def test_no_audience_rule_implies_all_users(self):
+        notif_id = self._insert_notification(title='implicit all-users')
+        rec = self.notif_tbl.record(pkey=notif_id).output('dict')
+        assert rec['all_users'], "no audience rule must imply all_users"
+
+    def test_tag_rule_does_not_imply_all_users(self):
+        notif_id = self._insert_notification(title='only tag rule', tag_rule=TAG_ADMIN)
+        rec = self.notif_tbl.record(pkey=notif_id).output('dict')
+        assert not rec['all_users'], "an explicit audience rule must not force all_users"
+
+    # --- re-snapshot on update --------------------------------------------
+
+    def test_audience_criteria_change_resnapshots(self):
+        admin = self._tagged_user('notif_resnap_admin', [TAG_ADMIN])
+        other = self._tagged_user('notif_resnap_other', [TAG_OTHER])
+        notif_id = self._insert_notification(title='criteria change',
+                                             tag_rule=TAG_ADMIN, dynamic_list=False)
+        linked = self._linked_users(notif_id)
+        assert admin in linked
+        assert other not in linked
+
+        with self.notif_tbl.recordToUpdate(notif_id) as rec:
+            rec['tag_rule'] = TAG_OTHER
+        self.db.commit()
+        linked = self._linked_users(notif_id)
+        assert other in linked
+        assert admin not in linked, "a criteria change must rebuild the membership"
+
+    def test_date_window_change_does_not_resnapshot_static_list(self):
+        """Re-photographing on a date edit would enrol exactly the newcomers a
+        static list exists to exclude."""
+        member = self._tagged_user('notif_window_member', [TAG_ADMIN])
+        notif_id = self._insert_notification(title='static window edit',
+                                             tag_rule=TAG_ADMIN, dynamic_list=False,
+                                             end_date=WORKDATE + datetime.timedelta(days=1))
+        assert member in self._linked_users(notif_id)
+
+        newcomer = self._tagged_user('notif_window_newcomer', [TAG_ADMIN])
+        with self.notif_tbl.recordToUpdate(notif_id) as rec:
+            rec['end_date'] = WORKDATE + datetime.timedelta(days=30)
+        self.db.commit()
+
+        linked = self._linked_users(notif_id)
+        assert member in linked, "the pending rows of a static list must survive"
+        assert newcomer not in linked
+
+    # --- date window -------------------------------------------------------
+
+    def test_date_window_gates_visibility(self):
+        user_id = self._insert_user('notif_datewindow_user')
+        notif_id = self._insert_notification(title='expired window',
+                                             dynamic_list=True,
+                                             end_date=WORKDATE - datetime.timedelta(days=10))
+
+        # The snapshot links the user regardless of the window...
+        assert user_id in self._linked_users(notif_id)
+        # ...but an expired notification is not surfaced to the user.
+        assert self.usernotif_tbl.nextUserNotification(user_id=user_id) is None
+
+        # Reopening the window makes it visible again.
+        with self.notif_tbl.recordToUpdate(notif_id) as rec:
+            rec['end_date'] = WORKDATE + datetime.timedelta(days=10)
+        self.db.commit()
+        assert self.usernotif_tbl.nextUserNotification(user_id=user_id) is not None


### PR DESCRIPTION
Supersedes #964, now closed: this PR is the sole carrier of the change, and it targets `master` as a hotfix.

## Summary

### The bug: one audience, two answers
The audience of `adm.notification` was evaluated in two divergent ways:
- **bulk snapshot** (triggers → `updateUserNotificationsFromQuery`): considered `tag_rule`, `group_code`, `linked_query`;
- **per-user alignment at login** (`updateGenericNotification`): considered only `all_users` and `tag_rule`.

So a notification restricted by `group_code` reached the users already enrolled and silently not the new ones. Both paths now share one evaluation, in two halves that both entry points pair:
- `audienceWhere()` builds the SQL pre-selection, with the criteria SQL can express: `group_code` and `linked_query`;
- `tagRuleMatches()` applies the tag rule on the candidate rows, delegating to `checkResourcePermission`.

The entry points are `audienceUserIds()` for the snapshot and `userMatchesAudience()` for the login.

**Tag rule.** Evaluated on `$all_tags`, the column `adm.main.authenticate` reads to build the avatar tags. A bare `$auth_tags LIKE '%tag%'` reaches a user tagged `superadmin` from a rule on `admin`, honors none of the rule syntax the permission engine understands (`%` wildcards, `NOT`, `;`), and misses the tags inherited from the group.

**Group code.** Matched on delimited codes, `',' || $all_groups || ','` against `%,code,%`. `all_groups` is a comma-join with no delimiter at the string boundaries, so the previous unanchored LIKE reached the users in `superadmin`, `admin_ro` or `nonadmin` from a rule on `admin` — a false positive, i.e. a group-restricted notification delivered outside its audience. This matters more now than it did before: that LIKE used to govern the snapshot alone, while the login ignored `group_code` entirely, so unifying the two paths applies the criterion at login as well and it has to be applied correctly.

Also fixed: a notification carrying only a `tag_rule` (no `linked_query`) was wrongly flagged `all_users`. `all_users` is now implied only when no explicit audience criterion is set.

### Dynamic vs static
New `dynamic_list` column, **dynamic by default**.
- **Dynamic** (default): newcomers matching the criteria are enrolled incrementally at login — what notifications have always done. The login path tests `dynamic_list IS NOT FALSE`, so the rows that predate the column (NULL) keep being delivered: **no migration needed**.
- **Static** (explicit opt-out): the audience is photographed once, at save time. If 1000 users match, those 1000 are frozen — newcomers are never added.

The list is re-photographed only when the audience criteria change (`tag_rule`, `group_code`, `linked_query`, `all_users`). The snapshot drops the pending rows and rebuilds membership from the current population, so firing it on the date window would enrol exactly the newcomers a static list exists to exclude.

### Activity window
New optional `start_date` / `end_date` columns (NULL = no limit). Outside the window a notification neither enrolls new users nor is surfaced to the user (`nextUserNotification` is date-gated).

### UI
Form/embed expose `dynamic_list`, `start_date`, `end_date`; the list view also shows `confirmed_count` / `pending_count` (idiomatic `formulaColumn(select=...)`).

## Deployment notes

- **This is not hotfix-shaped, and the decision is conscious.** It carries a schema change — three new columns on `adm.notification`, so instances need a `gnr migrate` — plus new UI and the static/dynamic feature. Whether it goes out in a hotfix release or a normal one is the maintainer's call, not something to inherit from the branch prefix.
- **No data migration**: `default=True` feeds `newrecord()` only and never becomes a SQL `DEFAULT`, so existing rows stay NULL — and `IS NOT FALSE` is what keeps them dynamic, i.e. behaving exactly as before. An installation that upgrades and never touches the new fields keeps the behavior it had.
- **Save-time cost**: saving a notification photographs its audience, so with `all_users` it writes one `adm.user_notification` row per user inside the insert transaction, where previously the eager insert only happened with a `linked_query`. When a `tag_rule` is set, `$all_tags` is a pyColumn and costs a query per candidate — on an operation that is already one insert per user. Worth timing against a realistic `adm.user` count before cutting the release; **not** measured here.

## Test plan

`projects/gnrcore/packages/adm/tests/test_notification_audience.py` — 19 tests on a throwaway SQLite application, run with `gnr dev tests <instance> adm`. Users, tags and groups are created through `adm.htag`, `adm.user_tag`, `adm.group` and `adm.user_group` the way the framework does, so the records go through the actual triggers.

Static / dynamic:
- static list frozen after the snapshot (newcomer not added);
- dynamic list grows at login;
- a new notification is dynamic unless opted out;
- a notification that predates the column (`dynamic_list` NULL, no snapshot of its own) still enrolls a user logging in.

Tag rule, each on both the snapshot and the login path:
- `tag_rule` audience coherent on both paths;
- a rule on `ZZADMIN` does not reach a user tagged `SUPERZZADMIN` (what a bare `LIKE '%tag%'` does);
- wildcards (`ZZADM%`), exclusions (`A NOT B`) and alternative rules (`A;B`) are honored;
- a tag inherited from the group matches on both paths;
- `all_users` implied only without explicit rules.

Group code — the criterion that previously had no audience coverage at all:
- `group_code` audience coherent on both paths;
- a notification restricted to `ZZADMG` does not reach a user in `SUPERZZADMG`;
- a group held through `adm.user_group` rather than through the user's own `group_code` still matches, which is where a delimited match on a comma-join could plausibly break;
- `group_code` alone does not imply `all_users`.

Re-snapshot and window:
- changing an audience criterion rebuilds the membership;
- editing only the date window does not re-photograph a static list (pending rows survive, newcomers stay out);
- the date window gates visibility (`nextUserNotification`).

Verified against `master`'s framework code: 19/19 passing, `gnrpy/tests/sql` green (1163 passed, 32 skipped), flake8 clean on the modified files. Mutation-checked: restoring the substring tag match fails 4 tests, restoring the unanchored group LIKE fails 1, restoring `IS TRUE` fails the legacy-notification one, restoring the date fields in the trigger fails the re-snapshot one.

## Known CI failure, unrelated to this change

`tests/core/gnrbag_test.py::TestBasicBag::test_fillFromUrl` fails on `master` with `HTTP Error 404`, and it fails for **any** PR opened against `master` today: master's copy of the test fetches `https://www.genropy.org/feed/`, which the site migration removed. `develop` already carries cgabriel's fix (`aa7818667d`, moving it to `/sitemap.xml`), one of the 134 commits master does not have yet.

That one-line fix is deliberately **not** included here, so this branch carries the hotfix and nothing else. It also would not fix the underlying problem: the test still reaches the live network either way, which the project's own guidelines rule out for tests — the durable fix is a local fixture, in its own PR against `develop`.
