### PR TITLE
refactor(config): move experimental switches to instanceconfig.xml

### DIFF
--- a/docs/genro/project/gnr/instanceconfig.rst
+++ b/docs/genro/project/gnr/instanceconfig.rst
@@ -73,6 +73,8 @@ Tags
       :ref:`instanceconfig_db` section.
     * The ``<authentication>`` tag allow to handle all the access authorization to your project.
       Check the :ref:`instanceconfig_authentication` section for more information.
+    * The ``<experimental>`` tag switches on features that are not yet part of the default
+      behaviour. Check the :ref:`instanceconfig_experimental` section for more information.
     * The ``_T="NN"`` is a special attribute that allow to keep track of datatypes (for more
       information, check the :ref:`bag_from_to_XML` section).
     
@@ -155,6 +157,28 @@ Tags
         <db dbname="mypersonaldatabase" implementation="postgres"
             host="localhost" password="superSecurePwd" user="postgres"  />
         
+.. _instanceconfig_experimental:
+
+``<experimental>``
+^^^^^^^^^^^^^^^^^^
+
+    The ``<experimental>`` tag groups the switches of features that are still opt-in.
+    Every switch is an attribute of a child tag named after the area it affects; the
+    value is read once at startup, so a change requires a restart::
+
+        <experimental>
+            <page no_mako="True" page_class_cache="True"/>
+        </experimental>
+
+    ``<page>`` switches:
+
+    * ``no_mako``: render the rootPage from a Python struct template (``<name>.py``)
+      when one is found next to the ``.tpl``, falling back to Mako otherwise.
+    * ``page_class_cache``: reuse the page class built at the page's birth for every
+      later request carrying the same ``page_id``.
+
+    A missing tag or attribute reads as ``False``.
+
 .. _instanceconfig_authentication:
 
 ``<authentication>``

--- a/docs/genro/project/gnr/instanceconfig.rst
+++ b/docs/genro/project/gnr/instanceconfig.rst
@@ -176,6 +176,8 @@ Tags
       when one is found next to the ``.tpl``, falling back to Mako otherwise.
     * ``page_class_cache``: reuse the page class built at the page's birth for every
       later request carrying the same ``page_id``.
+    * ``remoteForm``: default for the ``remote`` option of the table handler forms,
+      ``onEnter`` or ``delayed``; a form passing ``remote=`` overrides it.
 
     A missing tag or attribute reads as ``False``.
 

--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -979,6 +979,14 @@ class GnrApp(object):
             'dbname': parsed.path.lstrip('/'),
         }
     
+    def experimentalFlag(self, group, name):
+        """A switch from the ``<experimental>`` tag of instanceconfig.xml.
+
+        ``<experimental><page no_mako="True"/></experimental>`` is read as
+        ``experimentalFlag('page', 'no_mako')``; a missing tag is ``False``.
+        """
+        return boolean(self.config['experimental.%s?%s' % (group, name)])
+
     def init(self, db_attrs=None, restorepath=None):
         """Initiate a :class:`GnrApp`
 

--- a/gnrpy/gnr/app/gnrapp.py
+++ b/gnrpy/gnr/app/gnrapp.py
@@ -979,13 +979,17 @@ class GnrApp(object):
             'dbname': parsed.path.lstrip('/'),
         }
     
-    def experimentalFlag(self, group, name):
-        """A switch from the ``<experimental>`` tag of instanceconfig.xml.
+    def experimentalValue(self, group, name):
+        """A setting from the ``<experimental>`` tag of instanceconfig.xml.
 
-        ``<experimental><page no_mako="True"/></experimental>`` is read as
-        ``experimentalFlag('page', 'no_mako')``; a missing tag is ``False``.
+        ``<experimental><page remoteForm="delayed"/></experimental>`` is read
+        as ``experimentalValue('page', 'remoteForm')``; a missing tag is ``None``.
         """
