### PR TITLE
fix: make the relative storage service usable

### DIFF
--- a/gnrpy/tests/web/gnrstoragehandler_test.py
+++ b/gnrpy/tests/web/gnrstoragehandler_test.py
@@ -4,6 +4,9 @@ import tempfile
 import shutil
 
 from gnr.core.gnrbag import Bag
+from gnr.core.gnrconfig import getGenroRoot
+from gnr.core.gnrlang import GnrException, gnrImport
+from gnr.lib.services.storage import StorageResolver
 
 from webcommon import BaseGnrDaemonTest
 
@@ -67,7 +70,7 @@ class TestStorageHandler(BaseGnrDaemonTest):
             assert 'implementation' in params, \
                 f"Parameters for '{storage_name}' should have 'implementation' key"
             impl = params['implementation']
-            assert impl in ['local', 'symbolic', 'raw', 'http', 'aws_s3'], \
+            assert impl in ['local', 'symbolic', 'raw', 'http', 'aws_s3', 'relative'], \
                 f"Unknown implementation '{impl}' for storage '{storage_name}'"
 
     # ========================================================================
@@ -747,3 +750,230 @@ class TestStorageHandler(BaseGnrDaemonTest):
 
         # Clean up
         self.storage_handler.removeStorageFromCache('test_no_modify')
