### PR TITLE
fix(daemon): maintain the register link sets where the items change

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -298,6 +298,11 @@ class BaseRegister(BaseRemoteObject):
         register_item = self.get_item(register_item_id)
         if not register_item:
             return
+        if self.parent_field and upddict and self.parent_field in upddict:
+            # the parent field is one half of a link: writing it straight into the
+            # item would leave both sets naming the parent it no longer has
+            upddict = dict(upddict)
+            self.reparent_item(register_item_id, upddict.pop(self.parent_field))
         register_item.update(upddict)
         return register_item
 

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -103,6 +103,21 @@ class RemoteStoreBagHandler(BaseRemoteObject):
 
 class BaseRegister(BaseRemoteObject):
     """docstring for BaseRegister"""
+
+    # Where this register's items hang. The item field is the only statement of
+    # where a child belongs; the set on the parent says the same thing in the
+    # other direction, so it is an index, maintained here in the two calls that
+    # add and remove an item and derived from the children again on load.
+    # A register whose items have no parent leaves all three at None.
+    parent_field = None
+    parent_link_name = None
+    parent_register_name = None
+
+    # The set on this register's own items holding their children, named by the
+    # child register as parent_link_name. A register with no children leaves it
+    # at None; test_the_two_ends_of_a_link_agree_on_its_name checks the pair.
+    child_link_name = None
+
     def __init__(self, siteregister):
         self.siteregister = siteregister
         self.registerItems = dict()
@@ -110,6 +125,12 @@ class BaseRegister(BaseRemoteObject):
         self.itemsTS = dict()
         self.locked_items = dict()
         self.cached_tables = defaultdict(dict)
+
+    @property
+    def parent_register(self):
+        if not self.parent_register_name:
+            return None
+        return self.siteregister.get_register(self.parent_register_name)
 
     def lock_item(self, register_item_id, reason=None):
         locker = self.locked_items.get(register_item_id)
@@ -135,7 +156,27 @@ class BaseRegister(BaseRemoteObject):
 
     def addRegisterItem(self, register_item, data=None):
         register_item_id = register_item['register_item_id']
+        previous = self.registerItems.get(register_item_id)
+        if previous is not None:
+            # re-registering an id replaces the item wholesale, so the two ends of
+            # its links have to survive the replacement
+            if self.parent_field:
+                # the replacement may name another parent: unlink the previous one,
+                # or both end up claiming the same child
+                self.siteregister.updateRegisterLink(
+                    self.parent_register, previous.get(self.parent_field),
+                    self.parent_link_name, register_item_id)
+            if self.child_link_name:
+                # the replacement arrives with an empty set, but the children are
+                # still there and still name this item, so the set it had is true
+                register_item[self.child_link_name] = previous[self.child_link_name]
         self.registerItems[register_item_id] = register_item
+        if self.parent_field:
+            # the only insertion point, so no create can leave the parent's set
+            # behind whatever route reached it
+            self.siteregister.updateRegisterLink(
+                self.parent_register, register_item.get(self.parent_field),
+                self.parent_link_name, register_item_id, add=True)
         register_item['datachanges'] = list()
         register_item['datachanges_idx'] = 0
         register_item['subscribed_paths'] = set()
@@ -218,31 +259,40 @@ class BaseRegister(BaseRemoteObject):
         return self.__class__.__name__
 
     def drop_item(self, register_item_id):
+        if self.parent_field:
+            # before the pop, never after: the set is read to reach the items, so
+            # it must never point at one that is already gone
+            going = self.registerItems.get(register_item_id)
+            if going is not None:
+                self.siteregister.updateRegisterLink(
+                    self.parent_register, going.get(self.parent_field),
+                    self.parent_link_name, register_item_id)
         register_item = self.registerItems.pop(register_item_id, None)
         self.itemsData.pop(register_item_id, None)
         self.itemsTS.pop(register_item_id, None)
         return register_item
 
-    def _live_children(self, keys, parent_register, link_name):
-        """Pair each key with its item, pruning the keys that have none.
+    def reparent_item(self, register_item_id, parent_id):
+        """Move an item under another parent: the field and both sets, one call.
 
