### PR TITLE
fix(storage): skip the <services><storage> container in the flat service scan

### DIFF
--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
@@ -171,6 +171,15 @@ class BaseStorageHandler:
             for service_name, attrs in services.digest('#k,#a'):
                 if service_name == 'storage':
                     # <services><storage> is the type section handled above, not a service
+                    if attrs and attrs.get('service_name'):
+                        # the shape this docstring used to document: an instance that
+                        # followed it had the mount registered under the label 'storage',
+                        # and would now lose it without a word
+                        logger.warning(
+                            "<services><storage service_name=%r> is the storage type section, "
+                            "not a service: the mount is not loaded. Declare it as a child, "
+                            "<storage><%s implementation=... /></storage>",
+                            attrs['service_name'], attrs['service_name'])
                     continue
                 attrs = dict(attrs) if attrs else {}
                 service_type = attrs.pop('service_type', None) or service_name

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
@@ -144,8 +144,8 @@ class BaseStorageHandler:
 
         Reads from siteconfig.xml services section:
         <services>
-            <storage service_name="my_storage" implementation="local">
-                <base_path>/path/to/storage</base_path>
+            <storage>
+                <my_storage implementation="local" base_path="/path/to/storage"/>
             </storage>
             <my_s3 service_type="storage" implementation="aws_s3" bucket="my-bucket" />
         </services>
@@ -169,6 +169,9 @@ class BaseStorageHandler:
                     self._setStorageParams(service_name, parameters=attrs, implementation=implementation)
             # Also check flat structure: <services><my_storage service_type="storage" .../></services>
             for service_name, attrs in services.digest('#k,#a'):
+                if service_name == 'storage':
+                    # <services><storage> is the type section handled above, not a service
+                    continue
                 attrs = dict(attrs) if attrs else {}
                 service_type = attrs.pop('service_type', None) or service_name
                 if service_type == 'storage':

--- a/gnrpy/tests/web/gnrstoragehandler_test.py
+++ b/gnrpy/tests/web/gnrstoragehandler_test.py
@@ -551,6 +551,47 @@ class TestStorageHandler(BaseGnrDaemonTest):
         assert params.get('implementation') == 'local'
         assert params.get('base_path') == '/tmp/nested'
 
+        # The <storage> container node is not a service itself
+        assert 'storage' not in handler.storage_params
+
+    def test_load_storage_from_siteconfig_nested_and_flat_structure(self):
+        """Test that nested and flat storage services coexist without a phantom 'storage' mount."""
+        from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import BaseStorageHandler
+
+        # Create a mock site with both a nested section and a flat storage service
+        class MockSite:
+            def __init__(self):
+                self.config = Bag()
+                self.config['services.storage.minio'] = Bag()
+                self.config.setAttr('services.storage.minio',
+                    implementation='aws_s3', bucket='sandbox')
+                self.config['services.my_flat_store'] = Bag()
+                self.config.setAttr('services.my_flat_store',
+                    service_type='storage', implementation='local', base_path='/tmp/flat')
+                self.site_static_dir = '/tmp/test_site'
+
+            @property
+            def gnrapp(self):
+                class MockApp:
+                    packages = type('obj', (object,), {'keys': lambda self: []})()
+                return MockApp()
+
+            @property
+            def db(self):
+                return None
+
+        mock_site = MockSite()
+        handler = BaseStorageHandler.__new__(BaseStorageHandler)
+        handler.site = mock_site
+        handler.storage_params = {}
+
+        handler._loadStorageParametersFromSiteConfig()
+
+        assert handler.storage_params['minio'].get('implementation') == 'aws_s3'
+        assert handler.storage_params['minio'].get('bucket') == 'sandbox'
+        assert handler.storage_params['my_flat_store'].get('implementation') == 'local'
+        assert 'storage' not in handler.storage_params
+
     def test_load_storage_from_siteconfig_flat_structure(self):
         """Test loading storage params from flat <services><my_store service_type='storage' .../></services> structure."""
         from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import BaseStorageHandler

--- a/gnrpy/tests/web/gnrstoragehandler_test.py
+++ b/gnrpy/tests/web/gnrstoragehandler_test.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 import os
 import tempfile
 import shutil
@@ -591,6 +592,44 @@ class TestStorageHandler(BaseGnrDaemonTest):
         assert handler.storage_params['minio'].get('bucket') == 'sandbox'
         assert handler.storage_params['my_flat_store'].get('implementation') == 'local'
         assert 'storage' not in handler.storage_params
+
+    def test_load_storage_from_siteconfig_old_container_shape_is_warned(self, caplog):
+        """An instance that followed the shape this docstring used to document -
+        <storage service_name="..."> - had its mount registered under the label
+        'storage'. The skip is right, but it must not be silent."""
+        from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import BaseStorageHandler
+
+        class MockSite:
+            def __init__(self):
+                self.config = Bag()
+                self.config['services.storage'] = Bag()
+                self.config.setAttr('services.storage',
+                    service_name='my_storage', implementation='local')
+                self.site_static_dir = '/tmp/test_site'
+
+            @property
+            def gnrapp(self):
+                class MockApp:
+                    packages = type('obj', (object,), {'keys': lambda self: []})()
+                return MockApp()
+
+            @property
+            def db(self):
+                return None
+
+        mock_site = MockSite()
+        handler = BaseStorageHandler.__new__(BaseStorageHandler)
+        handler.site = mock_site
+        handler.storage_params = {}
+
+        with caplog.at_level(logging.WARNING, logger='gnr.web'):
+            handler._loadStorageParametersFromSiteConfig()
+
+        assert 'storage' not in handler.storage_params
+        assert 'my_storage' not in handler.storage_params
+        messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any('my_storage' in m for m in messages), \
+            'the skipped mount has to be named, or the instance loses it silently'
 
     def test_load_storage_from_siteconfig_flat_structure(self):
         """Test loading storage params from flat <services><my_store service_type='storage' .../></services> structure."""


### PR DESCRIPTION
Fixes #1233

`BaseStorageHandler._loadStorageParametersFromSiteConfig` reads the nested form from `services.storage` and then also scans every child of `<services>` for flat services, defaulting `service_type` to the node key. For the type section itself that key is literally `storage`, so the container node was registered as a phantom storage mount with no implementation: it showed up in `storage_params`, and `site.storage('storage')` would silently fall back to a local storage under `site_static_dir`.

The flat loop now skips that key. Both loops keep running: making it either/or as `ServiceHandler.serviceConfigurationsFromSiteConfig` does would drop flat `service_type="storage"` siblings whenever a nested section is present, which the storage handler supports today.

The docstring's nested example is corrected as well — it showed the container node carrying the service attributes, which is the ambiguity the code reads as a service.

### Tests

- `test_load_storage_from_siteconfig_nested_and_flat_structure`: a nested `minio` plus a flat `my_flat_store`, both registered, no `storage` key.
- The negative assertion added to the existing `test_load_storage_from_siteconfig_nested_structure`.

### Verification

- Repro confirmed against the unpatched code: `{'minio': {...}, 'storage': {}, 'my_flat_store': {...}}`; with the fix the `storage` entry is gone.
- `flake8` clean on both files; full `gnrpy` suite 2283 passed, 70 skipped.
- Note: `TestStorageHandler` inherits `BaseGnrDaemonTest`, so the whole class skips where the `gnrdevelop` site cannot be built (it does here). The new test bodies were driven directly against the patched module to check them; they are not verified through a normal pytest run in that condition.