+
+    # ========================================================================
+    # Relative Storage Service Tests (Bug #834)
+    # ========================================================================
+
+    def _addStorage(self, service_name, implementation=None, **parameters):
+        """Registers a storage service to be removed at the end of the test"""
+        self.storage_handler._setStorageParams(service_name,
+            parameters=parameters, implementation=implementation)
+        self._storages_to_clean.append(service_name)
+        return service_name
+
+    @pytest.fixture(autouse=True)
+    def cleanup_storages(self):
+        """Removes the storage services registered by a single test"""
+        self._storages_to_clean = []
+        yield
+        storage_type = self.services_handler('storage')
+        for service_name in self._storages_to_clean:
+            self.storage_handler.removeStorageFromCache(service_name)
+            storage_type.service_instances.pop(service_name, None)
+
+    @pytest.fixture
+    def relative_storages(self):
+        """A local storage plus a relative storage rooted on one of its subfolders"""
+        parent_dir = os.path.join(self.test_dir, 'relative_parent')
+        os.makedirs(os.path.join(parent_dir, 'docs', 'invoices'), exist_ok=True)
+        parent_name = self._addStorage('rel_parent_storage', implementation='local',
+                                       base_path=parent_dir, tags='admin')
+        child_name = self._addStorage('rel_child_storage', implementation='relative',
+                                       parent_service=parent_name, relative_path='docs/invoices')
+        return parent_name, child_name
+
+    def test_relative_storage_creation(self, relative_storages):
+        """Test that a relative storage service can be created (issue #834).
+
+        Creating it used to fail with AttributeError: 'Service' object has no
+        attribute '_call'.
+        """
+        parent_name, child_name = relative_storages
+        parent_service = self.site.storage(parent_name)
+        service = self.site.storage(child_name)
+
+        assert service is not None
+        # a relative service is an instance of the parent implementation
+        assert isinstance(service, type(parent_service))
+        assert service.service_implementation == 'relative'
+        assert service.service_name == child_name
+        assert service.parent_service is parent_service
+        assert service.relative_path == 'docs/invoices'
+
+    def test_relative_storage_base_path(self, relative_storages):
+        """Test that a relative storage is rooted inside its parent storage."""
+        parent_name, child_name = relative_storages
+        parent_service = self.site.storage(parent_name)
+        service = self.site.storage(child_name)
+
+        assert service.base_path == '%s/docs/invoices' % parent_service.base_path
+        assert service.internal_path('receipt.txt') == os.path.join(parent_service.base_path,
+                                                                    'docs', 'invoices', 'receipt.txt')
+
+    def test_relative_storage_write_and_read(self, relative_storages):
+        """Test that files written on a relative storage land in the parent subfolder."""
+        parent_name, child_name = relative_storages
+        node = self.site.storageNode('%s:receipt.txt' % child_name)
+        with node.open(mode='w') as output_file:
+            output_file.write('relative content')
+
+        assert node.exists
+        assert node.fullpath == '%s:receipt.txt' % child_name
+
+        # the same file is reachable from the parent storage through the relative path
+        parent_node = self.site.storageNode('%s:docs/invoices/receipt.txt' % parent_name)
+        assert parent_node.exists
+        with parent_node.open(mode='r') as input_file:
+            assert input_file.read() == 'relative content'
+
+        node.delete()
+        assert not node.exists
+
+    def test_relative_storage_children(self, relative_storages):
+        """Test that a relative storage lists only its own subtree."""
+        parent_name, child_name = relative_storages
+        for filename in ('first.txt', 'second.txt'):
+            with self.site.storageNode('%s:%s' % (child_name, filename)).open(mode='w') as output_file:
+                output_file.write(filename)
+        with self.site.storageNode('%s:outside.txt' % parent_name).open(mode='w') as output_file:
+            output_file.write('outside')
+
+        children = self.site.storageNode('%s:' % child_name).children()
+        assert sorted([child.basename for child in children]) == ['first.txt', 'second.txt']
+        assert all(child.service.service_name == child_name for child in children)
+
+    def test_relative_storage_inherits_parent_parameters(self, relative_storages):
+        """Test that the parameters of the parent service are used by the relative one."""
+        parent_name, child_name = relative_storages
+        parent_service = self.site.storage(parent_name)
+        service = self.site.storage(child_name)
+
+        assert service.tags == parent_service.tags == 'admin'
+        assert service.location_identifier == parent_service.location_identifier
+
+    def test_relative_storage_nested(self, relative_storages):
+        """Test that a relative storage can be the parent of another relative storage."""
+        parent_name, child_name = relative_storages
+        nested_name = self._addStorage('rel_nested_storage', implementation='relative',
+                                        parent_service=child_name, relative_path='2026')
+        parent_service = self.site.storage(parent_name)
+        service = self.site.storage(nested_name)
+
+        assert service.base_path == '%s/docs/invoices/2026' % parent_service.base_path
+        assert isinstance(service, type(parent_service))
+
+    def test_relative_storage_without_relative_path(self, relative_storages):
+        """Test that a relative storage without relative path is an alias of its parent."""
+        parent_name, child_name = relative_storages
+        alias_name = self._addStorage('rel_alias_storage', implementation='relative',
+                                       parent_service=parent_name)
+        parent_service = self.site.storage(parent_name)
+        service = self.site.storage(alias_name)
+
+        assert service.relative_path == ''
+        assert service.base_path == parent_service.base_path
+
+    def test_relative_storage_missing_parent_service(self):
+        """Test that a relative storage without parent service is empty and not writable.
+
+        A service that has just been created has no parameters yet: browsing it must
+        not fail (its own parameters form shows its tree) but nothing can be written
+        where there is no path.
+        """
+        service_name = self._addStorage('rel_no_parent_storage', implementation='relative',
+                                         relative_path='docs')
+        service = self.site.storage(service_name)
+        assert service.base_path is None
+        assert service.children() == []
+        assert service.exists('anything.txt') is False
+        assert service.url('anything.txt') == ''
+        node = self.site.storageNode('%s:anything.txt' % service_name)
+        assert not node.exists
+        with pytest.raises(GnrException):
+            node.open(mode='w')
+
+    def test_relative_storage_unsupported_parent_service(self):
+        """Test that a symbolic storage cannot be the parent of a relative storage."""
+        service_name = self._addStorage('rel_symbolic_storage', implementation='relative',
+                                         parent_service='rsrc', relative_path='docs')
+        service = self.site.storage(service_name)
+        assert service.base_path is None
+        with pytest.raises(GnrException):
+            service.mkdir('docs')
+
+    def test_relative_storage_tree_without_parent_service(self):
+        """Test that the storage tree of an unconfigured relative storage is empty.
+
+        This is the failure reported in issue #834: the tree of the service
+        parameters form used to break on the service it configures.
+        """
+        service_name = self._addStorage('rel_tree_storage', implementation='relative')
+        tree = StorageResolver(self.site.storageNode('%s:' % service_name),
+                               _page=self.site.dummyPage)()
+        assert len(tree) == 0
+
+    def test_relative_storage_from_service_record(self):
+        """Test a relative storage configured in sys.service end to end (issue #834).
+
+        This is the path that fails in a real instance: the parameters are read
+        from the service record, loaded in the storage_params registry by the
+        table triggers and passed to the service factory.
+        """
+        tblservice = self.site.db.table('sys.service')
+        service_name = 'rel_record_storage'
+        parameters = Bag()
+        parameters['parent_service'] = 'site'
+        parameters['relative_path'] = 'relative_from_record'
+        record = tblservice.newrecord(service_type='storage', service_name=service_name,
+                                      implementation='relative', parameters=parameters)
+        tblservice.insert(record)
+        self.site.db.commit()
+        try:
+            # the insert trigger fills the storage_params registry
+            stored_params = self.storage_handler.getStorageParameters(service_name)
+            assert stored_params['implementation'] == 'relative'
+            assert stored_params['parent_service'] == 'site'
+            assert stored_params['relative_path'] == 'relative_from_record'
+
+            service = self.site.storage(service_name)
+            assert service.parent_service is self.site.storage('site')
+            assert service.base_path == '%s/relative_from_record' % self.site.storage('site').base_path
+
+            node = self.site.storageNode('%s:probe.txt' % service_name)
+            node.parentStorageNode.mkdir()
+            with node.open(mode='w') as output_file:
+                output_file.write('from service record')
+            assert self.site.storageNode('site:relative_from_record/probe.txt').exists
+
+            # the storage tree of the service parameters form loads this service
+            tree = StorageResolver(self.site.storageNode('%s:' % service_name),
+                                   _page=self.site.dummyPage)()
+            assert 'probe_txt' in tree
+            node.delete()
+        finally:
+            tblservice.delete(record)
+            self.site.db.commit()
+            self.services_handler('storage').service_instances.pop(service_name, None)
+
+    def test_relative_storage_parent_options(self):
+        """Test the parent services offered by the relative storage parameters form."""
+        relative_module = gnrImport(os.path.join(getGenroRoot(), 'resources', 'common',
+                                                 'services', 'storage', 'relative.py'),
+                                    avoidDup=True)
+        service_name = self._addStorage('rel_options_storage', implementation='relative',
+                                         parent_service='removed_parent_storage')
+        self._addStorage('rel_options_parent', implementation='local', base_path='/tmp/rel_options')
+        form = relative_module.ServiceParameters()
+        form.site = self.site
+        options = relative_module.ServiceParameters.relativeStorageParents(
+            form, service_name=service_name).split(',')
+
+        assert 'rel_options_parent' in options
+        # a service cannot be the parent of itself
+        assert service_name not in options
+        # symbolic services have no real base path, internal ones are not configurable
+        assert 'rsrc' not in options
+        assert '_raw_' not in options
+        # the configured parent is always an option, even if it is not available any more
+        assert 'removed_parent_storage' in options

