### PR TITLE
fix(web): make TableScriptToHtml output file names record and resource specific

### DIFF
--- a/gnrpy/gnr/web/gnrbaseclasses.py
+++ b/gnrpy/gnr/web/gnrbaseclasses.py
@@ -32,7 +32,7 @@ from gnr.core.gnrdict import dictExtract
 from gnr.core.gnrstring import splitAndStrip, slugify, templateReplace
 from gnr.core.gnrlang import GnrObject
 from gnr.core.gnrbag import Bag
-from gnr.core.gnrlang import getUuid
+from gnr.core.gnrlang import getUuid, uniquify
 from gnr.web import logger
 from gnr.web.gnrwebpage_proxy.gnrbaseproxy import GnrBaseProxy
 
@@ -347,7 +347,7 @@ class TableScriptToHtml(BagToHtmlWeb):
         if record=='*':
             record = None
         else:
-            record = self.tblobj.recordAs(record, virtual_columns=self.virtual_columns)
+            record = self.tblobj.recordAs(record, virtual_columns=self.captionVirtualColumns())
         html_folder = self.getHtmlPath(autocreate=True)
         self.locale = locale or self.page.locale
         self.language = language or self.page.language
@@ -370,6 +370,15 @@ class TableScriptToHtml(BagToHtmlWeb):
             return self.getPdfUrl(os.path.basename(self.pdfpath)) if resultAs=='url' else self.pdfpath
             #with open(temp.name,'rb') as f:
             #    result=f.read()
+
+    def captionVirtualColumns(self):
+        """:attr:`virtual_columns` plus the virtual columns the rowcaption is built on,
+        which would otherwise be missing from the loaded record"""
+        virtual_columns = self.virtual_columns.split(',') if self.virtual_columns else []
+        model_virtual_columns = self.tblobj.model.virtual_columns
+        caption_columns = [c.replace('$', '') for c in self.tblobj.rowcaptionDecode()[0]]
+        virtual_columns.extend([c for c in caption_columns if c in model_virtual_columns])
+        return ','.join(uniquify(virtual_columns)) or None
 
     def getDocName(self):
         return os.path.splitext(os.path.basename(self.filepath))[0]