-        return boolean(self.config['experimental.%s?%s' % (group, name)])
+        return self.config['experimental.%s?%s' % (group, name)]
+
+    def experimentalFlag(self, group, name):
+        """A boolean switch from the ``<experimental>`` tag: a missing tag is ``False``."""
+        return boolean(self.experimentalValue(group, name))
 
     def init(self, db_attrs=None, restorepath=None):
         """Initiate a :class:`GnrApp`

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -403,7 +403,7 @@ class GnrWebPage(GnrBaseWebPage):
     @property
     def wsk_enabled(self):
         if not hasattr(self, '_wsk_enabled'):
-            self._wsk_enabled = self.wsk and not self.getPreference('experimental.wsk_disabled',pkg='sys')
+            self._wsk_enabled = bool(self.wsk)
         return self._wsk_enabled
 
     @property
@@ -1099,12 +1099,11 @@ class GnrWebPage(GnrBaseWebPage):
             tpl = '%s.%s' % (self.pagename, 'tpl')
         self.htmlHeaders()
 
-        # When ``experimental.no_mako`` is on, look for a ``<name>.py``
+        # With the ``no_mako`` experimental flag on, look for a ``<name>.py``
         # struct template in the same resource dirs the Mako lookup uses.
         # If one is found, render it; otherwise fall through to Mako so a
         # missing struct template never breaks the page.
-        no_mako = self.getPreference('experimental.no_mako', pkg='sys')
-        if no_mako:
+        if self.application.experimentalFlag('page', 'no_mako'):
             tpl_name = tpl[:-4] if tpl.endswith('.tpl') else tpl
             template_cls = lookup_template_class(self.tpldirectories, tpl_name)
             if template_cls is not None:

--- a/gnrpy/gnr/web/gnrwebpage_plugin/mako.py
+++ b/gnrpy/gnr/web/gnrwebpage_plugin/mako.py
@@ -45,10 +45,9 @@ class Plugin(GnrBasePlugin):
         arg_dict['mainpage'] = page
         arg_dict.update(kwargs)
 
-        # When the no_mako preference is on, look for a struct template
+        # With the no_mako experimental flag on, look for a struct template
         # next to the requested .tpl. Falls through to Mako otherwise.
-        no_mako = page.getPreference('experimental.no_mako', pkg='sys')
-        if no_mako:
+        if page.application.experimentalFlag('page', 'no_mako'):
             tpl_basename = os.path.basename(mako_path)
             tpl_name = tpl_basename[:-4] if tpl_basename.endswith('.tpl') else tpl_basename
             template_cls = lookup_template_class(tpldirectories, tpl_name)

--- a/gnrpy/gnr/web/gnrwebpage_proxy/frontend/basepagetemplate.py
+++ b/gnrpy/gnr/web/gnrwebpage_proxy/frontend/basepagetemplate.py
@@ -5,7 +5,8 @@ A ``PageTemplate`` is a Python class that produces the HTML of a GenroPy
 rootPage using :class:`GnrHtmlSrc` and ``toXml``, replacing the Mako
 ``.tpl`` rendering path.
 
-Activation is opt-in via the ``experimental.no_mako`` preference.
+Activation is opt-in via ``<experimental><page no_mako="True"/></experimental>``
+in instanceconfig.xml.
 """
 
 from gnr.core.gnrhtml import GnrHtmlSrc

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrresourceloader.py
@@ -10,7 +10,6 @@ import os
 
 import inspect
 import glob
-import time
 from collections import OrderedDict
 from threading import Lock
 
@@ -26,19 +25,17 @@ from gnr.core.gnrclasses import GnrMixinError,GnrMixinNotFound
 from gnr.core.gnrlang import uniquify
 from gnr.web import logger
 
