### PR TITLE
fix(gnrjs): keep subtree subscriptions on same-bag rebuilds

### DIFF
--- a/gnrjs/gnr_d11/js/genro_src.js
+++ b/gnrjs/gnr_d11/js/genro_src.js
@@ -223,7 +223,11 @@ dojo.declare("gnr.GnrSrcHandler", null, {
             console.log('missing destination in rebuild');
         }
         this._onDeletingContent(kw.oldvalue);
-        this.cleanupContentSubscriptions(kw.oldvalue);
+        if (kw.oldvalue !== kw.node._value) {
+            //on a same-bag rebuild the content is kept, not discarded: its
+            //data* nodes are already stripped and would never resubscribe
+            this.cleanupContentSubscriptions(kw.oldvalue);
+        }
         var domNode = kw.node.getDomNode();//get the domnode
         var newNode = document.createElement('div');
         var widget = kw.node.widget;

--- a/projects/gnrcore/packages/test/webpages/datastore/trigger_rebuild.py
+++ b/projects/gnrcore/packages/test/webpages/datastore/trigger_rebuild.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+"""Data node subscriptions across subtree rebuilds (#1206)"""
+
+from gnr.core.gnrdecorator import public_method
+
+
+class GnrCustomWebPage(object):
+    py_requires = "gnrcomponents/testhandler:TestHandlerFull"
+
+    def test_0_datacontroller_survives_rebuild(self, pane):
+        """Type in Input: Fired increments by 1 every time, Formula doubles it.
+        Click Rebuild box (even many times), then type again: both must still react."""
+        fb = pane.formbuilder(cols=4, border_spacing='3px')
+        fb.textbox(value='^.input', lbl='Input')
+        fb.button('Rebuild box').dataController("genro.nodeById('rb_box_0').rebuild();")
+        fb.numberTextBox(value='^.counter', lbl='Fired', readOnly=True)
+        fb.numberTextBox(value='^.doubled', lbl='Formula', readOnly=True)
+        box = pane.contentPane(nodeId='rb_box_0', border='1px solid silver',
+                               padding='5px', margin='5px')
+        box.div('The dataController and dataFormula of this box must survive its rebuild')
+        box.dataController("SET .counter = (GET .counter || 0) + 1;", _fired='^.input')
+        box.dataFormula('.doubled', 'inp*2', inp='^.counter')
+
+    def test_1_datacontroller_under_if(self, pane):
+        """Type in Input: Fired increments. Uncheck and recheck Visible (the box
+        rebuilds, like documentFrame does on every reload), then type again:
+        Fired must keep incrementing."""
+        pane.data('.flag', True)
+        fb = pane.formbuilder(cols=3, border_spacing='3px')
+        fb.textbox(value='^.input', lbl='Input')
+        fb.checkbox(value='^.flag', label='Visible')
+        fb.numberTextBox(value='^.counter', lbl='Fired', readOnly=True)
+        box = pane.contentPane(_if='^.flag', border='1px solid silver',
+                               padding='5px', margin='5px')
+        box.div('Box governed by _if')
+        box.dataController("SET .counter = (GET .counter || 0) + 1;", _fired='^.input')
+
+    def test_2_remote_content_replaced(self, pane):
+        """Change Reload token: the remote content is replaced with a fresh one.
+        Then type in Probe: Fired must increment by EXACTLY 1 per keystroke
+        (a higher step means stale subscriptions of the discarded content)."""
+        fb = pane.formbuilder(cols=3, border_spacing='3px')
+        fb.textbox(value='^.token', lbl='Reload token')
+        fb.textbox(value='^.probe', lbl='Probe')
+        fb.numberTextBox(value='^.counter', lbl='Fired', readOnly=True)
+        pane.contentPane(border='1px solid silver', padding='5px',
+                         margin='5px').remote(self.remoteInner, token='^.token')
+
+    @public_method
+    def remoteInner(self, pane, token=None, **kwargs):
+        pane.div('Remote content for token: %s' % (token or ''))
+        pane.dataController("SET .counter = (GET .counter || 0) + 1;", _fired='^.probe')
+
+    def test_3_sibling_isolation(self, pane):
+        """Rebuild box A many times, then type in both inputs: each counter
+        increments by exactly 1 on its own input. Box B must never be affected
+        by the rebuilds of box A."""
+        fb = pane.formbuilder(cols=5, border_spacing='3px')
+        fb.textbox(value='^.input_a', lbl='Input A')
+        fb.textbox(value='^.input_b', lbl='Input B')
+        fb.button('Rebuild A').dataController("genro.nodeById('rb_box_a').rebuild();")
+        fb.numberTextBox(value='^.counter_a', lbl='Fired A', readOnly=True)
+        fb.numberTextBox(value='^.counter_b', lbl='Fired B', readOnly=True)
+        box_a = pane.contentPane(nodeId='rb_box_a', border='1px solid silver',
+                                 padding='5px', margin='5px')
+        box_a.div('Box A')
+        box_a.dataController("SET .counter_a = (GET .counter_a || 0) + 1;", _fired='^.input_a')
+        box_b = pane.contentPane(border='1px solid silver', padding='5px', margin='5px')
+        box_b.div('Box B')
+        box_b.dataController("SET .counter_b = (GET .counter_b || 0) + 1;", _fired='^.input_b')


### PR DESCRIPTION
## Problem

Since #1152, a `documentFrame` whose `pkey` follows a selection renders only the first document: later changes never reach the server (#1206). Field report from icond production; reproduced locally on `test/components/document_frame`.

## Root cause

`rebuild()` re-sets the **same** content bag (`setValue(this._value)`, `gnrdomsource.js`). The incremental cleanup introduced by #1152 runs in `_trigger_upd` on `kw.oldvalue` — which on a rebuild IS the kept content — and unsubscribes every node of the subtree from the trigger index. Widget nodes re-register when they are rebuilt, but data nodes (`dataController`, `dataRpc`, `dataFormula`) register only once in `moveData`, behind the `_alreadyStripped` guard: they never resubscribe and go silent.

`documentFrame` is the visible casualty because its iframe `setSrc` calls `rebuild()` on every reload, killing the sibling dataController that drives the reload itself. The blast radius is wider: any data node inside a subtree that rebuilds after first build (`_if` toggles, `unfreeze`, dynamic `storepath`, the generic dynamic-attribute rebuild fallback).

The `_eventpath` memo hypothesis raised in #1206 was verified NOT to be the cause: both `getTriggerReason` callers run on the root-final pathlist. It remains a latent hardening, out of scope here.

## Fix

Skip the content-subscription cleanup when the node value is the same bag: the content is kept, not discarded — the case where the pre-#1152 `refreshSourceIndexAndSubscribers` preserved subscriptions of nodes still in the tree. Replaced content (a different bag) is still cleaned up as introduced by #1152.

## Verification

New test page `test/datastore/trigger_rebuild.py` covers the doubtful cases with exact-step counters:

- dataController + dataFormula surviving explicit rebuilds of their box
- dataController under an `_if`-governed container across visibility toggles
- remote content replacement: exactly one fire per trigger after multiple reloads (guards against stale duplicate subscriptions)
- sibling isolation: rebuilding one box never affects the other

All four verified in the browser (counters step by exactly 1). Also verified live on the sandbox instance:

- `test/components/document_frame`: each record change produces one `callTableScript`, with two documentFrames active on the same page
- `test15/gnrwdg/formhandler_baggrid`: grid selection reloads the linked form on every selection
- `test/perf/test_heavy_build` (the #1152 profiling page): builds and switches tabs with no console errors

flake8 clean on touched files; full gnrpy suite green (2202 passed, 10 skipped).

Fixes #1206