@@ -757,19 +766,32 @@ class TableScriptToHtml(BagToHtmlWeb):
         """
         return self.builder.calcRowsNumber(text, width_mm=width_mm, font_name=font_name, font_size=font_size)
 
+    def outputDocIdentifier(self):
+        """Identity of the print resource and of the printed record, so that concurrent
+        prints never write to the same file"""
+        public_name = getattr(self, '_gnrPublicName', None) or self.__class__.__name__
+        resource_id = slugify(' '.join(public_name.rsplit('.', 2)[-2:]).replace('/', ' '), sep='_')
+        record_id = None
+        if self.record is not None and not self.record.get('selectionPkeys'):
+            record_id = self.record.get(self.tblobj.pkey)
+        record_id = re.sub(r'\W', '_', str(record_id)) if record_id else getUuid()
+        return '%s_%s' % (resource_id, record_id)
+
     def outputDocName(self, ext=''):
-        """TODO
-        :param ext: TODO"""
+        """Return the output file name for the current record
+
+        :param ext: the filename extension"""
         if ext and not ext[0] == '.':
             ext = '.%s' % ext
-        caption = ''
+        chunks = [self.tblobj.name]
         if self.record is not None:
             caption = slugify(self.tblobj.recordCaption(self.record))
-            idx = self.record_idx
-            if idx is not None:
-                caption = '%s_%i' %(caption,idx)
-        doc_name = '%s_%s%s' % (self.tblobj.name, caption, ext)
-        return doc_name
+            if caption:
+                chunks.append(caption)
+            if self.record_idx is not None:
+                chunks.append(str(self.record_idx))
+        chunks.append(self.outputDocIdentifier())
+        return '%s%s' % ('_'.join(chunks), ext)
 
 
 

--- a/gnrpy/gnr/web/gnrbaseclasses.py
+++ b/gnrpy/gnr/web/gnrbaseclasses.py
@@ -347,7 +347,9 @@ class TableScriptToHtml(BagToHtmlWeb):
         if record=='*':
             record = None
         else:
-            record = self.tblobj.recordAs(record, virtual_columns=self.captionVirtualColumns())
+            record = self.tblobj.recordAs(record,
+                                          virtual_columns=self.virtual_columns if isinstance(record, Bag)
+                                          else self.captionVirtualColumns())
         html_folder = self.getHtmlPath(autocreate=True)
         self.locale = locale or self.page.locale
         self.language = language or self.page.language

--- a/gnrpy/tests/web/gnrbaseclasses_test.py
+++ b/gnrpy/tests/web/gnrbaseclasses_test.py
@@ -90,3 +90,21 @@ class TestTableScriptOutputName(BaseGnrTest):
         first = self.buildScript(FirstPrint, '*').filepath
         second = self.buildScript(FirstPrint, '*').filepath
         assert first != second
+
+    def test_a_bag_record_keeps_what_the_caller_merged_in(self):
+        # btcprint and print_template pass a Bag already loaded with the batch's
+        # own virtual_columns and extra keys merged in; asking recordAs for the
+        # caption columns would reload it from the database and drop both
+        record = self.tblobj.record(pkey=self.pkeys[0], mode='bag')
+        record['batch_parameter'] = 'kept'
+        script = self.buildScript(FirstPrint, record)
+        assert script.record['batch_parameter'] == 'kept'
+
+    def test_a_bag_record_still_prints_to_its_own_file(self):
+        names = []
+        for pkey in self.pkeys:
+            record = self.tblobj.record(pkey=pkey, mode='bag')
+            names.append(os.path.basename(self.buildScript(FirstPrint, record).filepath))
+        assert len(set(names)) == len(self.pkeys)
+        for pkey, name in zip(self.pkeys, names):
+            assert name.endswith('%s.html' % re.sub(r'\W', '_', pkey))

--- a/gnrpy/tests/web/gnrbaseclasses_test.py
+++ b/gnrpy/tests/web/gnrbaseclasses_test.py
@@ -1,1 +1,92 @@
-import gnr.web.gnrbaseclasses # noqa: F401
+"""Real checks on the output document naming of TableScriptToHtml.
+
+``sys.batch_log`` is the fixture table: its ``caption_field`` is the formula
+column ``log_caption``, the shape that made every record of a table print to
+the same file name.
+"""
+
+import os
+import re
+
+from core.common import BaseGnrTest
+
+from gnr.app.gnrapp import GnrApp
+from gnr.web import gnrbaseclasses
+from gnr.web.gnrbaseclasses import TableScriptToHtml
+from gnr.web.gnrdummysite import GnrDummySite
+
+
+class NoGridPrint(TableScriptToHtml):
+    def gridData(self):
+        return []
+
+
+class FirstPrint(NoGridPrint):
+    _gnrPublicName = '_tblscript.sys.batch_log.print/first.Main'
+
+
+class SecondPrint(NoGridPrint):
+    _gnrPublicName = '_tblscript.sys.batch_log.print/second.Main'
+
+
+class WithVirtualColumns(FirstPrint):
+    virtual_columns = 'logfile_url'
+
+
+class TestTableScriptOutputName(BaseGnrTest):
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        app = GnrApp(cls.test_instance_name)
+        app.db.model.check(applyChanges=True)
+        app.db.commit()
+        cls.site = GnrDummySite(cls.test_instance_name, site_name=cls.test_instance_name)
+        cls.tblobj = cls.site.db.table('sys.batch_log')
+        cls.pkeys = []
+        for tbl, title in (('invc.invoice', 'alpha'), ('invc.customer', 'beta')):
+            record = cls.tblobj.newrecord(tbl=tbl, batch_title=title)
+            cls.tblobj.insert(record)
+            cls.pkeys.append(record['id'])
+        cls.site.db.commit()
+
+    def buildScript(self, klass, record):
+        script = klass(page=self.site.dummyPage, resource_table=self.tblobj)
+        script(record=record)
+        return script
+
+    def test_module_under_test(self):
+        # the editable install resolves gnr.* to the main checkout, so make sure
+        # the module being exercised is the one in this working tree
+        checkout = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+        assert gnrbaseclasses.__file__.startswith(checkout + os.sep)
+
+    def test_caption_virtual_columns_are_loaded(self):
+        script = self.buildScript(FirstPrint, self.pkeys[0])
+        assert script.captionVirtualColumns() == 'log_caption'
+        assert script.record['log_caption'] == 'invc.invoicealpha'
+
+    def test_declared_virtual_columns_are_kept(self):
+        script = WithVirtualColumns(page=self.site.dummyPage, resource_table=self.tblobj)
+        assert script.captionVirtualColumns().split(',') == ['logfile_url', 'log_caption']
+
+    def test_caption_is_the_record_not_the_table_name(self):
+        name = os.path.basename(self.buildScript(FirstPrint, self.pkeys[0]).filepath)
+        assert 'invcinvoicealpha' in name
+
+    def test_name_is_record_specific(self):
+        names = []
+        for pkey in self.pkeys:
+            name = os.path.basename(self.buildScript(FirstPrint, pkey).filepath)
+            assert name.endswith('%s.html' % re.sub(r'\W', '_', pkey))
+            names.append(name)
+        assert len(set(names)) == len(self.pkeys)
+
+    def test_name_is_resource_specific(self):
+        pkey = self.pkeys[0]
+        assert self.buildScript(FirstPrint, pkey).filepath != self.buildScript(SecondPrint, pkey).filepath
+
+    def test_pkeyless_prints_never_share_a_file(self):
+        first = self.buildScript(FirstPrint, '*').filepath
+        second = self.buildScript(FirstPrint, '*').filepath
+        assert first != second


### PR DESCRIPTION
## Problem

`TableScriptToHtml` built its output document name as `<table>_<slugified recordCaption>`. That name is neither record-specific nor resource-specific: on a table whose `caption_field` is a virtual column, every record of the table and every print resource on it wrote to the very same file (`cliente_cliente.pdf` in the reported production instance). Since `rpc_callTableScript` writes the file and then reads it back to serve it, two prints in flight on the same page serve each other's document.

## Root cause

Two independent holes, both in `gnrpy/gnr/web/gnrbaseclasses.py`:

- the record was loaded with `recordAs(record, virtual_columns=self.virtual_columns)`, and `virtual_columns` is `None` by default. When the rowcaption is built on a virtual column, that column is simply absent from the loaded record, and `recordCaption()` substitutes the table name for the missing column — so the caption degenerated to the table name for every record;
- neither the record pkey nor the identity of the print resource took part in the name, so even a correct caption left two resources on the same record colliding.

## Change

- `TableScriptToHtml.captionVirtualColumns()` adds to the declared `virtual_columns` the virtual columns the rowcaption is built on, and `__call__` loads the record with them. Copy-adapt of the same idiom in `gnrpy/gnr/web/gnrwebpage_proxy/apphandler/get_record.py:181`, which already merges caption columns into `virtual_columns` before reading a record.
- `TableScriptToHtml.outputDocIdentifier()` returns the print resource identity (from `_gnrPublicName`) plus the record pkey, a uuid when there is no single record (selection prints, `record='*'`) — following `getExportIdentifier()` a few lines above in the same file. `outputDocName()` appends it, keeping table name, caption and `record_idx` for readability.

Names go from `batch_log_batch-log.html` for everything to, e.g., `batch_log_invcinvoicealpha_print_first_main_<pkey>.html`.

The output name is user-visible (download name when `downloadAs` is not set, files under `print_debug`), so this is a deliberate behaviour change on the file name.

## Not in scope

- `recordCaption()` substituting the table name for a column missing from the record (`gnrpy/gnr/sql/gnrsqltable/record.py:677`) is the actual defect generator, but it has 18 call sites and also feeds grids, selections and `db_caption`: it needs a maintainer decision and an issue of its own.
- `gnrpy/gnr/web/gnrtablescript.py` and `gnrpy/gnr/web/gnrtablescript_new.py` carry the same pattern but are imported nowhere outside their own import-smoke tests, so they are left untouched.

## Verification

- New real tests in `gnrpy/tests/web/gnrbaseclasses_test.py`: a real sqlite instance, real records inserted in `sys.batch_log` (whose `caption_field` is the formula column `log_caption`, exactly the reported shape), rendered through a real `GnrDummySite` page. They check that the caption virtual columns are loaded, that declared `virtual_columns` are kept, that the caption is the record's and not the table name, and that names differ per record, per resource and per pkeyless print. 6 of the 7 fail on the unpatched module.
- `pytest gnrpy/tests/web/gnrbaseclasses_test.py -q`: 7 passed.
- `pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql`: 1025 passed, 59 skipped.
- Full suite: 2182 passed, 69 skipped.
- `flake8` on both touched files: zero errors.

Fixes #1205
