### PR TITLE
fix(sql): rollback rolls back every connection of a multi-store selection

### DIFF
--- a/gnrpy/gnr/sql/gnrsql/transactions.py
+++ b/gnrpy/gnr/sql/gnrsql/transactions.py
@@ -250,8 +250,18 @@ class TransactionMixin(GnrSqlDbBaseMixin):
             cursor.setConstraintsDeferred()
 
     def rollback(self) -> None:
-        """Roll back the current connection's transaction."""
-        self.connection.rollback()
+        """Roll back the current connection's transaction.
+
+        With a multi-store storename (``'*'`` or comma-separated) the
+        ``connection`` property returns a list of connections: each one
+        is rolled back.
+        """
+        connection = self.connection
+        if isinstance(connection, list):
+            for c in connection:
+                c.rollback()
+        else:
+            connection.rollback()
 
     def rollbackAll(self) -> None:
         """Roll back every uncommitted connection of the current thread.


### PR DESCRIPTION
Fixes #1201

`GnrSqlDb.rollback()` assumed a single connection, but with a multi-store storename (`'*'` or comma-separated) the `connection` property returns a list, so the call raised `AttributeError: 'list' object has no attribute 'rollback'` — replacing, inside `execute()`'s except clause, the original SQL error of the failed multi-cursor execution.

Now each connection in the list is rolled back, so the real exception propagates. Found in production while diagnosing #1200.

Full gnrpy test suite green locally (2202 passed, 10 skipped).