--- a/gnrpy/tests/web/gnrstoragehandler_test.py
+++ b/gnrpy/tests/web/gnrstoragehandler_test.py
@@ -892,6 +892,8 @@ class TestStorageHandler(BaseGnrDaemonTest):
         assert not node.exists
         with pytest.raises(GnrException):
             node.open(mode='w')
+        with pytest.raises(GnrException):
+            node.delete()
 
     def test_relative_storage_unsupported_parent_service(self):
         """Test that a symbolic storage cannot be the parent of a relative storage."""
@@ -977,3 +979,74 @@ class TestStorageHandler(BaseGnrDaemonTest):
         assert '_raw_' not in options
         # the configured parent is always an option, even if it is not available any more
         assert 'removed_parent_storage' in options
+
+    def test_relative_storage_missing_parent_service_name(self):
+        """Test that a relative storage on a missing parent service does not re-root.
+
+        An unknown storage name is served as a new folder of the site static dir:
+        a relative storage must not silently move there when its parent is gone.
+        """
+        service_name = self._addStorage('rel_gone_storage', implementation='relative',
+                                         parent_service='rel_gone_parent_storage',
+                                         relative_path='docs')
+        service = self.site.storage(service_name)
+        assert service.base_path is None
+        assert not os.path.exists(os.path.join(self.site.site_static_dir,
+                                               'rel_gone_parent_storage'))
+        with pytest.raises(GnrException):
+            self.site.storageNode('%s:invoice.pdf' % service_name).open(mode='w')
+
+    def test_relative_storage_deleted_parent_service(self):
+        """Test that a relative storage stops resolving when its parent is deleted."""
+        parent_dir = os.path.join(self.test_dir, 'deleted_parent')
+        os.makedirs(parent_dir, exist_ok=True)
+        parent_name = self._addStorage('rel_deleted_parent', implementation='local',
+                                        base_path=parent_dir)
+        service_name = self._addStorage('rel_orphan_storage', implementation='relative',
+                                         parent_service=parent_name, relative_path='sub')
+        assert self.site.storage(service_name).base_path == '%s/sub' % parent_dir
+
+        self.storage_handler.removeStorageFromCache(parent_name)
+        self.services_handler('storage').service_instances.pop(service_name, None)
+        assert self.site.storage(service_name).base_path is None
+
+    def test_relative_storage_looping_parent_services(self):
+        """Test that relative storages pointing at each other do not recurse.
+
+        A service instance is cached only once it is built, so a loop in the
+        configuration would be resolved until the stack ends.
+        """
+        first_name = self._addStorage('rel_loop_first', implementation='relative',
+                                       parent_service='rel_loop_second', relative_path='a')
+        second_name = self._addStorage('rel_loop_second', implementation='relative',
+                                        parent_service='rel_loop_first', relative_path='b')
+        assert self.site.storage(first_name).base_path is None
+        assert self.site.storage(second_name).base_path is None
+
+    def test_relative_storage_parent_of_itself(self):
+        """Test that a relative storage cannot be its own parent."""
+        service_name = self._addStorage('rel_self_storage', implementation='relative',
+                                         parent_service='rel_self_storage',
+                                         relative_path='docs')
+        assert self.site.storage(service_name).base_path is None
+
+    def test_relative_storage_parent_without_base_path(self):
+        """Test that a local parent service with no base path cannot be the parent.
+
+        Its base path is None, so the relative path would be resolved from the
+        current working directory of the process.
+        """
+        parent_name = self._addStorage('rel_nobase_parent', implementation='local')
+        assert self.site.storage(parent_name).base_path is None
+        service_name = self._addStorage('rel_nobase_storage', implementation='relative',
+                                         parent_service=parent_name, relative_path='docs')
+        assert self.site.storage(service_name).base_path is None
+
+    def test_relative_storage_on_unconfigured_relative_parent(self):
+        """Test that an unconfigured relative storage cannot be the parent of another."""
+        parent_name = self._addStorage('rel_unconfigured_parent', implementation='relative',
+                                        relative_path='docs')
+        service_name = self._addStorage('rel_chained_storage', implementation='relative',
+                                         parent_service=parent_name, relative_path='2026')
+        assert self.site.storage(parent_name).base_path is None
+        assert self.site.storage(service_name).base_path is None

