### PR TITLE
fix(adm): with a multi-store selection the main store preferences apply

### DIFF
--- a/gnrpy/gnr/sql/gnrsql/env.py
+++ b/gnrpy/gnr/sql/gnrsql/env.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from gnr.core.gnrlocale import defaultLocale
 from gnr.sql._typing import GnrSqlDbBaseMixin
-from gnr.sql.gnrsql.helpers import TempEnv
+from gnr.sql.gnrsql.helpers import MAIN_CONNECTION_NAME, TempEnv
 
 
 class EnvMixin(GnrSqlDbBaseMixin):
@@ -192,9 +192,13 @@ class EnvMixin(GnrSqlDbBaseMixin):
 
     def usingMainConnection(self) -> bool:
         """Return ``True`` if the current connection is the main connection."""
-        from gnr.sql.gnrsql.helpers import MAIN_CONNECTION_NAME
-
         return self.currentConnectionName == MAIN_CONNECTION_NAME
+
+    def usingMultiStore(self) -> bool:
+        """Return ``True`` if the current storename addresses more than one
+        store (``'*'`` or a comma-separated selection)."""
+        storename = self.currentStorename
+        return storename == '*' or ',' in storename
 
     @property
     def currentStorename(self) -> str:
@@ -204,8 +208,6 @@ class EnvMixin(GnrSqlDbBaseMixin):
     @property
     def currentConnectionName(self) -> str:
         """The name of the currently active connection."""
-        from gnr.sql.gnrsql.helpers import MAIN_CONNECTION_NAME
-
         return self.currentEnv.get('connectionName') or MAIN_CONNECTION_NAME
 
     def setLocale(self) -> None:

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
@@ -59,16 +59,19 @@ class ResourceLoader(object):
     def page_class_cache_enabled(self):
         """The experimental flag, read through a small TTL (kill switch stays live).
 
-        ``getPreference`` resolves per dbstore: on a multidb instance the value
-        that holds for the next TTL is the one read by whichever store refreshed
-        it. That is fine for a kill switch - it is not a per-store setting.
+        The read is pinned to the root store: it runs at dispatch time, before
+        the page applies its own env, so the thread env still carries whatever
+        the previous request left there (possibly a multi-store selection).
+        A ``sys`` preference lives in the main store anyway.
         Turning the flag off also drops what is already cached, so the switch
         frees the classes instead of merely stopping new ones.
         """
         value, read_ts = self._page_class_cache_flag
         now = time.time()
         if now - read_ts > PAGE_CLASS_CACHE_FLAG_TTL:
-            new_value = bool(self.site.getPreference('experimental.page_class_cache', pkg='sys'))
+            db = self.site.db
+            with db.tempEnv(storename=db.rootstore):
+                new_value = bool(self.site.getPreference('experimental.page_class_cache', pkg='sys'))
             if value and not new_value:
                 self.clear_page_class_cache()
             value = new_value

--- a/gnrpy/tests/web/gnrpageclasscache_test.py
+++ b/gnrpy/tests/web/gnrpageclasscache_test.py
@@ -29,6 +29,23 @@ class _FakeStatic:
         return '/'.join(str(a) for a in args)
 
 
+class _FakeTempEnv:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeDb:
+    """The slice of GnrSqlDb that page_class_cache_enabled touches."""
+
+    rootstore = '_main_db'
+
+    def tempEnv(self, **kwargs):
+        return _FakeTempEnv()
+
+
 class _FakeSite:
     """The slice of GnrWsgiSite that ResourceLoader.__init__ touches."""
 
@@ -40,6 +57,7 @@ class _FakeSite:
         self.default_page = None
         self.preference = preference
         self.preference_reads = 0
+        self.db = _FakeDb()
 
     def getStatic(self, name):
         return _FakeStatic()

--- a/projects/gnrcore/packages/adm/model/preference.py
+++ b/projects/gnrcore/packages/adm/model/preference.py
@@ -28,6 +28,8 @@ class Table(object):
         return result.deepcopy()
     
     def getStorePreferences(self):
+        if self.db.usingMultiStore():
+            return self.getMainStorePreference()
         storename = self.db.currentEnv.get('storename')
         pref_cache_key = '_storepref_%s' %storename
         preference = None


### PR DESCRIPTION
Fixes #1203

With a multi-store selection (`storename` = `'*'` or comma-separated), `adm.preference.getStorePreferences()` handed the multi-store storename to `multidb.getStorePreference()`, whose single-record lookup on the storetable cannot succeed for a comma-joined string and — on storetables with `use_dbstores` truthy — was dispatched as a failing multi-cursor SELECT. Since the framework reads `sys.experimental.page_class_cache` on every dispatch, every page load with a multi-store selection died (the failure itself was masked by the rollback bug fixed in #1202).

**Design choice** (see #1203): store-local preferences are meaningful only with exactly one active store — merging several stores' preferences would be arbitrary (values mix, or the last store silently wins). So with a multi-store selection the main store preferences apply, with no per-store overlay; code needing a store-local preference must read it within a single-store `tempEnv`.

The short-circuit lives upstream in `getStorePreferences()`, via a new `db.usingMultiStore()` helper alongside `usingRootstore()`, so `multidb.getStorePreference()` keeps its single-store contract and is never called with a multi-store storename. The two runtime imports of `MAIN_CONNECTION_NAME` in `env.py` move to module level (style hook).

Full gnrpy test suite green locally (pre-push hook).