-        A link set is a cache of what the children say about their parent: a key
-        with no item is residual drift, not a reason to raise on every caller of
-        the parent. Pruning here keeps the set converging instead of carrying a
-        dead id for the life of the daemon.
-
-        The parent is not passed in: dropRegisterLinks scans them, so one call
-        cleans the key out of every parent that wrongly holds it, and a walk
-        spanning several parents (a user's pages, across its connections) needs
-        no special case. Pruning is the rare corrective path, so the scan costs
-        nothing on the ordinary one.
+        The only place an item's parent changes. Doing it in three statements at
+        the call site is what let the field and the sets disagree.
         """
-        for k in keys:
-            register_item = self.registerItems.get(k)
-            if register_item is None:
-                self.siteregister.dropRegisterLinks(parent_register, link_name, k)
-                continue
-            yield k, register_item
+        assert self.parent_field, \
+            'SITEREGISTER ERROR: %s items have no parent to move them under' % self.registerName
+        register_item = self.registerItems.get(register_item_id)
+        if register_item is None:
+            return False
+        old_parent_id = register_item.get(self.parent_field)
+        if old_parent_id == parent_id:
+            return False
+        parent_register = self.parent_register
+        self.siteregister.updateRegisterLink(parent_register, old_parent_id,
+                                             self.parent_link_name, register_item_id)
+        register_item[self.parent_field] = parent_id
+        self.siteregister.updateRegisterLink(parent_register, parent_id,
+                                             self.parent_link_name, register_item_id, add=True)
+        return True
 
     def update_item(self, register_item_id, upddict=None):
         register_item = self.get_item(register_item_id)
@@ -337,6 +387,9 @@ class GlobalRegister(BaseRegister):
 
 class UserRegister(BaseRegister):
     """docstring for UserRegister"""
+
+    child_link_name = 'connections'
+
     def create(self, user, user_id=None, user_name=None, user_tags=None, avatar_extra=None):
         register_item = dict(
             register_item_id=user,
@@ -358,6 +411,12 @@ class UserRegister(BaseRegister):
 
 class ConnectionRegister(BaseRegister):
     """docstring for ConnectionRegister"""
+
+    parent_field = 'user'
+    parent_link_name = 'connections'
+    parent_register_name = 'user'
+    child_link_name = 'pages'
+
     def create(self, connection_id, connection_name=None, user=None, user_id=None,
                user_name=None, user_tags=None, user_ip=None, user_agent=None, browser_name=None,
                electron_static=None):
@@ -395,10 +454,7 @@ class ConnectionRegister(BaseRegister):
         return list(user_item['connections'])
 
     def user_connection_items(self, user):
-        return [(k, register_item)
-                for k, register_item in self._live_children(
-                    self.user_connection_keys(user),
-                    self.siteregister.user_register, 'connections')]
+        return [(k, self.registerItems[k]) for k in self.user_connection_keys(user)]
 
     def user_connections(self, user):
         return [register_item for k, register_item in self.user_connection_items(user)]
@@ -408,15 +464,17 @@ class ConnectionRegister(BaseRegister):
         if not user:
             return self.values(include_data=include_data)
         if include_data:
-            # through user_connection_items so a dangling id is pruned here too:
-            # get_item would return None for it and the caller would carry that
-            # None instead of raising, which is the quieter of the two failures
             return [self.get_item(k, include_data=True)
-                    for k, register_item in self.user_connection_items(user)]
+                    for k in self.user_connection_keys(user)]
         return self.user_connections(user)
 
 
 class PageRegister(BaseRegister):
+
+    parent_field = 'connection_id'
+    parent_link_name = 'pages'
+    parent_register_name = 'connection'
+
     def __init__(self, *args, **kwargs):
         super(PageRegister, self).__init__(*args, **kwargs)
         self.pageProfilers = dict()
@@ -560,10 +618,7 @@ class PageRegister(BaseRegister):
         return list(connection_item['pages'])
 
     def connection_page_items(self, connection_id):
-        return [(k, register_item)
-                for k, register_item in self._live_children(
-                    self.connection_page_keys(connection_id),
-                    self.siteregister.connection_register, 'pages')]
+        return [(k, self.registerItems[k]) for k in self.connection_page_keys(connection_id)]
 
     def connection_pages(self, connection_id):
         return [register_item
@@ -581,17 +636,10 @@ class PageRegister(BaseRegister):
                         for page_id in self.connection_page_keys(cid)]
         if page_ids is None:
             pages = self.values(include_data=include_data)
+        elif include_data:
+            pages = [self.get_item(page_id, include_data=True) for page_id in page_ids]
         else:
-            # same pruning as the per-parent readers: this one is on the request
-            # path (validate_page_id falls back to it), and the include_data
-            # branch is the quieter half — get_item returns None for a missing
-            # key, so a dead id would travel on as a None into Bag(page)
-            live = list(self._live_children(page_ids,
-                                            self.siteregister.connection_register, 'pages'))
-            if include_data:
-                pages = [self.get_item(page_id, include_data=True) for page_id, _ in live]
-            else:
-                pages = [register_item for _, register_item in live]
+            pages = [self.registerItems[page_id] for page_id in page_ids]
         if connection_id and user:
             pages = [v for v in pages if v['user'] == user]
         if not filters or filters == '*':
@@ -746,23 +794,6 @@ class SiteRegister(BaseRemoteObject):
         children.discard(child_id)
         return True
 
-    def dropRegisterLinks(self, register, link_name, child_id):
-        """Discard *child_id* from every parent that holds it, parent unknown.
-
-        Driven by the link sets rather than by the child item, so the removal is
-        atomic with the drop whatever happened to the child before. Reading the
-        parent id off the child cannot do this: the child is exactly what may be
-        missing, and skipping the unlink there is what leaves an id in a set for
-        the life of the daemon.
-        """
-        dropped = False
-        for parent_item in register.registerItems.values():
-            children = parent_item.get(link_name)
-            if children and child_id in children:
-                children.discard(child_id)
-                dropped = True
-        return dropped
-
     def rebuildRegisterLinks(self, parent_register, child_register, parent_field, link_name):
         """Rebuild every parent's link set from the children that name it.
 
@@ -788,7 +819,6 @@ class SiteRegister(BaseRemoteObject):
             connection_id, connection_name=connection_name, user=user, user_id=user_id,
             user_name=user_name, user_tags=user_tags, user_ip=user_ip, user_agent=user_agent,
             browser_name=browser_name, electron_static=electron_static)
-        self.updateRegisterLink(self.user_register, user, 'connections', connection_id, add=True)
         return connection_item
 
     def drop_pages(self, connection_id):
@@ -796,9 +826,6 @@ class SiteRegister(BaseRemoteObject):
             self.drop_page(page_id)
 
     def drop_page(self, page_id, cascade=None):
-        # driven by the sets, not by the page item: the item is exactly what may
-        # already be gone, and that is when the unlink matters most
-        self.dropRegisterLinks(self.connection_register, 'pages', page_id)
         return self.page_register.drop(page_id, cascade=cascade)
 
     def drop_connections(self, user):
@@ -806,9 +833,6 @@ class SiteRegister(BaseRemoteObject):
             self.drop_connection(connection_id)
 
     def drop_connection(self, connection_id, cascade=None):
-        # same as drop_page: a connection whose item vanished must still leave its
-        # user's set, or drop_connections walks that id again on every call
-        self.dropRegisterLinks(self.user_register, 'connections', connection_id)
         self.connection_register.drop(connection_id, cascade=cascade)
 
     def drop_user(self, user):
@@ -837,7 +861,6 @@ class SiteRegister(BaseRemoteObject):
         page_item = self.page_register.create(page_id, pagename=pagename, connection_id=connection_id,
                                               user=user, user_ip=user_ip, user_agent=user_agent,
                                               relative_url=relative_url, data=data)
-        self.updateRegisterLink(self.connection_register, connection_id, 'pages', page_id, add=True)
         return page_item
 
     def new_user(self, user=None, user_tags=None, user_id=None, user_name=None, avatar_extra=None):
@@ -885,15 +908,11 @@ class SiteRegister(BaseRemoteObject):
         if not newuser_item:
             newuser_item = self.new_user(user=user, user_tags=user_tags, user_id=user_id, user_name=user_name,
                                          avatar_extra=avatar_extra)
-        connection_item['user'] = user
+        self.connection_register.reparent_item(connection_id, user)
         connection_item['user_tags'] = user_tags
         connection_item['user_name'] = user_name
         connection_item['user_id'] = user_id
         connection_item['avatar_extra'] = avatar_extra
-        # move the link before the drop_user guard below: it reads the old
-        # user's link set, which must no longer hold this connection
-        self.updateRegisterLink(self.user_register, olduser, 'connections', connection_id)
-        self.updateRegisterLink(self.user_register, user, 'connections', connection_id, add=True)
         for p in self.pages(connection_id=connection_id):
             p['user'] = user
         if not self.connection_register.connections(olduser):