--- a/localization.xml
+++ b/localization.xml
@@ -733,7 +733,9 @@
 <en_edit_ base="Edit " de="Bearbeiten" en="Edit " fr="Éditer" it="Modifica"></en_edit_>
 <en_save_pdf_form base="Save PDF form" it="Salva modulo PDF"></en_save_pdf_form>
 <en_save_template base="Save template" de="Vorlage speichern" en="Save template" fr="Enregistrer le modèle" it="Salva modello"></en_save_template>
-<en_new_pdf_form base="New PDF form" it="Nuovo modulo PDF"></en_new_pdf_form></component></pdftk></pdfform></services>
+<en_new_pdf_form base="New PDF form" it="Nuovo modulo PDF"></en_new_pdf_form></component></pdftk></pdfform>
+<storage><relative path="resources/common/services/storage/relative.py" ext="py"><en_parent_service base="Parent service" en="Parent service" it="Servizio padre"></en_parent_service>
+<en_relative_path base="Relative path" en="Relative path" it="Percorso relativo"></en_relative_path></relative></storage></services>
 <tables><_default><action><_common><_doc path="resources/common/tables/_default/action/_common/_doc.py" ext="py"><en_common base="Common" de="Gemeinsam" en="Common" fr="Commun" it="Comune"></en_common>
 <en_common_actions base="Common Actions" de="Gemeinsame Maßnahmen" en="Common Actions" fr="Actions communes" it="Azioni comuni"></en_common_actions></_doc>
 <align_counter path="resources/common/tables/_default/action/_common/align_counter.py" ext="py"><en_align_counter base="Align counter" de="Richten Gegen" en="Align counter" fr="Alignez compteur" it="Allineare contatore"></en_align_counter>

