### PR TITLE
fix(daemon): open the freeze file in binary mode when restoring

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -1081,7 +1081,9 @@ class SiteRegister(BaseRemoteObject):
 
     def load(self):
         try:
-            with open(self.storage_path) as storagefile:
+            # 'rb': dump writes the pickle in binary, and a text stream makes
+            # pickle.load raise UnicodeDecodeError on the protocol header
+            with open(self.storage_path, 'rb') as storagefile:
                 self.user_register.load(storagefile)
                 self.connection_register.load(storagefile)
                 self.page_register.load(storagefile)

--- a/gnrpy/tests/web/siteregister_freeze_test.py
+++ b/gnrpy/tests/web/siteregister_freeze_test.py
@@ -1,0 +1,98 @@
+"""The freeze round trip: dump the three registers, load them back.
+
+``dump`` writes the pickle with ``'wb'``. ``load`` opened the same file without a
+mode, which is text, so ``pickle.load`` hit ``UnicodeDecodeError`` on the first
+byte of the protocol header -- and the ``try`` around it catches ``EOFError``
+only, so the exception left the site register unable to start.
+
+The branch was reachable but rarely taken: ``start`` turns autorestore off unless
+the freeze file exists, and it is only written when the daemon is stopped with
+``savestatus``. These tests take it every time.
+"""
+
+import pytest
+
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _register(tmp_path, name='register.pik'):
+    reg = SiteRegister(_FakeServer(), sitename='testsite')
+    reg.setConfiguration()
+    reg.storage_path = str(tmp_path / name)
+    return reg
+
+
+def _populate(reg, users=2, connections=2, pages=2):
+    for u in range(users):
+        user = 'user-%d' % u
+        for c in range(connections):
+            connection_id = '%s/conn-%d' % (user, c)
+            reg.new_connection(connection_id, user=user)
+            for p in range(pages):
+                reg.new_page('%s/page-%d' % (connection_id, p), pagename='p',
+                             connection_id=connection_id, user=user)
+    return reg
+
+
+def _round_trip(reg, tmp_path):
+    reg.dump()
+    restored = _register(tmp_path)
+    assert restored.load() is True
+    return restored
+
+
+def test_a_dumped_register_loads_back(tmp_path):
+    reg = _populate(_register(tmp_path))
+    restored = _round_trip(reg, tmp_path)
+    assert (restored.page_register.registerItems.keys()
+            == reg.page_register.registerItems.keys())
+    assert (restored.connection_register.registerItems.keys()
+            == reg.connection_register.registerItems.keys())
+    assert (restored.user_register.registerItems.keys()
+            == reg.user_register.registerItems.keys())
+
+
+def test_an_empty_register_loads_back(tmp_path):
+    restored = _round_trip(_register(tmp_path), tmp_path)
+    assert restored.page_register.registerItems == {}
+
+
+def test_the_restored_items_keep_their_parent(tmp_path):
+    reg = _populate(_register(tmp_path), users=1, connections=1, pages=2)
+    restored = _round_trip(reg, tmp_path)
+    page = restored.page_register.registerItems['user-0/conn-0/page-0']
+    assert page['connection_id'] == 'user-0/conn-0'
+    assert restored.connection_register.registerItems['user-0/conn-0']['user'] == 'user-0'
+
+
+def test_the_restored_register_still_drops(tmp_path):
+    reg = _populate(_register(tmp_path), users=1, connections=1, pages=2)
+    restored = _round_trip(reg, tmp_path)
+    restored.drop_page('user-0/conn-0/page-0')
+    assert restored.connection_page_keys('user-0/conn-0') == ['user-0/conn-0/page-1']
+
+
+def test_the_freeze_file_is_consumed_by_the_load(tmp_path):
+    """Renamed to *_loaded.pik, so a restart cannot restore the same state twice."""
+    import os
+    reg = _populate(_register(tmp_path), users=1, connections=1, pages=1)
+    restored = _round_trip(reg, tmp_path)
+    assert not os.path.exists(restored.storage_path)
+    assert os.path.exists(restored.storage_path.replace('.pik', '_loaded.pik'))
+
+
+def test_loading_a_missing_file_is_not_a_crash(tmp_path):
+    reg = _register(tmp_path, name='never-written.pik')
+    with pytest.raises(FileNotFoundError):
+        reg.load()


### PR DESCRIPTION
## Problem

`dump` writes the pickle in binary, `load` read it back without a mode:

```python
with open(self.storage_path, 'wb') as storagefile:   # dump, siteregister.py:1077
with open(self.storage_path) as storagefile:         # load, siteregister.py:1084
```

A text stream makes `pickle.load` raise `UnicodeDecodeError` on the first byte of
the protocol header. The `try` around it catches `EOFError` only, so the
exception propagates out of `load`, out of `GnrSiteRegisterServer.run`, and the
site register never starts.

Introduced in 5b9c00a7b7 (26 March 2026).

## Why it went unnoticed

`start` guards the call with `autorestore = autorestore and os.path.exists(self.storage_path)`.
`siteregister_client.py:244` always asks for `autorestore=True`, but the freeze
file only exists when the previous shutdown ran `stop(saveStatus=True)` — that
is, a stop with `savestatus`. On an ordinary stop nothing is written, the guard
turns autorestore off, and the broken branch is never taken.

So the restore was not degraded, it failed whenever there was a state to restore.

## Change

`open(self.storage_path, 'rb')`, with a comment saying why the mode matters.

Nothing else. Whether the bare `except EOFError` should also cover a truncated or
unreadable freeze file is a separate call, left alone here: today a corrupt file
takes the daemon down rather than starting it empty.

## Tests

`gnrpy/tests/web/siteregister_freeze_test.py`, six cases that take the restore
branch every time. **Five verified failing on the unfixed module**, all on the
`UnicodeDecodeError` rather than on any content:

- a populated register dumps and loads back with the same keys in all three registers;
- an empty register round trips;
- the restored items keep their parent — a page its `connection_id`, a connection its `user`;
- the restored register still drops a page correctly;
- the freeze file is consumed, renamed to `_loaded.pik`, so a restart cannot restore the same state twice.

The sixth asserts that loading a file that was never written raises
`FileNotFoundError`; it passes either way and pins the behaviour of the guard
that hid this bug.

## Verification

- `gnrpy/tests/` — 2249 passed, 86 skipped, 2 failed, 8 errors
- the 2 failures and 8 errors are identical on `develop` without this change:
  `core/flatfiles_test.py` (CSV dialect) and `sql/test_gnrbaseadapter.py`
  (double colon), neither of which reaches the site register
- `gnrpy/tests/web/` alone — 377 passed, 76 skipped
- flake8 clean on both files

Closes #1224