--- a/gnrpy/tests/web/siteregister_authority_test.py
+++ b/gnrpy/tests/web/siteregister_authority_test.py
@@ -1,0 +1,570 @@
+"""The child item is authoritative, the parent's link set is derived from it.
+
+Three registers hold the hierarchy: a page item carries ``connection_id``, a
+connection item carries ``user``. Those two fields are the only statement of
+where a child belongs. The ``pages`` set on a connection item and the
+``connections`` set on a user item say the same thing in the other direction,
+so they are an index: reconstructible at any moment from the children alone,
+and never a source of truth.
+
+One invariant follows, and every test here asserts it after a single access:
+rebuilding the sets from the child fields must reproduce exactly the sets that
+are stored. When it does, no reader has to search for the parent of an orphan
+key, because no orphan key exists.
+
+The suite walks the whole mutating surface -- the ``SiteRegister`` facade, the
+registers underneath it, expiry and the freeze round trip -- so that a path
+which maintains the item but forgets the index fails here rather than months
+later on a running daemon.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _register(**cleanup):
+    reg = SiteRegister(_FakeServer(), sitename='testsite')
+    reg.setConfiguration(cleanup or None)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# the invariant
+# ---------------------------------------------------------------------------
+
+
+def _derived(reg):
+    """The link sets as a rebuild from the child items alone would produce them."""
+    connections = {user: set() for user in reg.user_register.registerItems}
+    for connection_id, item in reg.connection_register.registerItems.items():
+        connections.setdefault(item['user'], set()).add(connection_id)
+    pages = {c: set() for c in reg.connection_register.registerItems}
+    for page_id, item in reg.page_register.registerItems.items():
+        pages.setdefault(item['connection_id'], set()).add(page_id)
+    return connections, pages
+
+
+def _stored(reg):
+    connections = {user: set(item.get('connections') or ())
+                   for user, item in reg.user_register.registerItems.items()}
+    pages = {connection_id: set(item.get('pages') or ())
+             for connection_id, item in reg.connection_register.registerItems.items()}
+    return connections, pages
+
+
+def _orphans(reg):
+    """Children whose declared parent is not in the register."""
+    users = reg.user_register.registerItems
+    connections = reg.connection_register.registerItems
+    return (
+        sorted(c for c, i in connections.items() if i['user'] not in users),
+        sorted(p for p, i in reg.page_register.registerItems.items()
+               if i['connection_id'] not in connections),
+    )
+
+
+def assert_authoritative(reg):
+    """Every stored set equals its rebuild, and no child points at a dead parent."""
+    stored_connections, stored_pages = _stored(reg)
+    derived_connections, derived_pages = _derived(reg)
+    orphan_connections, orphan_pages = _orphans(reg)
+    assert orphan_connections == [], 'connections whose user is gone'
+    assert orphan_pages == [], 'pages whose connection is gone'
+    assert stored_connections == derived_connections, 'user connections sets drifted'
+    assert stored_pages == derived_pages, 'connection pages sets drifted'
+
+
+def _populate(reg, users=2, connections=2, pages=2):
+    """users x connections x pages, ids carrying their whole ancestry."""
+    for u in range(users):
+        user = 'user-%d' % u
+        for c in range(connections):
+            connection_id = '%s/conn-%d' % (user, c)
+            reg.new_connection(connection_id, user=user)
+            for p in range(pages):
+                reg.new_page('%s/page-%d' % (connection_id, p), pagename='p',
+                             connection_id=connection_id, user=user)
+    assert_authoritative(reg)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# the invariant holds on an untouched and on a populated register
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_register_is_authoritative():
+    assert_authoritative(_register())
+
+
+def test_a_populated_register_is_authoritative():
+    assert_authoritative(_populate(_register()))
+
+
+def test_the_helper_catches_a_set_that_lost_a_live_page():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.connection_register.registerItems['user-0/conn-0']['pages'].clear()
+    with pytest.raises(AssertionError):
+        assert_authoritative(reg)
+
+
+def test_the_helper_catches_a_set_holding_a_dead_page():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.connection_register.registerItems['user-0/conn-0']['pages'].add('ghost')
+    with pytest.raises(AssertionError):
+        assert_authoritative(reg)
+
+
+def test_the_helper_catches_a_page_whose_connection_is_gone():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.connection_register.drop_item('user-0/conn-0')
+    with pytest.raises(AssertionError):
+        assert_authoritative(reg)
+
+
+# ---------------------------------------------------------------------------
+# creation through the facade
+# ---------------------------------------------------------------------------
+
+
+def test_new_user_alone():
+    reg = _register()
+    reg.new_user(user='anna')
+    assert_authoritative(reg)
+
+
+def test_new_connection_on_an_existing_user():
+    reg = _register()
+    reg.new_user(user='anna')
+    reg.new_connection('conn-1', user='anna')
+    assert_authoritative(reg)
+
+
+def test_new_connection_creating_its_user():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    assert_authoritative(reg)
+
+
+def test_new_page():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    reg.new_page('page-1', pagename='p', connection_id='conn-1', user='anna')
+    assert_authoritative(reg)
+
+
+def test_new_page_repeated_with_the_same_id():
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    for _ in range(3):
+        reg.new_page('page-1', pagename='p', connection_id='conn-1', user='anna')
+    assert_authoritative(reg)
+
+
+def test_new_connection_refuses_an_id_already_registered():
+    """The duplicate is refused outright, so the set cannot gain a second entry."""
+    reg = _register()
+    reg.new_connection('conn-1', user='anna')
+    with pytest.raises(AssertionError, match='already registered'):
+        reg.new_connection('conn-1', user='anna')
+    assert_authoritative(reg)
+
+
+def test_two_users_holding_a_connection_each():
+    reg = _register()
+    reg.new_connection('conn-a', user='anna')
+    reg.new_connection('conn-b', user='bruno')
+    assert_authoritative(reg)
+
+
+# ---------------------------------------------------------------------------
+# removal through the facade
+# ---------------------------------------------------------------------------
+
+
+def test_drop_page():
+    reg = _populate(_register())
+    reg.drop_page('user-0/conn-0/page-0')
+    assert_authoritative(reg)
+
+
+def test_drop_every_page_one_by_one():
+    reg = _populate(_register())
+    for page_id in list(reg.page_register.registerItems):
+        reg.drop_page(page_id)
+        assert_authoritative(reg)
+
+
+def test_drop_pages_of_a_connection():
+    reg = _populate(_register())
+    reg.drop_pages('user-0/conn-0')
+    assert_authoritative(reg)
+
+
+def test_drop_connection():
+    reg = _populate(_register())
+    reg.drop_connection('user-0/conn-0')
+    assert_authoritative(reg)
+
+
+def test_drop_every_connection_one_by_one():
+    reg = _populate(_register())
+    for connection_id in list(reg.connection_register.registerItems):
+        reg.drop_connection(connection_id)
+        assert_authoritative(reg)
+
+
+def test_drop_connections_of_a_user():
+    reg = _populate(_register())
+    reg.drop_connections('user-0')
+    assert_authoritative(reg)
+
+
+def test_drop_user():
+    reg = _populate(_register())
+    reg.drop_user('user-0')
+    assert_authoritative(reg)
+
+
+def test_drop_every_user():
+    reg = _populate(_register())
+    for user in list(reg.user_register.registerItems):
+        reg.drop_user(user)
+        assert_authoritative(reg)
+    assert reg.page_register.registerItems == {}
+
+
+def test_drop_page_twice():
+    reg = _populate(_register())
+    reg.drop_page('user-0/conn-0/page-0')
+    reg.drop_page('user-0/conn-0/page-0')
+    assert_authoritative(reg)
+
+
+def test_drop_an_unknown_page():
+    reg = _populate(_register())
+    reg.drop_page('never-existed')
+    assert_authoritative(reg)
+
+
+def test_drop_an_unknown_connection():
+    reg = _populate(_register())
+    reg.drop_connection('never-existed')
+    assert_authoritative(reg)
+
+
+def test_drop_an_unknown_user():
+    reg = _populate(_register())
+    reg.drop_user('never-existed')
+    assert_authoritative(reg)
+
+
+# ---------------------------------------------------------------------------
+# cascade: the last child takes its parent down
+# ---------------------------------------------------------------------------
+
+
+def test_page_drop_cascade_takes_the_emptied_connection():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.page_register.drop('user-0/conn-0/page-0', cascade=True)
+    assert not reg.connection_register.exists('user-0/conn-0')
+    assert_authoritative(reg)
+
+
+def test_page_drop_cascade_spares_a_connection_with_pages_left():
+    reg = _populate(_register(), users=1, connections=1, pages=2)
+    reg.page_register.drop('user-0/conn-0/page-0', cascade=True)
+    assert reg.connection_register.exists('user-0/conn-0')
+    assert_authoritative(reg)
+
+
+def test_connection_drop_cascade_takes_the_emptied_user():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.connection_register.drop('user-0/conn-0', cascade=True)
+    assert not reg.user_register.exists('user-0')
+    assert_authoritative(reg)
+
+
+def test_connection_drop_cascade_spares_a_user_with_connections_left():
+    reg = _populate(_register(), users=1, connections=2, pages=1)
+    reg.connection_register.drop('user-0/conn-0', cascade=True)
+    assert reg.user_register.exists('user-0')
+    assert_authoritative(reg)
+
+
+def test_cascade_from_a_page_stops_at_the_connection():
+    """One level only: drop_connection is called without cascade, so the
+    emptied user stays. Asserted as it behaves, not as the name suggests."""
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.drop_page('user-0/conn-0/page-0', cascade=True)
+    assert not reg.connection_register.exists('user-0/conn-0')
+    assert reg.user_register.exists('user-0')
+    assert_authoritative(reg)
+
+
+# ---------------------------------------------------------------------------
+# the registers reached directly, bypassing the facade
+# ---------------------------------------------------------------------------
+
+
+def test_page_register_create_maintains_the_connection_set():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.page_register.create('loose-page', pagename='p',
+                             connection_id='user-0/conn-0', user='user-0')
+    assert_authoritative(reg)
+
+
+def test_connection_register_create_maintains_the_user_set():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.connection_register.create('loose-conn', user='user-0')
+    assert_authoritative(reg)
+
+
+def test_page_register_drop_maintains_the_connection_set():
+    reg = _populate(_register(), users=1, connections=1, pages=2)
+    reg.page_register.drop('user-0/conn-0/page-0')
+    assert_authoritative(reg)
+
+
+def test_connection_register_drop_maintains_the_user_set():
+    reg = _populate(_register(), users=1, connections=2, pages=1)
+    reg.connection_register.drop('user-0/conn-1')
+    assert_authoritative(reg)
+
+
+def test_a_register_reached_through_get_register_behaves_the_same():
+    reg = _populate(_register(), users=1, connections=1, pages=2)
+    reg.get_register('page').drop('user-0/conn-0/page-0')
+    assert_authoritative(reg)
+
+
+# ---------------------------------------------------------------------------
+# moving a connection between users
+# ---------------------------------------------------------------------------
+
+
+def test_change_connection_user_to_a_fresh_user():
+    reg = _populate(_register(), users=1, connections=2, pages=1)
+    reg.change_connection_user('user-0/conn-0', user='bruno')
+    assert_authoritative(reg)
+
+
+def test_change_connection_user_to_an_existing_user():
+    reg = _populate(_register(), users=2, connections=1, pages=1)
+    reg.change_connection_user('user-0/conn-0', user='user-1')
+    assert_authoritative(reg)
+
+
+def test_change_connection_user_emptying_the_old_user():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.change_connection_user('user-0/conn-0', user='bruno')
+    assert not reg.user_register.exists('user-0')
+    assert_authoritative(reg)
+
+
+def test_change_connection_user_to_the_same_user():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.change_connection_user('user-0/conn-0', user='user-0')
+    assert_authoritative(reg)
+
+
+def test_change_connection_user_then_drop_the_connection():
+    reg = _populate(_register(), users=2, connections=1, pages=1)
+    reg.change_connection_user('user-0/conn-0', user='user-1')
+    reg.drop_connection('user-0/conn-0')
+    assert_authoritative(reg)
+
+
+def test_change_connection_user_moves_the_pages_too():
+    reg = _populate(_register(), users=2, connections=1, pages=2)
+    reg.change_connection_user('user-0/conn-0', user='user-1')
+    assert all(p['user'] == 'user-1'
+               for p in reg.page_register.registerItems.values()
+               if p['connection_id'] == 'user-0/conn-0')
+    assert_authoritative(reg)
+
+
+# ---------------------------------------------------------------------------
+# expiry
+# ---------------------------------------------------------------------------
+
+
+def _age(item, seconds):
+    item['last_refresh_ts'] = datetime.now() - timedelta(seconds=seconds)
+
+
+def test_expire_pages_drops_the_idle_ones_only():
+    reg = _populate(_register(page_max_age=60), users=1, connections=1, pages=2)
+    _age(reg.page_register.registerItems['user-0/conn-0/page-0'], 3600)
+    _age(reg.page_register.registerItems['user-0/conn-0/page-1'], 5)
+    assert reg.expire_pages('user-0/conn-0') == ['user-0/conn-0/page-0']
+    assert_authoritative(reg)
+
+
+def test_expire_pages_draining_a_connection():
+    reg = _populate(_register(page_max_age=60), users=1, connections=1, pages=2)
+    for item in reg.page_register.registerItems.values():
+        _age(item, 3600)
+    reg.expire_pages('user-0/conn-0')
+    assert_authoritative(reg)
+
+
+def test_expire_pages_on_an_unknown_connection():
+    reg = _populate(_register(page_max_age=60), users=1, connections=1, pages=1)
+    assert reg.expire_pages('never-existed') == []
+    assert_authoritative(reg)
+
+
+def test_expire_connection_drops_it_with_its_pages():
+    reg = _populate(_register(connection_max_age=60), users=1, connections=2, pages=2)
+    _age(reg.connection_register.registerItems['user-0/conn-0'], 3600)
+    assert reg.expire_connection('user-0/conn-0') is True
+    assert_authoritative(reg)
+
+
+def test_expire_connection_spares_a_fresh_one():
+    reg = _populate(_register(connection_max_age=60), users=1, connections=1, pages=1)
+    _age(reg.connection_register.registerItems['user-0/conn-0'], 5)
+    assert reg.expire_connection('user-0/conn-0') is False
+    assert_authoritative(reg)
+
+
+def test_expire_connection_on_an_unknown_connection():
+    reg = _populate(_register(connection_max_age=60), users=1, connections=1, pages=1)
+    assert reg.expire_connection('never-existed') is False
+    assert_authoritative(reg)
+
+
+def test_expire_every_connection_of_a_user():
+    reg = _populate(_register(connection_max_age=60), users=1, connections=2, pages=1)
+    for item in reg.connection_register.registerItems.values():
+        _age(item, 3600)
+    for connection_id in list(reg.connection_register.registerItems):
+        reg.expire_connection(connection_id)
+        assert_authoritative(reg)
+    assert reg.user_register.registerItems == {}
+
+
+# ---------------------------------------------------------------------------
+# the freeze round trip rebuilds the sets from the children
+# ---------------------------------------------------------------------------
+
+
+def _round_trip(reg, tmp_path):
+    reg.storage_path = str(tmp_path / 'register.pik')
+    reg.dump()
+    restored = _register()
+    restored.storage_path = reg.storage_path
+    assert restored.load() is True
+    return restored
+
+
+def test_a_round_trip_preserves_the_hierarchy(tmp_path):
+    reg = _populate(_register())
+    restored = _round_trip(reg, tmp_path)
+    assert_authoritative(restored)
+    assert restored.page_register.registerItems.keys() == reg.page_register.registerItems.keys()
+
+
+def test_a_round_trip_rebuilds_a_set_that_had_drifted(tmp_path):
+    reg = _populate(_register(), users=1, connections=1, pages=2)
+    reg.connection_register.registerItems['user-0/conn-0']['pages'] = {'ghost'}
+    assert_authoritative(_round_trip(reg, tmp_path))
+
+
+def test_a_round_trip_of_an_empty_register(tmp_path):
+    assert_authoritative(_round_trip(_register(), tmp_path))
+
+
+def test_dropping_after_a_round_trip(tmp_path):
+    reg = _populate(_register())
+    restored = _round_trip(reg, tmp_path)
+    restored.drop_page('user-0/conn-0/page-0')
+    restored.drop_connection('user-1/conn-1')
+    restored.drop_user('user-0')
+    assert_authoritative(restored)
+
+
+# ---------------------------------------------------------------------------
+# re-registering an id: a replacement, and the replacement may name another parent
+# ---------------------------------------------------------------------------
+
+
+def test_re_registering_a_page_under_another_connection_moves_it():
+    """create replaces the item wholesale. Without unlinking the previous one,
+    both connections end up claiming the page -- the drift a parent-unknown scan
+    was there to clean up."""
+    reg = _populate(_register(), users=1, connections=2, pages=0)
+    reg.new_page('page-1', pagename='p', connection_id='user-0/conn-0', user='user-0')
+    reg.new_page('page-1', pagename='p', connection_id='user-0/conn-1', user='user-0')
+    assert_authoritative(reg)
+    assert reg.connection_page_keys('user-0/conn-0') == []
+    assert reg.connection_page_keys('user-0/conn-1') == ['page-1']
+
+
+def test_re_registering_a_connection_under_another_user_moves_it():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.new_user(user='bruno')
+    reg.connection_register.create('user-0/conn-0', user='bruno')
+    assert_authoritative(reg)
+
+
+def test_re_registering_a_page_on_the_same_connection_is_a_no_op():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.new_page('page-1', pagename='p', connection_id='user-0/conn-0', user='user-0')
+    reg.new_page('page-1', pagename='p', connection_id='user-0/conn-0', user='user-0')
+    assert_authoritative(reg)
+    assert sorted(reg.connection_page_keys('user-0/conn-0')) == [
+        'page-1', 'user-0/conn-0/page-0']
+
+
+def test_the_two_ends_of_a_link_agree_on_its_name():
+    """child_link_name on the parent and parent_link_name on the child name the
+    same set; they are declared in two classes, so the pair is asserted here."""
+    reg = _register()
+    assert reg.user_register.child_link_name == reg.connection_register.parent_link_name
+    assert reg.connection_register.child_link_name == reg.page_register.parent_link_name
+    assert reg.page_register.child_link_name is None
+    assert reg.user_register.parent_field is None
+
+
+def test_re_registering_a_connection_keeps_its_pages():
+    """The replacement item arrives with an empty set while its pages are still
+    there and still name it."""
+    reg = _populate(_register(), users=1, connections=1, pages=2)
+    reg.connection_register.create('user-0/conn-0', user='user-0')
+    assert_authoritative(reg)
+    assert sorted(reg.connection_page_keys('user-0/conn-0')) == [
+        'user-0/conn-0/page-0', 'user-0/conn-0/page-1']
+
+
+def test_re_registering_a_user_keeps_its_connections():
+    reg = _populate(_register(), users=1, connections=2, pages=1)
+    reg.user_register.create('user-0')
+    assert_authoritative(reg)
+    assert len(reg.user_connection_keys('user-0')) == 2
+
+
+def test_reparenting_a_register_whose_items_have_no_parent_is_refused():
+    """It used to write a None key into the item and then fail on the missing
+    parent register, leaving the item corrupted. Registers are reachable through
+    get_register, remotely included."""
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    with pytest.raises(AssertionError, match='no parent'):
+        reg.user_register.reparent_item('user-0', 'bruno')
+    assert None not in reg.user_register.registerItems['user-0']
+    assert_authoritative(reg)

--- a/gnrpy/tests/web/siteregister_authority_test.py
+++ b/gnrpy/tests/web/siteregister_authority_test.py
@@ -568,3 +568,51 @@ def test_reparenting_a_register_whose_items_have_no_parent_is_refused():
         reg.user_register.reparent_item('user-0', 'bruno')
     assert None not in reg.user_register.registerItems['user-0']
     assert_authoritative(reg)
+
+
+# ---------------------------------------------------------------------------
+# update_item: the parent field is a link, not an ordinary field
+# ---------------------------------------------------------------------------
+
+
+def test_update_item_moving_a_page_to_another_connection_moves_the_link():
+    """update_item writes whatever it is given straight into the item. The parent
+    field is half of a link, so it goes through reparent_item instead."""
+    reg = _populate(_register(), users=1, connections=2, pages=1)
+    reg.page_register.update_item('user-0/conn-0/page-0',
+                                  dict(connection_id='user-0/conn-1'))
+    assert_authoritative(reg)
+    assert reg.connection_page_keys('user-0/conn-0') == []
+    assert sorted(reg.connection_page_keys('user-0/conn-1')) == [
+        'user-0/conn-0/page-0', 'user-0/conn-1/page-0']
+
+
+def test_update_item_moving_a_connection_to_another_user_moves_the_link():
+    reg = _populate(_register(), users=2, connections=1, pages=1)
+    reg.connection_register.update_item('user-0/conn-0', dict(user='user-1'))
+    assert_authoritative(reg)
+    assert reg.user_connection_keys('user-0') == []
+
+
+def test_update_item_carries_the_other_fields_through():
+    reg = _populate(_register(), users=1, connections=2, pages=1)
+    reg.page_register.update_item('user-0/conn-0/page-0',
+                                  dict(connection_id='user-0/conn-1', pagename='moved'))
+    item = reg.page_register.registerItems['user-0/conn-0/page-0']
+    assert item['pagename'] == 'moved'
+    assert item['connection_id'] == 'user-0/conn-1'
+    assert_authoritative(reg)
+
+
+def test_update_item_without_the_parent_field_is_untouched():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.page_register.update_item('user-0/conn-0/page-0', dict(pagename='renamed'))
+    assert reg.page_register.registerItems['user-0/conn-0/page-0']['pagename'] == 'renamed'
+    assert_authoritative(reg)
+
+
+def test_update_item_on_a_register_whose_items_have_no_parent():
+    reg = _populate(_register(), users=1, connections=1, pages=1)
+    reg.user_register.update_item('user-0', dict(user_name='Zero'))
+    assert reg.user_register.registerItems['user-0']['user_name'] == 'Zero'
+    assert_authoritative(reg)

--- a/gnrpy/tests/web/siteregister_freeze_test.py
+++ b/gnrpy/tests/web/siteregister_freeze_test.py
@@ -10,6 +10,8 @@ the freeze file exists, and it is only written when the daemon is stopped with
 ``savestatus``. These tests take it every time.
 """
 
