### PR TITLE
hotfix(migrate): keep column commands when the table also needs a pkey rebuild

### DIFF
--- a/gnrpy/gnr/sql/gnrsqlmigration/executor.py
+++ b/gnrpy/gnr/sql/gnrsqlmigration/executor.py
@@ -22,9 +22,10 @@ Assembly follows a specific order to respect dependencies::
     3. CREATE SCHEMA (new schemas)
     4. For each table:
        a. Pre-commands (column backups for type conversions)
-       b. CREATE TABLE (new tables) or ALTER TABLE (columns)
-       c. ADD CONSTRAINT (UNIQUE, CHECK constraints)
-       d. CREATE INDEX (indexes)
+       b. ALTER TABLE (added/changed columns)
+       c. CREATE TABLE (new tables) or primary key rebuild
+       d. ADD CONSTRAINT (UNIQUE, CHECK constraints)
+       e. CREATE INDEX (indexes)
     5. ALTER TABLE ADD FOREIGN KEY (FK relations - last)
 
 **Foreign keys are applied last** because they might reference
@@ -144,9 +145,13 @@ class ExecutorMixin(SqlMigratorBaseMixin):
 
         The assembly order is:
         1. Pre-commands (column backups for conversions)
-        2. CREATE TABLE (new table) or ALTER TABLE with columns
-        3. ADD CONSTRAINT (separate constraints)
-        4. CREATE INDEX (separate indexes)
+        2. ALTER TABLE with the added/changed columns
+        3. CREATE TABLE (new table) or primary key rebuild
+        4. ADD CONSTRAINT (separate constraints)
+        5. CREATE INDEX (separate indexes)
+
+        Columns are emitted before the table command because a primary key
+        rebuild may target a column added by the same migration.
 
         Foreign keys are returned separately in ``relation_commands``
         to be applied last.
@@ -185,12 +190,16 @@ class ExecutorMixin(SqlMigratorBaseMixin):
         ]
 
         table_command = tbl_item.get('command')
-        if table_command:
-            # New table: the command is the complete CREATE TABLE
-            command_list.append(table_command)
-        elif col_commands:
+        # Column changes go first: the table command may be a primary key
+        # rebuild (changed_table) targeting a column added in this same
+        # migration. New tables never reach this point with column commands:
+        # added_table inlines their columns into the CREATE TABLE.
+        if col_commands:
             # Existing table: ALTER TABLE with all columns
             command_list.append(f"{alter_table_command}\n{col_commands};")
+        if table_command:
+            # New table (CREATE TABLE) or primary key rebuild
+            command_list.append(table_command)
 
         # Separate constraints: each constraint needs its own ALTER TABLE
         for constraint_sql in constraint_commands:

--- a/gnrpy/tests/sql/test_gnrsqlmigration.py
+++ b/gnrpy/tests/sql/test_gnrsqlmigration.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from gnr.sql.gnrsqlmigration import SqlMigrator, DbExtractor
 from gnr.sql.gnrsqlmigration import new_relation_item, new_index_item, nested_defaultdict
 from gnr.sql.gnrsqlmigration.command_builder import CommandBuilderMixin
+from gnr.sql.gnrsqlmigration.executor import ExecutorMixin
 from gnr.sql.gnrsql import GnrSqlDb
 from gnr.sql.adapters import gnrpostgres, gnrpostgres3
 from gnr.sql import AdapterCapabilities as Capabilities
@@ -1655,3 +1656,101 @@ class GeneralSqlMigrationCode:
             "prepareStructures() was called again even though structures "
             "were already set (to {}). Bug: 'not ({} or {})' is True."
         )