-# Experimental page-class cache (sys preference
-# ``experimental.page_class_cache``): a page's class is a function of values
-# fixed at the page's birth (module, main package, plugin/custom mixins), so
-# the first build can serve every later request of the same page. Entries are
-# keyed by ``(page_id, module_path)``: a page_id is validated against the
-# connection, never against the url it is posted to, so the module path keeps
-# a request that names another page's page_id from reading - or, worse, from
-# depositing - a class built for a different url. The cache is dropped on
-# page close and LRU-bounded for whatever escapes that; the preference is
-# re-read at most every PAGE_CLASS_CACHE_FLAG_TTL seconds because a
-# getPreference call deepcopies the whole preference bag.
+# Experimental page-class cache (instanceconfig.xml
+# ``<experimental><page page_class_cache="True"/></experimental>``): a page's
+# class is a function of values fixed at the page's birth (module, main
+# package, plugin/custom mixins), so the first build can serve every later
+# request of the same page. Entries are keyed by ``(page_id, module_path)``:
+# a page_id is validated against the connection, never against the url it is
+# posted to, so the module path keeps a request that names another page's
+# page_id from reading - or, worse, from depositing - a class built for a
+# different url. The cache is dropped on page close and LRU-bounded for
+# whatever escapes that.
 PAGE_CLASS_CACHE_MAXSIZE = 2000
-PAGE_CLASS_CACHE_FLAG_TTL = 10
 
 
 class ResourceLoader(object):
@@ -54,29 +51,11 @@ class ResourceLoader(object):
         self.default_path = self.site.default_page and self.site.default_page.split('/')
         self._page_class_cache = OrderedDict()
         self._page_class_cache_lock = Lock()
-        self._page_class_cache_flag = (False, 0.0)
+        self._page_class_cache_enabled = self.gnrapp.experimentalFlag('page', 'page_class_cache')
 
     def page_class_cache_enabled(self):
-        """The experimental flag, read through a small TTL (kill switch stays live).
-
-        The read is pinned to the root store: it runs at dispatch time, before
-        the page applies its own env, so the thread env still carries whatever
-        the previous request left there (possibly a multi-store selection).
-        A ``sys`` preference lives in the main store anyway.
-        Turning the flag off also drops what is already cached, so the switch
-        frees the classes instead of merely stopping new ones.
-        """
-        value, read_ts = self._page_class_cache_flag
-        now = time.time()
-        if now - read_ts > PAGE_CLASS_CACHE_FLAG_TTL:
-            db = self.site.db
-            with db.tempEnv(storename=db.rootstore):
-                new_value = bool(self.site.getPreference('experimental.page_class_cache', pkg='sys'))
-            if value and not new_value:
-                self.clear_page_class_cache()
-            value = new_value
-            self._page_class_cache_flag = (value, now)
-        return value
+        """The experimental flag, fixed for the life of the process."""
+        return self._page_class_cache_enabled
 
     def load_page_class_cache(self, cache_key):
         """The cached class of a live page, or None on a miss."""
@@ -107,10 +86,10 @@ class ResourceLoader(object):
                 self._page_class_cache.pop(cache_key)
 
     def clear_page_class_cache(self):
-        """Empty the cache (the flag going off, or an explicit reset)."""
+        """Empty the cache (an explicit reset)."""
         with self._page_class_cache_lock:
             self._page_class_cache.clear()
-    
+
     @property
     def gnrapp(self):
         return self.site.gnrapp
@@ -185,7 +164,7 @@ class ResourceLoader(object):
     def get_page_class(self, basepath=None,relpath=None, pkg=None, plugin=None,avoid_module_cache=None,request_args=None,request_kwargs=None, page_factory=None):
         """Build the page class for a request — or serve the page's cached one.
 
-        With the experimental ``page_class_cache`` preference on, a request
+        With the experimental ``page_class_cache`` flag on, a request
         that names a ``page_id`` reuses the class built at that page's birth,
         provided it asks for the same module: the key is the pair, because a
         page_id is only ever validated against the connection. An explicit

--- a/gnrpy/tests/app/gnrapp_test.py
+++ b/gnrpy/tests/app/gnrapp_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from common import BaseGnrAppTest
 import gnr.app.gnrapp as ga
+from gnr.core.gnrbag import Bag
 
 class TestGnrApp(BaseGnrAppTest):
     """