+import os
+
 import pytest
 
 from gnr.web.daemon.siteregister import SiteRegister
@@ -85,7 +87,6 @@ def test_the_restored_register_still_drops(tmp_path):
 
 def test_the_freeze_file_is_consumed_by_the_load(tmp_path):
     """Renamed to *_loaded.pik, so a restart cannot restore the same state twice."""
-    import os
     reg = _populate(_register(tmp_path), users=1, connections=1, pages=1)
     restored = _round_trip(reg, tmp_path)
     assert not os.path.exists(restored.storage_path)

--- a/gnrpy/tests/web/siteregister_links_test.py
+++ b/gnrpy/tests/web/siteregister_links_test.py
@@ -2,9 +2,10 @@
 
 A register item carries its parent id (a page knows its connection, a connection
 knows its user), but the other direction had no structure: every walk down the
-hierarchy scanned the whole registry. The user item now holds a ``connections``
-set and the connection item a ``pages`` set, both written exclusively through
-``SiteRegister.updateRegisterLink`` so the two directions of a link cannot drift.
+hierarchy scanned the whole registry. The user item holds a ``connections`` set
+and the connection item a ``pages`` set, maintained in ``addRegisterItem`` and
+``drop_item`` -- the only two calls that put an item in a register and take it
+out -- so no route can change the hierarchy and leave the sets behind.
 
 ``SiteRegister`` is built directly with a stand-in server: the only thing its
 constructor needs is ``server.daemon.register`` for the remote-bag handler.
