### PR TITLE
fix(sql): type X columns in the selection output

### DIFF
--- a/gnrpy/gnr/sql/gnrsqldata/selection.py
+++ b/gnrpy/gnr/sql/gnrsqldata/selection.py
@@ -1227,6 +1227,24 @@ class SqlSelection(object):
             result.addItem(label,content , _pkey=pkey)
         return result
 
+    def typedAttributes(self, attributes):
+        """Add the ``::X`` suffix every ``X`` column needs to reach the client.
+
+        Node attributes travel to the client as plain strings: without the
+        suffix an ``X`` column arrives as its serialized text instead of
+        being rebuilt as a Bag.
+
+        Args:
+            attributes: The row ``dict`` to type, modified in place.
+
+        Returns:
+            dict: The same *attributes*.
+        """
+        for k, v in list(attributes.items()):
+            if v and self.colAttrs.get(k, {}).get('dataType') == 'X':
+                attributes[k] = '%s::X' % v
+        return attributes
+
     def out_selection(self, outsource, recordResolver=False, caption=False):
         """Return a Bag where each item represents a row, keyed by pkey.
 
@@ -1270,7 +1288,8 @@ class SqlSelection(object):
                     rowcaption = None
                 row['caption'] = self.dbtable.recordCaption(row, rowcaption=rowcaption)
             result.addItem('%s' % spkey, content,
-                           _pkey=pkey, _attributes=row, _removeNullAttributes=False)
+                           _pkey=pkey, _attributes=self.typedAttributes(row),
+                           _removeNullAttributes=False)
         return result
 
     def out_grid(self, outsource, recordResolver=True, **kwargs):

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -866,7 +866,7 @@ class GnrWebPage(GnrBaseWebPage):
         missingMessage = missingMessage or '<div class="chunkeditor_emptytemplate">Missing Template</div>'
         dataInfo = dict()
         if ':' in template_address:
-            segments,pkey = template_address.split(':')
+            segments,pkey = template_address.split(':', 1)
             if segments:
                 segments = segments.split('.')
         else:
@@ -905,7 +905,7 @@ class GnrWebPage(GnrBaseWebPage):
         #pkg.table:resource_module
         #pkg.table:resource_module,custom
         if ':' in template_address:
-            segments,pkey = template_address.split(':')
+            segments,pkey = template_address.split(':', 1)
             if segments:
                 segments = segments.split('.')
         else:

--- a/gnrpy/gnr/web/gnrwebpage_proxy/apphandler/misc.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/apphandler/misc.py
@@ -513,11 +513,7 @@ class MiscMixin:
                           _relation_value=pkey,
                           _resolver_name='relOneResolver')
             value = None
-            attributes = kw.get('_attributes')
-            colAttrs = selection.colAttrs
-            for k, v in list(attributes.items()):
-                if v and colAttrs.get(k, {}).get('dataType') == 'X':
-                    attributes[k] = "%s::X" % v
+            attributes = selection.typedAttributes(kw.get('_attributes'))
             if attributes and '__value__' in attributes:
                 value = attributes.pop('__value__')
             result.appendNode(row_key, value, **kw)

--- a/gnrpy/tests/sql/test_selection_x_typing.py
+++ b/gnrpy/tests/sql/test_selection_x_typing.py
@@ -1,0 +1,65 @@
+"""Typing of X columns in the selection output (issue #1197).
+
+``out_selection`` feeds app.dbSelect: node attributes travel to the client as
+plain strings, so an X column has to carry the ``::X`` suffix or the client
+rebuilds it as text instead of a Bag.
+"""
+
+import pytest
+
+from gnr.core.gnrbag import Bag
+
+from core.common import BaseGnrTest
+
+# A value whose serialization holds more than one ':', the shape that broke
+# loadTemplate in the original report.
+DETAILS = Bag(dict(link='http://example.com/a:b'))
+
+
+def setup_module(module):
+    BaseGnrTest.setup_class()
+
+
+def teardown_module(module):
+    BaseGnrTest.teardown_class()
+
+
+@pytest.fixture(scope='module')
+def product_pkey(db_sqlite):
+    tbl = db_sqlite.table('invc.product')
+    rec = dict(
+        id=tbl.newPkeyValue(),
+        code='X1197',
+        description='Product with an X column',
+        details=DETAILS,
+    )
+    tbl.insert(rec)
+    db_sqlite.commit()
+    return rec['id']
+
+
+def _selection(db, pkey):
+    return db.table('invc.product').query(
+        columns='$id,$description,$details',
+        where='$id = :pk', pk=pkey,
+    ).selection()
+
+
+def test_out_selection_types_x_column(db_sqlite, product_pkey):
+    result = _selection(db_sqlite, product_pkey).output('selection')
+    attr = result.nodes[0].attr
+    assert attr['details'].endswith('::X')
+    assert Bag(attr['details'][:-3])['link'] == 'http://example.com/a:b'
+
+
+def test_out_selection_leaves_other_columns_untyped(db_sqlite, product_pkey):
+    result = _selection(db_sqlite, product_pkey).output('selection')
+    attr = result.nodes[0].attr
+    assert attr['description'] == 'Product with an X column'
+
+
+def test_typed_attributes_skips_empty_values(db_sqlite, product_pkey):
+    selection = _selection(db_sqlite, product_pkey)
+    attributes = selection.typedAttributes(dict(details=None, description='x'))
+    assert attributes['details'] is None
+    assert attributes['description'] == 'x'


### PR DESCRIPTION
## Problem

A column with `dtype='X'` returned to the client through **app.dbSelect** arrives as a raw XML string instead of a Bag. Every `defaultFrom` on an X column is therefore broken client-side, in any project: `_selected_defaultFrom` wires the column into the dbSelect automatically, so no application code is involved. When the target column feeds a `templateChunk`, the string fails the `instanceof gnr.GnrBag` check, is taken for a template name and concatenated into a template address, and `loadTemplate` dies with `ValueError: too many values to unpack (expected 2)`.

## Root cause

`out_selection` (`gnrpy/gnr/sql/gnrsqldata/selection.py`) — the only output mode `app.dbSelect` uses — stored the row values as node attributes with no type suffix. Node attributes reach the client as plain strings, and without the `::` suffix `gnrbag.js` does not convert them, so the client keeps the serialized XML text.

The grid path did it right but on its own: `gridSelectionData` rewrote every `X` column as `"%s::X" % v` inline.

A real Bag as a node attribute is not an option: RPC serialization runs with `omitUnknownTypes=True` (`gnrpy/gnr/web/gnrwebpage_proxy/rpc.py:83`) and would drop the attribute silently.

## Change

Variant (a), the shared helper:

- `SqlSelection.typedAttributes(attributes)` reads `colAttrs[...]['dataType']` and applies the suffix.
- `out_selection` calls it, and `gridSelectionData` reuses it instead of its own inline loop, so the two paths can no longer drift apart.
- `loadTemplate` and `saveTemplate` (`gnrpy/gnr/web/gnrwebpage.py`) split the template address with `split(':', 1)`. That fixes nothing by itself, but an unexpected address now takes the normal "missing template" path instead of raising.

Rejected alternative: typing inside `dbSelect` right after `output('selection')` — it stays in the web layer, but leaves the duplication in place and rewrites nodes that were just built.

## Verification

New `gnrpy/tests/sql/test_selection_x_typing.py`, on the real `db_sqlite` fixture and the `invc.product.details` X column of `test_invoice`: a product is inserted with a Bag whose serialization holds more than one `:`, and `output('selection')` is checked to carry `details` with the `::X` suffix and to round-trip back into a Bag; a plain text column is checked to be left alone.

- Narrow test: `pytest gnrpy/tests/sql/test_selection_x_typing.py -q` -> 3 passed. Reverted the `out_selection` call locally to confirm it fails without the fix (the attribute came back as the raw `<?xml ...?><GenRoBag>...` text).
- `pytest gnrpy/tests/sql/f_selection_test.py -q -k sqlite` -> 4 passed.
- `pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql` -> 1017 passed, 59 skipped, 1 failed: `gnrpy/tests/web/gnrasync_test.py::test_wsproxy_push` (TimeoutError), which passes on its own — timing under parallel load, unrelated to this change.
- flake8 clean on all four touched files.

Fixes #1197