@@ -184,3 +185,29 @@ class TestGnrApp(BaseGnrAppTest):
             assert p['sys.error']['extra_where_filter'] == None
             assert p['sys.task_execution']['extra_where_filter'] == None
        
+
+
+def _app_with_experimental(**attrs):
+    app = ga.GnrApp.__new__(ga.GnrApp)
+    app.config = Bag()
+    if attrs:
+        app.config.setItem('experimental.page', None, **attrs)
+    return app
+
+
+def test_experimental_flag_reads_the_page_tag():
+    app = _app_with_experimental(no_mako='True', page_class_cache='false')
+    assert app.experimentalFlag('page', 'no_mako') is True
+    assert app.experimentalFlag('page', 'page_class_cache') is False
+
+
+def test_experimental_flag_of_a_missing_tag_is_false():
+    app = _app_with_experimental()
+    assert app.experimentalFlag('page', 'no_mako') is False
+    assert app.experimentalFlag('other', 'no_mako') is False
+
+
+def test_experimental_value_keeps_the_raw_attribute():
+    app = _app_with_experimental(remoteForm='delayed')
+    assert app.experimentalValue('page', 'remoteForm') == 'delayed'
+    assert app.experimentalValue('page', 'missing') is None

--- a/gnrpy/tests/core/services_addservice_test.py
+++ b/gnrpy/tests/core/services_addservice_test.py
@@ -34,7 +34,7 @@ def make_site():
         debug=False,
         getStatic=lambda name: None,
         default_page=None,
-        gnrapp=SimpleNamespace(packages={}),
+        gnrapp=SimpleNamespace(packages={}, experimentalFlag=lambda group, name: False),
     )
     site.resource_loader = ResourceLoader(site)
     site.resources_dirs = [COMMON_RESOURCES]

--- a/gnrpy/tests/web/gnrpageclasscache_test.py
+++ b/gnrpy/tests/web/gnrpageclasscache_test.py
@@ -3,8 +3,8 @@
 Three things are pinned here:
 
 - the cache helpers on ``ResourceLoader``: hit, miss, LRU eviction at the
-  ceiling, drop on page close, clear on the flag going off;
-- the TTL on the preference read, in both directions of the boundary;
+  ceiling, drop on page close;
+- the flag, read once from the ``<experimental>`` tag of instanceconfig.xml;
 - the isolation of ``css_requires``/``js_requires``, which the cache turns
   from per-request lists into class attributes shared by every request of
   the same page.
@@ -29,46 +29,36 @@ class _FakeStatic:
         return '/'.join(str(a) for a in args)
 
 
-class _FakeTempEnv:
-    def __enter__(self):
-        return self
+class _FakeApp:
+    """The slice of GnrApp that page_class_cache_enabled touches."""
 
-    def __exit__(self, *exc):
-        return False
+    def __init__(self, flag):
+        self.flag = flag
+        self.flag_reads = 0
 
-
-class _FakeDb:
-    """The slice of GnrSqlDb that page_class_cache_enabled touches."""
-
-    rootstore = '_main_db'
-
-    def tempEnv(self, **kwargs):
-        return _FakeTempEnv()
+    def experimentalFlag(self, group, name):
+        assert (group, name) == ('page', 'page_class_cache')
+        self.flag_reads += 1
+        return self.flag
 
 
 class _FakeSite:
     """The slice of GnrWsgiSite that ResourceLoader.__init__ touches."""
 
-    def __init__(self, preference=False):
+    def __init__(self, flag=False):
         self.site_path = '/tmp/site'
         self.site_name = 'testsite'
         self.gnr_config = {}
         self.debug = False
         self.default_page = None
-        self.preference = preference
-        self.preference_reads = 0
-        self.db = _FakeDb()
+        self.gnrapp = _FakeApp(flag)
 
     def getStatic(self, name):
         return _FakeStatic()
 