--- a/projects/gnrcore/packages/sys/resources/tables/service/th_service.py
+++ b/projects/gnrcore/packages/sys/resources/tables/service/th_service.py
@@ -39,6 +39,8 @@ class Form(BaseComponent):
                                                     service_name='=.service_name', 
                                                     _if="service_type && implementation",
                                                     _fired='^#FORM.controller.loaded',
+                                                    _onRemote="""const frm = this.form;
+                                                        if(frm){this.delayedCall(()=>{frm.checkInvalidFields()},1,'serviceParameters');}""",
                                                     _async=True,_waitingMessage=True)
 
 

--- a/resources/common/services/storage/relative.py
+++ b/resources/common/services/storage/relative.py
@@ -1,61 +1,159 @@
 #!/usr/bin/env pythonw
 # -*- coding: utf-8 -*-
 
-from gnr.lib.services.storage import StorageService,GnrBaseService
+from gnr.core.gnrlang import GnrException
+from gnr.lib import logger
+from gnr.lib.services.storage import StorageService
 from gnr.web.gnrbaseclasses import BaseComponent
-import types
+
+#implementations whose base_path is not a real path: they cannot be the parent
+#of a relative service because their paths are resolved by service name
+UNSUPPORTED_PARENT_IMPLEMENTATIONS = ('symbolic', 'http')
+
+RELATIVE_SERVICE_CLASSES = {}
+
+
+def relativeServiceClass(parent_service):
+    """Returns the class of a relative service built over a parent storage service.
+
+    A relative service must behave exactly as its parent implementation, so its class
+    is created (and cached) as a subclass of the parent service class: Service comes
+    first in the mro, so it only overrides the base path, while every other method is
+    the one of the parent implementation.
+
+    :param parent_service: the parent storage service instance"""
+    parent_class = parent_service.__class__
+    if issubclass(parent_class, Service):
+        #the parent is a relative service itself: its class is already the right one
+        return parent_class
+    relative_class = RELATIVE_SERVICE_CLASSES.get(parent_class)
+    if relative_class is None:
+        implementation = getattr(parent_service, 'service_implementation', None)
+        relative_class = type('Relative_%s' % (implementation or parent_class.__name__),
+                              (Service, parent_class), {})
+        RELATIVE_SERVICE_CLASSES[parent_class] = relative_class
+    return relative_class
+
 
 class Service(StorageService):
+    """Storage service rooted on a subpath of another storage service.
 
-    def __init__(self, parent=None, relative_path=None, parent_service=None,**kwargs):
-        dir_base = dir(GnrBaseService)
-        for attr in dir(StorageService):
-            if not attr in dir_base:
-                delattr(self, attr)
+    Only the parent service and the relative path are configured: implementation and
+    parameters (base path, bucket, credentials...) are the ones of the parent service,
+    so a subfolder of an existing storage can be published as a service of its own
+    without repeating any parameter."""
+
+    def __init__(self, parent=None, relative_path=None, parent_service=None, **kwargs):
         self.parent = parent