@@ -400,79 +401,83 @@ def test_dropping_while_iterating_the_walk_is_safe():
 # ---------------------------------------------------------------------------
 
 
-def test_dropping_a_page_whose_item_already_vanished_still_unlinks_it():
-    """The unlink used to read the parent id off the page item, so it was skipped
-    exactly when the item was already gone — leaving a dead id in the set forever."""
+def test_removing_the_page_item_unlinks_it_from_its_connection():
+    """drop_item is the only removal, and it unlinks before the item goes, so the
+    page cannot vanish while its connection still lists it."""
     reg = _register()
     reg.new_connection('conn-1', user='anna')
     _new_page(reg, 'page-1', 'conn-1', 'anna')
-    reg.page_register.registerItems.pop('page-1')   # item gone, set still holds it
-    reg.drop_page('page-1')
+    reg.page_register.drop_item('page-1')
+    assert _pages_of(reg, 'conn-1') == set()
+    reg.drop_page('page-1')                          # nothing left to unlink
     assert _pages_of(reg, 'conn-1') == set()
 
 
-def test_dropping_a_connection_whose_item_already_vanished_still_unlinks_it():
+def test_removing_the_connection_item_unlinks_it_from_its_user():
     reg = _register()
     reg.new_connection('conn-1', user='anna')
