### PR TITLE
fix(daemon): make page drop atomic with subscriber unindexing

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -421,11 +421,19 @@ class PageRegister(BaseRegister):
             self.tableSubscribers[table].add(page_id)
         return bool(subscribed_tables)
 
-    def dropSubscriptions(self, page_id, subscribed_tables):
-        """Forget every subscription of a page that is going away."""
-        for table in list(subscribed_tables):
+    def dropSubscriptions(self, page_id, subscribed_tables=None):
+        """Forget every subscription of a page that is going away.
+
+        Driven by the index, not by the page's own list: the list says what the
+        current item believes, the index says what notifyDbEvents will actually
+        read. Scanning the index makes the removal atomic with the drop whatever
+        happened to the item before (an overwritten registration, a restored
+        pickle), so a dropped page can never leave a dangling subscriber behind.
+        """
+        for table in list(self.tableSubscribers):
             self._dropSubscriber(table, page_id)
-        del subscribed_tables[:]
+        if subscribed_tables:
+            del subscribed_tables[:]
 
     def _dropSubscriber(self, table, page_id):
         subscribers = self.tableSubscribers.get(table)
@@ -439,9 +447,24 @@ class PageRegister(BaseRegister):
         """Tables with at least one subscribed page."""
         return list(self.tableSubscribers)
 
+    def load(self, storagefile):
+        # A restored pickle replaces registerItems wholesale: rebuild the index from
+        # the restored per-page lists, or every restored subscription is invisible to
+        # notifyDbEvents and whatever the index held before dangles.
+        super(PageRegister, self).load(storagefile)
+        self.tableSubscribers = defaultdict(set)
+        for page_id, register_item in self.registerItems.items():
+            for table in register_item.get('subscribed_tables') or []:
+                self.tableSubscribers[table].add(page_id)
+
     def create(self, page_id, pagename=None, connection_id=None, subscribed_tables=None, user=None, user_ip=None, user_agent=None, relative_url=None, data=None):
         register_item_id = page_id
         start_ts = datetime.now()
+        if register_item_id in self.registerItems:
+            # Re-registering an existing page_id replaces the item wholesale: unindex
+            # the previous life first, or its subscriptions dangle in the index and
+            # outlive the item, breaking every notifyDbEvents on those tables.
+            self.dropSubscriptions(register_item_id)
         if subscribed_tables:
             subscribed_tables = subscribed_tables.split(',')
         subscribed_tables = subscribed_tables or []
@@ -467,7 +490,7 @@ class PageRegister(BaseRegister):
         # it must never point at one that is already gone.
         self.dropSubscriptions(register_item_id,
                                (self.registerItems.get(register_item_id) or {}
-                                ).get('subscribed_tables') or [])
+                                ).get('subscribed_tables'))
         register_item = self.drop_item(register_item_id)
         self.pageProfilers.pop(register_item_id, None)
         if cascade:
@@ -485,10 +508,20 @@ class PageRegister(BaseRegister):
     def subscribed_table_page_items(self, table):
         # registerItems rather than get_item: the scan this replaces did not refresh
         # a page's timestamp, and notifying an event must not keep a page alive.
-        return [(k, self.registerItems[k]) for k in self.subscribed_table_page_keys(table)]
+        items = []
+        for k in self.subscribed_table_page_keys(table):
+            register_item = self.registerItems.get(k)
+            if register_item is None:
+                # The index is a cache of the per-page lists: a key with no item is
+                # residual drift, and raising here would abort the notification for
+                # every live subscriber of the table. Prune it and move on.
+                self._dropSubscriber(table, k)
+                continue
+            items.append((k, register_item))
+        return items
 
     def subscribed_table_pages(self, table):
-        return [self.registerItems[k] for k in self.subscribed_table_page_keys(table)]
+        return [register_item for k, register_item in self.subscribed_table_page_items(table)]
 
     def connection_page_keys(self, connection_id):
         # from the connection item's link set; a list, so callers may drop while iterating

