### PR TITLE
fix(gnrjs): cache a translation only when its status is OK

### DIFF
--- a/gnrjs/gnr_d11/js/genro.js
+++ b/gnrjs/gnr_d11/js/genro.js
@@ -106,6 +106,7 @@ dojo.declare('gnr.GenroClient', null, {
         this.lastPing = start_ts;
         this._debugPaths = {};
         this._aliasDatapaths = {};
+        this._pageLocals = {};
         this.sendAllEvents=false;
         this._lastMouseEvent = {};
         this._longClickDuration = 1500;

--- a/gnrjs/gnr_d11/js/gnrlang.js
+++ b/gnrjs/gnr_d11/js/gnrlang.js
@@ -66,20 +66,23 @@ function _T(str,lazy){
         return str;
     }
     var localsdict = genro.getFromStorage('local',localekey) || {};
-    if(isNullOrBlank(localsdict[str])){
-        var toTranslate = noLocMarker?'!!'+str:str;
-        var result = genro.serverCall('getRemoteTranslation',{txt:toTranslate,language:language}) || {};
-        var localizedString = result['translation'];
-        if(result.status!='OK'){
-            localsdict[str] ='<span class="unlocalized">'+localizedString+'</span>';
-        }
-        localsdict[str] = localizedString;
-        genro.setInStorage('local',localekey,localsdict);
-        return localizedString;
-    }else{
+    if(!isNullOrBlank(localsdict[str])){
         return localsdict[str];
     }
-    return str;
+    var pagelocals = genro._pageLocals[localekey] = genro._pageLocals[localekey] || {};
+    if(!isNullOrBlank(pagelocals[str])){
+        return pagelocals[str];
+    }
+    var toTranslate = noLocMarker?'!!'+str:str;
+    var result = genro.serverCall('getRemoteTranslation',{txt:toTranslate,language:language}) || {};
+    var localizedString = result['translation'];
+    if(result.status=='OK'){
+        localsdict[str] = localizedString;
+        genro.setInStorage('local',localekey,localsdict);
+    }else{
+        pagelocals[str] = localizedString;
+    }
+    return localizedString;
 }
 
 function _F(val,format,dtype){

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -1186,7 +1186,11 @@ class GnrWebPage(GnrBaseWebPage):
 
     @public_method
     def getRemoteTranslation(self, txt=None,language=None,**kwargs):
-        return self.localizer.getTranslation(txt,language=language or self.locale)
+        language = language or self.locale
+        result = self.localizer.getTranslation(txt,language=language)
+        if result['status'] != 'OK':
+            logger.debug("Missing translation (%s) for %s in %s", result['status'], txt, language)
+        return result
 
     def localize(self, txt, language=None,**kwargs):
         return self.localizer.translate(txt,language=language or self.locale)

--- a/gnrpy/tests/app/gnrlocalization_test.py
+++ b/gnrpy/tests/app/gnrlocalization_test.py
@@ -71,6 +71,27 @@ class TestGnrLocalization(BaseGnrAppTest):
         assert r["status"] == "NOKEY"
         assert r["translation"] == "bkasjklasjsd"
 
+    def test_missing_language_is_reported_as_nolang(self):
+        """
+        A fallback answer must stay distinguishable from a real translation:
+        the client caches a translation only when the status is OK.
+        """
+        al = gl.AppLocalizer(self.app)
+        al.localizationDict['en_records_to_delete'] = {'base': 'Records to delete'}
+        al.localizationDict['en_condition_op'] = {'base': 'Condition op', 'it': 'Operatore condizione'}
+
+        r = al.getTranslation('!!Records to delete', 'it')
+        assert r['status'] == 'NOLANG'
+        assert r['translation'] == 'Records to delete'
+
+        r = al.getTranslation('!!Condition op', 'it')
+        assert r['status'] == 'OK'
+        assert r['translation'] == 'Operatore condizione'
+
+        r = al.getTranslation(gl.GnrLocString('en_records_to_delete'), 'it')
+        assert r['status'] == 'NOLANG'
+        assert r['translation'] == 'Records to delete'
+
     def test_symbol_only_captions_not_translated(self):
         """
         Symbol-only captions ('=', '>=', '%', '#', whitespace, ...) all flatten

--- a/localization.xml
+++ b/localization.xml
@@ -246,7 +246,7 @@
 <en_you_are_about_to_set_archiviation_date_in_the_selected_count_records base="You are about to set archiviation date in the selected $count records" it="Stai per archiviare, impostando la data di archiviazione a $count records"></en_you_are_about_to_set_archiviation_date_in_the_selected_count_records>
 <en_date fr="Date" de="Datum" en="Date" it="Data" base="Date"></en_date>
 <en_n_records base="N.Records"></en_n_records>
-<en_records_to_delete base="Records to delete"></en_records_to_delete>
+<en_records_to_delete base="Records to delete" it="Record da eliminare"></en_records_to_delete>
 <en_duplicate_rows base="Duplicate rows"></en_duplicate_rows>
 <en_you_are_going_to_duplicate base="You are going to duplicate"></en_you_are_going_to_duplicate>
 <en_records base="records" it="Record"></en_records></genro_components>


### PR DESCRIPTION
## Problem

On an `it-IT` instance the delete/unlink confirmation dialog can show up in English even though the Italian translations exist in `localization.xml`, and clearing local storage is the only thing that fixes it.

Two separate defects behind it: a failed translation is cached client-side as if it were valid, and the `unlocalized` marker meant to signal it is unreachable code.

## Root cause

`gnrjs/gnr_d11/js/gnrlang.js`, in `_T()`:

```js
var localizedString = result['translation'];
if(result.status!='OK'){
    localsdict[str] ='<span class="unlocalized">'+localizedString+'</span>';
}
localsdict[str] = localizedString;
genro.setInStorage('local',localekey,localsdict);
```

The second assignment overwrites the first unconditionally, so:

- the `unlocalized` marker never reaches the DOM — and no CSS ever defined the class (`grep -rn unlocalized` over the repo now returns nothing but this branch's removal), so it was dead in two ways;
- the English fallback of a `NOKEY`/`NOLANG` answer is persisted to `localsdict_<lang>` exactly like a real translation. That dictionary has no version and no expiry, so the fallback stays in that browser forever and a translation added to `localization.xml` later never reaches a user who already visited the page.

The server already distinguishes the cases: `AppLocalizer.getTranslation()` (`gnrpy/gnr/app/gnrlocalization.py`) returns `status` `OK` / `NOLANG` / `NOKEY`. It was only the client throwing it away.

## Change

Minimal variant, deliberately:

1. `_T()` persists to local storage **only** when `status == 'OK'`. A non-OK answer goes into a page-level memo, `genro._pageLocals`, keyed by the same `localsdict_<lang>` key — one server call per string per page, exactly as before, and the next page load picks up a translation written meanwhile. The memo is declared in the `gnr.GenroClient` constructor next to `this._debugPaths` / `this._aliasDatapaths` (`gnrjs/gnr_d11/js/genro.js`), the existing idiom for page-scoped dicts.
2. The dead `unlocalized` line is removed rather than resurrected as HTML: no CSS backs it, and it would land as literal markup inside labels and captions. In its place, `getRemoteTranslation()` (`gnrpy/gnr/web/gnrwebpage.py`) logs a `debug` line on a non-OK status, where the status is actually known.
3. `en_records_to_delete` in `localization.xml` gains its missing `it="Record da eliminare"` — the count label of the multi-row delete confirmation, which had only `base`.

### Not in scope

A version token on the client dictionary keyed to `gnr.vendoredMtime` (`gnrwebpage.py:2421`), which would also expire the translations already cached wrong in existing browsers. That is a separate improvement; the reported defect is fully fixed by never persisting a non-OK status, and existing bad entries still need one Clear LS.

## Verification

- `pytest gnrpy/tests/app/gnrlocalization_test.py -q` → **4 passed**. Adds `test_missing_language_is_reported_as_nolang`, which pins the server contract the client now gates on: a key present but missing the requested language answers `NOLANG` with the English fallback, both in the plain-text and in the `GnrLocString` branch, while a real translation answers `OK`.
- `pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql` → **1014 passed, 59 skipped, 5 failed**. The 5 are `gnrpy/tests/web/gnrasync_test.py` failing on `OSError: [Errno 48] Address already in use`; re-run alone that file is **7 passed**. `gnrpy/tests/sql` was excluded because the postgres fixture could not `initdb` in this environment (`could not create shared memory segment`), unrelated to this change — no SQL code is touched.
- `flake8` on `gnrpy/gnr/web/gnrwebpage.py` and `gnrpy/tests/app/gnrlocalization_test.py` → zero errors.
- **There is no JS test runner in this repo, so the `gnrlang.js` change has no automated test here.** It was verified by extracting `_T()` and running it under node against a stubbed `genro` (storage, `serverCall`, `locale`), asserting: an `OK` answer is written to storage and served from it on the second call; a `NOLANG` or `NOKEY` answer is never written to storage, is served from the page memo on the second call (still one server call), and carries no `<span>`; once the server starts answering `OK` for that same string, a fresh page gets the new translation and persists it; the blank and `lazy` short-circuits are unchanged. `node --check` passes on both edited JS files. Not verified in a browser on a live it-IT instance.

Fixes #1177