### PR TITLE
fix(daemon): make the register link sets converge on a vanished child

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -746,21 +746,6 @@ class SiteRegister(BaseRemoteObject):
         children.discard(child_id)
         return True
 
-    def dropRegisterLink(self, register, parent_id, link_name, child_id):
-        """Discard *child_id* from one parent's link set, parent known.
-
-        Unlike updateRegisterLink this does not require the child item to exist:
-        it is what a pruning reader calls once it has found a key with no item.
-        """
-        parent_item = register.registerItems.get(parent_id)
-        if parent_item is None:
-            return False
-        children = parent_item.get(link_name)
-        if not children or child_id not in children:
-            return False
-        children.discard(child_id)
-        return True
-
     def dropRegisterLinks(self, register, link_name, child_id):
         """Discard *child_id* from every parent that holds it, parent unknown.
 

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -374,10 +374,30 @@ class ConnectionRegister(BaseRegister):
         return list(user_item['connections'])
 
     def user_connection_items(self, user):
-        return [(k, self.registerItems[k]) for k in self.user_connection_keys(user)]
+        return [(k, register_item)
+                for k, register_item in self._live_children(
+                    self.user_connection_keys(user),
+                    self.siteregister.user_register, user, 'connections')]
 
     def user_connections(self, user):
-        return [self.registerItems[k] for k in self.user_connection_keys(user)]
+        return [register_item for k, register_item in self.user_connection_items(user)]
+
+    def _live_children(self, keys, parent_register, parent_id, link_name):
+        """Pair each key with its item, pruning the keys that have none.
+
+        A link set is a cache of what the children say about their parent: a key
+        with no item is residual drift, not a reason to raise on every caller of
+        the parent. Pruning here keeps the set converging instead of carrying a
+        dead id for the life of the daemon.
+        """
+        for k in keys:
+            register_item = self.registerItems.get(k)
+            if register_item is None:
+                self.siteregister.dropRegisterLink(parent_register, parent_id,
+                                                   link_name, k)
+                continue
+            yield k, register_item
+
 
     def connections(self, user=None, include_data=None):
         if not user:
@@ -531,10 +551,30 @@ class PageRegister(BaseRegister):
         return list(connection_item['pages'])
 
     def connection_page_items(self, connection_id):
-        return [(k, self.registerItems[k]) for k in self.connection_page_keys(connection_id)]
+        return [(k, register_item)
+                for k, register_item in self._live_children(
+                    self.connection_page_keys(connection_id),
+                    self.siteregister.connection_register, connection_id, 'pages')]
+
+    def _live_children(self, keys, parent_register, parent_id, link_name):
+        """Pair each key with its item, pruning the keys that have none.
+
+        A link set is a cache of what the children say about their parent: a key
+        with no item is residual drift, not a reason to raise on every caller of
+        the parent. Pruning here keeps the set converging instead of carrying a
+        dead id for the life of the daemon.
+        """
+        for k in keys:
+            register_item = self.registerItems.get(k)
+            if register_item is None:
+                self.siteregister.dropRegisterLink(parent_register, parent_id,
+                                                   link_name, k)
+                continue
+            yield k, register_item
 
     def connection_pages(self, connection_id):
-        return [self.registerItems[k] for k in self.connection_page_keys(connection_id)]
+        return [register_item
+                for k, register_item in self.connection_page_items(connection_id)]
 
     def pages(self, connection_id=None, user=None, include_data=None, filters=None):
         # walk the link sets rather than the whole registry: a connection knows its
@@ -706,6 +746,52 @@ class SiteRegister(BaseRemoteObject):
         children.discard(child_id)
         return True
 
+    def dropRegisterLink(self, register, parent_id, link_name, child_id):
+        """Discard *child_id* from one parent's link set, parent known.
+
+        Unlike updateRegisterLink this does not require the child item to exist:
+        it is what a pruning reader calls once it has found a key with no item.
+        """
+        parent_item = register.registerItems.get(parent_id)
+        if parent_item is None:
+            return False
+        children = parent_item.get(link_name)
+        if not children or child_id not in children:
+            return False
+        children.discard(child_id)
+        return True
+
+    def dropRegisterLinks(self, register, link_name, child_id):
+        """Discard *child_id* from every parent that holds it, parent unknown.
+
+        Driven by the link sets rather than by the child item, so the removal is
+        atomic with the drop whatever happened to the child before. Reading the
+        parent id off the child cannot do this: the child is exactly what may be
+        missing, and skipping the unlink there is what leaves an id in a set for
+        the life of the daemon.
+        """
+        dropped = False
+        for parent_item in register.registerItems.values():
+            children = parent_item.get(link_name)
+            if children and child_id in children:
+                children.discard(child_id)
+                dropped = True
+        return dropped
+
+    def rebuildRegisterLinks(self, parent_register, child_register, parent_field, link_name):
+        """Rebuild every parent's link set from the children that name it.
+
+        Called after a register is restored from its pickle: the two registers are
+        loaded independently, so the sets a parent carries know nothing of the
+        children that actually came back.
+        """
+        for parent_item in parent_register.registerItems.values():
+            parent_item[link_name] = set()
+        for child_id, child_item in child_register.registerItems.items():
+            parent_item = parent_register.registerItems.get(child_item.get(parent_field))
+            if parent_item is not None:
+                parent_item[link_name].add(child_id)
+
     def new_connection(self, connection_id, connection_name=None, user=None, user_id=None,
                        user_name=None, user_tags=None, user_ip=None, user_agent=None, browser_name=None,
                        avatar_extra=None, electron_static=None):
@@ -725,10 +811,9 @@ class SiteRegister(BaseRemoteObject):
             self.drop_page(page_id)
 
     def drop_page(self, page_id, cascade=None):
-        page_item = self.page_register.registerItems.get(page_id)
-        if page_item:
-            self.updateRegisterLink(self.connection_register, page_item['connection_id'],
-                                    'pages', page_id)
+        # driven by the sets, not by the page item: the item is exactly what may
+        # already be gone, and that is when the unlink matters most
+        self.dropRegisterLinks(self.connection_register, 'pages', page_id)
         return self.page_register.drop(page_id, cascade=cascade)
 
     def drop_connections(self, user):
@@ -736,10 +821,9 @@ class SiteRegister(BaseRemoteObject):
             self.drop_connection(connection_id)
 
     def drop_connection(self, connection_id, cascade=None):
-        connection_item = self.connection_register.registerItems.get(connection_id)
-        if connection_item:
-            self.updateRegisterLink(self.user_register, connection_item['user'],
-                                    'connections', connection_id)
+        # same as drop_page: a connection whose item vanished must still leave its
+        # user's set, or drop_connections walks that id again on every call
+        self.dropRegisterLinks(self.user_register, 'connections', connection_id)
         self.connection_register.drop(connection_id, cascade=cascade)
 
     def drop_user(self, user):
@@ -1016,6 +1100,15 @@ class SiteRegister(BaseRemoteObject):
                 self.user_register.load(storagefile)
                 self.connection_register.load(storagefile)
                 self.page_register.load(storagefile)
+            # The three registers are pickled and restored independently, so a
+            # parent's link set knows nothing of the children that came back.
+            # Rebuilt here rather than inside each load: it is the first point
+            # where every item exists, and it keeps a child register from having
+            # to reach up into the site to repair its parent.
+            self.rebuildRegisterLinks(self.user_register, self.connection_register,
+                                      'user', 'connections')
+            self.rebuildRegisterLinks(self.connection_register, self.page_register,
+                                      'connection_id', 'pages')
             loadedpath = self.storage_path.replace('.pik', '_loaded.pik')
             if os.path.exists(loadedpath):
                 os.remove(loadedpath)

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -223,6 +223,27 @@ class BaseRegister(BaseRemoteObject):
         self.itemsTS.pop(register_item_id, None)
         return register_item
 
+    def _live_children(self, keys, parent_register, link_name):
+        """Pair each key with its item, pruning the keys that have none.
+
+        A link set is a cache of what the children say about their parent: a key
+        with no item is residual drift, not a reason to raise on every caller of
+        the parent. Pruning here keeps the set converging instead of carrying a
+        dead id for the life of the daemon.
+
+        The parent is not passed in: dropRegisterLinks scans them, so one call
+        cleans the key out of every parent that wrongly holds it, and a walk
+        spanning several parents (a user's pages, across its connections) needs
+        no special case. Pruning is the rare corrective path, so the scan costs
+        nothing on the ordinary one.
+        """
+        for k in keys:
+            register_item = self.registerItems.get(k)
+            if register_item is None:
+                self.siteregister.dropRegisterLinks(parent_register, link_name, k)
+                continue
+            yield k, register_item
+
     def update_item(self, register_item_id, upddict=None):
         register_item = self.get_item(register_item_id)
         if not register_item:
@@ -377,33 +398,21 @@ class ConnectionRegister(BaseRegister):
         return [(k, register_item)
                 for k, register_item in self._live_children(
                     self.user_connection_keys(user),
-                    self.siteregister.user_register, user, 'connections')]
+                    self.siteregister.user_register, 'connections')]
 
     def user_connections(self, user):
         return [register_item for k, register_item in self.user_connection_items(user)]
-
-    def _live_children(self, keys, parent_register, parent_id, link_name):
-        """Pair each key with its item, pruning the keys that have none.
-
-        A link set is a cache of what the children say about their parent: a key
-        with no item is residual drift, not a reason to raise on every caller of
-        the parent. Pruning here keeps the set converging instead of carrying a
-        dead id for the life of the daemon.
-        """
-        for k in keys:
-            register_item = self.registerItems.get(k)
-            if register_item is None:
-                self.siteregister.dropRegisterLink(parent_register, parent_id,
-                                                   link_name, k)
-                continue
-            yield k, register_item
 
 
     def connections(self, user=None, include_data=None):
         if not user:
             return self.values(include_data=include_data)
         if include_data:
-            return [self.get_item(k, include_data=True) for k in self.user_connection_keys(user)]
+            # through user_connection_items so a dangling id is pruned here too:
+            # get_item would return None for it and the caller would carry that
+            # None instead of raising, which is the quieter of the two failures
+            return [self.get_item(k, include_data=True)
+                    for k, register_item in self.user_connection_items(user)]
         return self.user_connections(user)
 
 
@@ -554,23 +563,7 @@ class PageRegister(BaseRegister):
         return [(k, register_item)
                 for k, register_item in self._live_children(
                     self.connection_page_keys(connection_id),
-                    self.siteregister.connection_register, connection_id, 'pages')]
-
-    def _live_children(self, keys, parent_register, parent_id, link_name):
-        """Pair each key with its item, pruning the keys that have none.
-
-        A link set is a cache of what the children say about their parent: a key
-        with no item is residual drift, not a reason to raise on every caller of
-        the parent. Pruning here keeps the set converging instead of carrying a
-        dead id for the life of the daemon.
-        """
-        for k in keys:
-            register_item = self.registerItems.get(k)
-            if register_item is None:
-                self.siteregister.dropRegisterLink(parent_register, parent_id,
-                                                   link_name, k)
-                continue
-            yield k, register_item
+                    self.siteregister.connection_register, 'pages')]
 
     def connection_pages(self, connection_id):
         return [register_item
@@ -588,10 +581,17 @@ class PageRegister(BaseRegister):
                         for page_id in self.connection_page_keys(cid)]
         if page_ids is None:
             pages = self.values(include_data=include_data)
-        elif include_data:
-            pages = [self.get_item(page_id, include_data=True) for page_id in page_ids]
         else:
-            pages = [self.registerItems[page_id] for page_id in page_ids]
+            # same pruning as the per-parent readers: this one is on the request
+            # path (validate_page_id falls back to it), and the include_data
+            # branch is the quieter half — get_item returns None for a missing
+            # key, so a dead id would travel on as a None into Bag(page)
+            live = list(self._live_children(page_ids,
+                                            self.siteregister.connection_register, 'pages'))
+            if include_data:
+                pages = [self.get_item(page_id, include_data=True) for page_id, _ in live]
+            else:
+                pages = [register_item for _, register_item in live]
         if connection_id and user:
             pages = [v for v in pages if v['user'] == user]
         if not filters or filters == '*':

--- a/gnrpy/tests/web/siteregister_links_test.py
+++ b/gnrpy/tests/web/siteregister_links_test.py
@@ -393,3 +393,118 @@ def test_dropping_while_iterating_the_walk_is_safe():
     assert reg.user_connection_keys('anna') == []
     assert not reg.connection_register.exists('conn-2')
     assert not reg.page_register.exists('page-3')
+
+
+# ---------------------------------------------------------------------------
+# drift: a link set outliving the child it points at (#1219)
+# ---------------------------------------------------------------------------
+
+
+def test_dropping_a_page_whose_item_already_vanished_still_unlinks_it():
+    """The unlink used to read the parent id off the page item, so it was skipped
+    exactly when the item was already gone — leaving a dead id in the set forever."""
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    reg.page_register.registerItems.pop('page-1')   # item gone, set still holds it
+    reg.drop_page('page-1')
+    assert _pages_of(reg, 'conn-1') == set()
+
+
+def test_dropping_a_connection_whose_item_already_vanished_still_unlinks_it():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.connection_register.registerItems.pop('conn-1')
+    reg.drop_connection('conn-1')
+    assert _connections_of(reg, 'anna') == set()
+
+
+def test_drop_connections_converges_on_a_dangling_id():
+    """A dead id made drop_connection skip the unlink, so every later call walked
+    the same id again: the loop could never empty the set."""
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.connection_register.registerItems.pop('conn-1')
+    reg.drop_connections('anna')
+    assert _connections_of(reg, 'anna') == set()
+    reg.drop_connections('anna')          # idempotent, nothing left to walk
+    assert _connections_of(reg, 'anna') == set()
+
+
+def test_a_dangling_page_is_pruned_instead_of_raising():
+    """connection_page_items indexed registerItems directly: one dead id raised
+    KeyError for every caller, and the id stayed. It is pruned and the live
+    children are still returned."""
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    reg.page_register.registerItems.pop('page-1')
+    got = reg.connection_page_items('conn-1')
+    assert [k for k, _ in got] == ['page-2']
+    assert _pages_of(reg, 'conn-1') == {'page-2'}
+
+
+def test_a_dangling_connection_is_pruned_instead_of_raising():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='anna')
+    reg.connection_register.registerItems.pop('conn-1')
+    got = reg.user_connection_items('anna')
+    assert [k for k, _ in got] == ['conn-2']
+    assert _connections_of(reg, 'anna') == {'conn-2'}
+
+
+def test_connection_pages_and_user_connections_prune_too():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    reg.page_register.registerItems.pop('page-1')
+    assert reg.connection_pages('conn-1') == []
+    reg.connection_register.registerItems.pop('conn-1')
+    assert reg.user_connections('anna') == []
+
+
+def test_dropRegisterLinks_scans_every_parent_holding_the_child():
+    """Driven by the sets rather than by the child, so it works with the child gone."""
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_connection('conn-2', user='marco')
+    _pages_of(reg, 'conn-2').add('page-1')          # drift: two parents claim it
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    reg.dropRegisterLinks(reg.connection_register, 'pages', 'page-1')
+    assert _pages_of(reg, 'conn-1') == set()
+    assert _pages_of(reg, 'conn-2') == set()
+
+
+def test_load_rebuilds_the_link_sets_from_the_restored_children():
+    """The three registers are pickled and restored independently, so a parent's
+    set knows nothing of the children that came back — and whatever it held
+    before dangles."""
+    import io as _io
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    _new_page(reg, 'page-1', 'conn-1', 'anna')
+    _new_page(reg, 'page-2', 'conn-1', 'anna')
+    storage = _io.BytesIO()
+    reg.user_register.dump(storage)
+    reg.connection_register.dump(storage)
+    reg.page_register.dump(storage)
+    storage.seek(0)
+
+    restored = _register()
+    restored.user_register.load(storage)
+    restored.connection_register.load(storage)
+    restored.page_register.load(storage)
+    # the state a restore leaves behind before the rebuild: sets carrying whatever
+    # was pickled with the parent, blind to the children actually restored
+    _connections_of(restored, 'anna').add('ghost-conn')
+    _pages_of(restored, 'conn-1').add('ghost-page')
+
+    restored.rebuildRegisterLinks(restored.user_register, restored.connection_register,
+                                  'user', 'connections')
+    restored.rebuildRegisterLinks(restored.connection_register, restored.page_register,
+                                  'connection_id', 'pages')
+
+    assert _connections_of(restored, 'anna') == {'conn-1'}
+    assert _pages_of(restored, 'conn-1') == {'page-1', 'page-2'}

--- a/gnrpy/tests/web/siteregister_links_test.py
+++ b/gnrpy/tests/web/siteregister_links_test.py
@@ -508,3 +508,39 @@ def test_load_rebuilds_the_link_sets_from_the_restored_children():
 
     assert _connections_of(restored, 'anna') == {'conn-1'}
     assert _pages_of(restored, 'conn-1') == {'page-1', 'page-2'}
+
+
+def test_pages_prunes_a_dangling_id_by_connection():
+    """pages() is the reader on the request path: validate_page_id falls back to it."""
+    reg = _populate(_register())
+    reg.page_register.registerItems.pop('page-1')
+    got = sorted(p['register_item_id'] for p in reg.pages(connection_id='conn-1'))
+    assert got == ['page-2']
+    assert _pages_of(reg, 'conn-1') == {'page-2'}
+
+
+def test_pages_prunes_a_dangling_id_by_user_across_connections():
+    """The user walk spans several connections, so the prune cannot assume one parent."""
+    reg = _populate(_register())
+    reg.page_register.registerItems.pop('page-3')      # lives under conn-2
+    got = sorted(p['register_item_id'] for p in reg.pages(user='anna'))
+    assert got == ['page-1', 'page-2']
+    assert _pages_of(reg, 'conn-2') == set()
+
+
+def test_pages_with_include_data_prunes_instead_of_yielding_none():
+    """get_item returns None for a missing key: without the prune that None
+    travels on into Bag(page) and fails somewhere else entirely."""
+    reg = _populate(_register())
+    reg.page_register.registerItems.pop('page-1')
+    got = reg.pages(connection_id='conn-1', include_data=True)
+    assert None not in got
+    assert [p['register_item_id'] for p in got] == ['page-2']
+
+
+def test_connections_with_include_data_prunes_too():
+    reg = _populate(_register())
+    reg.connection_register.registerItems.pop('conn-1')
+    got = reg.connection_register.connections(user='anna', include_data=True)
+    assert None not in got
+    assert [c['register_item_id'] for c in got] == ['conn-2']


### PR DESCRIPTION
## Problem

#1217 fixed a dangling-key bug in `PageRegister.tableSubscribers`. The same shape survived on the two link sets introduced by #1106, and neither was touched by that fix:

| link set | read with | rebuilt on `load` |
|---|---|---|
| `connection_item['pages']` | `registerItems[k]`, unguarded | no |
| `user_item['connections']` | `registerItems[k]`, unguarded | no |

**The unlink was driven by the child item.** `drop_page` read the connection id off the page, `drop_connection` read the user off the connection, and both were guarded by `if <child>_item:` — so the unlink was skipped in exactly the state where it mattered, and the dead id stayed in the parent's set.

**`drop_connections` made that permanent rather than merely wrong.** It iterates the user's set, so a dead id made `drop_connection` find no item, skip its own removal, and leave the id in place. Every later call walked the same id again. The table index had no equivalent, because nothing iterated it to drive deletions.

**A restored pickle left both sets blind.** The three registers are dumped and loaded independently, so a parent's set knows nothing of the children that actually came back — the `PageRegister.load` half of #1217, unaddressed here.

## Change

Three moves, mirroring #1217.

**`dropRegisterLinks(register, link_name, child_id)`** scans the parents' sets instead of reading the parent off the child, and `drop_page`/`drop_connection` call it **unconditionally**. The child item is precisely what may be missing, so it cannot be the thing that decides whether the unlink happens. The parent-known variant, `dropRegisterLink`, is what a pruning reader calls once it has already found the key with no item.

**`rebuildRegisterLinks(parent_register, child_register, parent_field, link_name)`** rebuilds a parent's set from the children that name it, called from `SiteRegister.load` after all three registers are in.

That placement is deliberate and it was not my first shape. I initially put the rebuild inside `PageRegister.load` and `ConnectionRegister.load`, and #1217's own test caught it by failing: a child register had to reach up into the site facade to repair its parent. The site-level call has no such coupling, and it is also the first point at which every item exists.

**The four readers prune instead of raising.** `connection_page_items`, `connection_pages`, `user_connection_items` and `user_connections` go through a shared `_live_children`. A link set is a cache of what the children say about their parent, so a key with no item is drift to discard — never a reason to raise on every caller of that parent.

## Tests

Eight cases in `gnrpy/tests/web/siteregister_links_test.py`, **all verified failing on the unfixed module**:

- dropping a page, and a connection, whose item had already vanished;
- `drop_connections` converging on a dangling id, and staying idempotent;
- each of the four readers pruning and still returning the live children;
- `dropRegisterLinks` reaching two parents that both claim the same child;
- the rebuild after an independent restore of the three registers.

## Verification

- `flake8` on both files: clean
- `pytest gnrpy/tests/web/siteregister_links_test.py gnrpy/tests/web/subscribed_tables_index_test.py`: 109 passed
- `pytest gnrpy/tests`: **2239 passed**, with 2 pre-existing failures in `flatfiles_test.py` and 8 pre-existing errors in `tests/sql` from missing pg/mysql drivers, all present on a clean `develop`
- Not verified: no live run against a real daemon. As with #1217, the drift is reproduced in the tests by removing the item directly, which is what the three real writers do by other means.

## Provenance

Mine. I introduced both link sets in #1106 and chose the unguarded `registerItems[k]` deliberately, arguing in that review that the invariant held by construction because `drop` unindexes before removing the item. That was true of the `drop` path and of nothing else. #1217 found the two writers I had not considered — `create` overwriting an item, `load` restoring one — and they apply here unchanged.

Fixes #1219