--- a/gnrpy/tests/web/subscribed_tables_index_test.py
+++ b/gnrpy/tests/web/subscribed_tables_index_test.py
@@ -11,6 +11,8 @@ object, so no daemon and no Pyro are involved. The gate's memo is exercised on a
 ``GnrWsgiWebApp.subscribedTables`` with stubbed db/site.
 """
 
+import io
+
 from gnr.web.daemon.siteregister import PageRegister
 from gnr.web.gnrwebapp import GnrWsgiWebApp
 
@@ -252,3 +254,63 @@ def test_a_dropped_page_leaves_no_dangling_key_in_the_index():
     reg.drop('page-1')
     assert reg.subscribed_table_page_keys('foo.bar') == ['page-2']
     assert reg.subscribed_table_pages('foo.bar') == [reg.registerItems['page-2']]
+
+
+# ---------------------------------------------------------------------------
+# drop is atomic with unindexing, whatever happened to the item before
+# ---------------------------------------------------------------------------
+
+
+def test_reregistering_a_page_unindexes_its_previous_life():
+    """The dangling-subscriber regression: create() replaces the item wholesale, so
+    the subscriptions of the previous life must leave the index with it — or they
+    outlive the item and every notifyDbEvents on those tables raises KeyError."""
+    reg = _register()
+    reg.create('page-1')
+    reg.subscribeTable('page-1', table='foo.bar', subscribe=True)
+    reg.subscribeTable('page-1', table='foo.baz', subscribe=True)
+    reg.create('page-1')
+    reg.drop('page-1')
+    assert reg.subscribed_tables() == []
+    assert reg.subscribed_table_pages('foo.bar') == []
+
+
+def test_reregistering_keeps_the_index_aligned_with_the_lists():
+    reg = _register()
+    reg.create('page-1', subscribed_tables='foo.bar')
+    reg.create('page-1', subscribed_tables='foo.baz')
+    assert dict(reg.tableSubscribers) == _index_from_pages(reg)
+    assert reg.subscribed_tables() == ['foo.baz']
+
+
+def test_drop_unindexes_even_a_list_the_item_no_longer_carries():
+    """dropSubscriptions is driven by the index, not by the item's own list."""
+    reg = _register()
+    item = reg.create('page-1', subscribed_tables='foo.bar')
+    item['subscribed_tables'] = []
+    reg.drop('page-1')
+    assert reg.subscribed_tables() == []
+
+
+def test_load_rebuilds_the_index_from_the_restored_items():
+    reg = _register()
+    reg.create('page-1', subscribed_tables='foo.bar')
+    reg.create('page-2', subscribed_tables='foo.bar,foo.baz')
+    storage = io.BytesIO()
+    reg.dump(storage)
+    storage.seek(0)
+    restored = _register()
+    restored.tableSubscribers['foo.stale'].add('ghost-page')
+    restored.load(storage)
+    assert dict(restored.tableSubscribers) == _index_from_pages(restored)
+    assert sorted(restored.subscribed_tables()) == ['foo.bar', 'foo.baz']
+
+
+def test_a_residual_dangling_key_is_pruned_instead_of_raising():
+    """Defense in depth: the index is a cache, so a key with no item must never
+    abort the notification for the live subscribers of the table."""
+    reg = _register()
+    reg.create('page-1', subscribed_tables='foo.bar')
+    reg.tableSubscribers['foo.bar'].add('ghost-page')
+    assert reg.subscribed_table_pages('foo.bar') == [reg.registerItems['page-1']]
+    assert reg.subscribed_table_page_keys('foo.bar') == ['page-1']


### PR DESCRIPTION
Fixes #1217

A page_id could survive in `PageRegister.tableSubscribers` after its register item was gone. From then on every `notifyDbEvents` touching one of those tables raised `KeyError` inside the daemon, the exception travelled back through Pyro into `db.commit()` of every page of the site (with the data already committed), and no subscriber received db events until a daemon restart. Observed in production on a multidomain instance: one dangling page_id kept all users of a workspace failing on three tables for the whole daemon lifetime.

The drop path did unindex, but it unindexed what the item's own list said, not what the index said — so any item replacement that bypassed drop (a re-registered page_id overwriting the item via `create`, a pickle restored by `load`) left the two out of step, and the eventual drop cleaned the wrong list.

**Changes** (all in `PageRegister`):

- `dropSubscriptions` is now driven by the index: it scans `tableSubscribers` and discards the page_id, making unindexing atomic with the drop whatever happened to the item before. The item's own list is still emptied when passed.
- `create` unindexes an existing page_id before overwriting it (the counterpart of the `new_connection` assert; here re-registration is legal — guest pages do it — so clean instead of refuse).
- `load` rebuilds `tableSubscribers` from the restored items, instead of keeping whatever the previous lifetime held while `registerItems` is replaced wholesale.
- `subscribed_table_page_items` / `subscribed_table_pages` prune a residual dangling key instead of raising: the index is a cache of the per-page lists, and one stale key must not abort the notification for every live subscriber of the table.

**Tests**: six new cases in `subscribed_tables_index_test.py` — the re-registration regression (create → subscribe → create → drop leaves no dangling key), index/lists alignment across re-registration, drop with a diverged item list, `load` rebuild (including clearing stale pre-load entries), and the pruning lookup. Full gnrpy suite green (2261 passed).

Related observation, out of scope here: `SiteRegister.load` opens the pickle in text mode (`open(self.storage_path)`), which cannot work with `pickle.load`; autorestore likely never restores. Worth its own issue.