-    reg.connection_register.registerItems.pop('conn-1')
+    reg.connection_register.drop_item('conn-1')
+    assert _connections_of(reg, 'anna') == set()
     reg.drop_connection('conn-1')
     assert _connections_of(reg, 'anna') == set()
 
 
-def test_drop_connections_converges_on_a_dangling_id():
-    """A dead id made drop_connection skip the unlink, so every later call walked
-    the same id again: the loop could never empty the set."""
+def test_drop_connections_has_nothing_left_to_walk():
+    """drop_connections iterates the user's set: an id left in it after the item
+    went would be walked again on every call, and the loop could never empty."""
     reg = _register()
     reg.new_connection('conn-1', user='anna')
-    reg.connection_register.registerItems.pop('conn-1')
+    reg.connection_register.drop_item('conn-1')
+    assert _connections_of(reg, 'anna') == set()
     reg.drop_connections('anna')
     assert _connections_of(reg, 'anna') == set()
-    reg.drop_connections('anna')          # idempotent, nothing left to walk
+    reg.drop_connections('anna')          # idempotent
     assert _connections_of(reg, 'anna') == set()
 
 
-def test_a_dangling_page_is_pruned_instead_of_raising():
-    """connection_page_items indexed registerItems directly: one dead id raised
-    KeyError for every caller, and the id stayed. It is pruned and the live
-    children are still returned."""
+def test_connection_page_items_returns_the_pages_that_are_left():
+    """The reader indexes the set directly: it can, because the set never holds a
+    key whose item is gone."""
     reg = _register()
     reg.new_connection('conn-1', user='anna')
     _new_page(reg, 'page-1', 'conn-1', 'anna')
     _new_page(reg, 'page-2', 'conn-1', 'anna')