-    def getPreference(self, path, pkg=None):
-        self.preference_reads += 1
-        return self.preference
 
-
-def _loader(preference=False):
-    site = _FakeSite(preference=preference)
+def _loader(flag=False):
+    site = _FakeSite(flag=flag)
     return ResourceLoader(site=site), site
 
 
@@ -158,54 +148,25 @@ def test_drop_of_an_unknown_page_is_harmless():
 
 
 # ---------------------------------------------------------------------------
-# The flag and its TTL
+# The flag
 # ---------------------------------------------------------------------------
 
 
-def test_flag_is_read_once_within_the_ttl(monkeypatch):
-    clock = [1000.0]
-    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
-    loader, site = _loader(preference=True)
+def test_flag_on_enables_the_cache():
+    loader, _site = _loader(flag=True)
     assert loader.page_class_cache_enabled() is True
-    assert site.preference_reads == 1
-    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL - 1
-    assert loader.page_class_cache_enabled() is True
-    assert site.preference_reads == 1
 
 
-def test_flag_is_re_read_past_the_ttl(monkeypatch):
-    clock = [1000.0]
-    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
-    loader, site = _loader(preference=True)
-    loader.page_class_cache_enabled()
-    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL + 1
-    site.preference = False
+def test_flag_off_disables_the_cache():
+    loader, _site = _loader(flag=False)
     assert loader.page_class_cache_enabled() is False
-    assert site.preference_reads == 2
 
 
-def test_turning_the_flag_off_drops_what_is_already_cached(monkeypatch):
-    clock = [1000.0]
-    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
-    loader, site = _loader(preference=True)
+def test_flag_is_read_once_at_startup():
+    loader, site = _loader(flag=True)
     loader.page_class_cache_enabled()
-    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
-    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL + 1
-    site.preference = False
-    assert loader.page_class_cache_enabled() is False
-    assert len(loader._page_class_cache) == 0
-
-
-def test_turning_the_flag_on_leaves_the_cache_alone(monkeypatch):
-    clock = [1000.0]
-    monkeypatch.setattr(grl.time, 'time', lambda: clock[0])
-    loader, site = _loader(preference=False)
     loader.page_class_cache_enabled()
-    loader.store_page_class_cache(('page-1', '/pkg/a.py'), _PageA)
-    clock[0] += grl.PAGE_CLASS_CACHE_FLAG_TTL + 1
-    site.preference = True
-    assert loader.page_class_cache_enabled() is True
-    assert loader.load_page_class_cache(('page-1', '/pkg/a.py')) is _PageA
+    assert site.gnrapp.flag_reads == 1
 
 
 # ---------------------------------------------------------------------------

--- a/projects/gnrcore/packages/sys/resources/preference.py
+++ b/projects/gnrcore/packages/sys/resources/preference.py
@@ -36,7 +36,6 @@ class AppPref(object):
         self.printPreferences(tc.borderContainer(title='!![en]Print'))
         self.xlsxPrintPreferences(tc.contentPane(title='!![en]XLSX Print', datapath='.xlsx_print'))
         self.pdfPreferences(tc.borderContainer(title='!![en]PDF Preferences'))
-        self.developerPreferences(tc.contentPane(title='!![en]Developer'))
         self.site_config_override(tc.contentPane(title='!![en]Site config',datapath='.site_config'))
         self.tablesConfiguration(tc.contentPane(title='!![en]Tables Configuration'))
         self.notificationPreferences(tc.contentPane(title='!![en]Notification'))