-        self.parent_service =  self.parent.getService('storage',parent_service)
-        self.parent_path = self.parent_service.base_path
-        self.relative_path = relative_path
-        self.__class__ = self.parent_service.__class__
+        self.parent_service_name = parent_service
+        self.relative_path = (relative_path or '').strip('/')
+        self.parent_service = self._resolveParentService(parent_service)
+        if self.parent_service is None:
+            #not configured yet: the service is browsable (and empty) but not writable,
+            #so that the form where it gets configured does not fail on it
+            self.__class__ = UnconfiguredService
+        else:
+            self.__class__ = relativeServiceClass(self.parent_service)
 
-
-    @property
-    def _resolved_relative(self):
-        #resolve dbstore...
-        return self.relative_path
+    def _resolveParentService(self, parent_service):
+        """Returns the parent storage service, None if it is missing or unusable"""
+        if not parent_service:
+            logger.warning('Relative storage service without parent service')
+            return None
+        service = self.parent.storage(parent_service)
+        implementation = getattr(service, 'service_implementation', None)
+        if implementation in UNSUPPORTED_PARENT_IMPLEMENTATIONS:
+            logger.warning('Storage service %s cannot be the parent of a relative service',
+                           parent_service)
+            return None
+        return service
 
     @property
     def base_path(self):
-        return '%s/%s'%(self.parent_path, self._resolved_relative) if self.parent_path else self._resolved_relative
+        parent_base_path = self.parent_service.base_path
+        if not parent_base_path:
+            return self.relative_path
+        if not self.relative_path:
+            return parent_base_path
+        return '%s/%s' % (parent_base_path.rstrip('/'), self.relative_path)
 
     def __getattr__(self, name):
-        if name in self.__dict__:
-            return getattr(self, name)
-        else:
-            parent_attr = getattr(self.parent_service, name)
-            if callable(parent_attr):
-                parent_attr = types.MethodType(parent_attr.__func__, self, self.__class__)
-            self.__dict__[name] = parent_attr
-            return parent_attr
-    
+        """Every parameter not owned by the relative service is the one of its parent"""
+        parent_service = self.__dict__.get('parent_service')
+        if parent_service is None:
+            raise AttributeError(name)
+        return getattr(parent_service, name)
+
+
+class UnconfiguredService(StorageService):
+    """A relative storage service whose parent service is missing or unusable.
+
+    It behaves as an empty storage, so that listing it (the service parameters form
+    shows its tree) does not fail, and refuses any operation on its content: nothing
+    can be written where there is no path yet."""
+
+    @property
+    def base_path(self):
+        return None
+
+    def internal_path(self, *args, **kwargs):
+        return None
+
+    def exists(self, *args):
+        return False
+
+    def isdir(self, *args):
+        return False
+
+    def isfile(self, *args):
+        return False
+
+    def children(self, *args, **kwargs):
+        return []
+
+    def url(self, *args, **kwargs):
+        return ''
+
+    def open(self, *args, **kwargs):
+        raise GnrException(self._unconfigured_message)
+
+    def local_path(self, *args, **kwargs):
+        raise GnrException(self._unconfigured_message)
+
+    def mkdir(self, *args, **kwargs):
+        raise GnrException(self._unconfigured_message)
+
+    def makedirs(self, *args, **kwargs):
+        raise GnrException(self._unconfigured_message)
+
+    @property
+    def _unconfigured_message(self):
+        return 'Storage service %s has no usable parent service: set it in the service parameters' % self.service_name
 
 
 class ServiceParameters(BaseComponent):
     py_requires = 'gnrcomponents/storagetree:StorageTree'
-    def service_parameters(self,pane,datapath=None,**kwargs):
+
+    def service_parameters(self, pane, datapath=None, service_name=None, **kwargs):
         bc = pane.borderContainer()
         fb = bc.contentPane(region='top').formbuilder(datapath=datapath)