-    reg.page_register.registerItems.pop('page-1')
+    reg.page_register.drop_item('page-1')
     got = reg.connection_page_items('conn-1')
     assert [k for k, _ in got] == ['page-2']
     assert _pages_of(reg, 'conn-1') == {'page-2'}
 
 
-def test_a_dangling_connection_is_pruned_instead_of_raising():
+def test_user_connection_items_returns_the_connections_that_are_left():
     reg = _register()
     reg.new_connection('conn-1', user='anna')
     reg.new_connection('conn-2', user='anna')
-    reg.connection_register.registerItems.pop('conn-1')
+    reg.connection_register.drop_item('conn-1')
     got = reg.user_connection_items('anna')
     assert [k for k, _ in got] == ['conn-2']
     assert _connections_of(reg, 'anna') == {'conn-2'}
 
 
-def test_connection_pages_and_user_connections_prune_too():
+def test_connection_pages_and_user_connections_follow_the_same_rule():
     reg = _register()
     reg.new_connection('conn-1', user='anna')
     _new_page(reg, 'page-1', 'conn-1', 'anna')
-    reg.page_register.registerItems.pop('page-1')
+    reg.page_register.drop_item('page-1')
     assert reg.connection_pages('conn-1') == []
-    reg.connection_register.registerItems.pop('conn-1')
+    reg.connection_register.drop_item('conn-1')
     assert reg.user_connections('anna') == []
 
 
-def test_dropRegisterLinks_scans_every_parent_holding_the_child():
-    """Driven by the sets rather than by the child, so it works with the child gone."""
+def test_a_page_is_listed_by_one_connection_only():
+    """Two parents claiming the same child is what made a parent-unknown scan
+    necessary. The page item names one connection, and only that one lists it."""
     reg = _register()
     reg.new_connection('conn-1', user='anna')
     reg.new_connection('conn-2', user='marco')
-    _pages_of(reg, 'conn-2').add('page-1')          # drift: two parents claim it
     _new_page(reg, 'page-1', 'conn-1', 'anna')
-    reg.dropRegisterLinks(reg.connection_register, 'pages', 'page-1')
+    assert _pages_of(reg, 'conn-1') == {'page-1'}
+    assert _pages_of(reg, 'conn-2') == set()
+    reg.drop_page('page-1')
     assert _pages_of(reg, 'conn-1') == set()
     assert _pages_of(reg, 'conn-2') == set()
 
@@ -510,37 +515,37 @@ def test_load_rebuilds_the_link_sets_from_the_restored_children():
     assert _pages_of(restored, 'conn-1') == {'page-1', 'page-2'}
 
 
-def test_pages_prunes_a_dangling_id_by_connection():
+def test_pages_by_connection_returns_what_is_left():
     """pages() is the reader on the request path: validate_page_id falls back to it."""
     reg = _populate(_register())
-    reg.page_register.registerItems.pop('page-1')
+    reg.page_register.drop_item('page-1')
     got = sorted(p['register_item_id'] for p in reg.pages(connection_id='conn-1'))
     assert got == ['page-2']
     assert _pages_of(reg, 'conn-1') == {'page-2'}
 
 
-def test_pages_prunes_a_dangling_id_by_user_across_connections():
-    """The user walk spans several connections, so the prune cannot assume one parent."""
+def test_pages_by_user_span_several_connections():
+    """The user walk crosses connections: each page leaves the set of its own."""
     reg = _populate(_register())
-    reg.page_register.registerItems.pop('page-3')      # lives under conn-2
+    reg.page_register.drop_item('page-3')              # lives under conn-2
     got = sorted(p['register_item_id'] for p in reg.pages(user='anna'))
     assert got == ['page-1', 'page-2']
     assert _pages_of(reg, 'conn-2') == set()
 
 
-def test_pages_with_include_data_prunes_instead_of_yielding_none():
-    """get_item returns None for a missing key: without the prune that None
-    travels on into Bag(page) and fails somewhere else entirely."""
+def test_pages_with_include_data_never_yields_none():
+    """get_item returns None for a missing key, and that None would travel on into
+    Bag(page) to fail somewhere else entirely."""
     reg = _populate(_register())
-    reg.page_register.registerItems.pop('page-1')
+    reg.page_register.drop_item('page-1')
     got = reg.pages(connection_id='conn-1', include_data=True)
     assert None not in got
     assert [p['register_item_id'] for p in got] == ['page-2']
 
 
-def test_connections_with_include_data_prunes_too():
+def test_connections_with_include_data_never_yield_none():
     reg = _populate(_register())
-    reg.connection_register.registerItems.pop('conn-1')
+    reg.connection_register.drop_item('conn-1')
     got = reg.connection_register.connections(user='anna', include_data=True)
     assert None not in got
     assert [c['register_item_id'] for c in got] == ['conn-2']

--- a/gnrpy/tests/web/subscribed_tables_index_test.py
+++ b/gnrpy/tests/web/subscribed_tables_index_test.py
@@ -6,24 +6,33 @@ unions the subscriptions of every registered page, so a per-page question would 
 the cross-page updates that broadcast exists for — a menu badge on page A watching a
 table that page B writes.
 