@@ -115,13 +114,6 @@ class AppPref(object):
                                     spreadModeButtons:[!![en]Spread mode buttons],documentProperties:[!![en]Document properties]""",
                          cols=3,hidden='^.jsPdfViewer?=!#v')
         fbv.textbox(value='^.external_document_url',lbl='External document url')
-
-    def developerPreferences(self, pane):
-        fb = pane.formbuilder()
-        fb.comboBox(value='^.experimental.remoteForm',lbl='!![en]Remote forms',values='onEnter,delayed')
-        fb.checkbox(value='^.experimental.wsk_disabled',lbl='!![en]WSK Disabled (kill switch)')
-        fb.checkbox(value='^.experimental.no_mako',lbl='!![en]No Mako rootPage')
-        fb.checkbox(value='^.experimental.page_class_cache',lbl='!![en]Page class cache (per page_id)')
 
     def tablesConfiguration(self, pane):
         fb = pane.formbuilder(cols=1,border_spacing='3px',datapath='.tblconf')

--- a/resources/common/th/th_form.py
+++ b/resources/common/th/th_form.py
@@ -32,7 +32,7 @@ class TableHandlerForm(BaseComponent):
             grid =  pane.view.grid
             linkTo = grid
         #context_dbstore = pane.getInheritedAttributes().get('context_dbstore')
-        remoteForm = options.pop('remote',None) or (self.getPreference('experimental.remoteForm',pkg='sys'))
+        remoteForm = options.pop('remote',None) or self.application.experimentalValue('page', 'remoteForm')
         if formInIframe:
             remoteForm = False
         remotePars = dict()

--- a/resources/common/tpl/standard.py
+++ b/resources/common/tpl/standard.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Python equivalent of ``standard.tpl`` for GenroPy rootPage.
 
-Activated via ``experimental.no_mako`` preference. The Mako file
+Activated via ``<experimental><page no_mako="True"/></experimental>`` in
+instanceconfig.xml. The Mako file
 ``gnrjs/gnr_d{11,20}/tpl/standard.tpl`` remains as fallback.
 """
 


### PR DESCRIPTION
Fixes #1235

## What

The experimental feature switches move from the `sys` preferences (`experimental.*`) to a new `<experimental>` tag in `instanceconfig.xml`, read through a single `GnrApp.experimentalFlag(group, name)` accessor:

```xml
<experimental>
    <page no_mako="True" page_class_cache="True" remoteForm="delayed"/>
</experimental>
```

## Changes

- `gnrapp.py`: `experimentalValue(group, name)` reads `config['experimental.<group>?<name>']` (missing tag → `None`); `experimentalFlag` is its `boolean()`.
- `gnrwebpage.py`, `gnrwebpage_plugin/mako.py`: `no_mako` read from the flag.
- `gnrresourceloader.py`: `page_class_cache` read once at startup; the TTL/re-read logic and the clear-on-toggle go away (the value cannot change at runtime any more). `clear_page_class_cache` stays, the `sys/page_class_cache` webpage calls it.
- `wsk_enabled` follows `site.wsk` alone: `experimental.wsk_disabled` was a runtime kill switch on top of `<wsgi websockets="true"/>` in `siteconfig.xml`, and once it needs a restart it only duplicates that flag.
- `remoteForm` (`onEnter`/`delayed`), read by `resources/common/th/th_form.py` as the default of the `remote` form option, moves to the tag too via `experimentalValue`. It is slated for removal in a follow-up.
- `sys/resources/preference.py`: the `Developer` tab is removed.
- `instanceconfig.rst`: new `<experimental>` section; `resources/common/tpl/standard.py` docstring updated.
- `gnrpageclasscache_test.py`: the fake site exposes `gnrapp.experimentalFlag`; the four TTL tests are replaced by three on the flag source. `services_addservice_test.py`: its fake `gnrapp` gains the accessor.

## Migration

No fallback to the old preferences. An instance that had `no_mako` or `page_class_cache` on in the preferences has to set it in `instanceconfig.xml` and restart.

## Checks

- `flake8 --select=F,E9` clean on the touched files (one pre-existing `F811` on `gnrwebpage.py:52`, untouched by this PR)
- `pytest tests/web`: 515 passed
- full suite via the pre-commit hook: green on every commit