-        fb.dbSelect(value='^.parent_service_id',lbl='Parent service',hasDownArrow=True,
-                    selected_service_name='.parent_service',
-                    dbtable='sys.service',
-                    condition="""$service_type=:stype AND $implementation!='symbolic' AND
-                    $service_name!=:me""",
-                    condition_stype='storage', condition_me='^.service_name')
-        
-        fb.textbox(value='^.relative_path',lbl='Relative path')
-        bc.storageTreeFrame(frameCode='relativeStorage',storagepath='=#FORM.record.service_name?=#v+":"',
-                                border='1px solid silver',margin='2px',rounded=4,
-                                region='center',preview_region='right',
+        fb.filteringSelect(value='^.parent_service', lbl='!!Parent service', hasDownArrow=True,
+                           values=self.relativeStorageParents(service_name=service_name))
+        fb.textbox(value='^.relative_path', lbl='!!Relative path')
+        bc.storageTreeFrame(frameCode='relativeStorage', storagepath='^#FORM.record.service_name?=#v+":"',
+                                border='1px solid silver', margin='2px', rounded=4,
+                                region='center', preview_region='right',
                                 store__onBuilt=True,
-                                preview_border_left='1px solid silver',preview_width='50%')
+                                preview_border_left='1px solid silver', preview_width='50%')
 
+    def relativeStorageParents(self, service_name=None):
+        """Returns the storage services usable as parent of a relative service"""
+        storage_params = self.site.storage_handler.getAllStorageParameters()
+        names = set([name for name, params in storage_params.items()
+                     if name != service_name and not name.startswith('_')
+                     and params.get('implementation') not in UNSUPPORTED_PARENT_IMPLEMENTATIONS])
+        #the configured parent is always an option, even if it is not available any more
+        current_parent = (storage_params.get(service_name) or {}).get('parent_service')
+        if current_parent:
+            names.add(current_parent)
+        return ','.join(sorted(names))

--- a/resources/common/services/storage/relative.py
+++ b/resources/common/services/storage/relative.py
@@ -56,17 +56,53 @@ class Service(StorageService):
             self.__class__ = relativeServiceClass(self.parent_service)
 
     def _resolveParentService(self, parent_service):
-        """Returns the parent storage service, None if it is missing or unusable"""
+        """Returns the parent storage service, None if it is missing or unusable
+
+        :param parent_service: name of the parent storage service"""
         if not parent_service:
-            logger.warning('Relative storage service without parent service')
+            logger.warning('Relative storage service on %s has no parent service',
+                           self.relative_path or '/')
             return None
-        service = self.parent.storage(parent_service)
-        implementation = getattr(service, 'service_implementation', None)
-        if implementation in UNSUPPORTED_PARENT_IMPLEMENTATIONS:
+        parent_params = self.parent.storage_handler.getStorageParameters(parent_service)
+        if not parent_params:
+            #an unknown storage name is served as a new folder of the site static dir:
+            #a relative service must not silently re-root there when its parent is gone
+            logger.warning('Missing parent storage service %s', parent_service)
+            return None
+        if self._loopingParentChain(parent_service):
+            logger.warning('Parent storage service %s loops back on a relative service',
+                           parent_service)
+            return None
+        if parent_params.get('implementation') in UNSUPPORTED_PARENT_IMPLEMENTATIONS:
             logger.warning('Storage service %s cannot be the parent of a relative service',
                            parent_service)
             return None
+        service = self.parent.storage(parent_service)
+        if getattr(service, 'base_path', None) is None:
+            #a local service with no base path (and an unconfigured relative service)
+            #has no place a subpath could be relative to
+            logger.warning('Parent storage service %s has no base path', parent_service)
+            return None
         return service