-``PageRegister`` is built directly: ``BaseRegister.__init__`` only wants a siteregister
-object, so no daemon and no Pyro are involved. The gate's memo is exercised on a real
-``GnrWsgiWebApp.subscribedTables`` with stubbed db/site.
+The page register is taken from a real ``SiteRegister``, built with a stand-in server:
+its constructor only needs ``server.daemon.register`` for the remote-bag handler, so no
+daemon and no Pyro are involved. A register maintains its parent's link set as items come
+and go, so it needs the sibling registers next to it -- a stub site would have to
+reimplement that. The gate's memo is exercised on a real ``GnrWsgiWebApp.subscribedTables``
+with stubbed db/site.
 """
 
 import io
 
-from gnr.web.daemon.siteregister import PageRegister
+from gnr.web.daemon.siteregister import SiteRegister
 from gnr.web.gnrwebapp import GnrWsgiWebApp
 
 
-class _FakeSiteRegister:
-    def refresh_ts(self, *args, **kwargs):
+class _FakeDaemon:
+    def register(self, obj, name):
         pass
 
 
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
 def _register():
-    return PageRegister(_FakeSiteRegister())
+    return SiteRegister(_FakeServer(), sitename='testsite').page_register
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The link sets were maintained in the `SiteRegister` wrappers — `new_page` added
the key, `drop_page` removed it — one level above the code that actually adds and
removes an item. `create` and `drop` on the child registers never touched the
parent's set, and `get_register()` hands the registers out, remotely included, so
anything reaching one directly bypassed the maintenance entirely.

Three consequences:

1. `page_register.create(...)` — the page exists, its connection does not list it.
2. `page_register.drop(...)` — the page is gone, its connection still lists it.
3. `page_register.drop(pid, cascade=True)` — reads `connection_page_keys`, finds
   the key it should have removed, concludes the connection still has pages and
   does not close it. Emptied connections and users stop being collected.

The third is not index hygiene, it is cleanup that silently does not happen.

#1220 made the readers converge on a key with no item, which stopped the drift
from being permanent. It did not stop it from forming, and it paid for the rare
case on the ordinary path: `drop_page` scanned every live connection on each page
close, where it used to be O(1). That cost was raised in review on #1220.

## Change

A page item carries `connection_id`, a connection item carries `user`. Those
fields are the only statement of where a child belongs; the sets say the same
thing in the other direction, so they are an index — derived, reconstructible,
never a source of truth. This puts the maintenance where the items change.

`addRegisterItem` and `drop_item` are the only two calls that put an item in a
register and take it out. Each register declares where its items hang:

| register | `parent_field` | `parent_link_name` | `parent_register_name` | `child_link_name` |
|---|---|---|---|---|
| `PageRegister` | `connection_id` | `pages` | `connection` | — |
| `ConnectionRegister` | `user` | `connections` | `user` | `pages` |
| `UserRegister` | — | — | — | `connections` |

Those two calls maintain the parent's set, so no route can change the hierarchy
and leave the index behind. `drop_item` unlinks **before** the pop — the set is
read to reach the items, so it must never point at one already gone (the #1217
ordering). `child_link_name` names the set of an item's own children, so
replacing a parent item does not discard it.

`update_item` writes whatever it is given straight into the item, so a
`connection_id` or `user` in its `upddict` used to change the field and leave both
sets naming the parent the item no longer has. A parent field now goes to
`reparent_item` and the rest of the dict is applied as before (raised in review).

`reparent_item` moves an item under another parent — the field and both sets in
one call. It is the only place a parent field changes, and
`change_connection_user` now uses it instead of three separate statements, which
is what let the field and the sets disagree there.

**Removed.** With the child field authoritative on every path, `dropRegisterLinks`
has nothing left to find: `drop_page` and `drop_connection` become one line each
and the unlink is O(1) off the child's own field. The pruning in `_live_children`
goes with it — a key with no item can no longer exist, so the five readers index
the set directly rather than skipping silently over an impossible case.

Both were added by #1220, one day ago. They were the right fix while the drift
could form; this removes the reason they existed.

## Tests

**`gnrpy/tests/web/siteregister_authority_test.py`** (new) — one invariant,
asserted after every access that changes a register: rebuilding the sets from the
child fields reproduces exactly the sets that are stored, and no child points at a
parent that is gone. Three tests check the invariant itself can fail. It covers
the facade, the registers reached directly, `get_register`, the parent move,
expiry, cascade and the freeze round trip.

**`siteregister_links_test.py`** — eleven tests rewritten. Each manufactured its
orphan with `registerItems.pop(...)`, reaching past the API into the raw dict —
the one operation no real path can perform now that `drop_item` unlinks. They keep
their scenarios and use `drop_item`, asserting the orphan never forms rather than
that it is pruned afterwards.

**`subscribed_tables_index_test.py`** — built `PageRegister` on a stub site with a
single method. A register now maintains its parent's set as items come and go, so
it needs its siblings; the stub would have had to reimplement that. It builds a
real `SiteRegister` instead, like the other two files.

## Self-review found and fixed

Written up because each one is a defect this branch introduced, caught before
review rather than by it:

- **re-registering a page under another connection** left the key in the old one.
  `create` replaces the item wholesale and the replacement may name another
  parent — two connections claiming one page, exactly the drift a parent-unknown
  scan existed to clean up.
- **replacing a parent item wiped its children set.** The new dict arrives with
  `pages=set()` while the pages are still there and still name it.
- **`reparent_item` on a register whose items have no parent** wrote a `None` key
  into the item and then failed on the missing parent register, leaving it
  corrupted. Now an explicit error before any mutation.
- **the unlink was after the pop** in an earlier revision of this branch, against
  the #1217 ordering. Restored to before.
- **one new test compared a list built from a set without sorting it**: it passed
  alone and failed in the suite. The suite was then re-run under several
  `PYTHONHASHSEED` values.

## Open

`drop_page(cascade=True)` descends one level: the emptied connection is closed,
the emptied user is not, while `expire_connection` does drop it. Behaviour
unchanged here and pinned by
`test_cascade_from_a_page_stops_at_the_connection`; the intended shape is #1226.

The sets are still pickled inside the items and overwritten at load by
`rebuildRegisterLinks`. Harmless — the rebuild wins — but it persists a second
statement of the same fact. Left alone deliberately: stripping them at dump costs
a copy of every item on each freeze, for no correctness gain.

## Verification

- `gnrpy/tests/` — 2312 passed, 86 skipped
- the 2 failures and 8 errors are identical on `develop` without this change:
  `core/flatfiles_test.py` and `sql/test_gnrbaseadapter.py`, neither reaching the
  site register
- `gnrpy/tests/web/` — 440 passed, 76 skipped, re-run under `PYTHONHASHSEED` 0, 42, 12345
- flake8 clean

Closes #1223
