### PR TITLE
fix(services): filter service parameters against the factory signature

### DIFF
--- a/gnrpy/gnr/lib/services/__init__.py
+++ b/gnrpy/gnr/lib/services/__init__.py
@@ -24,6 +24,7 @@
 #Copyright (c) 2007 Softwell. All rights reserved.
 
 
+import inspect
 import os
 import threading
 from datetime import datetime
@@ -100,7 +101,8 @@ class BaseServiceType(object):
         if service_factory is None:
             raise GnrException('no implementation %r for service type %r (service %r)'
                                % (implementation, self.service_type, service_name))
-        service_conf = service_conf or {}
+        service_conf = self.filterServiceConf(service_factory, service_conf or {},
+                                              service_name=service_name, implementation=implementation)
         service = service_factory(self.site, **service_conf)
         service.service_name = service_name
         service.service_type = self.service_type
@@ -109,6 +111,21 @@ class BaseServiceType(object):
         service._config_from_db = db_conf is not None
         self.service_instances[service_name] = service
         return service
+
+    def filterServiceConf(self, service_factory, service_conf, service_name=None, implementation=None):
+        # The parameters bag is shared by every implementation of every service type,
+        # so it can carry keys a given factory never declared (see issue #1181).
+        try:
+            parameters = inspect.signature(service_factory).parameters
+        except (TypeError, ValueError):
+            return service_conf
+        if any(p.kind is p.VAR_KEYWORD for p in parameters.values()):
+            return service_conf
+        unknown = sorted(k for k in service_conf if k not in parameters)
+        if unknown:
+            logger.warning("Service %s/%s: implementation %s does not accept parameters %s: ignored",
+                           self.service_type, service_name, implementation, ', '.join(unknown))
+        return {k: v for k, v in service_conf.items() if k in parameters}
 
     def getConfiguration(self, service_name):
         return self.getServiceConfigurationFromDb(service_name) or \

--- a/gnrpy/tests/core/services_addservice_test.py
+++ b/gnrpy/tests/core/services_addservice_test.py
@@ -1,4 +1,5 @@
-"""Regression tests for BaseServiceType.addService factory resolution.
+"""Regression tests for BaseServiceType.addService factory resolution and
+parameter filtering.
 
 A missing service implementation used to crash with a bare
 ``TypeError: 'NoneType' object is not callable`` at the factory call site
@@ -7,11 +8,18 @@ error a cold-start race on ``site.resources_dirs`` produced in production
 (see issue #984). ``addService`` must instead raise a clear ``GnrException``
 naming the implementation and the service type.
 
+A stray key in the stored ``parameters`` bag used to crash the same call site
+with ``TypeError: got an unexpected keyword argument`` for every implementation
+not declaring ``**kwargs``, making the service permanently unusable
+(see issue #1181). ``addService`` must drop what the factory cannot accept and
+log it, while factories declaring ``**kwargs`` keep receiving everything.
+
 The harness exercises the real ``BaseServiceType`` and the real
 ``ResourceLoader.getResourceList`` over the repository's own ``resources/common``
 tree — no site instance, no register daemon needed.
 """
 
+import logging
 import os
 from types import SimpleNamespace
 
@@ -54,3 +62,24 @@ def test_add_service_missing_implementation_raises_clear_error():
     handler = BaseServiceType(site=make_site(), service_type='faketype')
     with pytest.raises(GnrException, match='faketype'):
         handler.addService('x', implementation='any')
+
+
+def test_add_service_ignores_parameters_the_factory_does_not_accept(caplog):
+    """authentication/dummy declares no **kwargs: a foreign key must not break it."""
+    handler = BaseServiceType(site=make_site(), service_type='authentication')
+    with caplog.at_level(logging.WARNING, logger='gnr.lib'):
+        service = handler.addService('auth', implementation='dummy',
+                                     url='www.dummy.com', bogus_param=None)
+    assert service is not None
+    assert service.url == 'www.dummy.com'
+    assert not hasattr(service, 'bogus_param')
+    assert 'bogus_param' in caplog.text
+
+
+def test_add_service_keeps_every_parameter_for_var_keyword_factory(caplog):
+    """storage/symbolic declares **kwargs: nothing may be filtered out."""
+    handler = BaseServiceType(site=make_site(), service_type='storage')
+    with caplog.at_level(logging.WARNING, logger='gnr.lib'):
+        service = handler.addService('sym', implementation='symbolic', extra_param=7)
+    assert service is not None
+    assert 'extra_param' not in caplog.text


### PR DESCRIPTION
## Problem

The `parameters` bag of a `sys.service` record is shared by every implementation of every service type, so it can accumulate keys belonging to a different implementation (or keys that an implementation later renamed or dropped). Every such key was exploded into the implementation constructor as a keyword argument, and most implementations do not declare `**kwargs`: a single stray key made the service permanently unusable, with `TypeError: Service.__init__() got an unexpected keyword argument 'in_cluster'` raised before the instance was even built. There was no way out from the UI, because the service configuration form itself needs `getService` on some pages.

## Root cause

`gnrpy/gnr/lib/services/__init__.py`, `BaseServiceType.addService`:

```python
service_conf = service_conf or {}
service = service_factory(self.site, **service_conf)
```

The stored configuration was passed through unfiltered, with no check against what the resolved factory actually accepts.

## Change

Server-side filter only. `addService` now passes the configuration through `filterServiceConf`, which inspects `inspect.signature(service_factory)`:

- a factory declaring `**kwargs` receives everything, untouched;
- otherwise, only the parameters it declares are passed, and the discarded keys are named in a `logger.warning` following the idiom already used in `_buildImplementations`.

Deliberately **not** in scope:

- pruning the bag in the `buildServiceParameters` meta form (`projects/gnrcore/packages/sys/resources/tables/service/th_service.py:46`). The server-side filter is the real fix: it also repairs every record already dirty in the database, and it covers the case of a parameter renamed or removed from an implementation, which no form-side prune would. The UI prune remains a separate, optional improvement.
- the related form defect at `th_service.py:49` — `mixinComponent(..., safeMode=True)` sets `service_parameters` on the page instance, so `hasattr(self, 'service_parameters')` stays true when a second record whose implementation has no `ServiceParameters` component is opened in the same page. It gets its own issue.

## Verification

- `gnrpy/tests/core/services_addservice_test.py` extended with two tests over real repository implementations, no mocking of the stack:
  - `authentication/dummy` (`Main.__init__(self, parent=None, url=None, template=None, case=None)`, no `**kwargs`) built with a stray `bogus_param`: the service is created, the parameter is dropped and named in the log. This test fails with `TypeError: Main.__init__() got an unexpected keyword argument 'bogus_param'` when the filter is neutralized.
  - `storage/symbolic` (declares `**kwargs`) built with an extra parameter: nothing is filtered, nothing is logged.
- `pytest gnrpy/tests/core/services_addservice_test.py -q` → 4 passed.
- `pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql` → 1020 passed, 59 skipped.
- Full suite including `gnrpy/tests/sql` → 2177 passed, 69 skipped.
- `flake8` on both touched files → zero errors.

Fixes #1181