+
+    def _loopingParentChain(self, parent_service):
+        """Returns True if the chain of relative parent services loops on itself.
+
+        The instance of a service is cached only once it is built, so a loop in the
+        configuration would be resolved recursively until the stack ends: the chain
+        is walked on the stored parameters instead.
+
+        :param parent_service: name of the parent storage service"""
+        getStorageParameters = self.parent.storage_handler.getStorageParameters
+        walked = set()
+        service_name = parent_service
+        while service_name and service_name not in walked:
+            params = getStorageParameters(service_name) or {}
+            if params.get('implementation') != 'relative':
+                return False
+            walked.add(service_name)
+            service_name = params.get('parent_service')
+        return bool(service_name)
 
     @property
     def base_path(self):
@@ -115,6 +151,15 @@ class UnconfiguredService(StorageService):
         return ''
 
     def open(self, *args, **kwargs):
+        raise GnrException(self._unconfigured_message)
+
+    def delete(self, *args):
+        raise GnrException(self._unconfigured_message)
+
+    def renameNode(self, sourceNode=None, destNode=None):
+        raise GnrException(self._unconfigured_message)
+
+    def duplicateNode(self, sourceNode=None, destNode=None):
         raise GnrException(self._unconfigured_message)
 
     def local_path(self, *args, **kwargs):


### PR DESCRIPTION
## Problem

Adding a `relative` storage service always failed with `AttributeError: 'Service' object has no attribute '_call'`: the implementation tried to strip the `StorageService` methods from a fresh instance with `delattr` (they are class attributes, so the first name already raised) and then to morph the instance into the parent service class, losing the `base_path` property that was its whole purpose. The implementation has never worked.

## Solution

A relative service is built as a subclass of the parent service class, `Service` first in the mro:

```
Relative_local -> Service -> local.Service -> BaseLocalService -> StorageService
```

`internal_path`, `open`, `children`, `url`, `serve`... are the ones of the parent implementation, whatever it is (local, aws_s3, sftp), while `Service` overrides only `base_path` (parent base path + relative path). The parameters are not copied: they are read from the live parent service, so credentials and buckets have a single source. A relative service can also be the parent of another one.

A service record is created before its parameters are filled in, so a relative service with no usable parent is an ordinary state, not an error: it behaves as an empty storage (no base path, no children, `exists()` false) instead of raising, otherwise the storage tree of the very form where the parent gets chosen fails on the service it configures. Writing on it is still refused with an explicit message: nothing can be written where there is no path.

Two fixes on the parameters form:

- the parent can now be any configured storage service (built-in and siteconfig ones included), instead of the sole services registered in `sys.service`; the configured parent stays an option even if it is not available any more;
- the pane is rebuilt on every record load and the form kept the validations of the widgets destroyed by the rebuild, so on a new record the status stayed invalid whatever was chosen. `th_service` now forgets them the same way the `bagField` and `grouplet` dynamic contents already do (`form.checkInvalidFields()` on `_onRemote`).

## Test cases

`gnrpy/tests/web/gnrstoragehandler_test.py`, on the real site infrastructure, with files written and read back on disk:

- `test_relative_storage_creation`: the service is created and is an instance of the parent implementation (fails on the old code with the `AttributeError` of the issue);
- `test_relative_storage_base_path` / `test_relative_storage_without_relative_path`: base path composition, an empty relative path is an alias of the parent;
- `test_relative_storage_write_and_read`: a file written through the relative service is the same file the parent sees under the relative path;
- `test_relative_storage_children`: listing is limited to the subtree;
- `test_relative_storage_inherits_parent_parameters`: parameters and `location_identifier` come from the parent (so copies stay native);
- `test_relative_storage_nested`: relative service over a relative service;
- `test_relative_storage_missing_parent_service` / `test_relative_storage_unsupported_parent_service` / `test_relative_storage_tree_without_parent_service`: an unconfigured service is an empty, non-writable storage and its tree loads empty;
- `test_relative_storage_from_service_record`: end to end from a real `sys.service` record, through the triggers, the `storage_params` registry, the service factory, a written file and the `StorageResolver` used by the tree;
- `test_relative_storage_parent_options`: the parents offered by the form.

Manual test on a running instance: create a storage service with implementation `relative`, choose a parent and a relative path, save; the tree of the chosen folder shows up and files written on the service land in the parent subfolder.

Fixes #834