+
+
+class TestSqlCommandsForTable:
+    """Unit tests for the SQL assembly done by ``ExecutorMixin.sqlCommandsForTable``."""
+
+    @staticmethod
+    def tbl_item(command=None, columns=None, constraints=None,
+                 relations=None, indexes=None):
+        """Build a table command item as the command builders produce it."""
+        item = {
+            'columns': columns or {},
+            'constraints': constraints or {},
+            'relations': relations or {},
+            'indexes': indexes or {},
+        }
+        if command:
+            item['command'] = command
+        return item
+
+    def test_added_column_kept_with_pkey_rebuild(self):
+        """A table needing both a primary key rebuild and a new column must
+        emit the ADD COLUMN.
+
+        ``changed_table`` writes the primary key rebuild into the same
+        ``command`` key used by ``added_table`` for the CREATE TABLE. Treating
+        the two as alternatives drops the column commands while the index and
+        the foreign key on the same column are still emitted, producing SQL
+        that references a column the migration never created.
+        """
+        executor = ExecutorMixin.__new__(ExecutorMixin)
+        tbl_item = self.tbl_item(
+            command=('ALTER TABLE "adm"."adm_user" DROP CONSTRAINT IF EXISTS adm_user_pkey;\n'
+                     'ALTER TABLE "adm"."adm_user" ADD PRIMARY KEY (id);'),
+            columns={'xgroup': {'command': 'ADD COLUMN "xgroup" character varying(10)'}},
+            indexes={'idx_xgroup': {
+                'command': 'CREATE INDEX idx_xgroup ON "adm"."adm_user" USING btree ("xgroup");'}},
+            relations={'fk_xgroup': {
+                'command': 'ADD CONSTRAINT "fk_xgroup" FOREIGN KEY ("xgroup") '
+                           'REFERENCES "adm"."adm_xgroup" ("code")'}},
+        )
+
+        result = executor.sqlCommandsForTable(schema_name='adm',
+                                              table_name='adm_user',
+                                              tbl_item=tbl_item)
+        commands = result['commands']
+        joined = '\n'.join(commands)
+
+        assert 'ADD COLUMN "xgroup"' in joined, (
+            'ADD COLUMN was dropped because the table also needs a primary key '
+            f'rebuild. Generated commands: {commands}')
+
+        add_column_idx = next(i for i, c in enumerate(commands)
+                              if 'ADD COLUMN "xgroup"' in c)
+        pkey_idx = next(i for i, c in enumerate(commands)
+                        if 'ADD PRIMARY KEY' in c)
+        index_idx = next(i for i, c in enumerate(commands)
+                         if 'CREATE INDEX' in c)
+        assert add_column_idx < pkey_idx, (
+            'The column must exist before the primary key rebuild, which may '
+            'target it.')
+        assert add_column_idx < index_idx, (
+            'The column must exist before the index built on it.')
+
+    def test_new_table_emits_only_create_table(self):
+        """A new table carries its columns inline in the CREATE TABLE, so no
+        separate ALTER TABLE must be produced for it."""
+        executor = ExecutorMixin.__new__(ExecutorMixin)
+        tbl_item = self.tbl_item(
+            command='CREATE TABLE "adm"."adm_xgroup"(\n "code" character varying(10),\n'
+                    ' PRIMARY KEY (code)\n);',
+        )
+
+        result = executor.sqlCommandsForTable(schema_name='adm',
+                                              table_name='adm_xgroup',
+                                              tbl_item=tbl_item)
+
+        assert result['commands'] == [tbl_item['command']]
+
+    def test_changed_column_without_pkey_rebuild(self):
+        """Without a table command, column changes are still emitted as a
+        single ALTER TABLE."""
+        executor = ExecutorMixin.__new__(ExecutorMixin)
+        tbl_item = self.tbl_item(
+            columns={
+                'code': {'command': 'ADD COLUMN "code" character varying(12)'},
+                'descr': {'command': 'ADD COLUMN "descr" text'},
+            },
+        )
+
+        result = executor.sqlCommandsForTable(schema_name='alfa',
+                                              table_name='alfa_recipe',
+                                              tbl_item=tbl_item)
+
+        assert result['commands'] == [
+            'ALTER TABLE "alfa"."alfa_recipe"\n'
+            'ADD COLUMN "code" character varying(12),\n'
+            'ADD COLUMN "descr" text;'
+        ]


### PR DESCRIPTION
Backport of #1194 (merged into `develop`) onto `master`.

Fixes #1193

## Problem

`ExecutorMixin.sqlCommandsForTable` treated the table `command` and the column commands as mutually exclusive:

```python
table_command = tbl_item.get('command')
if table_command:
    # New table: the command is the complete CREATE TABLE
    command_list.append(table_command)
elif col_commands:
    command_list.append(f"{alter_table_command}\n{col_commands};")
```

The comment assumes `tbl_item['command']` is only set by `added_table` for a `CREATE TABLE`. It is also set by `changed_table` when a primary key must be dropped and recreated, so any existing table needing **both** a PK rebuild and a column change lost every one of its `ADD COLUMN` / `ALTER COLUMN` statements.

`added_index` and `added_relation` write to separate keys, so they were still emitted — producing SQL that references a column the migration never created:

```
ERROR: gnr.db/gnrmigrate - store main: column "xgroup" does not exist
```

The silent variant is worse: when a lost column had neither an index nor a foreign key, the migration reported success and the column was simply never created.

## Fix

Emit the column commands **before** the table command instead of as an alternative to it. The order matters: a PK rebuild may target a column added by the same migration.

New tables are unaffected — `added_table` inlines their columns into the `CREATE TABLE` and never populates `tbl_item['columns']`, so `col_commands` is empty for them and the two branches cannot overlap.

The docstrings describing the assembly order were updated accordingly.

## Test Cases

New `TestSqlCommandsForTable` class in `gnrpy/tests/sql/test_gnrsqlmigration.py`, three unit tests, no database required:

- `test_added_column_kept_with_pkey_rebuild` — a table with a PK rebuild + a new column + an index and an FK on that column: asserts the `ADD COLUMN` is emitted, and that it precedes both the PK rebuild and the index. **Fails on `master` without this change**, passes with it.
- `test_new_table_emits_only_create_table` — a new table emits its `CREATE TABLE` and nothing else (guards against a duplicate `ALTER TABLE`).
- `test_changed_column_without_pkey_rebuild` — with no table command, column changes are still merged into a single `ALTER TABLE`.

`pytest tests/sql` on this branch → 1166 passed, 32 skipped. flake8 clean on both modified files.

## Verification on a real instance

Reproduced on a database restored without its post-data section (103 tables, 0 primary keys, 0 indexes), which makes every table produce a `changed_table/pkeys` event. Before the fix, six `ADD COLUMN` and 27 `ALTER COLUMN ... SET NOT NULL` were discarded; after it the generated SQL is correctly ordered:

```sql
ALTER TABLE "adm"."adm_user"
ALTER COLUMN "id" SET NOT NULL,
ADD COLUMN "xgroup" character varying(10);
ALTER TABLE "adm"."adm_user" DROP CONSTRAINT IF EXISTS adm_user_pkey;
ALTER TABLE "adm"."adm_user" ADD PRIMARY KEY (id);
...
CREATE INDEX idx_5fd0c3cf ON "adm"."adm_user" USING btree ("xgroup");
```

and `gnr db migrate` completes, followed by `STRUCTURE OK` on a re-check.
