### PR TITLE
guarantee temp-dir cleanup regardless of invocation directory

### DIFF
--- a/gnrpy/tests/app/conftest.py
+++ b/gnrpy/tests/app/conftest.py
@@ -29,12 +29,23 @@ def sqlite_temp_dir():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-def setup_module(module):
+@pytest.fixture(scope='module', autouse=True)
+def gnr_test_config():
+    """Ensure every module in this package runs with a genro configuration.
+
+    pytest does not call setup_module/teardown_module defined in conftest.py
+    for test modules, so this autouse fixture fills that role instead.
+    Modules that already provide their own GENRO_GNRFOLDER (via a
+    setup_module of their own) are detected and left alone.
+    """
+    if os.environ.get('GENRO_GNRFOLDER'):
+        yield
+        return
     BaseGnrTest.setup_class()
-
-
-def teardown_module(module):
-    BaseGnrTest.teardown_class()
+    try:
+        yield
+    finally:
+        BaseGnrTest.teardown_class()
 
 
 def _csv_dir():

--- a/gnrpy/tests/conftest.py
+++ b/gnrpy/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Top-level test configuration.
+
+Provides a session-scoped cleanup fixture that removes any leftover
+tmp_* directories from tests/core/ at the end of the test session.
+These directories are created by BaseGnrTest.setup_class() and should
+be removed by each test's teardown_class() or its atexit backstop, but
+this fixture is a final guarantee that they never accumulate in the
+source tree regardless of how the test suite is invoked.
+"""
+
+import os
+import shutil
+
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def _cleanup_core_tmp_dirs():
+    yield
+    core_dir = os.path.join(os.path.dirname(__file__), 'core')
+    if not os.path.isdir(core_dir):
+        return
+    for entry in os.listdir(core_dir):
+        if entry.startswith('tmp_'):
+            shutil.rmtree(os.path.join(core_dir, entry), ignore_errors=True)

--- a/gnrpy/tests/sql/conftest.py
+++ b/gnrpy/tests/sql/conftest.py
@@ -25,19 +25,13 @@ def sqlite_temp_dir():
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
-def setup_module(module):
-    BaseGnrTest.setup_class()
-def teardown_module(module):
-    BaseGnrTest.teardown_class()
-
-
 @pytest.fixture(scope='module', autouse=True)
 def gnr_test_config():
     """Make sure every module in this package runs with a genro configuration.
 
-    The setup_module/teardown_module above are never called: pytest honours
-    xunit module hooks on test modules, not on a conftest.  Every module that
-    needs a configuration therefore repeats the call itself -- and
+    pytest does not call setup_module/teardown_module defined in conftest.py
+    for test modules.  Every module that needs a configuration therefore
+    repeats the call itself -- and
     test_db_notify and test_gnrlistener do not, so on a machine without a
     ~/.gnr of its own, CI included, their fixtures died with
     'Missing genro configuration'.  Modules that already set one up keep it.


### PR DESCRIPTION
pytest does not call setup_module/teardown_module defined in a conftest.py for other test modules, so the stubs in app/conftest.py and sql/conftest.py were dead code: app test modules that needed a Genropy environment never got one, and no cleanup was performed when the full suite ran from gnrpy/tests/.

Three changes:

* app/conftest.py: replace the dead setup_module/teardown_module pair with a gnr_test_config autouse fixture (scope=module), mirroring the fixture that sql/conftest.py already has.  The fixture checks GENRO_GNRFOLDER before acting so that test modules with their own setup_module remain undisturbed.

* sql/conftest.py: remove the same dead stubs; update the fixture docstring to reflect the corrected understanding.

* tests/conftest.py (new): add a session-scoped autouse fixture that scans tests/core/ for leftover tmp_* directories at session end and removes them. This is a belt-and-suspenders guarantee that temp dirs never accumulate in the source tree regardless of how the suite is invoked or whether an individual teardown or atexit handler fires.

The change now cleanup correctly the temporary environments created during test via tempfile, avoiding disk usage and dirt left around.