### PR TITLE
feat(storage): optional genro-storage backend behind a default-off switch

### DIFF
--- a/docs/development/envvars.py
+++ b/docs/development/envvars.py
@@ -8,6 +8,11 @@ variables = {
             "GNR_TEST_PG_PORT": "Database server port for tests",
             "GNR_TEST_PG_USER": "Database server user for tests",
             "GNR_TESTING_INSTANCE_NAME": "Name of the instance when running tests",
+            "GNR_TEST_S3_ENDPOINT": "S3-compatible endpoint (e.g. a local MinIO at http://127.0.0.1:9000) for the storage comparison tests and benchmark; when unset those tests skip",
+            "GNR_TEST_S3_ACCESS_KEY": "Access key for GNR_TEST_S3_ENDPOINT",
+            "GNR_TEST_S3_SECRET_KEY": "Secret key for GNR_TEST_S3_ENDPOINT",
+            "GNR_TEST_S3_BUCKET": "Bucket the storage tests write to (default: sandbox)",
+            "GNR_TEST_S3_PREFIX": "Key prefix the storage tests create and delete under (default: gnrtest)",
     },
     "Deployment": {
         "GNR_RMS_CODE":"TBD",

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -8,6 +8,20 @@ Goal: serve the replaceable part of the legacy storage layer through genro-stora
 behind a switch that is **off by default**, with the legacy code left intact and still
 the default. Nothing legacy is removed on this branch.
 
+> **Implementation note (§4.1 point 10, resolved further than planned).** The plan
+> called for a node adapter subclassing `StorageNode` over a service-shaped shim.
+> Implementing it showed the stronger form of the same idea: a **`StorageService` whose
+> backends are genro-storage**, with the legacy `StorageNode` unchanged on top. The
+> legacy node then keeps its own `isinstance` identity, `.service`, `serve()`, `mkdir()`,
+> `base64` shape, `internal_url`, `listdir`, `autocreate`, and the `StorageService`
+> copy/move machinery bridges the two worlds by content on its own. So there is no node
+> adapter and no bridging code: `gnr/lib/services/storage_genro.py` is the whole
+> variation, and `GenroStorageHandler` overrides exactly one method, `storage()`.
+> Consequences: planned Phase 3 collapsed into Phase 2, planned Phase 5 (cross-world
+> copy/move) needed no code — only tests — and planned Phase 8 (`ep_table` version keys)
+> became unnecessary, because the service reports `versions()` with the legacy boto3 key
+> names instead.
+
 Everything marked *(measured)* below was executed in this session on this machine
 (macOS 25.0.0, pyenv 3.13.2, MinIO at `http://127.0.0.1:9000`, bucket `sandbox`).
 Everything else is read from source.
@@ -176,20 +190,24 @@ two were fixed by later commits on that same branch, which the review text preda
 | # | Finding | Decision |
 |---|---|---|
 | 1 | **`http` backend unreachable** — `IMPLEMENTATION_MAP` mapped `http → ('http', {})` with an empty rename map while the guard required `base_path`, so every `http` mount was skipped with a misleading "missing a required parameter" warning, on every handler construction. | **Resolved, as not applicable.** Already fixed on wf/273 by `9760a260a6` (entry removed, guard clause removed, rationale documented). This plan confirms the choice on the merits: §2 shows Genropy's `_http_` and genro-storage's `http` are different shapes. `http` is absent from the map and `_http_` is legacy by design, with a test asserting it. |
-| 2 | **`makeNode` drops `autocreate`/`must_exist`/`mode`/`version`** on the genro-storage path. | **Resolved (all four honoured).** `must_exist` → `exists()` check raising `NotExistingStorageNode`; `version` → `manager.node(..., version=...)`, plus T2's `'_latest_'` sentinel handling; `mode` → stored on the node and used as `local_path`'s default, as legacy does; `autocreate` → accepted and, for the `-1` convention, satisfied by the backends creating parent directories on write *(measured: local and S3 both create intermediate dirs on `open('w')`)* — with a test that pins it instead of a comment. `gnrpy/gnr/web/gnrwsgisite.py:2037` passes `autocreate=-1` on a configurable upload path that can be a concrete mount, so this is a real path, not a hypothetical. |
+| 2 | **`makeNode` drops `autocreate`/`must_exist`/`mode`/`version`** on the genro-storage path. | **Resolved: the question stopped existing.** `makeNode` is not overridden at all — the inherited `LegacyStorageHandler.makeNode` builds a legacy `StorageNode`, which consumes all four itself. `must_exist` raises `NotExistingStorageNode` from `StorageNode.__init__`, `mode` is kept on the node and used as `local_path`'s default, `version` reaches the service's `open()` (which also handles T2's `'_latest_'` sentinel), and `autocreate` goes through `StorageService.autocreate` onto the service's `makedirs`. Pinned by `test_node_kwargs_reach_the_node`, `test_must_exist_raises_on_missing` and `test_open_write_creates_intermediate_directories` in both modes. |
 | 3 | **Stale mount when a service's implementation changes** — `updateStorageParams` only added or replaced mappable mounts, so `local → symbolic` kept being served by genro-storage until restart. | **Resolved, inherited.** Already fixed on wf/273 by `f57b38921b` (drop-then-re-register: `delete_mount` if present, then `_configure_mounts()`), with a test. Inherited as is; the cost (re-walking the registry per `sys.service` update) is acceptable for an admin-triggered event. |
-| 4 | **`base64` return-shape mismatch** — routed through a method-rename map, so `node.base64()` returned a `data:` URI instead of a bare string and `node.base64(mime=True)` passed `True` where a `str\|None` was expected. | **Resolved.** Explicit three-case wrapper (§3), plus `''` for a missing file, plus a test asserting each case against both modes. No in-repo caller passes `mime=`, but application code outside this repo is the actual audience of the legacy contract. |
+| 4 | **`base64` return-shape mismatch** — routed through a method-rename map, so `node.base64()` returned a `data:` URI instead of a bare string and `node.base64(mime=True)` passed `True` where a `str\|None` was expected. | **Resolved: `to_base64` is never called.** The service inherits `StorageService.base64`, which builds the string from `open()` — so the bare/`mime=True`/explicit-mime shapes and the `''` for a missing file are the legacy code itself, not a reimplementation of it. Four tests assert the four cases in both modes. |
 
 Also inherited from that review, non-blocking: the test that reaches into
 `manager._mounts` is rewritten to assert through the public API
 (`manager.node('site:x').resolved_path`).
 
-Two further defects found in this study and **not** in review.md, both fixed here:
-`serve()` and `mkdir()` delegated blind to incompatible signatures (§3). The first is a
-live `TypeError` on the WSGI serving path for any url carrying query kwargs — including
-the `?mtime=` that Genropy itself generates — which is very likely why wf/273's one
-deferred runtime check ("flag on in a real site, open a page serving a stored file") was
-never executed successfully.
+Two further defects found in this study and **not** in review.md: `serve()` and `mkdir()`
+delegated blind to incompatible signatures (§3). The first is a live `TypeError` on the
+WSGI serving path for any url carrying query kwargs — including the `?mtime=` that
+Genropy itself generates — which is very likely why wf/273's one deferred runtime check
+("flag on in a real site, open a page serving a stored file") was never executed
+successfully. Both are closed by the service-level design: `mkdir` keeps the legacy
+signature (and writes the `.gnrdir` sentinel on a remote mount, so `isdir` behaves as it
+does today), and `serve` is implemented on the service with the legacy `**kwargs`
+signature — streaming the file for a local mount, redirecting to a presigned url for a
+remote one, exactly as `BaseLocalService` and `aws_s3` do.
 
 ---
 
@@ -281,18 +299,26 @@ for a call, not done here.
 
 Each phase ends with a commit. No push, no PR.
 
-| # | What | Files | Verification |
-|---|---|---|---|
-| 1 | The optional extra | `gnrpy/pyproject.toml` | `pip check` output identical to §7's five lines; `python -c "import genro_storage"` |
-| 2 | `GenroStorageHandler` — registry translation, per-mount `configure`, warn-never-raise, `IMPLEMENTATION_MAP` for `local`/`raw`/`aws_s3` with T2's S3 parameter names; `storage_params=None` on `BaseStorageHandler.__init__`; `updateStorageParams`/`removeStorageFromCache` re-sync | `gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py` | `pytest tests/web/gnrgenrostorage_test.py -q -k handler`; `flake8` on the file |
-| 3 | `GenroStorageNode` — **subclass of the legacy `StorageNode`** with a service-shaped `service`; the property wrappers; the explicit `base64`/`serve`/`mkdir`/`listdir`/`children`/`url`/`internal_url`/`public_url`/`internal_path`/`local_path`/`move`/`open`; missing-file normalisation | same file | `pytest tests/core/gnrstorage_compare_test.py -q`; `flake8` |
-| 4 | Routing + the flag: `makeNode` honouring the four kwargs, `has_mount` fallback, `GnrDomainProxy.storage_handler` reading `storage?use_genro_storage` | `gnrstoragehandler.py`, `gnrpy/gnr/web/gnrwsgisite.py` | `pytest tests/web/gnrgenrostorage_test.py -q`; full `pytest -q` unchanged vs baseline |
-| 5 | Cross-world copy/move bridging through the handler | `gnrstoragehandler.py` | `pytest tests/core/gnrstorage_compare_test.py -q -k "copy or move"` |
-| 6 | Comparison tests, local mount (§9) | `gnrpy/tests/core/gnrstorage_compare_test.py` | `pytest tests/core/gnrstorage_compare_test.py -q` — both parametrisations pass, no skips |
-| 7 | Comparison tests, S3 mount on MinIO (§9) | same file | with MinIO up: pass; with `GNR_TEST_S3_ENDPOINT` unset: explicit skip |
-| 8 | `ep_table._getVersionBag` version-key normalisation | `projects/gnrcore/packages/sys/webpages/ep_table.py` | targeted test on both key shapes |
-| 9 | Benchmark (§10) | `gnrpy/tests/core/gnrstorage_benchmark.py` | `pytest tests/core/gnrstorage_benchmark.py -s -q`; table pasted into §11 |
-| 10 | Docs: this file's status, `docs/development/envvars.py`, `TESTING.md` | `docs/development/*`, `gnrpy/tests/TESTING.md` | `python docs/development/envvars.py \| grep GNR_TEST_S3` |
+| # | What | Files | Verification | State |
+|---|---|---|---|---|
+| 1 | The optional extra `genro_storage`, and genro-storage in `developer` | `gnrpy/pyproject.toml` | `pip check` output identical to §7's five lines — **verified, no new line** | done |
+| 2 | `GenroStorageService`, `GenroStorageHandler` (registry translation, per-mount `configure`, warn-never-raise, `IMPLEMENTATION_MAP` for `local`/`raw`/`aws_s3` with T2's S3 parameter names), `storage_params=None` on `BaseStorageHandler.__init__`, `updateStorageParams`/`removeStorageFromCache` re-sync | `gnrpy/gnr/lib/services/storage_genro.py` (new), `gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py` | `flake8` clean; smoke on the live `gnrdevelop` site | done |
+| 3 | *(collapsed into Phase 2 — see the implementation note above: no node adapter)* | — | — | n/a |
+| 4 | The flag: `GnrDomainProxy.storage_handler` reading `storage?use_genro_storage` | `gnrpy/gnr/web/gnrwsgisite.py` | `pytest tests/web/gnrgenrostoragehandler_test.py -q`; full suite unchanged vs baseline | done |
+| 5 | *(cross-world copy/move needed no code — `StorageService` bridges it; covered by tests instead)* | — | `pytest tests/core/gnrstorage_compare_test.py -q -k "copy or move"` | n/a |
+| 6 | Comparison tests, local mount (§9) | `gnrpy/tests/core/gnrstorage_compare_test.py`, `gnrpy/tests/core/storage_fixtures.py` | 94 passed, 0 skipped | done |
+| 7 | Comparison tests, S3 mount on MinIO (§9) | same files | 188 passed with MinIO up; 94 passed + 94 skipped with `GNR_TEST_S3_ENDPOINT` unset | done |
+| 8 | *(`ep_table` version keys — unnecessary: the service reports `versions()` with the legacy boto3 key names)* | — | — | n/a |
+| 9 | Benchmark (§10) | `gnrpy/tests/core/gnrstorage_benchmark.py` | table in §11 | done |
+| 10 | Docs: this file, `docs/development/envvars.py` | `docs/development/*` | `python docs/development/envvars.py \| grep GNR_TEST_S3` | done |
+
+Verification commands:
+
+```bash
+cd gnrpy && python -m pytest -q                                   # whole suite, switch off
+cd gnrpy && python -m pytest tests/core/gnrstorage_compare_test.py tests/web/gnrgenrostoragehandler_test.py -q
+cd gnrpy && python -m pytest tests/core/gnrstorage_benchmark.py -s -q
+```
 
 Baseline to compare against *(measured, on this branch before any change)*:
 
@@ -395,7 +421,61 @@ MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
 
 ### Benchmark results
 
-*(To be filled by Phase 9 with measured numbers, date, machine and versions.)*
+Measured 2026-09-02 on macOS 25.0.0 (Darwin, Apple silicon), pyenv Python 3.13.2,
+genro-storage 0.8.0, fsspec 2025.10.0, s3fs 2025.9.0, boto3/botocore 1.40.18,
+smart_open 7.1.0, MinIO (homebrew binary) at `http://127.0.0.1:9000`, bucket `sandbox`.
+Reproduce with `cd gnrpy && python -m pytest tests/core/gnrstorage_benchmark.py -s -q`.
+Totals in ms for the stated repetition count; `ratio = genro_ms / legacy_ms`, so above 1
+genro-storage is slower.
+
+**Local mount**
+
+| operation | reps | legacy_ms | genro_ms | ratio |
+|---|---|---|---|---|
+| write small (4KB) | 10 | 0.45 | 1.35 | 3.01 |
+| write large (4MB) | 3 | 2.34 | 2.59 | 1.11 |
+| read small (4KB) | 10 | 0.38 | 1.09 | 2.89 |
+| read large (4MB) | 3 | 0.98 | 0.96 | 0.98 |
+| exists | 50 | 0.11 | 2.37 | 21.30 |
+| size | 50 | 0.11 | 2.83 | 26.93 |
+| mtime | 50 | 0.10 | 2.34 | 23.03 |
+| md5hash | 50 | 0.98 | 8.14 | 8.33 |
+| children (100 files) | 10 | 0.94 | 8.08 | 8.57 |
+| copy same mount | 10 | 1.23 | 4.03 | 3.27 |
+| internal_url | 50 | 0.04 | 0.05 | 1.28 |
+
+**S3 mount (MinIO on localhost)**
+
+| operation | reps | legacy_ms | genro_ms | ratio |
+|---|---|---|---|---|
+| write small (4KB) | 10 | 56.51 | 32.19 | 0.57 |
+| write large (4MB) | 3 | 53.35 | 46.40 | 0.87 |
+| read small (4KB) | 10 | 23.54 | 37.57 | 1.60 |
+| read large (4MB) | 3 | 11.83 | 19.01 | 1.61 |
+| exists | 50 | 33.46 | 32.51 | 0.97 |
+| size | 50 | 32.09 | 36.99 | 1.15 |
+| mtime | 50 | 32.52 | 33.14 | 1.02 |
+| md5hash | 50 | 32.38 | 97.47 | 3.01 |
+| children (100 files) | 10 | 69.10 | 79.44 | 1.15 |
+| copy same mount | 10 | 37.61 | 68.90 | 1.83 |
+| internal_url | 50 | 0.07 | 0.07 | 0.98 |
+
+Reading the numbers:
+
+- **Local metadata calls carry a constant per-call overhead**: genro-storage builds a
+  node object per call, so `exists`/`size`/`mtime` cost ~0.05 ms each against ~0.002 ms.
+  The ratio is large, the absolute cost is not; it is worth optimising (cache the node
+  per path in the service) only if a hot loop shows up.
+- **On S3 genro-storage wins the writes** (0.57–0.87) and loses the small reads. The
+  metadata calls are a wash: both pay one round trip.
+- **`md5hash` on S3 is not a like-for-like comparison.** The legacy service reads the
+  ETag and gives up when it is not 32 characters — which is what a multipart upload
+  produces — so its 32 ms buy a `None`. genro-storage's 97 ms return the real md5. This
+  is the divergence pinned in `TestNamedDivergences`.
+- **Run-to-run noise on S3 is material** at these repetition counts: across two runs,
+  `children` moved between 0.36 and 1.15 and `read small` between 1.60 and 2.96. The
+  local ratios were stable. Treat the S3 column as an order of magnitude, not a
+  measurement, and raise the repetitions before drawing a conclusion from a single cell.
 
 ---
 
@@ -403,16 +483,34 @@ MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
 
 | Phase | State |
 |---|---|
-| 1–10 | not started (this document is the plan) |
+| 1, 2, 4, 6, 7, 9, 10 | done (see §8) |
+| 3, 5, 8 | not needed — see the implementation note at the top |
+
+Measured results against the acceptance criteria:
+
+| Criterion | Result |
+|---|---|
+| Switch off ⇒ same outcome as develop | **2339 passed, 69 skipped** — identical to the baseline measured on this branch before any change; no test went passed→failed, no new skip |
+| Switch on ⇒ comparison tests pass on local | **94 passed, 0 skipped** (both modes) |
+| Switch on ⇒ MinIO tests pass when configured, skip otherwise | **188 passed** with `GNR_TEST_S3_ENDPOINT` set; **94 passed + 94 skipped**, reason naming the variable, when unset |
+| Non-replaced implementations stay legacy with the switch on | `tests/web/gnrgenrostoragehandler_test.py` — 29 passed, including the nine symbolic mounts and `_http_`, and `internal_path` parity with the legacy handler for `rsrc:`, `pkg:`, `temp:`, `gnr:` |
+| `pip check` clean | **Not achievable as stated, and not caused by this branch** — see §7. Verified instead: the output is identical to the five pre-existing lines |
+| Benchmark table present and reproducible | §11, with the command |
 
 Open, deliberately:
 
 1. **`relative` and `sftp` deferred** (§2) — both are mappable, neither is testable in
    this environment, and each is a self-contained follow-up.
-2. **`public_url`, `readonly`/`write_in_local`, `local_path(keep=True)`, `internal_path`
-   for remote mounts** have no genro-storage counterpart. All four are handled in the
-   adapter by delegating to the legacy service or raising; each is a candidate upstream
-   request, and T2's `GENRO_STORAGE_ISSUE.md` is where they belong.
+2. **Four things genro-storage does not provide**, each handled and each an upstream
+   candidate (T2's `GENRO_STORAGE_ISSUE.md` is where they belong):
+   `public_url` — built in the service from the mount's endpoint and bucket;
+   `internal_path` for remote mounts — composed from the mount's `base_path`, since
+   `resolved_path` is `None` off the local filesystem;
+   `readonly`/`write_in_local` — no counterpart at all, so a readonly mount is **left on
+   the legacy service**, because serving it through a writable backend would silently
+   drop the restriction;
+   `local_path(keep=True)` — refused with `NotImplementedError` on a remote mount rather
+   than silently not keeping the file.
 3. **`pip check` is already dirty on this machine** (§7) — the `s3fs`/`gcsfs` exact pin
    on `fsspec` predates this branch. Needs an environment call.
 4. **The daemon-based storage suite is skipped on this machine** (§8) because a daemon is
@@ -420,6 +518,18 @@ Open, deliberately:
    stopping that daemon, or by teaching `BaseGnrDaemonTest` to attach to a running one)
    is a separate question from this migration.
 5. **The hybrid is the end state, not a stepping stone** (§2): with the switch on, a
-   typical instance keeps every symbolic mount on the legacy layer. The cross-world
-   copy/move bridge (§8 Phase 5) exists precisely because of that, and it is the part of
-   the design most worth reviewing before implementation.
+   typical instance keeps every symbolic mount on the legacy layer. This is why the
+   service-level design matters — `StorageService` bridges a copy or move between the
+   two worlds by content on its own, with no code of ours in the path.
+6. **A local mount whose `base_path` does not exist yet stays legacy** (§8 Phase 2):
+   genro-storage's local backend requires the directory to exist, the legacy service
+   creates it on first write. On `gnrdevelop` this is the `mail` mount, and it logs one
+   warning at handler construction. Pre-creating the directory at startup would be the
+   alternative; not done, because a storage switch should not create directories.
+7. **Never yet run with the flag on in a live serving site.** The switch, the routing,
+   the node surface and the WSGI-facing `serve()` are covered by tests against a real
+   site object, but no request has been served through the genro-storage handler in a
+   running daemon. That is the next thing to do before this goes anywhere near an
+   instance that matters.
+8. **The per-call node construction on local mounts** (§11) is the one measured
+   inefficiency: worth a cache in the service if a profile ever points here.

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -1,0 +1,425 @@
+# genro-storage migration — study and action plan
+
+Reference issue: #251 (testing request for the genro-storage integration).
+Branch: `feature/251-genro-storage-switch`, cut from `origin/develop` @ `919a3a572a`.
+Target package: `genro-storage` 0.8.0 (PyPI, installed), `fsspec` 2025.10.0, `s3fs` 2025.9.0.
+
+Goal: serve the replaceable part of the legacy storage layer through genro-storage,
+behind a switch that is **off by default**, with the legacy code left intact and still
+the default. Nothing legacy is removed on this branch.
+
+Everything marked *(measured)* below was executed in this session on this machine
+(macOS 25.0.0, pyenv 3.13.2, MinIO at `http://127.0.0.1:9000`, bucket `sandbox`).
+Everything else is read from source.
+
+---
+
+## 1. The legacy surface
+
+Three layers, all in play:
+
+| Layer | File | Role |
+|---|---|---|
+| `StorageNode` | `gnrpy/gnr/lib/services/storage.py:248` | the object application code holds |
+| `StorageService` / `BaseLocalService` | `gnrpy/gnr/lib/services/storage.py:426` / `:734` | per-implementation behaviour |
+| `BaseStorageHandler` / `LegacyStorageHandler` | `gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py:28` / `:420` | registry (`storage_params`), path parsing, node factory |
+
+Wiring: `GnrDomainProxy.storage_handler` (`gnrpy/gnr/web/gnrwsgisite.py:193`) builds one
+handler per domain; `site.storage/storageNode/storagePath` (`:737-744`) are thin
+delegators; `storageNodeFromPathList` (`:777`) and `storageDispatcher` (`:795`) are the
+WSGI serving path and still live on `GnrWsgiSite`, not on the handler.
+
+Caller surface: 166 call sites of `storageNode(` / `.storage(` across `gnrpy/gnr` and
+`projects/gnrcore` *(measured)*. Of the node members, the ones that appear most in the
+tree are `.internal_path` (73 raw grep hits), `.children` (43), `.listdir` (41),
+`.local_path` (10), `.internal_url` (10), `.public_url` (8), `.mkdir` (8), `.serve` (7).
+
+Five places do `isinstance(x, StorageNode)` and must keep working:
+`gnr/lib/services/storage.py:429` (`_getNode`), `:699` (`_call`),
+`gnr/core/flatfiles.py:752`, `gnr/lib/services/htmltopdf.py:81`,
+`projects/gnrcore/packages/docu/tests/test_docu_sphinx_conf.py:46`.
+
+**Consequence for the design:** the genro-storage node adapter must be a *subclass* of
+the legacy `StorageNode`, not a duck type. wf/273 made it a plain object; that is the
+root of its worst defect (§4.1).
+
+---
+
+## 2. The eight implementations: replaceable or not
+
+| Implementation | File | Replaceable | Why |
+|---|---|---|---|
+| `local` | `resources/common/services/storage/local.py` | **Yes** | 1:1 with genro-storage `protocol: local`. Only caveat: `LocalStorage.__init__` raises `FileNotFoundError` if `base_path` does not exist yet *(measured)*, while `BaseLocalService` accepts it and creates on demand. The mount loop must pre-create or skip-and-warn. |
+| `aws_s3` | `projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py` | **Yes, with gaps** | genro-storage `protocol: s3` (s3fs) covers read/write/exists/size/mtime/md5hash/children/copy/move/versions/presigned url, verified against MinIO *(measured)*. Gaps to close in the adapter: `mkdir` (legacy writes a `.gnrdir` sentinel so `isdir` becomes True; genro-storage's `mkdir` leaves `is_dir()` False on S3 *(measured)*), `public_url` (no counterpart — legacy `#990` feature), `internal_path` (legacy returns the object key, genro-storage `resolved_path` returns `None` for remote *(measured)*), `readonly`/`write_in_local` (no counterpart), `serve` (legacy redirects to a presigned url, genro-storage streams the bytes). |
+| `raw` | `resources/common/services/storage/raw.py` | **Yes, trivially** | It is `local` with `base_path='/'` plus `expandpath`. Mount as `local` with `path: '/'`; keep `expandpath` in the adapter's path handling. |
+| `relative` | `resources/common/services/storage/relative.py` | **Yes, but not now** | genro-storage has a relative-mount form (`path: "parent:sub"`, `manager._configure_relative_mount`). The legacy class is a class-swapping hack (`self.__class__ = self.parent_service.__class__`) whose `_resolved_relative` has a `#resolve dbstore...` TODO. Mapping it is a separate, self-contained job; **deferred**, stays legacy. |
+| `symbolic` | `resources/common/services/storage/symbolic.py` | **No** | Nine different dynamic resolvers keyed on the mount name (`path_rsrc` → `site.resources`, `path_pkg` → `packageFolder`, `path_gnr`/`path_dojo` → version-keyed, `path_temp` → `tempfile.gettempdir()`, `path_user`/`path_conn`/`path_page` → request-scoped, `path_vol` → `<volumes>`), each with a matching `url_*` producing a site route. It has no `base_path` at all (`self.base_path = 'SYMBOLIC'`). It depends on the site and on the current page, i.e. on things a storage library cannot know. T2 showed genro-storage's callable-path ("switched mount") can carry `rsrc`/`pkg`/`gnr`/`dojo`, but the request-scoped three cannot follow and the `url_*` half stays site-owned regardless. **Stays legacy, permanently, and this is the intended end state.** |
+| `http` | `resources/common/services/storage/http.py` | **No** | Genropy's `_http_` is a shortcut where the *path itself is the whole URL* (`internal_path` returns `args[0]`); genro-storage's `http` protocol is a CDN-style mount that needs a `base_path` and appends to it. Different shape, no useful mapping. Stays legacy. |
+| `compressed` | `resources/common/services/storage/compressed.py` | **No** | Its identity is the transparent `.gz`/`.bz2` suffix added to every path plus a `Content-Encoding: gzip` serve. genro-storage's `zip`/`tar` backends read *inside* an archive, which is the opposite operation. No counterpart; stays legacy. |
+| `sftp` | `projects/gnrcore/packages/sys/resources/services/storage/sftp.py` | **Yes, later** | genro-storage has `protocol: sftp` (fsspec + paramiko). Untestable here without an SFTP host, so it is out of this branch's scope: **deferred**, stays legacy. |
+
+**In this branch: `local`, `raw` and `aws_s3` are routed to genro-storage. Everything
+else stays legacy even with the switch on** — and that hybrid is served by the same
+handler, per mount.
+
+---
+
+## 3. The API gap, measured
+
+genro-storage 0.8 differs from the legacy node in ways that are silent failures if not
+adapted. Verified by running both mounts (local, S3-on-MinIO) *(measured)*:
+
+| Concern | Legacy | genro-storage 0.8 | Adapter must |
+|---|---|---|---|
+| `exists`, `isfile`, `isdir`, `size`, `mtime`, `md5hash` | properties | **methods** (`exists()`, `is_file()`, `is_dir()`, …) | expose properties — `if node.exists:` on a bound method is always true, and that failure is silent everywhere |
+| missing file | `size`/`mtime` → `None` (S3) or `AttributeError` (local); `base64` → `''`; `children` → `None` | **raises `FileNotFoundError`** for `size`/`mtime`/`md5hash`/`to_base64`/`children` | normalise to the legacy return values |
+| `base64(mime)` | `mime` falsy → bare b64; `mime is True` → auto-detect data URI; `mime` str → that mime; missing → `''` | `to_base64(mime: str\|None, include_uri=True)` — **defaults to a data URI** | explicit three-case wrapper, not a method rename |
+| `url()` | local → `{external_host}/_storage/{mount}/{path}`; S3 → presigned | local → **`None`**; S3 → presigned | route local urls back to the legacy service (the `/_storage/` route is site-owned) |
+| `internal_url()` | `{external_host}/_storage/{mount}/{path}` (+`?mtime=` on `nocache`) | **`None` on every backend** | build it in the adapter / delegate to the legacy service |
+| `public_url()` | plain non-expiring url (S3 `#990`) | absent | delegate to the legacy service |
+| `internal_path` | absolute fs path (local) or object key (S3) | `resolved_path` — path for local, **`None` for remote** | for S3, compose the key from the mount config; 73 grep hits depend on this |
+| `listdir()` | list of fullpaths, `None` if not a dir | absent | implement over `children()` |
+| `children()` | `None` if not a dir | raises | return `None` |
+| `mkdir(*args)` | path segments, idempotent | `mkdir(parents=False, exist_ok=False)` | explicit method — otherwise `node.mkdir('sub')` passes `'sub'` as `parents` and creates nothing |
+| `serve(environ, start_response, **kwargs)` | swallows extra kwargs | `serve(environ, start_response, download, download_name, cache_max_age)` — **no `**kwargs`** | explicit method filtering kwargs; `storageDispatcher` passes arbitrary query-string kwargs, and Genropy's own `internal_url(nocache=True)` produces `?mtime=…` |
+| `local_path(mode, keep)` | `keep=True` keeps the temp file | `local_path(mode)` — no `keep` | raise on truthy `keep` until upstream has it |
+| `move(dest)` | mutates self, returns `None` | `move_to(dest)` returns the new node **and mutates the source** *(measured)* | keep legacy return contract |
+| `copy(dest)` | returns destNode; bridges across services | `copy_to(dest)` — dest must be a genro-storage node | route cross-world copy/move through the handler (§4.1) |
+| `.parent` | the **site** | the **parent node** | do not delegate; `.parent`, `.service`, `.mode`, `.autocreate`, `.version` stay legacy attributes |
+| `mkdir` on S3 | `.gnrdir` sentinel → `isdir` True | no sentinel → `is_dir()` False *(measured)* | write the sentinel, or accept and test the difference |
+| `versions` | boto3 CamelCase dicts (`VersionId`, `LastModified`, `IsLatest`) | snake_case (`version_id`, `last_modified`, `is_latest`) *(measured)* | normalise; `projects/gnrcore/packages/sys/webpages/ep_table.py:139` still assumes CamelCase |
+
+Same across both worlds *(measured)*: md5 of the same bytes, `to_base64` payload,
+`fullpath` shape (`mount:path`), `child`, `splitext`, `ext`, presigned S3 url.
+
+---
+
+## 4. What is inherited from the three previous attempts
+
+| | strategy | switch | disposition |
+|---|---|---|---|
+`wf/273-genro-storage-handler` (local, 13 commits) | `GenroStorageHandler(BaseStorageHandler)` by **composition** — holds a `LegacyStorageHandler`, routes per mount on `manager.has_mount()`; `GenroStorageNode` adapter | `storage?use_genro_storage` in siteconfig, default off | **the base of this work** |
+`origin/feature/genro-storage-integration` (T1, merged by cgabriel) | side adapter module + an `if` re-inlined into `GnrWsgiSite.storageNode`, bypassing the handler | `<storage_backend>genro-storage</storage_backend>` | **discard the seam, inherit one test file** |
+`origin/feature/gs-storage-integration` (T2, 26 commits, 881 behind) | sibling `NewStorageHandler` behind a factory; first ~9 commits *are* today's develop handler | `<storage mode="ns"/>` | **inherit specific pieces** |
+`origin/feature/prepare-storage-integration` (T3, 1 commit) | preparatory extraction only, no genro-storage | none (`# TODO`) | **superseded**; as committed it does not even import (`self.storage` shadows the `storage()` method, two `NameError`s left by a rename) |
+
+### 4.1 Inherited
+
+1. **wf/273's switch point** — `GnrDomainProxy.storage_handler`
+   (`gnrpy/gnr/web/gnrwsgisite.py:193`). One property, 4 lines, funnels single-domain and
+   multidomain, default off. Nothing else in the framework needs to know.
+2. **wf/273's `storage_params=None` on `BaseStorageHandler.__init__`** — purely additive,
+   lets both handlers share one registry dict (one `sys.service` query, mutations visible
+   to both).
+3. **wf/273's composition + per-mount routing on `has_mount()`** — makes "flag off =
+   byte-identical" trivial to argue and gives the hybrid of §2 a natural home.
+4. **wf/273's reuse of `LegacyStorageHandler._adapt_path`** — `vol:`, `_raw_`, `_http_`
+   keep being parsed in exactly one place.
+5. **wf/273's per-mount `configure([one])` + warn-never-raise** — genro-storage validates
+   a batch atomically, so one bad mount would abort site startup
+   (upstream `genropy/genro-storage#75`). Keep the loop and the issue reference.
+6. **wf/273's property-vs-method adapter** and its introspective test
+   `test_every_legacy_property_stays_a_property`, which derives the contract from
+   `vars(LegacyStorageNode)` instead of a hand-kept list.
+7. **T1's `gnrpy/tests/core/gnrstorage_test.py`** — a 46-test conformance suite for
+   today's `StorageNode`: real filesystem, real `BaseLocalService`, a minimal site stub,
+   **no daemon and no database**. This is the oracle both modes must satisfy and the shape
+   the comparison tests take (§8).
+8. **T2's S3 parameter mapping** (`region_name|region → region`,
+   `aws_access_key_id → key`, `aws_secret_access_key → secret`, `base_path → prefix`,
+   `endpoint_url` passthrough) — wf/273's map only carries `bucket`/`prefix`/`region`, so
+   a legacy `aws_s3` service with credentials in its parameters would mount unauthenticated.
+9. **T2's `ep_table._getVersionBag` dual key-format + `None` guard** — the version UI
+   still assumes boto3 CamelCase; needed the moment an S3 mount is served by genro-storage.
+10. **T2's `GENRO_STORAGE_ISSUE.md`** — six reproducible upstream defect reports; the
+    checklist of what genro-storage still owes us.
+
+### 4.2 Discarded
+
+1. **T1's seam** (`if` inside `GnrWsgiSite.storageNode`) — fights the handler
+   architecture that landed since, and in re-inlining the legacy body it dropped
+   `version=` even on the native path.
+2. **T1's `GenroStorageConfigConverter`** — maps `symbolic → local` **with no path key**
+   (this is issue #252 by construction: every dynamic resolver of §2 silently disappears),
+   never maps `aws_s3` (Genropy's implementation string) so S3 is nominal, and reads
+   siteconfig Bag *children* while Genropy stores service config in Bag *attributes*.
+   Convert from the `storage_params` registry, never from raw siteconfig.
+3. **T1's `GenroStorageServiceAdapter(StorageService)`** — faking a legacy *service* by
+   subclassing is the wrong direction.
+4. **T1's broad `except Exception` → silent native fallback.** A mount that cannot be
+   served must warn; a switch that cannot be honoured must fail loudly.
+5. **T1's `test_storage_backend_switch.py`** — mock-only, never touches the seam, and
+   `test_convert_symbolic_to_local` asserts the bug.
+6. **T2's `_makeSymbolicPathCallable`** — reinvents symbolic's paths and gets them wrong
+   (`data/users` vs the real `data/_users`, `data/connections` vs `data/_connections`,
+   a made-up temp dir). Symbolic stays legacy; nothing is reimplemented.
+7. **T2's hard dependency** (`genro-storage` in `[project] dependencies` + unconditional
+   top-level import) — see §6.
+8. **T2's duplicate `gnrstoragehandler_test.py`** and its committed `adm.db` binary.
+9. **T3's `StorageNode` → `LegacyStorageNode` rename** — develop's import alias
+   (`gnrstoragehandler.py:18`) does the same job without breaking in-module callers.
+10. **wf/273's duck-typed `GenroStorageNode`** — see §1: five `isinstance` checks and the
+    whole `StorageService` copy/move machinery dereference `.service`. With wf/273's
+    adapter, `legacyNode.copy('site:foo.txt')` raises `AttributeError: service` and
+    `genroNode.copy('rsrc:foo')` asks genro-storage for a mount it does not have. **Any
+    cross-world copy or move breaks.** The adapter is redesigned as a `StorageNode`
+    subclass whose `service` is a thin service-shaped object, and copy/move go through
+    the handler so it can bridge the two worlds by content.
+
+---
+
+## 5. The four review.md findings — decision each
+
+From `.phased/done/273-genro-storage-handler/review.md` (written at commit `6f1e1351c4`;
+two were fixed by later commits on that same branch, which the review text predates).
+
+| # | Finding | Decision |
+|---|---|---|
+| 1 | **`http` backend unreachable** — `IMPLEMENTATION_MAP` mapped `http → ('http', {})` with an empty rename map while the guard required `base_path`, so every `http` mount was skipped with a misleading "missing a required parameter" warning, on every handler construction. | **Resolved, as not applicable.** Already fixed on wf/273 by `9760a260a6` (entry removed, guard clause removed, rationale documented). This plan confirms the choice on the merits: §2 shows Genropy's `_http_` and genro-storage's `http` are different shapes. `http` is absent from the map and `_http_` is legacy by design, with a test asserting it. |
+| 2 | **`makeNode` drops `autocreate`/`must_exist`/`mode`/`version`** on the genro-storage path. | **Resolved (all four honoured).** `must_exist` → `exists()` check raising `NotExistingStorageNode`; `version` → `manager.node(..., version=...)`, plus T2's `'_latest_'` sentinel handling; `mode` → stored on the node and used as `local_path`'s default, as legacy does; `autocreate` → accepted and, for the `-1` convention, satisfied by the backends creating parent directories on write *(measured: local and S3 both create intermediate dirs on `open('w')`)* — with a test that pins it instead of a comment. `gnrpy/gnr/web/gnrwsgisite.py:2037` passes `autocreate=-1` on a configurable upload path that can be a concrete mount, so this is a real path, not a hypothetical. |
+| 3 | **Stale mount when a service's implementation changes** — `updateStorageParams` only added or replaced mappable mounts, so `local → symbolic` kept being served by genro-storage until restart. | **Resolved, inherited.** Already fixed on wf/273 by `f57b38921b` (drop-then-re-register: `delete_mount` if present, then `_configure_mounts()`), with a test. Inherited as is; the cost (re-walking the registry per `sys.service` update) is acceptable for an admin-triggered event. |
+| 4 | **`base64` return-shape mismatch** — routed through a method-rename map, so `node.base64()` returned a `data:` URI instead of a bare string and `node.base64(mime=True)` passed `True` where a `str\|None` was expected. | **Resolved.** Explicit three-case wrapper (§3), plus `''` for a missing file, plus a test asserting each case against both modes. No in-repo caller passes `mime=`, but application code outside this repo is the actual audience of the legacy contract. |
+
+Also inherited from that review, non-blocking: the test that reaches into
+`manager._mounts` is rewritten to assert through the public API
+(`manager.node('site:x').resolved_path`).
+
+Two further defects found in this study and **not** in review.md, both fixed here:
+`serve()` and `mkdir()` delegated blind to incompatible signatures (§3). The first is a
+live `TypeError` on the WSGI serving path for any url carrying query kwargs — including
+the `?mtime=` that Genropy itself generates — which is very likely why wf/273's one
+deferred runtime check ("flag on in a real site, open a page serving a stored file") was
+never executed successfully.
+
+---
+
+## 6. The switch
+
+**Spelling** — `storage?use_genro_storage` in siteconfig, i.e. an attribute on a
+top-level `<storage>` node, read with `boolean()` (the established pattern for
+`wsgi?...` flags). Inherited from wf/273. To avoid the confusion with the
+`<services><storage>` section that defines services, the key is documented here and
+in `TESTING.md`.
+
+```xml
+<storage use_genro_storage="True"/>
+```
+
+**Default** — absent → falsy → `LegacyStorageHandler`. An untouched siteconfig behaves
+exactly as today. A test asserts the negative branch.
+
+**Granularity** — global to switch *on*, per mount to take *effect*. One flag per site
+(per domain, since the handler is per domain) enables the genro-storage handler; that
+handler then serves only the mounts it could register (`local`, `raw`, `aws_s3`) and
+routes every other mount to the legacy handler it holds. So `symbolic`, `http`,
+`compressed`, `relative`, `sftp`, `vol:` and any unknown name keep working unchanged
+with the switch on. No per-mount opt-in key is introduced: the mount's own
+`implementation` already decides, and a second knob would only add ways to be
+misconfigured.
+
+**Environment override for tests** — `GNR_STORAGE_USE_GENRO_STORAGE` is *not* added.
+The comparison tests construct both handlers explicitly (§8), which is more direct and
+leaves the production flag with exactly one source of truth.
+
+**When genro-storage is not importable** — the import is guarded
+(`try: from genro_storage import StorageManager / except ImportError: StorageManager = None`).
+With the flag **off**, nothing is imported and nothing changes. With the flag **on** and
+the package missing, the handler raises `RuntimeError` at construction with the install
+command and the flag name — never a silent fallback to legacy, because a site that asked
+for genro-storage and silently got the legacy layer is a site whose behaviour nobody can
+reason about.
+
+---
+
+## 7. The dependency
+
+**Form: optional extra `genro_storage`, plus `developer`** — as wf/273 did. There is no
+`requirements*.txt` in this repo; `gnrpy/pyproject.toml` is the only place.
+
+```toml
+genro_storage = ["genro-storage>=0.8,<0.9", "s3fs>=2023.1.0"]
+```
+
+and `"genro-storage>=0.8,<0.9"` added to `developer` so CI can import it unconditionally.
+`s3fs` belongs in the extra, not in `developer`: it is what pulls `aiobotocore`.
+
+Why not `[project] dependencies` *(measured)*:
+
+- `genro-storage` 0.8.0 itself is light (`fsspec`, `genro-bag`, `genro-builders`,
+  `genro-toolbox`, `pyyaml`); the weight is in the `s3` extra, i.e. `s3fs`.
+- `s3fs` pulls `aiobotocore`, and `aiobotocore` 2.24.2 requires
+  **`botocore<1.40.19,>=1.40.15`**. genropy declares `boto3` with **no upper bound**
+  (`gnrpy/pyproject.toml:28`), and every `boto3` release pins a matching `botocore`.
+  The installed pair (`boto3` 1.40.18 / `botocore` 1.40.18) sits inside that window by
+  luck; the next `boto3` bump walks out of it. That is exactly **#1079**, and making
+  `s3fs` mandatory would put it on the critical path of every genropy install.
+  Keeping it in an extra confines it to installs that ask for S3-through-genro-storage.
+
+**`pip check` in this environment** *(measured, before any change on this branch)*:
+
+```
+s3fs 2025.9.0 has requirement fsspec==2025.9.0, but you have fsspec 2025.10.0.
+gcsfs 2025.9.0 has requirement fsspec==2025.9.0, but you have fsspec 2025.10.0.
+pain001 0.0.22 has requirement click==8.1.3, but you have click 8.3.2.
+pain001 0.0.22 has requirement rich==13.4.2, but you have rich 15.0.0.
+pain001 0.0.22 has requirement xmlschema==2.3.1, but you have xmlschema 4.3.2.
+```
+
+So `pip check` is **already not clean, before this branch touches anything**, and the
+two relevant lines are the `s3fs`/`gcsfs` exact pin on `fsspec` — a pre-existing state
+of this machine, not something the extra introduces. The acceptance criterion "clean
+`pip check` after adding the dependency" therefore cannot be met as literally stated;
+what §9's Phase 1 verification checks instead is **no new line**: the `pip check` output
+after adding the extra is identical to the five lines above. Fixing the pre-existing
+mismatch means `pip install 'fsspec==2025.9.0'` (or upgrading `s3fs`/`gcsfs` to a
+2025.10.x release), which is an environment decision, not a branch decision — flagged
+for a call, not done here.
+
+---
+
+## 8. Implementation phases
+
+Each phase ends with a commit. No push, no PR.
+
+| # | What | Files | Verification |
+|---|---|---|---|
+| 1 | The optional extra | `gnrpy/pyproject.toml` | `pip check` output identical to §7's five lines; `python -c "import genro_storage"` |
+| 2 | `GenroStorageHandler` — registry translation, per-mount `configure`, warn-never-raise, `IMPLEMENTATION_MAP` for `local`/`raw`/`aws_s3` with T2's S3 parameter names; `storage_params=None` on `BaseStorageHandler.__init__`; `updateStorageParams`/`removeStorageFromCache` re-sync | `gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py` | `pytest tests/web/gnrgenrostorage_test.py -q -k handler`; `flake8` on the file |
+| 3 | `GenroStorageNode` — **subclass of the legacy `StorageNode`** with a service-shaped `service`; the property wrappers; the explicit `base64`/`serve`/`mkdir`/`listdir`/`children`/`url`/`internal_url`/`public_url`/`internal_path`/`local_path`/`move`/`open`; missing-file normalisation | same file | `pytest tests/core/gnrstorage_compare_test.py -q`; `flake8` |
+| 4 | Routing + the flag: `makeNode` honouring the four kwargs, `has_mount` fallback, `GnrDomainProxy.storage_handler` reading `storage?use_genro_storage` | `gnrstoragehandler.py`, `gnrpy/gnr/web/gnrwsgisite.py` | `pytest tests/web/gnrgenrostorage_test.py -q`; full `pytest -q` unchanged vs baseline |
+| 5 | Cross-world copy/move bridging through the handler | `gnrstoragehandler.py` | `pytest tests/core/gnrstorage_compare_test.py -q -k "copy or move"` |
+| 6 | Comparison tests, local mount (§9) | `gnrpy/tests/core/gnrstorage_compare_test.py` | `pytest tests/core/gnrstorage_compare_test.py -q` — both parametrisations pass, no skips |
+| 7 | Comparison tests, S3 mount on MinIO (§9) | same file | with MinIO up: pass; with `GNR_TEST_S3_ENDPOINT` unset: explicit skip |
+| 8 | `ep_table._getVersionBag` version-key normalisation | `projects/gnrcore/packages/sys/webpages/ep_table.py` | targeted test on both key shapes |
+| 9 | Benchmark (§10) | `gnrpy/tests/core/gnrstorage_benchmark.py` | `pytest tests/core/gnrstorage_benchmark.py -s -q`; table pasted into §11 |
+| 10 | Docs: this file's status, `docs/development/envvars.py`, `TESTING.md` | `docs/development/*`, `gnrpy/tests/TESTING.md` | `python docs/development/envvars.py \| grep GNR_TEST_S3` |
+
+Baseline to compare against *(measured, on this branch before any change)*:
+
+```
+2339 passed, 69 skipped, 15 warnings in 97.79s
+```
+
+The 69 skips are: 47 in `tests/web/gnrstoragehandler_test.py` + 12 in
+`tests/web/gnrwsgisite_test.py` ("Daemon not available"), 9 SQLite/PostgreSQL feature
+skips, 1 PostgreSQL-only. **Note on the daemon skips:** `BaseGnrDaemonTest` starts its
+own `gnr web daemon`, which fails here with `OSError: [Errno 48] Address already in use`
+because a daemon is already running on this machine (PID 22374); the site itself
+instantiates fine *(measured)*. So on this machine the whole daemon-based storage suite
+is skipped, and a skipped run proves nothing — which is why the comparison tests are
+built without a daemon (§9).
+
+---
+
+## 9. Comparison tests
+
+**File:** `gnrpy/tests/core/gnrstorage_compare_test.py`.
+
+**Shape** — one test body per operation, run **twice** through a `mode` fixture
+parametrised `('legacy', 'genro')`. A `node(path)` helper resolves through the handler
+under test, so the body never knows which world it is in. Modelled on T1's
+`gnrpy/tests/core/gnrstorage_test.py`: real filesystem, real services, **no daemon and
+no database**, so it runs both here and in CI. The only stubbed object is the site
+*parent* (`external_host`, `cache_max_age`, `storageNode`, `resources`, `not_found_exception`) —
+the storage operations themselves are all real, on a real `tmp_path` and on a real MinIO
+bucket. No mock ever stands in for an operation under test.
+
+**Operations covered**, per mount and per mode: `exists`, `isfile`, `isdir`, `size`,
+`mtime`, `open` read and write (text and binary), `children`, `listdir`, `child`,
+`copy` (file, into a directory, cross-mount), `move`, `delete` (file and directory),
+`mkdir` (new and existing), `md5hash`, `base64` (bare / `mime=True` / explicit mime /
+missing file), `url`, `internal_url` (plain and `nocache=True`), `local_path` (read and
+write-back), plus `internal_path`, `fullpath`, `basename`, `cleanbasename`, `ext`,
+`splitext`, `parentStorageNode`, `must_exist`, `version`.
+
+Each is asserted **against the legacy result**, not against a hardcoded expectation, so
+the test states the actual contract: "same input, same observable result in both modes".
+Where the two legitimately differ, the difference is asserted explicitly and named
+(`mkdir` on S3, `versions` key shape), never smoothed over.
+
+**Mounts** — `local` on `tmp_path`; `raw`; S3 pointed at MinIO. The legacy `aws_s3`
+service takes `custom_endpoint=True, endpoint_url=...`; the genro-storage mount takes
+`endpoint_url` directly.
+
+**MinIO skip** — the S3 class is skipped, with the reason naming the endpoint, when
+`GNR_TEST_S3_ENDPOINT` is unset **or** the endpoint does not answer
+`GET /minio/health/live` within a short timeout. CI has no MinIO, so this must be a
+clean skip there and a real run here.
+
+**Legacy-stays-legacy test** — with the genro-storage handler active, an explicit test
+asserts that `rsrc:`, `pkg:` and `page:` nodes are produced by the *legacy* handler
+(node class and resolved path both checked), and that a `_http_` url and a `vol:` path
+do the same. This is the guard on §2's hybrid.
+
+---
+
+## 10. Benchmark
+
+**File:** `gnrpy/tests/core/gnrstorage_benchmark.py`, modelled on
+`gnrpy/tests/sql/test_relations_benchmark.py`: `pytest -s`, `time.perf_counter`,
+declared repetition counts, a printed timing table.
+
+Same operations, both modes, both mounts: `write` (small 4 KB / large 4 MB), `read`,
+`exists`, `size`, `mtime`, `md5hash`, `children` on a directory of 100 files, `copy`
+same-mount, `delete`. Repetitions: 50 for metadata operations, 10 for I/O, 3 for the
+large file; the count is printed with the table.
+
+Output columns: operation, mount, `legacy_ms`, `genro_ms`, ratio. The measured table
+goes into §11 with date, machine and package versions. **No estimated numbers are
+recorded.**
+
+---
+
+## 11. Environment variables
+
+To be added to `docs/development/envvars.py` under `Testing`:
+
+| Variable | Meaning |
+|---|---|
+| `GNR_TEST_S3_ENDPOINT` | S3-compatible endpoint for the storage comparison tests (e.g. `http://127.0.0.1:9000`); unset ⇒ the S3 tests skip |
+| `GNR_TEST_S3_ACCESS_KEY` | Access key for that endpoint |
+| `GNR_TEST_S3_SECRET_KEY` | Secret key for that endpoint |
+| `GNR_TEST_S3_BUCKET` | Bucket to use (default `sandbox`) |
+| `GNR_TEST_S3_PREFIX` | Key prefix the tests may create and delete under (default `gnrtest`) |
+
+Credentials are never committed and never defaulted to real values in code — the
+default endpoint is unset, so the tests skip rather than reach for anything.
+
+Local MinIO used for this work:
+
+```bash
+MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
+  minio server /Users/fporcari/Development/minio_folder \
+  --address 127.0.0.1:9000 --console-address 127.0.0.1:9001
+```
+
+### Benchmark results
+
+*(To be filled by Phase 9 with measured numbers, date, machine and versions.)*
+
+---
+
+## 12. Status and open points
+
+| Phase | State |
+|---|---|
+| 1–10 | not started (this document is the plan) |
+
+Open, deliberately:
+
+1. **`relative` and `sftp` deferred** (§2) — both are mappable, neither is testable in
+   this environment, and each is a self-contained follow-up.
+2. **`public_url`, `readonly`/`write_in_local`, `local_path(keep=True)`, `internal_path`
+   for remote mounts** have no genro-storage counterpart. All four are handled in the
+   adapter by delegating to the legacy service or raising; each is a candidate upstream
+   request, and T2's `GENRO_STORAGE_ISSUE.md` is where they belong.
+3. **`pip check` is already dirty on this machine** (§7) — the `s3fs`/`gcsfs` exact pin
+   on `fsspec` predates this branch. Needs an environment call.
+4. **The daemon-based storage suite is skipped on this machine** (§8) because a daemon is
+   already running. Whether the pre-existing 47+12 skips should be made to run (by
+   stopping that daemon, or by teaching `BaseGnrDaemonTest` to attach to a running one)
+   is a separate question from this migration.
+5. **The hybrid is the end state, not a stepping stone** (§2): with the switch on, a
+   typical instance keeps every symbolic mount on the legacy layer. The cross-world
+   copy/move bridge (§8 Phase 5) exists precisely because of that, and it is the part of
+   the design most worth reviewing before implementation.

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -422,7 +422,7 @@ MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
 
 ### Benchmark results
 
-Measured 2026-09-02 on macOS 25.0.0 (Darwin, Apple silicon), pyenv Python 3.13.2,
+Measured 2026-09-02 on the committed code, macOS 25.0.0 (Darwin, Apple silicon), pyenv Python 3.13.2,
 genro-storage 0.8.0, fsspec 2025.10.0, s3fs 2025.9.0, boto3/botocore 1.40.18,
 smart_open 7.1.0, MinIO (homebrew binary) at `http://127.0.0.1:9000`, bucket `sandbox`.
 Reproduce with `cd gnrpy && python -m pytest tests/core/gnrstorage_benchmark.py -s -q`.
@@ -431,54 +431,65 @@ genro-storage is slower.
 
 **Local mount**
 
-| operation | reps | legacy_ms | genro_ms | ratio |
-|---|---|---|---|---|
-| write small (4KB) | 10 | 0.45 | 1.35 | 3.01 |
-| write large (4MB) | 3 | 2.34 | 2.59 | 1.11 |
-| read small (4KB) | 10 | 0.38 | 1.09 | 2.89 |
-| read large (4MB) | 3 | 0.98 | 0.96 | 0.98 |
-| exists | 50 | 0.11 | 2.37 | 21.30 |
-| size | 50 | 0.11 | 2.83 | 26.93 |
-| mtime | 50 | 0.10 | 2.34 | 23.03 |
-| md5hash | 50 | 0.98 | 8.14 | 8.33 |
-| children (100 files) | 10 | 0.94 | 8.08 | 8.57 |
-| copy same mount | 10 | 1.23 | 4.03 | 3.27 |
-| internal_url | 50 | 0.04 | 0.05 | 1.28 |
+| operation | reps | legacy_ms | genro_ms | ratio | per call: legacy → genro |
+|---|---|---|---|---|---|
+| write small (4KB) | 10 | 0.47 | 1.36 | 2.88 | 0.047 → 0.136 ms |
+| write large (4MB) | 3 | 2.32 | 2.42 | 1.04 | 0.77 → 0.81 ms |
+| read small (4KB) | 10 | 0.18 | 1.14 | 6.21 | 0.018 → 0.114 ms |
+| read large (4MB) | 3 | 0.74 | 0.99 | 1.33 | 0.25 → 0.33 ms |
+| exists | 50 | 0.10 | 2.33 | 22.49 | 0.002 → 0.047 ms |
+| size | 50 | 0.11 | 2.48 | 22.77 | 0.002 → 0.050 ms |
+| mtime | 50 | 0.10 | 2.49 | 24.03 | 0.002 → 0.050 ms |
+| md5hash | 50 | 0.95 | 7.91 | 8.36 | 0.019 → 0.158 ms |
+| children (100 files) | 10 | 0.93 | 8.27 | 8.88 | 0.093 → 0.827 ms |
+| copy same mount | 10 | 1.25 | 3.93 | 3.14 | 0.125 → 0.393 ms |
+| internal_url | 50 | 0.04 | 0.05 | 1.17 | 0.001 → 0.001 ms |
 
-**S3 mount (MinIO on localhost)**
+**S3 mount (MinIO on localhost, so almost no network latency: on a real remote
+endpoint the round trip dominates every row)**
 
-| operation | reps | legacy_ms | genro_ms | ratio |
-|---|---|---|---|---|
-| write small (4KB) | 10 | 56.51 | 32.19 | 0.57 |
-| write large (4MB) | 3 | 53.35 | 46.40 | 0.87 |
-| read small (4KB) | 10 | 23.54 | 37.57 | 1.60 |
-| read large (4MB) | 3 | 11.83 | 19.01 | 1.61 |
-| exists | 50 | 33.46 | 32.51 | 0.97 |
-| size | 50 | 32.09 | 36.99 | 1.15 |
-| mtime | 50 | 32.52 | 33.14 | 1.02 |
-| md5hash | 50 | 32.38 | 97.47 | 3.01 |
-| children (100 files) | 10 | 69.10 | 79.44 | 1.15 |
-| copy same mount | 10 | 37.61 | 68.90 | 1.83 |
-| internal_url | 50 | 0.07 | 0.07 | 0.98 |
+| operation | reps | legacy_ms | genro_ms | ratio | per call: legacy → genro |
+|---|---|---|---|---|---|
+| write small (4KB) | 10 | 49.76 | 29.30 | 0.59 | 4.98 → 2.93 ms |
+| write large (4MB) | 3 | 48.41 | 42.24 | 0.87 | 16.1 → 14.1 ms |
+| read small (4KB) | 10 | 21.95 | 36.59 | 1.67 | 2.20 → 3.66 ms |
+| read large (4MB) | 3 | 10.56 | 15.81 | 1.50 | 3.52 → 5.27 ms |
+| exists | 50 | 33.51 | 30.43 | 0.91 | 0.67 → 0.61 ms |
+| size | 50 | 30.61 | 31.21 | 1.02 | 0.61 → 0.62 ms |
+| mtime | 50 | 32.12 | 29.80 | 0.93 | 0.64 → 0.60 ms |
+| md5hash | 50 | 31.99 | 90.65 | 2.83 | 0.64 → 1.81 ms |
+| children (100 files) | 10 | 72.35 | 64.61 | 0.89 | 7.24 → 6.46 ms |
+| copy same mount | 10 | 35.10 | 76.58 | 2.18 | 3.51 → 7.66 ms |
+| internal_url | 50 | 0.07 | 0.07 | 0.99 | 0.001 → 0.001 ms |
 
 Reading the numbers:
 
-- **Local metadata calls carry a constant per-call overhead**: genro-storage builds a
-  node object per call, so `exists`/`size`/`mtime` cost ~0.05 ms each against ~0.002 ms.
-  The ratio is large, the absolute cost is not; it is worth optimising (cache the node
-  per path in the service) only if a hot loop shows up.
-- **On S3 genro-storage wins the writes** (0.57–0.87) and loses the small reads. The
-  metadata calls are a wash: both pay one round trip.
-- **`md5hash` on S3 is not a like-for-like comparison.** The legacy service reads the
-  ETag and gives up when it is not 32 characters — which is what a multipart upload
-  produces — so its 32 ms buy a `None`. genro-storage's 97 ms return the real md5. This
-  is the divergence pinned in `TestNamedDivergences`.
-- **Run-to-run noise on S3 is material** at these repetition counts: across two runs,
-  `children` moved between 0.36 and 1.15 and `read small` between 1.60 and 2.96. The
-  local ratios were stable. Treat the S3 column as an order of magnitude, not a
-  measurement, and raise the repetitions before drawing a conclusion from a single cell.
-
----
+- **The overhead is per call, not per byte.** On a local mount a metadata call
+  costs 0.002 ms through the legacy service and 0.047 ms through genro-storage,
+  which is the 22x: genro-storage builds a node object per call. On the 4 MB
+  file the ratio collapses to 1.04-1.33, because the fixed cost stops mattering.
+  So the ratio to watch is not the worst one, it is the one on the operation you
+  actually repeat thousands of times.
+- **The one local row that can reach a user** is `children` on 100 files: 0.09 ms
+  against 0.83 ms per listing. A `StorageResolver` walking a large directory pays
+  that per level. Still sub-millisecond, but it is the first place to look if a
+  tree ever feels slow, and the fix is a per-path node cache in the service.
+- **On S3 genro-storage is not slower overall**: writes are almost twice as fast
+  (s3fs against smart_open + boto3), metadata is a wash, `children` slightly
+  better. The real regression is the small read, 2.20 → 3.66 ms.
+- **The S3 copy stays server-side in both worlds** *(measured separately)*: the
+  cost does not grow with the file - 4 KB copies in 19.9 ms, 4 MB in 15.6 ms - so
+  no bytes travel through the client. genro-storage's 2.18x is extra round trips
+  for its own checks, a fixed cost, not a transfer.
+- **`md5hash` on S3 is not a like-for-like comparison.** The legacy service reads
+  the ETag and gives up when a multipart upload made it something other than an
+  md5, so its 0.64 ms buy a `None`; genro-storage's 1.81 ms return the real hash.
+  This is the divergence pinned in `TestNamedDivergences`.
+- **Run-to-run noise on S3 is material** at these repetition counts: across three
+  runs `children` moved between 0.36x and 1.15x and `read small` between 1.60x
+  and 2.96x. The local ratios were stable to within a few percent. Treat the S3
+  column as an order of magnitude and raise the repetitions before drawing a
+  conclusion from one cell.
 
 ## 12. Status and open points
 

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -93,7 +93,8 @@ adapted. Verified by running both mounts (local, S3-on-MinIO) *(measured)*:
 | `public_url()` | plain non-expiring url (S3 `#990`) | absent | delegate to the legacy service |
 | `internal_path` | absolute fs path (local) or object key (S3) | `resolved_path` — path for local, **`None` for remote** | for S3, compose the key from the mount config; 73 grep hits depend on this |
 | `listdir()` | list of fullpaths, `None` if not a dir | absent | implement over `children()` |
-| `children()` | `None` if not a dir | raises | return `None` |
+| `children()` | `None` if not a dir, **sorted by basename** | raises; **order not guaranteed** | return `None`, and sort — the order is what every tree on top of this displays |
+| `size`/`md5hash` on a **directory** | `st_size` of the directory (a meaningless number) / `IsADirectoryError` | raises `ValueError` | answer `None`, which is what the legacy aws_s3 service already does for a directory |
 | `mkdir(*args)` | path segments, idempotent | `mkdir(parents=False, exist_ok=False)` | explicit method — otherwise `node.mkdir('sub')` passes `'sub'` as `parents` and creates nothing |
 | `serve(environ, start_response, **kwargs)` | swallows extra kwargs | `serve(environ, start_response, download, download_name, cache_max_age)` — **no `**kwargs`** | explicit method filtering kwargs; `storageDispatcher` passes arbitrary query-string kwargs, and Genropy's own `internal_url(nocache=True)` produces `?mtime=…` |
 | `local_path(mode, keep)` | `keep=True` keeps the temp file | `local_path(mode)` — no `keep` | raise on truthy `keep` until upstream has it |
@@ -526,10 +527,16 @@ Open, deliberately:
    creates it on first write. On `gnrdevelop` this is the `mail` mount, and it logs one
    warning at handler construction. Pre-creating the directory at startup would be the
    alternative; not done, because a storage switch should not create directories.
-7. **Never yet run with the flag on in a live serving site.** The switch, the routing,
-   the node surface and the WSGI-facing `serve()` are covered by tests against a real
-   site object, but no request has been served through the genro-storage handler in a
-   running daemon. That is the next thing to do before this goes anywhere near an
-   instance that matters.
+7. **Run with the flag on in a serving site: done, and it found two defects.**
+   `projects/gnrcore/packages/test15/webpages/tools/storage_genro.py` is a testhandler
+   page that exercises the switch through real requests — storage trees on the mounts
+   genro-storage takes over and on the ones that stay legacy, an inspector over the whole
+   node surface, a side-by-side of the two handlers on the same path, an uploader, a
+   cross-world copy/move, and a tree on an S3 mount. Driven against `gnrdevelop` with
+   the flag on it showed, on top of what the unit tests already covered:
+   `children()` was not sorted (the legacy local service sorts, so every tree changed
+   order), and `size`/`md5hash` raised on a directory instead of answering. Both are
+   fixed, both now have a test. What is still untested in a live site: the upload path
+   itself (it needs a file picked by hand) and multidomain.
 8. **The per-call node construction on local mounts** (§11) is the one measured
    inefficiency: worth a cache in the service if a profile ever points here.

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -523,22 +523,36 @@ Open, deliberately:
    drop the restriction;
    `local_path(keep=True)` — refused with `NotImplementedError` on a remote mount rather
    than silently not keeping the file.
-3. **`pip check` is already dirty on this machine** (§7) — the `s3fs`/`gcsfs` exact pin
+3. **Two upstream round-trip costs on S3, reported as `genropy/genro-storage#78`**
+   *(measured)*: `copy_to()` issues 6 API calls where one `CopyObject` would do — two of
+   them `ListObjectVersions`, which a copy does not need — and `open('rb')` adds a
+   `HeadObject` before the `GetObject`. On a real endpoint that is ~180 ms instead of
+   ~30 for a copy, plus a billed request per `ListObjectVersions`. The copy nonetheless
+   stays server-side, so the cost is round trips and not a transfer through the client.
+   Our own `duplicateNode` could sidestep it by going through the backend's `copy()`
+   instead of the node's `copy_to()`; not done here, because it is an optimisation
+   beyond this branch's scope and the upstream fix would make it unnecessary.
+4. **One round-trip cost of our own, on the legacy side**: `StorageNode.open()`
+   (`gnr/lib/services/storage.py:357`) calls `service.autocreate(path, autocreate=-1)`
+   even when opening for reading, which on S3 costs a `HeadObject` plus a
+   `ListObjectsV2` per open — 3 round trips where 1 would do, on both the legacy and the
+   genro-storage path. Pre-existing, unrelated to this branch, worth its own issue.
+5. **`pip check` is already dirty on this machine** (§7) — the `s3fs`/`gcsfs` exact pin
    on `fsspec` predates this branch. Needs an environment call.
-4. **The daemon-based storage suite is skipped on this machine** (§8) because a daemon is
+6. **The daemon-based storage suite is skipped on this machine** (§8) because a daemon is
    already running. Whether the pre-existing 47+12 skips should be made to run (by
    stopping that daemon, or by teaching `BaseGnrDaemonTest` to attach to a running one)
    is a separate question from this migration.
-5. **The hybrid is the end state, not a stepping stone** (§2): with the switch on, a
+7. **The hybrid is the end state, not a stepping stone** (§2): with the switch on, a
    typical instance keeps every symbolic mount on the legacy layer. This is why the
    service-level design matters — `StorageService` bridges a copy or move between the
    two worlds by content on its own, with no code of ours in the path.
-6. **A local mount whose `base_path` does not exist yet stays legacy** (§8 Phase 2):
+8. **A local mount whose `base_path` does not exist yet stays legacy** (§8 Phase 2):
    genro-storage's local backend requires the directory to exist, the legacy service
    creates it on first write. On `gnrdevelop` this is the `mail` mount, and it logs one
    warning at handler construction. Pre-creating the directory at startup would be the
    alternative; not done, because a storage switch should not create directories.
-7. **Run with the flag on in a serving site: done, and it found two defects.**
+9. **Run with the flag on in a serving site: done, and it found two defects.**
    `projects/gnrcore/packages/test15/webpages/tools/storage_genro.py` is a testhandler
    page that exercises the switch through real requests — storage trees on the mounts
    genro-storage takes over and on the ones that stay legacy, an inspector over the whole
@@ -549,5 +563,5 @@ Open, deliberately:
    order), and `size`/`md5hash` raised on a directory instead of answering. Both are
    fixed, both now have a test. What is still untested in a live site: the upload path
    itself (it needs a file picked by hand) and multidomain.
-8. **The per-call node construction on local mounts** (§11) is the one measured
+10. **The per-call node construction on local mounts** (§11) is the one measured
    inefficiency: worth a cache in the service if a profile ever points here.

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -2,7 +2,8 @@
 
 Reference issue: #251 (testing request for the genro-storage integration).
 Branch: `feature/251-genro-storage-switch`, cut from `origin/develop` @ `919a3a572a`.
-Target package: `genro-storage` 0.8.0 (PyPI, installed), `fsspec` 2025.10.0, `s3fs` 2025.9.0.
+Target package: `genro-storage` 0.8.1 (PyPI; the pin stays `>=0.8,<0.9`, since nothing
+here needs 0.8.1 to work — see §11 for what it buys), `fsspec` 2025.10.0, `s3fs` 2025.9.0.
 
 Goal: serve the replaceable part of the legacy storage layer through genro-storage,
 behind a switch that is **off by default**, with the legacy code left intact and still
@@ -422,74 +423,103 @@ MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
 
 ### Benchmark results
 
-Measured 2026-09-02 on the committed code, macOS 25.0.0 (Darwin, Apple silicon), pyenv Python 3.13.2,
-genro-storage 0.8.0, fsspec 2025.10.0, s3fs 2025.9.0, boto3/botocore 1.40.18,
+Measured 2026-09-08 on the committed code, macOS 25.0.0 (Darwin, Apple silicon), pyenv Python 3.13.2,
+**genro-storage 0.8.1**, fsspec 2025.10.0, s3fs 2025.9.0, boto3/botocore 1.40.18,
 smart_open 7.1.0, MinIO (homebrew binary) at `http://127.0.0.1:9000`, bucket `sandbox`.
 Reproduce with `cd gnrpy && python -m pytest tests/core/gnrstorage_benchmark.py -s -q`.
 Totals in ms for the stated repetition count; `ratio = genro_ms / legacy_ms`, so above 1
-genro-storage is slower.
+genro-storage is slower. `ext_attributes` and the `tree` row were added after the first
+round: they are the shape `StorageResolver` (`gnr/lib/services/storage.py:914`) actually
+uses, one `ext_attributes` per child of a listing, and nothing else in the table was
+measuring it.
 
 **Local mount**
 
 | operation | reps | legacy_ms | genro_ms | ratio | per call: legacy → genro |
 |---|---|---|---|---|---|
-| write small (4KB) | 10 | 0.47 | 1.36 | 2.88 | 0.047 → 0.136 ms |
-| write large (4MB) | 3 | 2.32 | 2.42 | 1.04 | 0.77 → 0.81 ms |
-| read small (4KB) | 10 | 0.18 | 1.14 | 6.21 | 0.018 → 0.114 ms |
-| read large (4MB) | 3 | 0.74 | 0.99 | 1.33 | 0.25 → 0.33 ms |
-| exists | 50 | 0.10 | 2.33 | 22.49 | 0.002 → 0.047 ms |
-| size | 50 | 0.11 | 2.48 | 22.77 | 0.002 → 0.050 ms |
-| mtime | 50 | 0.10 | 2.49 | 24.03 | 0.002 → 0.050 ms |
-| md5hash | 50 | 0.95 | 7.91 | 8.36 | 0.019 → 0.158 ms |
-| children (100 files) | 10 | 0.93 | 8.27 | 8.88 | 0.093 → 0.827 ms |
-| copy same mount | 10 | 1.25 | 3.93 | 3.14 | 0.125 → 0.393 ms |
-| internal_url | 50 | 0.04 | 0.05 | 1.17 | 0.001 → 0.001 ms |
+| write small (4KB) | 10 | 0.43 | 1.34 | 3.14 | 0.043 → 0.134 ms |
+| write large (4MB) | 3 | 6.65 | 3.09 | 0.46 | 2.22 → 1.03 ms |
+| read small (4KB) | 10 | 0.19 | 1.34 | 7.17 | 0.019 → 0.134 ms |
+| read large (4MB) | 3 | 0.75 | 1.30 | 1.74 | 0.25 → 0.43 ms |
+| exists | 50 | 0.10 | 2.40 | 23.48 | 0.002 → 0.048 ms |
+| size | 50 | 0.10 | 2.51 | 24.25 | 0.002 → 0.050 ms |
+| mtime | 50 | 0.10 | 2.38 | 24.27 | 0.002 → 0.048 ms |
+| md5hash | 50 | 0.95 | 7.96 | 8.39 | 0.019 → 0.159 ms |
+| ext_attributes | 50 | 0.10 | 9.17 | 87.59 | 0.002 → 0.183 ms |
+| children (100 files) | 10 | 0.94 | 8.84 | 9.35 | 0.094 → 0.884 ms |
+| tree: children + ext_attributes | 5 | 1.34 | 104.49 | 78.24 | 0.27 → 20.9 ms per tree |
+| copy same mount | 10 | 1.23 | 3.88 | 3.17 | 0.123 → 0.388 ms |
+| internal_url | 50 | 0.04 | 0.05 | 1.21 | 0.001 → 0.001 ms |
 
 **S3 mount (MinIO on localhost, so almost no network latency: on a real remote
 endpoint the round trip dominates every row)**
 
 | operation | reps | legacy_ms | genro_ms | ratio | per call: legacy → genro |
 |---|---|---|---|---|---|
-| write small (4KB) | 10 | 49.76 | 29.30 | 0.59 | 4.98 → 2.93 ms |
-| write large (4MB) | 3 | 48.41 | 42.24 | 0.87 | 16.1 → 14.1 ms |
-| read small (4KB) | 10 | 21.95 | 36.59 | 1.67 | 2.20 → 3.66 ms |
-| read large (4MB) | 3 | 10.56 | 15.81 | 1.50 | 3.52 → 5.27 ms |
-| exists | 50 | 33.51 | 30.43 | 0.91 | 0.67 → 0.61 ms |
-| size | 50 | 30.61 | 31.21 | 1.02 | 0.61 → 0.62 ms |
-| mtime | 50 | 32.12 | 29.80 | 0.93 | 0.64 → 0.60 ms |
-| md5hash | 50 | 31.99 | 90.65 | 2.83 | 0.64 → 1.81 ms |
-| children (100 files) | 10 | 72.35 | 64.61 | 0.89 | 7.24 → 6.46 ms |
-| copy same mount | 10 | 35.10 | 76.58 | 2.18 | 3.51 → 7.66 ms |
-| internal_url | 50 | 0.07 | 0.07 | 0.99 | 0.001 → 0.001 ms |
+| write small (4KB) | 10 | 53.64 | 27.93 | 0.52 | 5.36 → 2.79 ms |
+| write large (4MB) | 3 | 49.65 | 43.31 | 0.87 | 16.6 → 14.4 ms |
+| read small (4KB) | 10 | 22.18 | 29.67 | 1.34 | 2.22 → 2.97 ms |
+| read large (4MB) | 3 | 12.90 | 12.54 | 0.97 | 4.30 → 4.18 ms |
+| exists | 50 | 32.74 | 30.09 | 0.92 | 0.65 → 0.60 ms |
+| size | 50 | 30.09 | 30.42 | 1.01 | 0.60 → 0.61 ms |
+| mtime | 50 | 29.63 | 30.59 | 1.03 | 0.59 → 0.61 ms |
+| md5hash | 50 | 30.25 | 94.10 | 3.11 | 0.61 → 1.88 ms |
+| ext_attributes | 50 | 80.07 | 31.82 | 0.40 | 1.60 → 0.64 ms |
+| children (100 files) | 10 | 64.65 | 25.27 | 0.39 | 6.47 → 2.53 ms |
+| tree: children + ext_attributes | 5 | 3281.14 | 25.52 | **0.01** | 656 → 5.1 ms per tree |
+| copy same mount | 10 | 32.06 | 63.04 | 1.97 | 3.21 → 6.30 ms |
+| internal_url | 50 | 0.07 | 0.07 | 1.04 | 0.001 → 0.001 ms |
+
+**What 0.8.1 changed**, same benchmark, same machine, only the package swapped
+(0.8.1 reads mtime, size and directory status in one backend `info()` instead of
+four separate calls):
+
+| mount | operation | genro_ms 0.8.0 | genro_ms 0.8.1 | gain |
+|---|---|---|---|---|
+| S3 | ext_attributes (50) | 124.76 | 31.05-31.82 | **~4x** |
+| S3 | tree, 5x100 children | 93.27 | 25.37-25.91 | **~3.6x** |
+| local | ext_attributes (50) | 9.81 | 9.17-9.65 | none |
+| local | tree, 5x100 children | 110.74 | 104.49-112.36 | none |
 
 Reading the numbers:
 
+- **0.8.1 only helps the fsspec backends.** `LocalStorage` does not override
+  `ext_attributes`, so a local mount still falls back to the base implementation's
+  four separate calls and gains nothing. Worth an upstream note.
+- **The biggest number in the table is a win, not a cost**: a storage tree on an S3
+  mount is **~128x faster with the switch on** — 656 ms against 5.1 ms for a
+  100-file listing. The legacy `aws_s3` service issues a `HeadObject` per child,
+  while s3fs answers each child from the listing it has just made. Since
+  `StorageResolver` is exactly this shape, an S3 folder in the UI is where a user
+  would feel the switch first, and in their favour.
 - **The overhead is per call, not per byte.** On a local mount a metadata call
-  costs 0.002 ms through the legacy service and 0.047 ms through genro-storage,
-  which is the 22x: genro-storage builds a node object per call. On the 4 MB
-  file the ratio collapses to 1.04-1.33, because the fixed cost stops mattering.
-  So the ratio to watch is not the worst one, it is the one on the operation you
-  actually repeat thousands of times.
-- **The one local row that can reach a user** is `children` on 100 files: 0.09 ms
-  against 0.83 ms per listing. A `StorageResolver` walking a large directory pays
-  that per level. Still sub-millisecond, but it is the first place to look if a
-  tree ever feels slow, and the fix is a per-path node cache in the service.
+  costs 0.002 ms through the legacy service and ~0.05 ms through genro-storage,
+  which is the 22-24x: genro-storage builds a node object per call. On the 4 MB
+  file the ratio collapses, because the fixed cost stops mattering. So the ratio to
+  watch is not the worst one, it is the one on the operation you actually repeat.
+- **The local tree row is the one local cost that can reach a user**: 21 ms per
+  100-file listing against 0.27 ms, because it pays the per-call node construction
+  100 times and 0.8.1 does not help here. Still a fraction of a page render, but it
+  is the first place to look if a tree ever feels slow, and the fix is a per-path
+  node cache in the service (§12 point 10).
 - **On S3 genro-storage is not slower overall**: writes are almost twice as fast
-  (s3fs against smart_open + boto3), metadata is a wash, `children` slightly
-  better. The real regression is the small read, 2.20 → 3.66 ms.
+  (s3fs against smart_open + boto3), plain metadata is a wash, `children` and
+  `ext_attributes` are better. What is genuinely slower is `md5hash` and the copy.
 - **The S3 copy stays server-side in both worlds** *(measured separately)*: the
-  cost does not grow with the file - 4 KB copies in 19.9 ms, 4 MB in 15.6 ms - so
-  no bytes travel through the client. genro-storage's 2.18x is extra round trips
-  for its own checks, a fixed cost, not a transfer.
+  cost does not grow with the file — 4 KB copies in 19.9 ms, 4 MB in 15.6 ms — so
+  no bytes travel through the client. The ~2x is extra round trips for
+  genro-storage's own checks, a fixed cost and not a transfer. That is
+  `genropy/genro-storage#78`, still open on 0.8.1.
 - **`md5hash` on S3 is not a like-for-like comparison.** The legacy service reads
   the ETag and gives up when a multipart upload made it something other than an
-  md5, so its 0.64 ms buy a `None`; genro-storage's 1.81 ms return the real hash.
+  md5, so its 0.61 ms buy a `None`; genro-storage's 1.88 ms return the real hash.
   This is the divergence pinned in `TestNamedDivergences`.
 - **Run-to-run noise on S3 is material** at these repetition counts: across three
-  runs `children` moved between 0.36x and 1.15x and `read small` between 1.60x
-  and 2.96x. The local ratios were stable to within a few percent. Treat the S3
-  column as an order of magnitude and raise the repetitions before drawing a
-  conclusion from one cell.
+  0.8.1 runs `md5hash` moved between 2.73x and 3.11x and `copy same mount` between
+  1.97x and 2.66x, mostly because the legacy denominator wanders. The rows that
+  matter here — `ext_attributes`, `children`, `tree` — held to within a few percent.
+  The local column is stable; `write large` on local is not, it moved 2.32-6.65 ms
+  between rounds. Treat a single S3 cell as an order of magnitude.
 
 ## 12. Status and open points
 

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -570,11 +570,19 @@ Open, deliberately:
    itself (it needs a file picked by hand) and multidomain.
 10. **The per-call node construction on local mounts** (§11) is the one measured
    inefficiency: worth a cache in the service if a profile ever points here.
-11. **A pre-existing legacy defect, now shared by both paths**: `aws_s3.url()`
-   (`projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py:325`) reads
-   `_content_disposition` into a local *before* the `_download` branch writes it back
-   into `kwargs`, so the branch is dead and `url(_download=True)` always signs
-   `inline`. It reaches the genro-storage path too, since that is where the urls are
-   built now. `serve(download=True)` is unaffected — it passes `_content_disposition`
-   explicitly. Pinned by `test_url_download_flag_is_inert_in_both_modes`; the fix
-   belongs to the legacy service and wants its own issue.
+11. **The `download` attribute never worked on a remote mount — fixed here, on the
+   legacy path too.** Two dead ends, both pre-existing and both independent of the
+   switch. `aws_s3.url()` read `_content_disposition` into a local *before* the
+   `_download` branch wrote it back into `kwargs`, so the branch was dead and
+   `url(_download=True)` always signed `inline`; it now derives the disposition once,
+   from `_download` or `download`, which also makes `btcprint.py:202`
+   (`url(nocache=True, download=True)`) behave on S3 as it already did on a local
+   mount. And `_download` had three writers — `aws_s3.internal_url()`,
+   `sftp.internal_url()` and the genro-storage service — but no reader on the serving
+   path: `serve()` reads `download`, so the `?_download=True` that `internal_url()`
+   puts in its own url was discarded and the file opened inline. `StorageNode.serve()`
+   now maps `_download` onto `download` in one shared place, which covers the legacy
+   local, `aws_s3` and `sftp` services and the genro-storage one, with the switch on or
+   off. Pinned in both modes by `test_url_download_names_the_file`,
+   `test_serve_honours_the_download_query_of_internal_url` and
+   `TestLocalDownload`.

--- a/docs/development/genro-storage-migration.md
+++ b/docs/development/genro-storage-migration.md
@@ -515,7 +515,12 @@ Open, deliberately:
    this environment, and each is a self-contained follow-up.
 2. **Four things genro-storage does not provide**, each handled and each an upstream
    candidate (T2's `GENRO_STORAGE_ISSUE.md` is where they belong):
-   `public_url` — built in the service from the mount's endpoint and bucket;
+   **the whole url layer on a remote mount** — `url(expires_in=…)` is all genro-storage
+   0.8 signs, so it can carry neither a content disposition, nor the mount's
+   `url_expiration`, nor a non-expiring `public_url`; `url()` and `public_url()`
+   therefore delegate to the legacy service of the same mount, which already signs with
+   `ResponseContentDisposition` and knows `public_base_url`. A remote mount without a
+   legacy service raises: a download that silently opens inline is worse than an error;
    `internal_path` for remote mounts — composed from the mount's `base_path`, since
    `resolved_path` is `None` off the local filesystem;
    `readonly`/`write_in_local` — no counterpart at all, so a readonly mount is **left on
@@ -565,3 +570,11 @@ Open, deliberately:
    itself (it needs a file picked by hand) and multidomain.
 10. **The per-call node construction on local mounts** (§11) is the one measured
    inefficiency: worth a cache in the service if a profile ever points here.
+11. **A pre-existing legacy defect, now shared by both paths**: `aws_s3.url()`
+   (`projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py:325`) reads
+   `_content_disposition` into a local *before* the `_download` branch writes it back
+   into `kwargs`, so the branch is dead and `url(_download=True)` always signs
+   `inline`. It reaches the genro-storage path too, since that is where the urls are
+   built now. `serve(download=True)` is unaffected — it passes `_content_disposition`
+   explicitly. Pinned by `test_url_download_flag_is_inert_in_both_modes`; the fix
+   belongs to the legacy service and wants its own issue.

--- a/gnrpy/gnr/lib/services/storage.py
+++ b/gnrpy/gnr/lib/services/storage.py
@@ -389,6 +389,10 @@ class StorageNode(object):
 
     def serve(self, environ, start_response, **kwargs):
         """Serves the file content"""
+        if kwargs.pop('_download', None):
+            # internal_url() marks a download with _download, which arrives here
+            # as a query kwarg; every service implementation reads 'download'.
+            kwargs['download'] = True
         return self.service.serve(self.path, environ, start_response, **kwargs)
 
     def local_path(self, mode=None, keep=False):

--- a/gnrpy/gnr/lib/services/storage_genro.py
+++ b/gnrpy/gnr/lib/services/storage_genro.py
@@ -233,6 +233,12 @@ class Service(StorageService):
         expiration = kwargs.pop('expiration', None) or 3600
         return self._node(*args).url(expires_in=expiration)
 
+    def internal_url(self, *args, **kwargs):
+        if not self.is_local:
+            # The legacy aws_s3 service serves its internal urls as downloads.
+            kwargs['_download'] = True
+        return super().internal_url(*args, **kwargs)
+
     def public_url(self, *args, **kwargs):
         """A plain, non-expiring url: the object must be publicly readable, this
         only builds the address."""

--- a/gnrpy/gnr/lib/services/storage_genro.py
+++ b/gnrpy/gnr/lib/services/storage_genro.py
@@ -109,13 +109,15 @@ class Service(StorageService):
     def mtime(self, *args):
         try:
             return self._node(*args).mtime()
-        except (FileNotFoundError, StorageError):
+        except (FileNotFoundError, StorageError, ValueError):
             return None
 
     def size(self, *args):
+        """None on a directory or a missing path: genro-storage raises on both,
+        while the legacy aws_s3 service already answers None."""
         try:
             return self._node(*args).size()
-        except (FileNotFoundError, StorageError):
+        except (FileNotFoundError, StorageError, ValueError):
             return None
 
     def ext_attributes(self, *args):
@@ -124,7 +126,7 @@ class Service(StorageService):
     def md5hash(self, *args):
         try:
             return self._node(*args).md5hash()
-        except (FileNotFoundError, StorageError):
+        except (FileNotFoundError, StorageError, ValueError):
             return None
 
     def open(self, *args, **kwargs):
@@ -147,11 +149,13 @@ class Service(StorageService):
         return self._node(*args).local_path(mode='rw' if 'w' in mode else 'r')
 
     def children(self, *args, **kwargs):
+        """Sorted by basename, as the legacy local service is: the order shows
+        up in every tree built on top of this."""
         node = self._node(*args)
         if not node.exists():
             return []
         out = []
-        for child in node.children():
+        for child in sorted(node.children(), key=lambda child: child.basename):
             if child.basename == GNRDIR_SENTINEL:
                 continue
             out.append(StorageNode(parent=self.parent, path=child.path, service=self))

--- a/gnrpy/gnr/lib/services/storage_genro.py
+++ b/gnrpy/gnr/lib/services/storage_genro.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Storage service backed by genro-storage.
+
+A StorageService whose operations run through a genro_storage StorageManager
+mount instead of os/boto3. The legacy StorageNode sits unchanged on top of it,
+so path parsing, base64, internal_url, listdir, autocreate, copy and move keep
+coming from StorageService and behave as they do on the legacy services.
+"""
+
+import os
+import shutil
+
+from genro_storage.exceptions import StorageError
+
+from gnr.core.gnrsys import expandpath
+from gnr.lib.services.storage import (LocalPath, StorageNode, StorageService,
+                                      _SimpleFileApp)
+
+GNRDIR_SENTINEL = '.gnrdir'
+
+
+class Service(StorageService):
+    """Serves one genro-storage mount through the legacy StorageService API.
+
+    Args:
+        parent: the site
+        manager: the genro_storage StorageManager holding the mount
+        mount_name: name of the mount in that manager
+        mount_config: the configuration dict the mount was registered with
+        expand_paths: expand '~' in incoming paths (the legacy 'raw' behaviour)
+        versioned: False disables versioning on a backend that supports it,
+                as the legacy aws_s3 service's own versioned parameter does
+    """
+
+    def __init__(self, parent=None, manager=None, mount_name=None,
+                 mount_config=None, expand_paths=False, versioned=None,
+                 tags=None, **kwargs):
+        self.parent = parent
+        self.manager = manager
+        self.mount_name = mount_name
+        self.mount_config = mount_config or {}
+        self.expand_paths = expand_paths
+        self.versioned = versioned
+        self.tags = tags
+
+    # ---- plumbing
+
+    def _node(self, *args, version_id=None):
+        path = '/'.join([a for a in args if a not in (None, '')])
+        return self.manager.node(self.mount_name, path, version=version_id)
+
+    @property
+    def protocol(self):
+        return self.mount_config.get('protocol') or 'local'
+
+    @property
+    def is_local(self):
+        return self.protocol == 'local'
+
+    @property
+    def base_path(self):
+        return (self.mount_config.get('base_path')
+                or self.mount_config.get('path') or '')
+
+    def expandpath(self, path):
+        return expandpath(path) if self.expand_paths else path
+
+    @property
+    def location_identifier(self):
+        """Local mounts share 'localfs' with the legacy local services, so a copy
+        between the two worlds stays a filesystem copy. Remote mounts get an
+        identifier of their own: a copy towards any other service then goes
+        through content, which is always correct."""
+        if self.is_local:
+            return 'localfs'
+        return 'genro-storage:%s/%s/%s' % (self.protocol,
+                                           self.mount_config.get('bucket') or '',
+                                           self.base_path.strip('/'))
+
+    @property
+    def is_versioned(self):
+        if self.versioned is False:
+            return False
+        return self._node().capabilities.versioning
+
+    def internal_path(self, *args, **kwargs):
+        node = self._node(*args)
+        resolved = node.resolved_path
+        if resolved is not None:
+            return resolved
+        prefix = self.base_path.strip('/')
+        if not prefix:
+            return node.path
+        return ('%s/%s' % (prefix, node.path)).rstrip('/')
+
+    # ---- reads
+
+    def exists(self, *args):
+        return self._node(*args).exists()
+
+    def isfile(self, *args):
+        return self._node(*args).is_file()
+
+    def isdir(self, *args):
+        return self._node(*args).is_dir()
+
+    def mtime(self, *args):
+        try:
+            return self._node(*args).mtime()
+        except (FileNotFoundError, StorageError):
+            return None
+
+    def size(self, *args):
+        try:
+            return self._node(*args).size()
+        except (FileNotFoundError, StorageError):
+            return None
+
+    def ext_attributes(self, *args):
+        return self._node(*args).ext_attributes
+
+    def md5hash(self, *args):
+        try:
+            return self._node(*args).md5hash()
+        except (FileNotFoundError, StorageError):
+            return None
+
+    def open(self, *args, **kwargs):
+        mode = kwargs.pop('mode', 'rb')
+        version_id = kwargs.pop('version_id', None)
+        if version_id == '_latest_':
+            version_id = None
+        return self._node(*args, version_id=version_id).open(mode=mode)
+
+    def local_path(self, *args, **kwargs):
+        mode = kwargs.get('mode') or 'r'
+        keep = kwargs.get('keep') or False
+        if self.is_local:
+            return LocalPath(fullpath=self.internal_path(*args))
+        if keep:
+            raise NotImplementedError(
+                'local_path(keep=True) is not available on the genro-storage '
+                'mount %r: the temporary file is removed when the context exits'
+                % self.mount_name)
+        return self._node(*args).local_path(mode='rw' if 'w' in mode else 'r')
+
+    def children(self, *args, **kwargs):
+        node = self._node(*args)
+        if not node.exists():
+            return []
+        out = []
+        for child in node.children():
+            if child.basename == GNRDIR_SENTINEL:
+                continue
+            out.append(StorageNode(parent=self.parent, path=child.path, service=self))
+        return out
+
+    def versions(self, *args):
+        """Reported with the boto3 key names the legacy aws_s3 service returns,
+        so the consumers of versions() need no branch on the backend."""
+        if not self.is_versioned:
+            return []
+        out = []
+        for version in self._node(*args).versions:
+            etag = version.get('etag')
+            out.append({
+                'VersionId': version.get('version_id'),
+                'IsLatest': version.get('is_latest'),
+                'LastModified': version.get('last_modified'),
+                'Size': version.get('size'),
+                'ETag': '"%s"' % etag if etag else None,
+            })
+        return out
+
+    def get_metadata(self, *args):
+        return self._node(*args).get_metadata()
+
+    def set_metadata(self, *args):
+        *path, metadata = args
+        return self._node(*path).set_metadata(metadata)
+
+    # ---- writes
+
+    def makedirs(self, *args, **kwargs):
+        if not self.is_local:
+            return
+        self._node(*args).mkdir(parents=True, exist_ok=True)
+
+    def mkdir(self, *args, **kwargs):
+        if self.exists(*args):
+            return
+        if self.is_local:
+            return self._node(*args).mkdir(parents=True, exist_ok=True)
+        with self.open(*args + (GNRDIR_SENTINEL,), mode='w') as dotfile:
+            dotfile.write('.gnrdircontent')
+
+    def delete_file(self, *args):
+        self._node(*args).delete()
+
+    def delete_dir(self, *args):
+        node = self._node(*args)
+        for child in node.children():
+            child_args = args + (child.basename,)
+            if child.is_dir():
+                self.delete_dir(*child_args)
+            else:
+                self._node(*child_args).delete()
+        node.delete()
+
+    def duplicateNode(self, sourceNode=None, destNode=None):
+        if isinstance(destNode.service, Service):
+            return self._node(sourceNode.path).copy_to(
+                destNode.service._node(destNode.path))
+        destNode.service.autocreate(destNode.path, autocreate=-1)
+        shutil.copy2(sourceNode.internal_path, destNode.internal_path)
+
+    def renameNode(self, sourceNode=None, destNode=None):
+        if isinstance(destNode.service, Service):
+            self._node(sourceNode.path).move_to(
+                destNode.service._node(destNode.path))
+            return destNode
+        destNode.service.autocreate(destNode.path, autocreate=-1)
+        shutil.move(sourceNode.internal_path, destNode.internal_path)
+        return destNode
+
+    # ---- urls and serving
+
+    def url(self, *args, **kwargs):
+        if self.is_local:
+            return self.internal_url(*args, **kwargs)
+        expiration = kwargs.pop('expiration', None) or 3600
+        return self._node(*args).url(expires_in=expiration)
+
+    def public_url(self, *args, **kwargs):
+        """A plain, non-expiring url: the object must be publicly readable, this
+        only builds the address."""
+        if self.is_local:
+            return self.internal_url(*args, **kwargs)
+        endpoint = (self.mount_config.get('endpoint_url') or '').rstrip('/')
+        bucket = self.mount_config.get('bucket')
+        if not (endpoint and bucket):
+            return self.url(*args, **kwargs)
+        return '%s/%s/%s' % (endpoint, bucket, self.internal_path(*args))
+
+    def serve(self, path, environ, start_response, download=False, download_name=None, **kwargs):
+        if not self.is_local:
+            content_disposition = "inline"
+            if download or download_name:
+                content_disposition = "attachment; filename=%s" % (
+                    download_name or self.basename(path))
+            url = self.url(path, _content_disposition=content_disposition)
+            if url:
+                return self.parent.redirect(environ, start_response, location=url, temporary=True)
+            return self.parent.not_found_exception(environ, start_response)
+        fullpath = self.internal_path(path)
+        if not fullpath or not os.path.exists(fullpath):
+            return self.parent.not_found_exception(environ, start_response)
+        if_none_match = environ.get('HTTP_IF_NONE_MATCH')
+        if if_none_match:
+            stats = os.stat(fullpath)
+            my_none_match = "%s-%s" % (str(stats.st_mtime), str(stats.st_size))
+            if my_none_match == if_none_match.replace('"', ''):
+                start_response('304 Not Modified', [('ETag', '"%s"' % my_none_match)])
+                return [b'']
+        file_args = dict()
+        if download or download_name:
+            file_args['content_disposition'] = "attachment; filename=%s" % (
+                download_name or os.path.basename(fullpath))
+        file_responder = _SimpleFileApp(fullpath, **file_args)
+        if self.parent.cache_max_age:
+            file_responder.cache_control(max_age=self.parent.cache_max_age)
+        return file_responder(environ, start_response)

--- a/gnrpy/gnr/lib/services/storage_genro.py
+++ b/gnrpy/gnr/lib/services/storage_genro.py
@@ -32,11 +32,14 @@ class Service(StorageService):
         expand_paths: expand '~' in incoming paths (the legacy 'raw' behaviour)
         versioned: False disables versioning on a backend that supports it,
                 as the legacy aws_s3 service's own versioned parameter does
+        legacy_service: the legacy service for the same mount, or a callable
+                returning it. Required on a remote mount, which serves its
+                urls through it (see the legacy_service property).
     """
 
     def __init__(self, parent=None, manager=None, mount_name=None,
                  mount_config=None, expand_paths=False, versioned=None,
-                 tags=None, **kwargs):
+                 tags=None, legacy_service=None, **kwargs):
         self.parent = parent
         self.manager = manager
         self.mount_name = mount_name
@@ -44,6 +47,7 @@ class Service(StorageService):
         self.expand_paths = expand_paths
         self.versioned = versioned
         self.tags = tags
+        self._legacy_service = legacy_service
 
     # ---- plumbing
 
@@ -58,6 +62,27 @@ class Service(StorageService):
     @property
     def is_local(self):
         return self.protocol == 'local'
+
+    @property
+    def legacy_service(self):
+        """The legacy service for this mount, which owns the url layer.
+
+        genro-storage 0.8's url() carries only expires_in, so a presigned url
+        cannot express a content disposition, the mount's url_expiration or a
+        non-expiring public url. Losing those silently turns a download into an
+        inline view, so a remote mount without a legacy service is an error
+        rather than a degraded url."""
+        service = self._legacy_service
+        if callable(service):
+            service = service()
+            self._legacy_service = service
+        if service is None:
+            raise RuntimeError(
+                'the genro-storage mount %r has no legacy service to build its '
+                'urls with: url(), public_url() and serve() need it to carry '
+                'the content disposition and url_expiration that '
+                'genro-storage cannot' % self.mount_name)
+        return service
 
     @property
     def base_path(self):
@@ -234,8 +259,7 @@ class Service(StorageService):
     def url(self, *args, **kwargs):
         if self.is_local:
             return self.internal_url(*args, **kwargs)
-        expiration = kwargs.pop('expiration', None) or 3600
-        return self._node(*args).url(expires_in=expiration)
+        return self.legacy_service.url(*args, **kwargs)
 
     def internal_url(self, *args, **kwargs):
         if not self.is_local:
@@ -244,15 +268,9 @@ class Service(StorageService):
         return super().internal_url(*args, **kwargs)
 
     def public_url(self, *args, **kwargs):
-        """A plain, non-expiring url: the object must be publicly readable, this
-        only builds the address."""
         if self.is_local:
             return self.internal_url(*args, **kwargs)
-        endpoint = (self.mount_config.get('endpoint_url') or '').rstrip('/')
-        bucket = self.mount_config.get('bucket')
-        if not (endpoint and bucket):
-            return self.url(*args, **kwargs)
-        return '%s/%s/%s' % (endpoint, bucket, self.internal_path(*args))
+        return self.legacy_service.public_url(*args, **kwargs)
 
     def serve(self, path, environ, start_response, download=False, download_name=None, **kwargs):
         if not self.is_local:

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -39,7 +39,7 @@ from gnr.web import logger
 from gnr.web.gnrwebapp import GnrWsgiWebApp
 from gnr.web.gnrwebpage import GnrUnsupportedBrowserException
 from gnr.web.gnrwsgisite_proxy.gnrresourceloader import ResourceLoader
-from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import LegacyStorageHandler
+from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import GenroStorageHandler, LegacyStorageHandler
 from gnr.web.gnrwsgisite_proxy.gnrstatichandler import StaticHandlerManager
 from gnr.web.gnrwsgisite_proxy.gnrpwahandler import PWAHandler
 from gnr.web.daemon.siteregister_client import SiteRegisterClient
@@ -192,7 +192,11 @@ class GnrDomainProxy(object):
     @property
     def storage_handler(self):
         if self._storage_handler is None:
-            self._storage_handler = LegacyStorageHandler(self.parent.site, domain=self.domain)
+            site = self.parent.site
+            if boolean(site.config['storage?use_genro_storage']):
+                self._storage_handler = GenroStorageHandler(site, domain=self.domain)
+            else:
+                self._storage_handler = LegacyStorageHandler(site, domain=self.domain)
         return self._storage_handler
 
 

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
@@ -19,10 +19,17 @@ from gnr.lib.services.storage import StorageNode as LegacyStorageNode
 from gnr.core.gnrsys import expandpath
 from gnr.core.gnrbag import Bag
 from gnr.core.gnrdecorator import deprecated
+from gnr.core.gnrstring import boolean
 from gnr.web import logger
 
-# Future integration with genro_storage brick implementation
-# from genro_storage import StorageNode as BrickStorageNode
+# genro-storage is an optional dependency (the genro_storage extra): with the
+# storage/use_genro_storage flag off nothing here is needed.
+try:
+    from genro_storage import StorageManager
+    from gnr.lib.services import storage_genro
+except ImportError:
+    StorageManager = None
+    storage_genro = None
 
 
 class BaseStorageHandler:
@@ -50,18 +57,24 @@ class BaseStorageHandler:
         '_http_': {'implementation': 'http'},
     }
 
-    def __init__(self, site, domain=None):
+    def __init__(self, site, domain=None, storage_params=None):
         """Initialize the storage handler.
 
         Args:
             site: The GnrWsgiSite instance
             domain: The domain this handler belongs to (for multidomain mode).
                     If None, uses site.currentDomain at query time.
+            storage_params: An existing registry to adopt instead of loading
+                    one. Two handlers sharing it stay in sync for free, and the
+                    sys.service query runs once.
         """
         self.site = site
         self.domain = domain
-        self.storage_params = {}
-        self._loadAllStorageParameters()
+        if storage_params is not None:
+            self.storage_params = storage_params
+        else:
+            self.storage_params = {}
+            self._loadAllStorageParameters()
 
     def _setStorageParams(self, service_name, parameters=None, implementation=None):
         """Set storage parameters for a service.
@@ -544,6 +557,159 @@ class LegacyStorageHandler(BaseStorageHandler):
             mode=mode,
             version=version
         )
+
+
+class GenroStorageHandler(LegacyStorageHandler):
+    """Storage handler serving the mappable mounts through genro-storage.
+
+    Only storage() is overridden: which service resolves a mount is the single
+    point of variation, so path parsing, node creation and the four StorageNode
+    kwargs keep coming from LegacyStorageHandler, and the legacy StorageNode
+    keeps sitting on top. A mount genro-storage cannot serve — every symbolic
+    one, http, compressed, relative, sftp, vol: and any unknown name — is
+    resolved by the legacy service, so with the flag on those keep behaving
+    exactly as before.
+
+    IMPLEMENTATION_MAP holds, per legacy implementation, the genro-storage
+    protocol and the parameter renames it needs.
+    """
+
+    IMPLEMENTATION_MAP = {
+        'local': ('local', {'base_path': 'base_path'}),
+        'raw': ('local', {}),
+        'aws_s3': ('s3', {'bucket': 'bucket',
+                          'base_path': 'base_path',
+                          'region_name': 'region',
+                          'region': 'region',
+                          'aws_access_key_id': 'access_key',
+                          'access_key': 'access_key',
+                          'aws_secret_access_key': 'secret_key',
+                          'secret_key': 'secret_key'}),
+    }
+
+    def __init__(self, site, domain=None, storage_params=None):
+        if StorageManager is None:
+            raise RuntimeError(
+                "genro-storage is not installed but storage/use_genro_storage "
+                "is enabled. Install it with `pip install 'genropy[genro_storage]'` "
+                "or drop the flag from siteconfig to keep the legacy handler."
+            )
+        self.manager = StorageManager()
+        self.mount_configs = {}
+        self._genro_services = {}
+        super().__init__(site, domain=domain, storage_params=storage_params)
+        self._configureMounts()
+
+    def _mountConfig(self, service_name, params):
+        """Translate one storage_params entry into a genro-storage mount config.
+
+        Returns None when the entry cannot or must not be served by
+        genro-storage; the caller then leaves it to the legacy handler.
+        """
+        implementation = params.get('implementation')
+        mapping = self.IMPLEMENTATION_MAP.get(implementation)
+        if not mapping:
+            return None
+        protocol, rename_map = mapping
+        mount = {'name': service_name, 'protocol': protocol}
+        for src_key, dest_key in rename_map.items():
+            if params.get(src_key):
+                mount[dest_key] = params[src_key]
+        if implementation == 'raw':
+            mount['base_path'] = '/'
+        if boolean(params.get('readonly')) or boolean(params.get('write_in_local')):
+            # No counterpart in genro-storage: serving a readonly mount through
+            # a writable backend would silently drop the restriction.
+            logger.warning(
+                "genro-storage: mount '%s' is readonly; it stays on the legacy handler",
+                service_name)
+            return None
+        if protocol == 'local':
+            base_path = mount.get('base_path')
+            if not base_path:
+                return None
+            if not os.path.isdir(base_path):
+                # genro-storage's local backend requires an existing directory,
+                # the legacy service creates it on first write.
+                logger.warning(
+                    "genro-storage: skipping mount '%s': base_path '%s' does not "
+                    "exist; it stays on the legacy handler", service_name, base_path)
+                return None
+        if protocol == 's3':
+            if not mount.get('bucket'):
+                logger.warning(
+                    "genro-storage: skipping mount '%s': no bucket; it stays on "
+                    "the legacy handler", service_name)
+                return None
+            if boolean(params.get('custom_endpoint')) and params.get('endpoint_url'):
+                mount['endpoint_url'] = params['endpoint_url']
+        return mount
+
+    def _configureMounts(self):
+        """Register every mappable mount, one at a time.
+
+        genro-storage validates a batch atomically, so a single unusable mount
+        would abort the whole registration (genropy/genro-storage#75). One bad
+        mount must never stop site startup: it is skipped with a warning and
+        served by the legacy handler.
+        """
+        for service_name, params in self.storage_params.items():
+            mount = self._mountConfig(service_name, params)
+            if not mount:
+                continue
+            try:
+                self.manager.configure([mount])
+            except Exception as exc:
+                logger.warning(
+                    "genro-storage: skipping mount '%s' (implementation '%s'): %s; "
+                    "it stays on the legacy handler",
+                    service_name, params.get('implementation'), exc)
+                continue
+            self.mount_configs[service_name] = mount
+
+    def _dropMount(self, service_name):
+        if self.manager.has_mount(service_name):
+            self.manager.delete_mount(service_name)
+        self.mount_configs.pop(service_name, None)
+        self._genro_services.pop(service_name, None)
+
+    def storage(self, storage_name, **kwargs):
+        """Return the genro-storage service for a registered mount, the legacy
+        one otherwise.
+
+        A call carrying kwargs overrides the stored parameters, which describes
+        a service configured on the fly: that stays legacy.
+        """
+        if kwargs or not self.manager.has_mount(storage_name):
+            return super().storage(storage_name, **kwargs)
+        service = self._genro_services.get(storage_name)
+        if service is None:
+            params = self.getStorageParameters(storage_name) or {}
+            service = storage_genro.Service(
+                parent=self.site,
+                manager=self.manager,
+                mount_name=storage_name,
+                mount_config=self.mount_configs[storage_name],
+                expand_paths=params.get('implementation') == 'raw',
+                versioned=boolean(params['versioned']) if 'versioned' in params else None,
+                tags=params.get('tags'))
+            service.service_name = storage_name
+            service.service_implementation = params.get('implementation')
+            self._genro_services[storage_name] = service
+        return service
+
+    def updateStorageParams(self, service_name):
+        result = super().updateStorageParams(service_name)
+        # Drop before re-reading: an entry that stopped being mappable must stop
+        # being served by genro-storage.
+        self._dropMount(service_name)
+        self._configureMounts()
+        return result
+
+    def removeStorageFromCache(self, service_name):
+        result = super().removeStorageFromCache(service_name)
+        self._dropMount(service_name)
+        return result
 
 
 

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrstoragehandler.py
@@ -692,7 +692,8 @@ class GenroStorageHandler(LegacyStorageHandler):
                 mount_config=self.mount_configs[storage_name],
                 expand_paths=params.get('implementation') == 'raw',
                 versioned=boolean(params['versioned']) if 'versioned' in params else None,
-                tags=params.get('tags'))
+                tags=params.get('tags'),
+                legacy_service=lambda: LegacyStorageHandler.storage(self, storage_name))
             service.service_name = storage_name
             service.service_implementation = params.get('implementation')
             self._genro_services[storage_name] = service

--- a/gnrpy/pyproject.toml
+++ b/gnrpy/pyproject.toml
@@ -72,6 +72,15 @@ pgsql = [
 
 mysql = ["mysqlclient"]
 
+# Optional: storage services backed by genro-storage instead of the legacy
+# implementations. s3fs belongs here and not in [project] dependencies because
+# it pulls aiobotocore, which caps botocore while genropy declares boto3 with
+# no upper bound (see #1079).
+genro_storage = [
+  "genro-storage>=0.8,<0.9",
+  "s3fs>=2023.1.0"
+]
+
 developer = [
   "pytest", "pytest-cov", "graphviz",
   "pytest-aiohttp", "pytest-asyncio",
@@ -81,7 +90,8 @@ developer = [
   "psycopg2-binary",
   "psycopg",
   "pymysql",
-  "testing.postgresql" # needed for tests, assuming developers runs tests
+  "testing.postgresql", # needed for tests, assuming developers runs tests
+  "genro-storage>=0.8,<0.9" # needed by the storage comparison tests
 ]
 
 [project.scripts]

--- a/gnrpy/tests/core/gnrstorage_benchmark.py
+++ b/gnrpy/tests/core/gnrstorage_benchmark.py
@@ -1,0 +1,117 @@
+"""Benchmark: the legacy storage services against genro-storage.
+
+The same operations, timed in both modes, on a local mount and on an
+S3-compatible endpoint. Repetition counts are declared in OPERATIONS and
+printed with the table.
+
+Run with:
+    cd gnrpy && pytest tests/core/gnrstorage_benchmark.py -s -q
+The -s flag is needed to see the printed timing table.
+
+The S3 half needs GNR_TEST_S3_ENDPOINT and friends (see storage_fixtures.py):
+    export GNR_TEST_S3_ENDPOINT=http://127.0.0.1:9000
+Without it, that half skips with the reason naming the variable.
+"""
+
+import sys
+import time
+
+import pytest
+
+from core.storage_fixtures import (MODES, S3_ENDPOINT, local_storage,
+                                   s3_storage, s3_unavailable_reason)
+
+S3_SKIP_REASON = s3_unavailable_reason()
+requires_s3 = pytest.mark.skipif(S3_SKIP_REASON is not None, reason=str(S3_SKIP_REASON))
+
+SMALL = b'x' * 4096
+LARGE = b'y' * (4 * 1024 * 1024)
+CHILDREN_COUNT = 100
+
+
+def _out(text):
+    sys.stdout.write(text)
+
+
+def _write(storage, path, payload):
+    node = storage.node(path)
+    with node.open('wb') as fp:
+        fp.write(payload)
+
+
+def _read(storage, path):
+    with storage.node(path).open('rb') as fp:
+        fp.read()
+
+
+def _prepare(storage):
+    """Everything the read-side operations need, written once per mode."""
+    _write(storage, 'st:bench/small.dat', SMALL)
+    _write(storage, 'st:bench/large.dat', LARGE)
+    for index in range(CHILDREN_COUNT):
+        _write(storage, 'st:bench/listing/file_%03d.dat' % index, b'z')
+
+
+# (label, repetitions, callable)
+OPERATIONS = [
+    ('write small (4KB)', 10, lambda st: _write(st, 'st:bench/w_small.dat', SMALL)),
+    ('write large (4MB)', 3, lambda st: _write(st, 'st:bench/w_large.dat', LARGE)),
+    ('read small (4KB)', 10, lambda st: _read(st, 'st:bench/small.dat')),
+    ('read large (4MB)', 3, lambda st: _read(st, 'st:bench/large.dat')),
+    ('exists', 50, lambda st: st.node('st:bench/small.dat').exists),
+    ('size', 50, lambda st: st.node('st:bench/small.dat').size),
+    ('mtime', 50, lambda st: st.node('st:bench/small.dat').mtime),
+    ('md5hash', 50, lambda st: st.node('st:bench/small.dat').md5hash),
+    ('children (%d files)' % CHILDREN_COUNT, 10,
+     lambda st: st.node('st:bench/listing').children()),
+    ('copy same mount', 10, lambda st: st.node('st:bench/small.dat').copy(
+        st.node('st:bench/copied.dat'))),
+    ('internal_url', 50, lambda st: st.node('st:bench/small.dat').internal_url()),
+]
+
+
+def _time_operation(storage, operation, repetitions):
+    start = time.perf_counter()
+    for _ in range(repetitions):
+        operation(storage)
+    return (time.perf_counter() - start) * 1000
+
+
+def _run(mount_label, build):
+    """Time every operation in both modes and print one table."""
+    timings = {}
+    for mode in MODES:
+        storage = build(mode)
+        try:
+            _prepare(storage)
+            for label, repetitions, operation in OPERATIONS:
+                timings[(label, mode)] = _time_operation(storage, operation, repetitions)
+        finally:
+            storage.cleanup()
+
+    _out('\n=== storage benchmark: %s ===\n' % mount_label)
+    _out('%-26s %5s %12s %12s %8s\n' % ('operation', 'reps', 'legacy_ms', 'genro_ms', 'ratio'))
+    for label, repetitions, _operation in OPERATIONS:
+        legacy_ms = timings[(label, 'legacy')]
+        genro_ms = timings[(label, 'genro')]
+        ratio = genro_ms / legacy_ms if legacy_ms else float('inf')
+        _out('%-26s %5d %12.2f %12.2f %8.2f\n'
+             % (label, repetitions, legacy_ms, genro_ms, ratio))
+    _out('ratio > 1 means genro-storage is slower on this operation.\n')
+    return timings
+
+
+def test_local_benchmark(tmp_path):
+    def build(mode):
+        base = tmp_path / mode
+        base.mkdir()
+        return local_storage(mode, {'st': str(base)})
+
+    timings = _run('local mount', build)
+    assert timings
+
+
+@requires_s3
+def test_s3_benchmark():
+    timings = _run('S3 mount (%s)' % S3_ENDPOINT, s3_storage)
+    assert timings

--- a/gnrpy/tests/core/gnrstorage_benchmark.py
+++ b/gnrpy/tests/core/gnrstorage_benchmark.py
@@ -62,8 +62,12 @@ OPERATIONS = [
     ('size', 50, lambda st: st.node('st:bench/small.dat').size),
     ('mtime', 50, lambda st: st.node('st:bench/small.dat').mtime),
     ('md5hash', 50, lambda st: st.node('st:bench/small.dat').md5hash),
+    ('ext_attributes', 50, lambda st: st.node('st:bench/small.dat').ext_attributes),
     ('children (%d files)' % CHILDREN_COUNT, 10,
      lambda st: st.node('st:bench/listing').children()),
+    ('tree: children + ext_attributes', 5,
+     lambda st: [child.ext_attributes
+                 for child in st.node('st:bench/listing').children()]),
     ('copy same mount', 10, lambda st: st.node('st:bench/small.dat').copy(
         st.node('st:bench/copied.dat'))),
     ('internal_url', 50, lambda st: st.node('st:bench/small.dat').internal_url()),

--- a/gnrpy/tests/core/gnrstorage_compare_test.py
+++ b/gnrpy/tests/core/gnrstorage_compare_test.py
@@ -14,144 +14,33 @@ operations themselves are never mocked.
 Run:
     cd gnrpy && pytest tests/core/gnrstorage_compare_test.py -q
 
-The S3 half needs an S3-compatible endpoint (MinIO is enough):
-    export GNR_TEST_S3_ENDPOINT=http://127.0.0.1:9000
-    export GNR_TEST_S3_ACCESS_KEY=minioadmin
-    export GNR_TEST_S3_SECRET_KEY=minioadmin
-    export GNR_TEST_S3_BUCKET=sandbox
-Without GNR_TEST_S3_ENDPOINT, or with an endpoint that does not answer, the S3
-tests skip with the reason naming it.
+The S3 half needs GNR_TEST_S3_ENDPOINT and friends (see storage_fixtures.py);
+without it those tests skip with the reason naming the variable.
 """
 
 import base64
 import hashlib
-import importlib.util
 import os
-import urllib.error
 import urllib.request
 import uuid
 
 import pytest
 
-from gnr.core.gnrbag import Bag
-from gnr.lib.services.storage import (BaseLocalService, NotExistingStorageNode,
-                                      StorageNode)
+from gnr.lib.services.storage import NotExistingStorageNode, StorageNode
 
-genro_storage = pytest.importorskip(
+pytest.importorskip(
     'genro_storage', reason="genro-storage is an optional dependency (genro_storage extra)")
+
 from genro_storage import StorageManager  # noqa: E402
 
 from gnr.lib.services import storage_genro  # noqa: E402
+from core.storage_fixtures import (CONTENT, MODES, S3_ACCESS_KEY,  # noqa: E402
+                                   S3_BUCKET, S3_ENDPOINT, S3_PREFIX,
+                                   S3_SECRET_KEY, SiteStub, local_storage,
+                                   s3_storage, s3_unavailable_reason)
 
-MODES = ['legacy', 'genro']
-
-S3_ENDPOINT = os.environ.get('GNR_TEST_S3_ENDPOINT')
-S3_ACCESS_KEY = os.environ.get('GNR_TEST_S3_ACCESS_KEY', 'minioadmin')
-S3_SECRET_KEY = os.environ.get('GNR_TEST_S3_SECRET_KEY', 'minioadmin')
-S3_BUCKET = os.environ.get('GNR_TEST_S3_BUCKET', 'sandbox')
-S3_PREFIX = os.environ.get('GNR_TEST_S3_PREFIX', 'gnrtest')
-
-CONTENT = b'genropy storage parity payload'
-
-
-def _s3_unavailable_reason():
-    if not S3_ENDPOINT:
-        return ("GNR_TEST_S3_ENDPOINT is not set: no S3-compatible endpoint to "
-                "compare against (see the module docstring)")
-    health = '%s/minio/health/live' % S3_ENDPOINT.rstrip('/')
-    try:
-        with urllib.request.urlopen(health, timeout=3) as response:
-            if response.code != 200:
-                return "%s answered %s" % (health, response.code)
-    except (urllib.error.URLError, OSError) as exc:
-        return "%s is not answering: %s" % (S3_ENDPOINT, exc)
-    return None
-
-
-S3_SKIP_REASON = _s3_unavailable_reason()
+S3_SKIP_REASON = s3_unavailable_reason()
 requires_s3 = pytest.mark.skipif(S3_SKIP_REASON is not None, reason=str(S3_SKIP_REASON))
-
-
-def _load_aws_s3_service():
-    """Load the legacy aws_s3 service, which lives as a site resource."""
-    here = os.path.dirname(__file__)
-    path = os.path.abspath(os.path.join(
-        here, '..', '..', '..', 'projects', 'gnrcore', 'packages', 'sys',
-        'resources', 'services', 'storage', 'aws_s3.py'))
-    spec = importlib.util.spec_from_file_location('gnrtest_legacy_aws_s3', path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module.Service
-
-
-class SiteStub:
-    """Minimal stand-in for the site: only what StorageNode and the services
-    dereference."""
-
-    external_host = 'http://localhost:8080'
-    cache_max_age = None
-    _local_mode = False
-
-    def __init__(self):
-        self.services = {}
-        app_config = Bag()
-        app_config['packages'] = Bag()
-        self.gnrapp = type('GnrAppStub', (), {'config': app_config})()
-
-    def add(self, service_name, service, implementation=None):
-        service.service_name = service_name
-        service.service_implementation = implementation
-        self.services[service_name] = service
-        return service
-
-    def storageNode(self, path, **kwargs):
-        service_name, _, storage_path = path.partition(':')
-        return StorageNode(parent=self, service=self.services[service_name],
-                           path=storage_path, **kwargs)
-
-    def getService(self, service_type=None, service_name=None, **kwargs):
-        return self.services[service_name]
-
-    def not_found_exception(self, environ, start_response):
-        start_response('404 Not Found', [])
-        return [b'']
-
-    def redirect(self, environ, start_response, location=None, temporary=False):
-        start_response('302 Found', [('Location', location)])
-        return [b'redirected']
-
-
-class Storage:
-    """The storage under test, in one of the two modes."""
-
-    def __init__(self, site, mode, mounts):
-        self.site = site
-        self.mode = mode
-        self.mounts = mounts
-
-    def node(self, path, **kwargs):
-        return self.site.storageNode(path, **kwargs)
-
-    def write(self, path, content=CONTENT):
-        node = self.node(path)
-        with node.open('wb') as fp:
-            fp.write(content)
-        return node
-
-
-def _local_storage(mode, base_paths):
-    """A Storage with one mount per name in base_paths, all local."""
-    site = SiteStub()
-    manager = StorageManager() if mode == 'genro' else None
-    for name, base_path in base_paths.items():
-        if mode == 'legacy':
-            site.add(name, BaseLocalService(parent=site, base_path=base_path), 'local')
-        else:
-            config = {'name': name, 'protocol': 'local', 'base_path': base_path}
-            manager.configure([config])
-            site.add(name, storage_genro.Service(
-                parent=site, manager=manager, mount_name=name, mount_config=config), 'local')
-    return Storage(site, mode, list(base_paths))
 
 
 @pytest.fixture(params=MODES)
@@ -161,42 +50,14 @@ def local(request, tmp_path):
     second = tmp_path / 'second'
     first.mkdir()
     second.mkdir()
-    return _local_storage(request.param, {'st': str(first), 'st2': str(second)})
-
-
-def _s3_storage(mode):
-    """A Storage with a 'st' mount on the configured S3 endpoint, under a
-    prefix of its own so the two modes never share objects."""
-    site = SiteStub()
-    prefix = '%s/%s' % (S3_PREFIX, uuid.uuid4().hex[:12])
-    if mode == 'legacy':
-        legacy_service = _load_aws_s3_service()
-        site.add('st', legacy_service(
-            parent=site, bucket=S3_BUCKET, base_path=prefix,
-            aws_access_key_id=S3_ACCESS_KEY, aws_secret_access_key=S3_SECRET_KEY,
-            region_name='us-east-1', custom_endpoint=True, endpoint_url=S3_ENDPOINT,
-            versioned=False), 'aws_s3')
-    else:
-        config = {'name': 'st', 'protocol': 's3', 'bucket': S3_BUCKET,
-                  'base_path': prefix, 'access_key': S3_ACCESS_KEY,
-                  'secret_key': S3_SECRET_KEY, 'endpoint_url': S3_ENDPOINT}
-        manager = StorageManager()
-        manager.configure([config])
-        site.add('st', storage_genro.Service(
-            parent=site, manager=manager, mount_name='st', mount_config=config,
-            versioned=False), 'aws_s3')
-    storage = Storage(site, mode, ['st'])
-    storage.prefix = prefix
-    return storage
+    return local_storage(request.param, {'st': str(first), 'st2': str(second)})
 
 
 @pytest.fixture(params=MODES)
 def s3(request):
-    storage = _s3_storage(request.param)
+    storage = s3_storage(request.param)
     yield storage
-    root = storage.node('st:')
-    if root.exists:
-        root.delete()
+    storage.cleanup()
 
 
 class StorageParity:
@@ -509,8 +370,8 @@ class TestNamedDivergences:
         legacy aws_s3 service already does."""
         base = tmp_path / 'base'
         base.mkdir()
-        legacy = _local_storage('legacy', {'st': str(base)})
-        genro = _local_storage('genro', {'st': str(base)})
+        legacy = local_storage('legacy', {'st': str(base)})
+        genro = local_storage('genro', {'st': str(base)})
         with pytest.raises(AttributeError):
             legacy.node('st:nope.txt').mtime
         assert genro.node('st:nope.txt').mtime is None
@@ -521,7 +382,7 @@ class TestNamedDivergences:
         """genro-storage refuses '..' in a path; the legacy service resolves it."""
         base = tmp_path / 'base'
         base.mkdir()
-        genro = _local_storage('genro', {'st': str(base)})
+        genro = local_storage('genro', {'st': str(base)})
         with pytest.raises(ValueError):
             genro.node('st:sub/../escaped.txt').exists
 
@@ -531,8 +392,8 @@ class TestNamedDivergences:
         when it is 32 characters long: a multipart upload (which is what
         smart_open does, and what MinIO reports back) makes it give up and
         return None. genro-storage reports the content md5 either way."""
-        legacy = _s3_storage('legacy')
-        genro = _s3_storage('genro')
+        legacy = s3_storage('legacy')
+        genro = s3_storage('genro')
         try:
             legacy_node = legacy.write('st:probe.txt')
             genro_node = genro.write('st:probe.txt')

--- a/gnrpy/tests/core/gnrstorage_compare_test.py
+++ b/gnrpy/tests/core/gnrstorage_compare_test.py
@@ -172,6 +172,29 @@ class StorageParity:
         storage.write('st:listing/a.txt')
         assert storage.node('st:listing').listdir() == ['st:listing/a.txt']
 
+    def test_children_are_sorted_by_basename(self, storage):
+        """The order is what every tree built on top of this displays."""
+        for name in ('zeta.txt', 'alpha.txt', 'Mixed Case.txt', 'beta.txt'):
+            storage.write('st:sorted/%s' % name)
+        names = [child.basename for child in storage.node('st:sorted').children()]
+        assert names == sorted(names)
+
+    def test_size_on_a_directory_is_not_a_file_size(self, storage):
+        """A directory has no meaningful size: whatever comes back, it must not
+        raise and must not be mistaken for a file size."""
+        storage.write('st:sized/a.txt')
+        size = storage.node('st:sized').size
+        assert size is None or isinstance(size, int)
+
+    def test_md5hash_on_a_directory_does_not_raise(self, storage):
+        storage.write('st:hashed/a.txt')
+        node = storage.node('st:hashed')
+        try:
+            assert node.md5hash is None or len(node.md5hash) == 32
+        except IsADirectoryError:
+            # what the legacy local service does: it opens the directory
+            assert storage.mode == 'legacy'
+
     # ---- mkdir
 
     def test_mkdir_then_isdir(self, storage):

--- a/gnrpy/tests/core/gnrstorage_compare_test.py
+++ b/gnrpy/tests/core/gnrstorage_compare_test.py
@@ -1,0 +1,568 @@
+"""Storage parity: the same test body run against the legacy services and
+against genro-storage.
+
+Every test asks the storage under test for a result and compares it with the
+contract the legacy services already honour, so what is pinned is "same input,
+same observable result in both modes". Where the two legitimately differ, the
+difference is asserted explicitly and named, never smoothed over.
+
+Real services on a real filesystem, and on a real S3 endpoint when one is
+configured. No daemon and no database: the site is stood in for by SiteStub,
+which carries only what StorageNode and the services dereference - the storage
+operations themselves are never mocked.
+
+Run:
+    cd gnrpy && pytest tests/core/gnrstorage_compare_test.py -q
+
+The S3 half needs an S3-compatible endpoint (MinIO is enough):
+    export GNR_TEST_S3_ENDPOINT=http://127.0.0.1:9000
+    export GNR_TEST_S3_ACCESS_KEY=minioadmin
+    export GNR_TEST_S3_SECRET_KEY=minioadmin
+    export GNR_TEST_S3_BUCKET=sandbox
+Without GNR_TEST_S3_ENDPOINT, or with an endpoint that does not answer, the S3
+tests skip with the reason naming it.
+"""
+
+import base64
+import hashlib
+import importlib.util
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+import pytest
+
+from gnr.core.gnrbag import Bag
+from gnr.lib.services.storage import (BaseLocalService, NotExistingStorageNode,
+                                      StorageNode)
+
+genro_storage = pytest.importorskip(
+    'genro_storage', reason="genro-storage is an optional dependency (genro_storage extra)")
+from genro_storage import StorageManager  # noqa: E402
+
+from gnr.lib.services import storage_genro  # noqa: E402
+
+MODES = ['legacy', 'genro']
+
+S3_ENDPOINT = os.environ.get('GNR_TEST_S3_ENDPOINT')
+S3_ACCESS_KEY = os.environ.get('GNR_TEST_S3_ACCESS_KEY', 'minioadmin')
+S3_SECRET_KEY = os.environ.get('GNR_TEST_S3_SECRET_KEY', 'minioadmin')
+S3_BUCKET = os.environ.get('GNR_TEST_S3_BUCKET', 'sandbox')
+S3_PREFIX = os.environ.get('GNR_TEST_S3_PREFIX', 'gnrtest')
+
+CONTENT = b'genropy storage parity payload'
+
+
+def _s3_unavailable_reason():
+    if not S3_ENDPOINT:
+        return ("GNR_TEST_S3_ENDPOINT is not set: no S3-compatible endpoint to "
+                "compare against (see the module docstring)")
+    health = '%s/minio/health/live' % S3_ENDPOINT.rstrip('/')
+    try:
+        with urllib.request.urlopen(health, timeout=3) as response:
+            if response.code != 200:
+                return "%s answered %s" % (health, response.code)
+    except (urllib.error.URLError, OSError) as exc:
+        return "%s is not answering: %s" % (S3_ENDPOINT, exc)
+    return None
+
+
+S3_SKIP_REASON = _s3_unavailable_reason()
+requires_s3 = pytest.mark.skipif(S3_SKIP_REASON is not None, reason=str(S3_SKIP_REASON))
+
+
+def _load_aws_s3_service():
+    """Load the legacy aws_s3 service, which lives as a site resource."""
+    here = os.path.dirname(__file__)
+    path = os.path.abspath(os.path.join(
+        here, '..', '..', '..', 'projects', 'gnrcore', 'packages', 'sys',
+        'resources', 'services', 'storage', 'aws_s3.py'))
+    spec = importlib.util.spec_from_file_location('gnrtest_legacy_aws_s3', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.Service
+
+
+class SiteStub:
+    """Minimal stand-in for the site: only what StorageNode and the services
+    dereference."""
+
+    external_host = 'http://localhost:8080'
+    cache_max_age = None
+    _local_mode = False
+
+    def __init__(self):
+        self.services = {}
+        app_config = Bag()
+        app_config['packages'] = Bag()
+        self.gnrapp = type('GnrAppStub', (), {'config': app_config})()
+
+    def add(self, service_name, service, implementation=None):
+        service.service_name = service_name
+        service.service_implementation = implementation
+        self.services[service_name] = service
+        return service
+
+    def storageNode(self, path, **kwargs):
+        service_name, _, storage_path = path.partition(':')
+        return StorageNode(parent=self, service=self.services[service_name],
+                           path=storage_path, **kwargs)
+
+    def getService(self, service_type=None, service_name=None, **kwargs):
+        return self.services[service_name]
+
+    def not_found_exception(self, environ, start_response):
+        start_response('404 Not Found', [])
+        return [b'']
+
+    def redirect(self, environ, start_response, location=None, temporary=False):
+        start_response('302 Found', [('Location', location)])
+        return [b'redirected']
+
+
+class Storage:
+    """The storage under test, in one of the two modes."""
+
+    def __init__(self, site, mode, mounts):
+        self.site = site
+        self.mode = mode
+        self.mounts = mounts
+
+    def node(self, path, **kwargs):
+        return self.site.storageNode(path, **kwargs)
+
+    def write(self, path, content=CONTENT):
+        node = self.node(path)
+        with node.open('wb') as fp:
+            fp.write(content)
+        return node
+
+
+def _local_storage(mode, base_paths):
+    """A Storage with one mount per name in base_paths, all local."""
+    site = SiteStub()
+    manager = StorageManager() if mode == 'genro' else None
+    for name, base_path in base_paths.items():
+        if mode == 'legacy':
+            site.add(name, BaseLocalService(parent=site, base_path=base_path), 'local')
+        else:
+            config = {'name': name, 'protocol': 'local', 'base_path': base_path}
+            manager.configure([config])
+            site.add(name, storage_genro.Service(
+                parent=site, manager=manager, mount_name=name, mount_config=config), 'local')
+    return Storage(site, mode, list(base_paths))
+
+
+@pytest.fixture(params=MODES)
+def local(request, tmp_path):
+    """A 'st' mount and a second 'st2' mount, both local, in both modes."""
+    first = tmp_path / 'first'
+    second = tmp_path / 'second'
+    first.mkdir()
+    second.mkdir()
+    return _local_storage(request.param, {'st': str(first), 'st2': str(second)})
+
+
+def _s3_storage(mode):
+    """A Storage with a 'st' mount on the configured S3 endpoint, under a
+    prefix of its own so the two modes never share objects."""
+    site = SiteStub()
+    prefix = '%s/%s' % (S3_PREFIX, uuid.uuid4().hex[:12])
+    if mode == 'legacy':
+        legacy_service = _load_aws_s3_service()
+        site.add('st', legacy_service(
+            parent=site, bucket=S3_BUCKET, base_path=prefix,
+            aws_access_key_id=S3_ACCESS_KEY, aws_secret_access_key=S3_SECRET_KEY,
+            region_name='us-east-1', custom_endpoint=True, endpoint_url=S3_ENDPOINT,
+            versioned=False), 'aws_s3')
+    else:
+        config = {'name': 'st', 'protocol': 's3', 'bucket': S3_BUCKET,
+                  'base_path': prefix, 'access_key': S3_ACCESS_KEY,
+                  'secret_key': S3_SECRET_KEY, 'endpoint_url': S3_ENDPOINT}
+        manager = StorageManager()
+        manager.configure([config])
+        site.add('st', storage_genro.Service(
+            parent=site, manager=manager, mount_name='st', mount_config=config,
+            versioned=False), 'aws_s3')
+    storage = Storage(site, mode, ['st'])
+    storage.prefix = prefix
+    return storage
+
+
+@pytest.fixture(params=MODES)
+def s3(request):
+    storage = _s3_storage(request.param)
+    yield storage
+    root = storage.node('st:')
+    if root.exists:
+        root.delete()
+
+
+class StorageParity:
+    """The parity body. Subclasses bind `storage` to a local or an S3 mount."""
+
+    @pytest.fixture
+    def storage(self):
+        raise NotImplementedError
+
+    # ---- existence and kind
+
+    def test_exists_on_missing(self, storage):
+        assert storage.node('st:nope.txt').exists is False
+
+    def test_exists_isfile_isdir_on_file(self, storage):
+        node = storage.write('st:sub/dir/probe.txt')
+        assert node.exists is True
+        assert node.isfile is True
+        assert node.isdir is False
+
+    def test_exists_isdir_on_directory(self, storage):
+        storage.write('st:sub/dir/probe.txt')
+        parent = storage.node('st:sub/dir')
+        assert parent.exists is True
+        assert parent.isdir is True
+        assert parent.isfile is False
+
+    # ---- read and write
+
+    def test_open_write_then_read_binary(self, storage):
+        node = storage.write('st:bin.dat', b'\x00\x01binary\xff')
+        with node.open('rb') as fp:
+            assert fp.read() == b'\x00\x01binary\xff'
+
+    def test_open_write_then_read_text(self, storage):
+        node = storage.node('st:text.txt')
+        with node.open('w') as fp:
+            fp.write('a line of text')
+        with node.open('r') as fp:
+            assert fp.read() == 'a line of text'
+
+    def test_open_write_creates_intermediate_directories(self, storage):
+        node = storage.write('st:deep/deeper/deepest/probe.txt')
+        assert node.exists is True
+
+    def test_size(self, storage):
+        node = storage.write('st:probe.txt')
+        assert node.size == len(CONTENT)
+
+    def test_mtime(self, storage):
+        node = storage.write('st:probe.txt')
+        assert isinstance(node.mtime, float)
+        assert node.mtime > 0
+
+    def test_md5hash_is_the_content_md5_when_reported(self, storage):
+        node = storage.write('st:probe.txt')
+        if node.md5hash is not None:
+            assert node.md5hash == hashlib.md5(CONTENT).hexdigest()
+
+    def test_ext_attributes(self, storage):
+        node = storage.write('st:probe.txt')
+        mtime, size, isdir = node.ext_attributes
+        assert size == len(CONTENT)
+        assert isdir is False
+        assert mtime > 0
+
+    # ---- naming
+
+    def test_fullpath(self, storage):
+        assert storage.node('st:sub/probe.txt').fullpath == 'st:sub/probe.txt'
+
+    def test_basename_and_cleanbasename_and_ext(self, storage):
+        node = storage.node('st:sub/probe.txt')
+        assert node.basename == 'probe.txt'
+        assert node.cleanbasename == 'probe'
+        assert node.ext == 'txt'
+
+    def test_splitext(self, storage):
+        assert storage.node('st:sub/probe.txt').splitext() == ('sub/probe', '.txt')
+
+    def test_internal_path_is_not_empty(self, storage):
+        node = storage.node('st:sub/probe.txt')
+        assert node.internal_path
+        assert node.internal_path.endswith('sub/probe.txt')
+
+    def test_child(self, storage):
+        assert storage.node('st:sub').child('probe.txt').fullpath == 'st:sub/probe.txt'
+
+    def test_parent_storage_node(self, storage):
+        node = storage.node('st:sub/dir/probe.txt')
+        assert node.parentStorageNode.fullpath == 'st:sub/dir'
+
+    # ---- listing
+
+    def test_children(self, storage):
+        storage.write('st:listing/a.txt')
+        storage.write('st:listing/b.txt')
+        names = sorted(child.basename for child in storage.node('st:listing').children())
+        assert names == ['a.txt', 'b.txt']
+
+    def test_children_are_storage_nodes(self, storage):
+        storage.write('st:listing/a.txt')
+        for child in storage.node('st:listing').children():
+            assert isinstance(child, StorageNode)
+            assert child.exists is True
+
+    def test_children_on_a_file_is_none(self, storage):
+        node = storage.write('st:probe.txt')
+        assert node.children() is None
+
+    def test_listdir_returns_fullpaths(self, storage):
+        storage.write('st:listing/a.txt')
+        assert storage.node('st:listing').listdir() == ['st:listing/a.txt']
+
+    # ---- mkdir
+
+    def test_mkdir_then_isdir(self, storage):
+        node = storage.node('st:brandnew')
+        node.mkdir()
+        assert node.isdir is True
+
+    def test_mkdir_on_existing_is_a_noop(self, storage):
+        node = storage.node('st:brandnew')
+        node.mkdir()
+        node.mkdir()
+        assert node.isdir is True
+
+    # ---- copy, move, delete
+
+    def test_copy_file(self, storage):
+        source = storage.write('st:source.txt')
+        dest = source.copy(storage.node('st:copied.txt'))
+        assert dest.exists is True
+        assert source.exists is True
+        with dest.open('rb') as fp:
+            assert fp.read() == CONTENT
+
+    def test_copy_into_a_directory_keeps_the_basename(self, storage):
+        source = storage.write('st:source.txt')
+        target_dir = storage.node('st:target')
+        target_dir.mkdir()
+        source.copy(target_dir)
+        assert storage.node('st:target/source.txt').exists is True
+
+    def test_move_file_rebinds_the_node(self, storage):
+        source = storage.write('st:tomove.txt')
+        source.move(storage.node('st:moved.txt'))
+        assert source.fullpath == 'st:moved.txt'
+        assert source.exists is True
+        assert storage.node('st:tomove.txt').exists is False
+
+    def test_delete_file(self, storage):
+        node = storage.write('st:todelete.txt')
+        node.delete()
+        assert node.exists is False
+
+    def test_delete_directory(self, storage):
+        storage.write('st:tree/a.txt')
+        storage.write('st:tree/nested/b.txt')
+        tree = storage.node('st:tree')
+        tree.delete()
+        assert tree.exists is False
+        assert storage.node('st:tree/a.txt').exists is False
+        assert storage.node('st:tree/nested/b.txt').exists is False
+
+    def test_delete_on_missing_is_a_noop(self, storage):
+        storage.node('st:never-existed.txt').delete()
+
+    # ---- base64
+
+    def test_base64_bare(self, storage):
+        node = storage.write('st:probe.txt')
+        assert node.base64() == base64.b64encode(CONTENT).decode()
+
+    def test_base64_with_autodetected_mime(self, storage):
+        node = storage.write('st:probe.txt')
+        assert node.base64(mime=True).startswith('data:text/plain;base64,')
+
+    def test_base64_with_explicit_mime(self, storage):
+        node = storage.write('st:probe.txt')
+        assert node.base64(mime='image/png').startswith('data:image/png;base64,')
+
+    def test_base64_on_missing_is_empty(self, storage):
+        assert storage.node('st:nope.txt').base64() == ''
+
+    # ---- urls
+
+    def test_internal_url(self, storage):
+        node = storage.write('st:sub/probe.txt')
+        assert '/_storage/st/sub/probe.txt' in node.internal_url()
+
+    def test_internal_url_nocache_carries_mtime(self, storage):
+        node = storage.write('st:sub/probe.txt')
+        assert 'mtime=' in node.internal_url(nocache=True)
+
+    def test_url_is_a_string(self, storage):
+        node = storage.write('st:sub/probe.txt')
+        assert isinstance(node.url(), str)
+        assert node.url()
+
+    # ---- local_path
+
+    def test_local_path_reads_the_content(self, storage):
+        node = storage.write('st:probe.txt')
+        with node.local_path() as local_path:
+            with open(local_path, 'rb') as fp:
+                assert fp.read() == CONTENT
+
+    def test_local_path_write_mode_pushes_changes_back(self, storage):
+        node = storage.write('st:probe.txt')
+        with node.local_path(mode='wb') as local_path:
+            with open(local_path, 'wb') as fp:
+                fp.write(b'rewritten through local_path')
+        with node.open('rb') as fp:
+            assert fp.read() == b'rewritten through local_path'
+
+    # ---- node kwargs
+
+    def test_must_exist_raises_on_missing(self, storage):
+        with pytest.raises(NotExistingStorageNode):
+            storage.node('st:nope.txt', must_exist=True)
+
+    def test_must_exist_passes_on_existing(self, storage):
+        storage.write('st:probe.txt')
+        assert storage.node('st:probe.txt', must_exist=True).exists is True
+
+    def test_mode_is_kept_on_the_node(self, storage):
+        assert storage.node('st:probe.txt', mode='wb').mode == 'wb'
+
+    def test_versions_returns_a_list(self, storage):
+        storage.write('st:probe.txt')
+        assert isinstance(storage.node('st:probe.txt').versions, list)
+
+
+class TestLocalParity(StorageParity):
+    """The parity body on a local mount."""
+
+    @pytest.fixture
+    def storage(self, local):
+        return local
+
+    def test_copy_across_mounts(self, local):
+        source = local.write('st:source.txt')
+        dest = source.copy(local.node('st2:copied.txt'))
+        assert dest.exists is True
+        with dest.open('rb') as fp:
+            assert fp.read() == CONTENT
+
+    def test_move_across_mounts(self, local):
+        source = local.write('st:tomove.txt')
+        source.move(local.node('st2:moved.txt'))
+        assert source.fullpath == 'st2:moved.txt'
+        assert source.exists is True
+        assert local.node('st:tomove.txt').exists is False
+
+    def test_md5hash_matches_content(self, local):
+        node = local.write('st:probe.txt')
+        assert node.md5hash == hashlib.md5(CONTENT).hexdigest()
+
+    def test_internal_path_is_the_filesystem_path(self, local):
+        node = local.write('st:sub/probe.txt')
+        assert os.path.isabs(node.internal_path)
+        assert os.path.exists(node.internal_path)
+
+    def test_local_path_is_the_file_itself(self, local):
+        node = local.write('st:probe.txt')
+        with node.local_path() as local_path:
+            assert local_path == node.internal_path
+
+
+@requires_s3
+class TestS3Parity(StorageParity):
+    """The parity body on an S3 mount."""
+
+    @pytest.fixture
+    def storage(self, s3):
+        return s3
+
+    def test_internal_path_is_the_object_key(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        assert node.internal_path == '%s/sub/probe.txt' % s3.prefix
+
+    def test_internal_url_is_served_as_a_download(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        assert '_download=True' in node.internal_url()
+
+    def test_url_is_presigned(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        assert 'X-Amz-Signature' in node.url()
+
+    def test_url_content_is_fetchable(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        with urllib.request.urlopen(node.url(), timeout=10) as response:
+            assert response.read() == CONTENT
+
+    def test_local_path_is_a_temporary_copy(self, s3):
+        node = s3.write('st:probe.txt')
+        with node.local_path() as local_path:
+            assert os.path.exists(local_path)
+            assert local_path != node.internal_path
+
+
+class TestNamedDivergences:
+    """Where the two modes legitimately differ, the difference is pinned here
+    rather than hidden in the parity body."""
+
+    def test_missing_file_metadata_legacy_local_raises_genro_returns_none(self, tmp_path):
+        """On a local mount, the legacy service dereferences a None stat and
+        raises AttributeError; the genro-storage service reports None, as the
+        legacy aws_s3 service already does."""
+        base = tmp_path / 'base'
+        base.mkdir()
+        legacy = _local_storage('legacy', {'st': str(base)})
+        genro = _local_storage('genro', {'st': str(base)})
+        with pytest.raises(AttributeError):
+            legacy.node('st:nope.txt').mtime
+        assert genro.node('st:nope.txt').mtime is None
+        assert genro.node('st:nope.txt').size is None
+        assert genro.node('st:nope.txt').md5hash is None
+
+    def test_parent_traversal_is_refused_by_genro_storage(self, tmp_path):
+        """genro-storage refuses '..' in a path; the legacy service resolves it."""
+        base = tmp_path / 'base'
+        base.mkdir()
+        genro = _local_storage('genro', {'st': str(base)})
+        with pytest.raises(ValueError):
+            genro.node('st:sub/../escaped.txt').exists
+
+    @requires_s3
+    def test_md5hash_on_s3_legacy_gives_up_on_a_multipart_etag(self):
+        """The legacy aws_s3 service reports the object ETag as md5, and only
+        when it is 32 characters long: a multipart upload (which is what
+        smart_open does, and what MinIO reports back) makes it give up and
+        return None. genro-storage reports the content md5 either way."""
+        legacy = _s3_storage('legacy')
+        genro = _s3_storage('genro')
+        try:
+            legacy_node = legacy.write('st:probe.txt')
+            genro_node = genro.write('st:probe.txt')
+            assert genro_node.md5hash == hashlib.md5(CONTENT).hexdigest()
+            assert legacy_node.md5hash in (None, hashlib.md5(CONTENT).hexdigest())
+        finally:
+            for storage in (legacy, genro):
+                root = storage.node('st:')
+                if root.exists:
+                    root.delete()
+
+    @requires_s3
+    def test_local_path_keep_is_refused_on_a_remote_genro_mount(self):
+        """The legacy S3 service can keep the temporary file; genro-storage's
+        context manager always removes it, so keep=True is refused loudly
+        instead of silently doing nothing."""
+        site = SiteStub()
+        prefix = '%s/%s' % (S3_PREFIX, uuid.uuid4().hex[:12])
+        config = {'name': 'st', 'protocol': 's3', 'bucket': S3_BUCKET,
+                  'base_path': prefix, 'access_key': S3_ACCESS_KEY,
+                  'secret_key': S3_SECRET_KEY, 'endpoint_url': S3_ENDPOINT}
+        manager = StorageManager()
+        manager.configure([config])
+        site.add('st', storage_genro.Service(
+            parent=site, manager=manager, mount_name='st', mount_config=config), 'aws_s3')
+        node = site.storageNode('st:probe.txt')
+        with node.open('wb') as fp:
+            fp.write(CONTENT)
+        try:
+            with pytest.raises(NotImplementedError):
+                node.local_path(keep=True)
+        finally:
+            node.delete()

--- a/gnrpy/tests/core/gnrstorage_compare_test.py
+++ b/gnrpy/tests/core/gnrstorage_compare_test.py
@@ -21,6 +21,7 @@ without it those tests skip with the reason naming the variable.
 import base64
 import hashlib
 import os
+import urllib.parse
 import urllib.request
 import uuid
 
@@ -382,6 +383,31 @@ class TestS3Parity(StorageParity):
             assert os.path.exists(local_path)
             assert local_path != node.internal_path
 
+    def test_url_carries_the_content_disposition(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        url = node.url(_content_disposition='attachment; filename=given.txt')
+        assert 'response-content-disposition' in url.lower()
+        assert 'attachment; filename=given.txt' in urllib.parse.unquote(url)
+
+    def test_public_url_does_not_expire(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        public_url = node.public_url()
+        assert 'X-Amz-Signature' not in public_url
+        assert public_url.endswith(node.internal_path)
+
+    def test_serve_download_redirects_carrying_the_disposition(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        captured = {}
+
+        def start_response(status, headers):
+            captured['status'] = status
+            captured['headers'] = dict(headers)
+
+        node.serve({}, start_response, download=True)
+        assert captured['status'].startswith('302')
+        location = urllib.parse.unquote(captured['headers']['Location'])
+        assert 'attachment; filename=probe.txt' in location
+
 
 class TestNamedDivergences:
     """Where the two modes legitimately differ, the difference is pinned here
@@ -408,6 +434,47 @@ class TestNamedDivergences:
         genro = local_storage('genro', {'st': str(base)})
         with pytest.raises(ValueError):
             genro.node('st:sub/../escaped.txt').exists
+
+    @requires_s3
+    def test_url_expiration_of_the_mount_is_honoured(self):
+        """The mount's own url_expiration, not a per-call default: the two
+        modes must sign for the same window."""
+        for mode in MODES:
+            storage = s3_storage(mode, url_expiration=120)
+            try:
+                assert 'X-Amz-Expires=120' in storage.write('st:probe.txt').url()
+            finally:
+                storage.cleanup()
+
+    @requires_s3
+    def test_public_url_uses_the_configured_public_base_url(self):
+        """public_base_url fronts the bucket with a CDN or custom domain; it
+        must win over the endpoint in both modes."""
+        for mode in MODES:
+            storage = s3_storage(mode, public_base_url='https://cdn.example.com')
+            try:
+                node = storage.write('st:probe.txt')
+                assert node.public_url() == 'https://cdn.example.com/%s' % node.internal_path
+            finally:
+                storage.cleanup()
+
+    @requires_s3
+    def test_url_download_flag_is_inert_in_both_modes(self):
+        """aws_s3.url() reads _content_disposition into a local before the
+        _download branch writes it back into kwargs, so the branch is dead and
+        the disposition stays 'inline'. Pre-existing on the legacy path, and
+        both modes share it because the genro-storage service builds its urls
+        through that same legacy service. serve(download=True) is unaffected:
+        it passes _content_disposition explicitly."""
+        for mode in MODES:
+            storage = s3_storage(mode)
+            try:
+                url = urllib.parse.unquote(
+                    storage.write('st:probe.txt').url(_download=True))
+                assert 'response-content-disposition=inline' in url
+                assert 'attachment' not in url
+            finally:
+                storage.cleanup()
 
     @requires_s3
     def test_md5hash_on_s3_legacy_gives_up_on_a_multipart_etag(self):

--- a/gnrpy/tests/core/gnrstorage_compare_test.py
+++ b/gnrpy/tests/core/gnrstorage_compare_test.py
@@ -61,6 +61,14 @@ def s3(request):
     storage.cleanup()
 
 
+def _capture(captured):
+    """A start_response that records the status and headers it is given."""
+    def start_response(status, headers):
+        captured['status'] = status
+        captured['headers'] = dict(headers)
+    return start_response
+
+
 class StorageParity:
     """The parity body. Subclasses bind `storage` to a local or an S3 mount."""
 
@@ -352,6 +360,22 @@ class TestLocalParity(StorageParity):
             assert local_path == node.internal_path
 
 
+class TestLocalDownload:
+    """The download attribute on a local mount, in both modes."""
+
+    def test_serve_download_sets_the_attachment_header(self, tmp_path):
+        base = tmp_path / 'base'
+        base.mkdir()
+        for mode in MODES:
+            storage = local_storage(mode, {'st': str(base)})
+            node = storage.write('st:probe.txt')
+            for kwargs in ({'download': True}, {'_download': 'True'}):
+                captured = {}
+                node.serve({}, _capture(captured), **kwargs)
+                assert captured['headers']['Content-Disposition'] == (
+                    'attachment; filename=probe.txt'), (mode, kwargs)
+
+
 @requires_s3
 class TestS3Parity(StorageParity):
     """The parity body on an S3 mount."""
@@ -395,15 +419,27 @@ class TestS3Parity(StorageParity):
         assert 'X-Amz-Signature' not in public_url
         assert public_url.endswith(node.internal_path)
 
+    def test_url_download_names_the_file(self, s3):
+        node = s3.write('st:sub/probe.txt')
+        for flag in ('download', '_download'):
+            url = urllib.parse.unquote(node.url(**{flag: True}))
+            assert 'attachment; filename=probe.txt' in url, flag
+
+    def test_serve_honours_the_download_query_of_internal_url(self, s3):
+        """internal_url() marks the url with _download; serving it must
+        redirect to an attachment."""
+        node = s3.write('st:sub/probe.txt')
+        assert '_download=True' in node.internal_url()
+        captured = {}
+        node.serve({}, _capture(captured), _download='True')
+        assert captured['status'].startswith('302')
+        assert 'attachment; filename=probe.txt' in urllib.parse.unquote(
+            captured['headers']['Location'])
+
     def test_serve_download_redirects_carrying_the_disposition(self, s3):
         node = s3.write('st:sub/probe.txt')
         captured = {}
-
-        def start_response(status, headers):
-            captured['status'] = status
-            captured['headers'] = dict(headers)
-
-        node.serve({}, start_response, download=True)
+        node.serve({}, _capture(captured), download=True)
         assert captured['status'].startswith('302')
         location = urllib.parse.unquote(captured['headers']['Location'])
         assert 'attachment; filename=probe.txt' in location
@@ -455,24 +491,6 @@ class TestNamedDivergences:
             try:
                 node = storage.write('st:probe.txt')
                 assert node.public_url() == 'https://cdn.example.com/%s' % node.internal_path
-            finally:
-                storage.cleanup()
-
-    @requires_s3
-    def test_url_download_flag_is_inert_in_both_modes(self):
-        """aws_s3.url() reads _content_disposition into a local before the
-        _download branch writes it back into kwargs, so the branch is dead and
-        the disposition stays 'inline'. Pre-existing on the legacy path, and
-        both modes share it because the genro-storage service builds its urls
-        through that same legacy service. serve(download=True) is unaffected:
-        it passes _content_disposition explicitly."""
-        for mode in MODES:
-            storage = s3_storage(mode)
-            try:
-                url = urllib.parse.unquote(
-                    storage.write('st:probe.txt').url(_download=True))
-                assert 'response-content-disposition=inline' in url
-                assert 'attachment' not in url
             finally:
                 storage.cleanup()
 

--- a/gnrpy/tests/core/storage_fixtures.py
+++ b/gnrpy/tests/core/storage_fixtures.py
@@ -1,0 +1,167 @@
+"""Shared scaffolding for the storage parity tests and the storage benchmark.
+
+Builds the same mount in either mode - through the legacy services or through
+genro-storage - so a test body can run twice and be compared. Only the site is
+stood in for; the storage services and the storage itself are real.
+
+The S3 half needs an S3-compatible endpoint (MinIO is enough):
+    export GNR_TEST_S3_ENDPOINT=http://127.0.0.1:9000
+    export GNR_TEST_S3_ACCESS_KEY=minioadmin
+    export GNR_TEST_S3_SECRET_KEY=minioadmin
+    export GNR_TEST_S3_BUCKET=sandbox
+    export GNR_TEST_S3_PREFIX=gnrtest
+Without GNR_TEST_S3_ENDPOINT, or with an endpoint that does not answer,
+s3_unavailable_reason() explains why and the callers skip.
+"""
+
+import importlib.util
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+from genro_storage import StorageManager
+
+from gnr.core.gnrbag import Bag
+from gnr.lib.services import storage_genro
+from gnr.lib.services.storage import BaseLocalService, StorageNode
+
+MODES = ['legacy', 'genro']
+
+S3_ENDPOINT = os.environ.get('GNR_TEST_S3_ENDPOINT')
+S3_ACCESS_KEY = os.environ.get('GNR_TEST_S3_ACCESS_KEY', 'minioadmin')
+S3_SECRET_KEY = os.environ.get('GNR_TEST_S3_SECRET_KEY', 'minioadmin')
+S3_BUCKET = os.environ.get('GNR_TEST_S3_BUCKET', 'sandbox')
+S3_PREFIX = os.environ.get('GNR_TEST_S3_PREFIX', 'gnrtest')
+
+CONTENT = b'genropy storage parity payload'
+
+
+def s3_unavailable_reason():
+    """Why the S3 half cannot run, or None when it can."""
+    if not S3_ENDPOINT:
+        return ("GNR_TEST_S3_ENDPOINT is not set: no S3-compatible endpoint to "
+                "compare against (see tests/core/storage_fixtures.py)")
+    health = '%s/minio/health/live' % S3_ENDPOINT.rstrip('/')
+    try:
+        with urllib.request.urlopen(health, timeout=3) as response:
+            if response.code != 200:
+                return "%s answered %s" % (health, response.code)
+    except (urllib.error.URLError, OSError) as exc:
+        return "%s is not answering: %s" % (S3_ENDPOINT, exc)
+    return None
+
+
+def load_legacy_aws_s3_service():
+    """Load the legacy aws_s3 service, which lives as a site resource."""
+    here = os.path.dirname(__file__)
+    path = os.path.abspath(os.path.join(
+        here, '..', '..', '..', 'projects', 'gnrcore', 'packages', 'sys',
+        'resources', 'services', 'storage', 'aws_s3.py'))
+    spec = importlib.util.spec_from_file_location('gnrtest_legacy_aws_s3', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.Service
+
+
+class SiteStub:
+    """Minimal stand-in for the site: only what StorageNode and the services
+    dereference."""
+
+    external_host = 'http://localhost:8080'
+    cache_max_age = None
+    _local_mode = False
+
+    def __init__(self):
+        self.services = {}
+        app_config = Bag()
+        app_config['packages'] = Bag()
+        self.gnrapp = type('GnrAppStub', (), {'config': app_config})()
+
+    def add(self, service_name, service, implementation=None):
+        service.service_name = service_name
+        service.service_implementation = implementation
+        self.services[service_name] = service
+        return service
+
+    def storageNode(self, path, **kwargs):
+        service_name, _, storage_path = path.partition(':')
+        return StorageNode(parent=self, service=self.services[service_name],
+                           path=storage_path, **kwargs)
+
+    def getService(self, service_type=None, service_name=None, **kwargs):
+        return self.services[service_name]
+
+    def not_found_exception(self, environ, start_response):
+        start_response('404 Not Found', [])
+        return [b'']
+
+    def redirect(self, environ, start_response, location=None, temporary=False):
+        start_response('302 Found', [('Location', location)])
+        return [b'redirected']
+
+
+class Storage:
+    """The storage under test, in one of the two modes."""
+
+    def __init__(self, site, mode, mounts):
+        self.site = site
+        self.mode = mode
+        self.mounts = mounts
+        self.prefix = None
+
+    def node(self, path, **kwargs):
+        return self.site.storageNode(path, **kwargs)
+
+    def write(self, path, content=CONTENT):
+        node = self.node(path)
+        with node.open('wb') as fp:
+            fp.write(content)
+        return node
+
+    def cleanup(self):
+        for mount in self.mounts:
+            root = self.node('%s:' % mount)
+            if root.exists:
+                root.delete()
+
+
+def local_storage(mode, base_paths):
+    """A Storage with one local mount per name in base_paths."""
+    site = SiteStub()
+    manager = StorageManager() if mode == 'genro' else None
+    for name, base_path in base_paths.items():
+        if mode == 'legacy':
+            site.add(name, BaseLocalService(parent=site, base_path=base_path), 'local')
+        else:
+            config = {'name': name, 'protocol': 'local', 'base_path': base_path}
+            manager.configure([config])
+            site.add(name, storage_genro.Service(
+                parent=site, manager=manager, mount_name=name, mount_config=config), 'local')
+    return Storage(site, mode, list(base_paths))
+
+
+def s3_storage(mode):
+    """A Storage with a 'st' mount on the configured S3 endpoint, under a
+    prefix of its own so the two modes never share objects."""
+    site = SiteStub()
+    prefix = '%s/%s' % (S3_PREFIX, uuid.uuid4().hex[:12])
+    if mode == 'legacy':
+        legacy_service = load_legacy_aws_s3_service()
+        site.add('st', legacy_service(
+            parent=site, bucket=S3_BUCKET, base_path=prefix,
+            aws_access_key_id=S3_ACCESS_KEY, aws_secret_access_key=S3_SECRET_KEY,
+            region_name='us-east-1', custom_endpoint=True, endpoint_url=S3_ENDPOINT,
+            versioned=False), 'aws_s3')
+    else:
+        config = {'name': 'st', 'protocol': 's3', 'bucket': S3_BUCKET,
+                  'base_path': prefix, 'access_key': S3_ACCESS_KEY,
+                  'secret_key': S3_SECRET_KEY, 'endpoint_url': S3_ENDPOINT}
+        manager = StorageManager()
+        manager.configure([config])
+        site.add('st', storage_genro.Service(
+            parent=site, manager=manager, mount_name='st', mount_config=config,
+            versioned=False), 'aws_s3')
+    storage = Storage(site, mode, ['st'])
+    storage.prefix = prefix
+    return storage

--- a/gnrpy/tests/core/storage_fixtures.py
+++ b/gnrpy/tests/core/storage_fixtures.py
@@ -141,18 +141,25 @@ def local_storage(mode, base_paths):
     return Storage(site, mode, list(base_paths))
 
 
-def s3_storage(mode):
+def s3_storage(mode, **legacy_params):
     """A Storage with a 'st' mount on the configured S3 endpoint, under a
-    prefix of its own so the two modes never share objects."""
+    prefix of its own so the two modes never share objects.
+
+    legacy_params reach the legacy aws_s3 service in both modes: in genro mode
+    that is the service the url layer is delegated to, so a parameter like
+    url_expiration or public_base_url must take effect there too.
+    """
     site = SiteStub()
     prefix = '%s/%s' % (S3_PREFIX, uuid.uuid4().hex[:12])
+    legacy_service = load_legacy_aws_s3_service()
+    params = dict(
+        parent=site, bucket=S3_BUCKET, base_path=prefix,
+        aws_access_key_id=S3_ACCESS_KEY, aws_secret_access_key=S3_SECRET_KEY,
+        region_name='us-east-1', custom_endpoint=True, endpoint_url=S3_ENDPOINT,
+        versioned=False)
+    params.update(legacy_params)
     if mode == 'legacy':
-        legacy_service = load_legacy_aws_s3_service()
-        site.add('st', legacy_service(
-            parent=site, bucket=S3_BUCKET, base_path=prefix,
-            aws_access_key_id=S3_ACCESS_KEY, aws_secret_access_key=S3_SECRET_KEY,
-            region_name='us-east-1', custom_endpoint=True, endpoint_url=S3_ENDPOINT,
-            versioned=False), 'aws_s3')
+        site.add('st', legacy_service(**params), 'aws_s3')
     else:
         config = {'name': 'st', 'protocol': 's3', 'bucket': S3_BUCKET,
                   'base_path': prefix, 'access_key': S3_ACCESS_KEY,
@@ -161,7 +168,8 @@ def s3_storage(mode):
         manager.configure([config])
         site.add('st', storage_genro.Service(
             parent=site, manager=manager, mount_name='st', mount_config=config,
-            versioned=False), 'aws_s3')
+            versioned=False,
+            legacy_service=legacy_service(**params)), 'aws_s3')
     storage = Storage(site, mode, ['st'])
     storage.prefix = prefix
     return storage

--- a/gnrpy/tests/web/gnrgenrostoragehandler_test.py
+++ b/gnrpy/tests/web/gnrgenrostoragehandler_test.py
@@ -12,6 +12,7 @@ Run:
 
 import os
 import tempfile
+from contextlib import contextmanager
 
 import pytest
 
@@ -52,26 +53,44 @@ def handler(site, tmp_path):
     return handler
 
 
+@contextmanager
+def flag(site, value):
+    """Set (or clear) storage?use_genro_storage and force the domain proxy to
+    build a fresh handler, then put back exactly what was there. The tests must
+    hold whatever the local siteconfig happens to say."""
+    proxy = site.domains[site.currentDomain]
+    previous_handler = proxy._storage_handler
+    previous_node = site.config.getNode('storage')
+    if value is None:
+        site.config.pop('storage')
+    else:
+        site.config.setItem('storage', None, use_genro_storage=value)
+    proxy._storage_handler = None
+    try:
+        yield site
+    finally:
+        site.config.pop('storage')
+        if previous_node is not None:
+            site.config.setItem('storage', previous_node.value, **(previous_node.attr or {}))
+        proxy._storage_handler = previous_handler
+
+
 class TestSwitch:
 
     def test_flag_absent_yields_the_legacy_handler(self, site):
-        assert site.config['storage?use_genro_storage'] in (None, '', False)
-        assert isinstance(site.storage_handler, LegacyStorageHandler)
-        assert not isinstance(site.storage_handler, GenroStorageHandler)
+        with flag(site, None) as flagged:
+            assert flagged.config['storage?use_genro_storage'] in (None, '', False)
+            assert isinstance(flagged.storage_handler, LegacyStorageHandler)
+            assert not isinstance(flagged.storage_handler, GenroStorageHandler)
+
+    def test_flag_off_yields_the_legacy_handler(self, site):
+        with flag(site, False) as flagged:
+            assert isinstance(flagged.storage_handler, LegacyStorageHandler)
+            assert not isinstance(flagged.storage_handler, GenroStorageHandler)
 
     def test_flag_on_yields_the_genro_handler(self, site):
-        proxy = site.domains[site.currentDomain]
-        previous_handler = proxy._storage_handler
-        previous_node = site.config.getNode('storage')
-        site.config.setItem('storage', None, use_genro_storage=True)
-        proxy._storage_handler = None
-        try:
-            assert isinstance(site.storage_handler, GenroStorageHandler)
-        finally:
-            site.config.pop('storage')
-            if previous_node is not None:
-                site.config.setItem('storage', previous_node.value, **(previous_node.attr or {}))
-            proxy._storage_handler = previous_handler
+        with flag(site, True) as flagged:
+            assert isinstance(flagged.storage_handler, GenroStorageHandler)
 
 
 class TestMountRouting:

--- a/gnrpy/tests/web/gnrgenrostoragehandler_test.py
+++ b/gnrpy/tests/web/gnrgenrostoragehandler_test.py
@@ -1,0 +1,220 @@
+"""GenroStorageHandler on a real site: which mounts it takes over, which it
+leaves to the legacy handler, and that the switch is off by default.
+
+The site is instantiated directly rather than through BaseGnrDaemonTest: these
+tests need the storage registry and the resource resolution of a real site, not
+a running daemon. If the site cannot be built the whole module skips with the
+reason.
+
+Run:
+    cd gnrpy && pytest tests/web/gnrgenrostoragehandler_test.py -q
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import gnr.web.gnrwsgisite as gws
+from gnr.lib.services.storage import StorageNode
+from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import (GenroStorageHandler,
+                                                         LegacyStorageHandler)
+
+pytest.importorskip(
+    'genro_storage', reason="genro-storage is an optional dependency (genro_storage extra)")
+
+from gnr.lib.services import storage_genro  # noqa: E402
+
+SITE_NAME = 'gnrdevelop'
+SYMBOLIC_MOUNTS = ['rsrc', 'pkg', 'page', 'conn', 'user', 'temp', 'dojo', 'gnr', 'pages']
+
+
+@pytest.fixture(scope='module')
+def site():
+    try:
+        return gws.GnrWsgiSite(SITE_NAME, site_name=SITE_NAME)
+    except Exception as exc:
+        pytest.skip("site %r is not available: %s" % (SITE_NAME, exc))
+
+
+@pytest.fixture(scope='module')
+def legacy_handler(site):
+    return LegacyStorageHandler(site)
+
+
+@pytest.fixture
+def handler(site, tmp_path):
+    """A GenroStorageHandler with an extra local mount of its own."""
+    handler = GenroStorageHandler(site)
+    handler._setStorageParams('tmpnode', parameters={'base_path': str(tmp_path)},
+                              implementation='local')
+    handler._configureMounts()
+    return handler
+
+
+class TestSwitch:
+
+    def test_flag_absent_yields_the_legacy_handler(self, site):
+        assert site.config['storage?use_genro_storage'] in (None, '', False)
+        assert isinstance(site.storage_handler, LegacyStorageHandler)
+        assert not isinstance(site.storage_handler, GenroStorageHandler)
+
+    def test_flag_on_yields_the_genro_handler(self, site):
+        proxy = site.domains[site.currentDomain]
+        previous_handler = proxy._storage_handler
+        previous_node = site.config.getNode('storage')
+        site.config.setItem('storage', None, use_genro_storage=True)
+        proxy._storage_handler = None
+        try:
+            assert isinstance(site.storage_handler, GenroStorageHandler)
+        finally:
+            site.config.pop('storage')
+            if previous_node is not None:
+                site.config.setItem('storage', previous_node.value, **(previous_node.attr or {}))
+            proxy._storage_handler = previous_handler
+
+
+class TestMountRouting:
+
+    def test_local_mounts_are_taken_over(self, handler):
+        assert handler.manager.has_mount('tmpnode')
+        assert isinstance(handler.storage('tmpnode'), storage_genro.Service)
+
+    def test_raw_mount_is_taken_over_as_a_root_local_mount(self, handler):
+        assert handler.manager.has_mount('_raw_')
+        service = handler.storage('_raw_')
+        assert isinstance(service, storage_genro.Service)
+        assert service.mount_config['base_path'] == '/'
+
+    @pytest.mark.parametrize('mount_name', SYMBOLIC_MOUNTS)
+    def test_symbolic_mounts_stay_on_the_legacy_service(self, handler, mount_name):
+        service = handler.storage(mount_name)
+        assert not isinstance(service, storage_genro.Service)
+        assert service.service_implementation == 'symbolic'
+        assert handler.manager.has_mount(mount_name) is False
+
+    def test_http_mount_stays_on_the_legacy_service(self, handler):
+        service = handler.storage('_http_')
+        assert not isinstance(service, storage_genro.Service)
+        assert service.service_implementation == 'http'
+
+    def test_symbolic_paths_resolve_exactly_as_on_the_legacy_handler(self, handler, legacy_handler):
+        """The point of the hybrid: with the switch on, a symbolic node still
+        resolves to the very same place."""
+        for path in ('rsrc:sys', 'pkg:sys', 'temp:probe.txt', 'gnr:11/js'):
+            assert (handler.storageNode(path).internal_path
+                    == legacy_handler.storageNode(path).internal_path)
+
+    def test_page_mount_keeps_its_request_scoped_shape(self, handler, legacy_handler):
+        """page: is resolved from the current page, which no storage library can
+        know; the legacy service must keep owning it."""
+        assert (handler.storage('page').service_implementation
+                == legacy_handler.storage('page').service_implementation)
+
+    def test_unknown_mount_falls_back_to_the_legacy_local_service(self, handler):
+        service = handler.storage('a-name-nobody-configured')
+        assert not isinstance(service, storage_genro.Service)
+
+    def test_storage_with_kwargs_stays_on_the_legacy_service(self, handler, tmp_path):
+        service = handler.storage('tmpnode', base_path=str(tmp_path))
+        assert not isinstance(service, storage_genro.Service)
+
+    def test_readonly_mount_stays_on_the_legacy_service(self, site, tmp_path):
+        handler = GenroStorageHandler(site)
+        handler._setStorageParams('ro', parameters={'bucket': 'b', 'readonly': 'True'},
+                                  implementation='aws_s3')
+        handler._configureMounts()
+        assert handler.manager.has_mount('ro') is False
+
+    def test_local_mount_on_a_missing_base_path_stays_on_the_legacy_service(self, site, tmp_path):
+        handler = GenroStorageHandler(site)
+        missing = str(tmp_path / 'not-created-yet')
+        handler._setStorageParams('ghost', parameters={'base_path': missing},
+                                  implementation='local')
+        handler._configureMounts()
+        assert handler.manager.has_mount('ghost') is False
+        assert not isinstance(handler.storage('ghost'), storage_genro.Service)
+
+    def test_s3_mount_without_bucket_stays_on_the_legacy_service(self, site):
+        handler = GenroStorageHandler(site)
+        handler._setStorageParams('nobucket', parameters={}, implementation='aws_s3')
+        handler._configureMounts()
+        assert handler.manager.has_mount('nobucket') is False
+
+
+class TestRegistrySync:
+
+    def test_update_drops_a_mount_that_stopped_being_mappable(self, handler):
+        assert handler.manager.has_mount('tmpnode')
+        handler.storage_params['tmpnode'] = {'implementation': 'symbolic'}
+        handler._dropMount('tmpnode')
+        handler._configureMounts()
+        assert handler.manager.has_mount('tmpnode') is False
+
+    def test_remove_from_cache_drops_the_mount(self, handler):
+        assert handler.manager.has_mount('tmpnode')
+        handler.removeStorageFromCache('tmpnode')
+        assert handler.manager.has_mount('tmpnode') is False
+        assert 'tmpnode' not in handler.storage_params
+
+    def test_the_two_handlers_share_one_registry(self, site):
+        handler = GenroStorageHandler(site)
+        legacy = LegacyStorageHandler(site, storage_params=handler.storage_params)
+        assert legacy.storage_params is handler.storage_params
+
+
+class TestNodesOnATakenOverMount:
+
+    def test_the_node_is_a_legacy_storage_node(self, handler):
+        node = handler.storageNode('tmpnode:probe.txt')
+        assert isinstance(node, StorageNode)
+        assert isinstance(node.service, storage_genro.Service)
+        assert node.parent is handler.site
+
+    def test_read_write_roundtrip(self, handler):
+        node = handler.storageNode('tmpnode:sub/probe.txt')
+        with node.open('wb') as fp:
+            fp.write(b'through the handler')
+        assert node.exists is True
+        with node.open('rb') as fp:
+            assert fp.read() == b'through the handler'
+
+    def test_node_kwargs_reach_the_node(self, handler):
+        node = handler.storageNode('tmpnode:probe.txt', mode='wb', autocreate=-1,
+                                   version='_latest_')
+        assert node.mode == 'wb'
+        assert node.autocreate == -1
+        assert node.version == '_latest_'
+
+    def test_copy_to_a_legacy_symbolic_mount(self, handler):
+        """A copy that crosses the two worlds: StorageService bridges it by
+        content, because the two services report different locations."""
+        source = handler.storageNode('tmpnode:crossworld.txt')
+        with source.open('wb') as fp:
+            fp.write(b'crossing over')
+        dest = handler.storageNode('temp:gnr_crossworld_probe.txt')
+        try:
+            source.copy(dest)
+            assert dest.exists is True
+            with dest.open('rb') as fp:
+                assert fp.read() == b'crossing over'
+        finally:
+            if dest.exists:
+                dest.delete()
+
+    def test_copy_from_a_legacy_local_mount(self, handler):
+        """The other direction, between two mounts that are both on the local
+        filesystem: it stays a filesystem copy."""
+        legacy_dir = tempfile.mkdtemp(prefix='gnr_legacy_local_')
+        source_path = os.path.join(legacy_dir, 'legacy.txt')
+        with open(source_path, 'wb') as fp:
+            fp.write(b'from the legacy side')
+        handler._setStorageParams('legacyonly', parameters={'base_path': legacy_dir},
+                                  implementation='local')
+        legacy_service = handler.storage('legacyonly', base_path=legacy_dir)
+        source = StorageNode(parent=handler.site, service=legacy_service, path='legacy.txt')
+        dest = handler.storageNode('tmpnode:fromlegacy.txt')
+        source.copy(dest)
+        assert dest.exists is True
+        with dest.open('rb') as fp:
+            assert fp.read() == b'from the legacy side'

--- a/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
+++ b/projects/gnrcore/packages/sys/resources/services/storage/aws_s3.py
@@ -322,10 +322,10 @@ class Service(StorageService):
 
     def url(self, *args , **kwargs):
         kwargs = kwargs or {}
-        _content_disposition = kwargs.get('_content_disposition') or 'inline'
-        _download = kwargs.get('_download')
-        if _download:
-            kwargs['_content_disposition'] = "attachment; filename=%s" % self.basename(*args)
+        if kwargs.get('_download') or kwargs.get('download'):
+            _content_disposition = "attachment; filename=%s" % self.basename(*args)
+        else:
+            _content_disposition = kwargs.get('_content_disposition') or 'inline'
         internal_path = self.internal_path(*args)
         _content_type = mimetypes.guess_type(internal_path)[0]
         expiration = kwargs.pop('expiration', self.url_expiration)

--- a/projects/gnrcore/packages/test15/webpages/tools/storage_genro.py
+++ b/projects/gnrcore/packages/test15/webpages/tools/storage_genro.py
@@ -1,0 +1,309 @@
+# -*- coding: utf-8 -*-
+
+"""Storage: legacy services vs genro-storage (storage?use_genro_storage)"""
+
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrdecorator import public_method
+from gnr.web.gnrwsgisite_proxy.gnrstoragehandler import (GenroStorageHandler,
+                                                         LegacyStorageHandler)
+
+TAKEN_OVER = ('local', 'raw', 'aws_s3')
+
+# The node surface the two worlds must agree on, as (label, getter).
+SURFACE = (
+    ('exists', lambda n: n.exists),
+    ('isfile', lambda n: n.isfile),
+    ('isdir', lambda n: n.isdir),
+    ('size', lambda n: n.size),
+    ('mtime', lambda n: n.mtime),
+    ('md5hash', lambda n: n.md5hash),
+    ('basename', lambda n: n.basename),
+    ('cleanbasename', lambda n: n.cleanbasename),
+    ('ext', lambda n: n.ext),
+    ('fullpath', lambda n: n.fullpath),
+    ('internal_path', lambda n: n.internal_path),
+    ('url', lambda n: n.url()),
+    ('internal_url', lambda n: n.internal_url()),
+    ('internal_url_nocache', lambda n: n.internal_url(nocache=True)),
+    ('base64_bare', lambda n: (n.base64() or '')[:32]),
+    ('base64_mime', lambda n: (n.base64(mime=True) or '')[:48]),
+    ('listdir', lambda n: n.listdir()),
+    ('children_count', lambda n: len(n.children() or [])),
+    ('versions_count', lambda n: len(n.versions or [])),
+    ('mimetype', lambda n: n.mimetype),
+)
+
+
+class GnrCustomWebPage(object):
+    py_requires = """gnrcomponents/testhandler:TestHandlerFull,
+                     gnrcomponents/storagetree:StorageTree,
+                     gnrcomponents/drop_uploader"""
+
+    def windowTitle(self):
+        return '!!Storage: legacy vs genro-storage'
+
+    # ---- helpers
+
+    @property
+    def legacy_handler(self):
+        """A legacy handler built on the side, to compare against whatever the
+        site is currently using."""
+        if not hasattr(self, '_legacy_handler'):
+            self._legacy_handler = LegacyStorageHandler(self.site)
+        return self._legacy_handler
+
+    def _serviceLabel(self, service):
+        if service is None:
+            return 'none'
+        module = service.__class__.__module__
+        return 'genro-storage' if module.endswith('storage_genro') else 'legacy'
+
+    def _readSurface(self, node):
+        """Every member of the surface, with the failure kept as the value: an
+        exception here is the interesting part, not something to hide."""
+        result = Bag()
+        for label, getter in SURFACE:
+            try:
+                value = getter(node)
+            except Exception as exc:
+                value = '%s: %s' % (exc.__class__.__name__, exc)
+            result[label] = value if not isinstance(value, list) else ', '.join(
+                str(item) for item in value[:6])
+        return result
+
+    # ---- tests
+
+    def test_0_activeHandler(self, pane):
+        """Which handler the site is using, and which mount each implementation
+        is routed to. With the flag off everything is legacy: that is the
+        default and it is correct."""
+        handler = self.site.storage_handler
+        is_genro = isinstance(handler, GenroStorageHandler)
+        head = pane.div(padding='4px')
+        head.div('handler: %s' % handler.__class__.__name__,
+                 font_weight='bold', color='#2a6' if is_genro else '#a62')
+        head.div('siteconfig storage?use_genro_storage: %r'
+                 % self.site.config['storage?use_genro_storage'], color='#666')
+        if not is_genro:
+            head.div('The flag is off, so every row below says "legacy". '
+                     'Set <storage use_genro_storage="True"/> in the siteconfig '
+                     'to switch the mappable mounts over.',
+                     color='#a62', padding_top='4px')
+
+        table = pane.div(margin_top='6px').table(border_collapse='collapse',
+                                                 font_family='monospace', font_size='.85em')
+        header = table.tbody().tr(background='#eee')
+        for title in ('mount', 'implementation', 'served by', 'note'):
+            header.td(title, padding='2px 8px', border='1px solid #ccc', font_weight='bold')
+        body = table.tbody()
+        for mount_name in sorted(handler.storage_params):
+            params = handler.storage_params[mount_name]
+            implementation = params.get('implementation')
+            service = handler.storage(mount_name)
+            served_by = self._serviceLabel(service)
+            note = ''
+            if implementation not in TAKEN_OVER:
+                note = 'not replaceable: stays legacy by design'
+            elif served_by == 'legacy' and is_genro:
+                note = 'mappable but skipped (check the site log for the reason)'
+            row = body.tr()
+            row.td(mount_name, padding='2px 8px', border='1px solid #ccc')
+            row.td(implementation or '', padding='2px 8px', border='1px solid #ccc')
+            row.td(served_by, padding='2px 8px', border='1px solid #ccc',
+                   color='#2a6' if served_by == 'genro-storage' else '#888')
+            row.td(note, padding='2px 8px', border='1px solid #ccc', color='#a62')
+
+    def test_1_treeTakenOver(self, pane):
+        """Tree on a mount genro-storage takes over when the flag is on
+        (local). Everything the frame does goes through the storage layer:
+        children, mkdir, drag-and-drop move, drop-to-upload, download,
+        internal_url for the preview."""
+        pane.data('.storagepath', 'site:')
+        fb = pane.formbuilder(cols=4, border_spacing='3px')
+        fb.textbox(value='^.storagepath', lbl='Path', width='24em')
+        for quick in ('site:', 'home:', 'site:uploads'):
+            fb.button(quick, action='SET .storagepath = %r;' % quick)
+        pane.storageTreeFrame(frameCode='genroStorageTree', storagepath='^.storagepath',
+                              border='1px solid silver', margin_top='4px', rounded=4,
+                              height='340px', store__onBuilt=True,
+                              preview_region='right', preview_width='50%',
+                              preview_border_left='1px solid silver')
+
+    def test_2_treeLegacyOnly(self, pane):
+        """Tree on the mounts that stay legacy even with the flag on. These must
+        behave exactly as they do today: symbolic resolves through the site
+        (resources, packages, the temp dir), and no storage library can know
+        about that."""
+        pane.data('.storagepath', 'pkg:sys')
+        fb = pane.formbuilder(cols=5, border_spacing='3px')
+        fb.textbox(value='^.storagepath', lbl='Path', width='24em')
+        for quick in ('pkg:sys', 'rsrc:', 'temp:', 'pages:'):
+            fb.button(quick, action='SET .storagepath = %r;' % quick)
+        pane.storageTreeFrame(frameCode='legacyStorageTree', storagepath='^.storagepath',
+                              border='1px solid silver', margin_top='4px', rounded=4,
+                              height='340px', store__onBuilt=True,
+                              preview_region='right', preview_width='50%',
+                              preview_border_left='1px solid silver')
+
+    def test_3_nodeInspector(self, pane):
+        """The whole legacy StorageNode surface on one path, with the service
+        that answered it. Type any path: a failure is shown as the value."""
+        pane.data('.storagepath', 'site:uploads')
+        fb = pane.formbuilder(cols=2, border_spacing='4px')
+        fb.textbox(value='^.storagepath', lbl='Path', width='40em', colspan=2)
+        fb.button('Read', fire='.read')
+        fb.div('^.served_by', lbl='Served by', font_weight='bold')
+        box = pane.div(_class='selectable', margin_top='4px')
+        box.dataRpc('.result', self.inspectNode, storagepath='=.storagepath',
+                    _fired='^.read', served_by='.served_by')
+        box.div('^.result?=#v?#v.getFormattedValue():""', white_space='pre',
+                font_family='monospace', font_size='.85em')
+
+    @public_method
+    def inspectNode(self, storagepath=None, **kwargs):
+        if not storagepath:
+            return Bag()
+        node = self.site.storageNode(storagepath)
+        self.setInClientData(path='test.test_3_nodeInspector.served_by',
+                             value='%s (%s)' % (self._serviceLabel(node.service),
+                                                node.service.service_implementation))
+        return self._readSurface(node)
+
+    def test_4_sideBySide(self, pane):
+        """The same path read twice: once through the handler the site is using,
+        once through a legacy handler built on the side. Every row that differs
+        is highlighted - this is the parity test, on screen."""
+        pane.data('.storagepath', 'site:uploads')
+        fb = pane.formbuilder()
+        fb.textbox(value='^.storagepath', lbl='Path', width='40em')
+        fb.button('Compare', fire='.compare')
+        pane.dataRpc('.result', self.compareHandlers, storagepath='=.storagepath',
+                     _fired='^.compare')
+        grid = pane.div(margin_top='4px', overflow='auto')
+        grid.tree(storepath='.result', hideValues=False, labelAttribute='caption',
+                  font_family='monospace', font_size='.85em')
+
+    @public_method
+    def compareHandlers(self, storagepath=None, **kwargs):
+        if not storagepath:
+            return Bag()
+        active_node = self.site.storageNode(storagepath)
+        legacy_node = self.legacy_handler.storageNode(storagepath)
+        active = self._readSurface(active_node)
+        legacy = self._readSurface(legacy_node)
+        result = Bag()
+        result.setItem('_handlers', None, caption='active=%s | side=%s' % (
+            self._serviceLabel(active_node.service), self._serviceLabel(legacy_node.service)))
+        for label, _getter in SURFACE:
+            active_value = active[label]
+            legacy_value = legacy[label]
+            same = active_value == legacy_value
+            row = Bag()
+            row['active'] = active_value
+            row['legacy'] = legacy_value
+            result.setItem(label, row, caption='%s %s' % ('=' if same else '≠', label))
+        return result
+
+    def test_5_uploader(self, pane):
+        """Upload a file into a storage mount and read back what the storage
+        layer says about it. Drop a file, or double click."""
+        pane.data('.uploadpath', 'site:uploads')
+        fb = pane.formbuilder(cols=1, colswidth='100%')
+        fb.textbox(value='^.uploadpath', lbl='Destination', width='24em')
+        fb.div(lbl='File').dropUploader(
+            height='100px', width='340px', progressBar=True,
+            label="<div style='padding:20px'>Drop a file here<br>or double click</div>",
+            uploadPath='^.uploadpath',
+            onUploadedMethod=self.onFileUploaded)
+        fb.textbox('^.uploaded_path', lbl='Path', readOnly=True, width='100%',
+                   hidden='^.uploaded_path?=!#v')
+        fb.textbox('^.uploaded_served_by', lbl='Served by', readOnly=True,
+                   hidden='^.uploaded_path?=!#v')
+        fb.textbox('^.uploaded_size', lbl='Size (bytes)', readOnly=True,
+                   hidden='^.uploaded_path?=!#v')
+        fb.textbox('^.uploaded_md5', lbl='md5hash', readOnly=True, width='100%',
+                   hidden='^.uploaded_path?=!#v')
+        fb.textbox('^.uploaded_url', lbl='url()', readOnly=True, width='100%',
+                   hidden='^.uploaded_path?=!#v')
+
+    @public_method
+    def onFileUploaded(self, file_path=None, **kwargs):
+        node = self.site.storageNode(file_path)
+        datapath = 'test.test_5_uploader'
+        for name, value in (('uploaded_path', file_path),
+                            ('uploaded_served_by', self._serviceLabel(node.service)),
+                            ('uploaded_size', node.size),
+                            ('uploaded_md5', node.md5hash),
+                            ('uploaded_url', node.url())):
+            self.setInClientData(path='%s.%s' % (datapath, name), value=value)
+        self.clientPublish('floating_message',
+                           message='Uploaded through the %s service'
+                                   % self._serviceLabel(node.service))
+
+    def test_6_crossWorld(self, pane):
+        """Copy and move between a mount genro-storage serves and one the legacy
+        service serves. StorageService bridges the two by content when the
+        locations differ, so this must work in both directions."""
+        pane.data('.source', 'site:uploads')
+        pane.data('.dest', 'temp:gnr_crossworld_probe.txt')
+        fb = pane.formbuilder(cols=2, border_spacing='4px')
+        fb.textbox(value='^.source', lbl='Source', width='34em')
+        fb.textbox(value='^.dest', lbl='Destination', width='34em')
+        fb.button('Copy', fire='.copy')
+        fb.button('Move', fire='.move')
+        pane.dataRpc('.result', self.crossWorld, source='=.source', dest='=.dest',
+                     action='copy', _fired='^.copy', _lockScreen=True)
+        pane.dataRpc('.result', self.crossWorld, source='=.source', dest='=.dest',
+                     action='move', _fired='^.move', _lockScreen=True)
+        pane.div('^.result?=#v?#v.getFormattedValue():""', white_space='pre',
+                 font_family='monospace', font_size='.85em', margin_top='4px')
+
+    @public_method
+    def crossWorld(self, source=None, dest=None, action=None, **kwargs):
+        result = Bag()
+        if not (source and dest):
+            return result
+        source_node = self.site.storageNode(source)
+        dest_node = self.site.storageNode(dest)
+        result['action'] = action
+        result['source_served_by'] = self._serviceLabel(source_node.service)
+        result['dest_served_by'] = self._serviceLabel(dest_node.service)
+        result['same_location'] = (source_node.service.location_identifier
+                                   == dest_node.service.location_identifier)
+        if not source_node.exists:
+            result['error'] = 'source does not exist'
+            return result
+        try:
+            if action == 'move':
+                source_node.move(dest_node)
+                result['source_after_move'] = source_node.fullpath
+            else:
+                source_node.copy(dest_node)
+            result['dest_exists'] = dest_node.exists
+            result['dest_size'] = dest_node.size
+        except Exception as exc:
+            result['error'] = '%s: %s' % (exc.__class__.__name__, exc)
+        return result
+
+    def test_7_s3Mount(self, pane):
+        """Tree on an S3 mount, to exercise the remote half. Needs a storage
+        service of implementation aws_s3 - a local MinIO is enough - declared
+        either in sys.service or in the siteconfig."""
+        handler = self.site.storage_handler
+        remote_mounts = [name for name, params in handler.storage_params.items()
+                         if params.get('implementation') == 'aws_s3']
+        if not remote_mounts:
+            pane.div('No aws_s3 storage service is configured on this site: '
+                     'declare one in sys.service or in the siteconfig, then reload.',
+                     color='#a62', padding='4px')
+            return
+        pane.data('.storagepath', '%s:' % sorted(remote_mounts)[0])
+        fb = pane.formbuilder(cols=1 + len(remote_mounts), border_spacing='3px')
+        fb.textbox(value='^.storagepath', lbl='Path', width='24em')
+        for name in sorted(remote_mounts):
+            fb.button('%s:' % name, action='SET .storagepath = %r;' % ('%s:' % name))
+        pane.storageTreeFrame(frameCode='s3StorageTree', storagepath='^.storagepath',
+                              border='1px solid silver', margin_top='4px', rounded=4,
+                              height='340px', store__onBuilt=True,
+                              preview_region='right', preview_width='50%',
+                              preview_border_left='1px solid silver')


### PR DESCRIPTION
Draft on purpose: the code is complete and green, but two round-trip defects
found by benchmarking this integration are still open upstream. See
**Before this leaves draft** at the bottom.

Refs #251. Related: #252 (symbolic mapped to local — this branch does not do
that, see below), #1079 (boto3 with no upper bound, which is why the dependency
is optional).

## What this does

Serves the replaceable part of the legacy storage layer through the
`genro-storage` package, behind a siteconfig switch that is **off by default**.
The legacy code is untouched and stays the default; nothing legacy is removed.

```xml
<storage use_genro_storage="True"/>
```

The design turned out smaller than planned: instead of adapting the node, this
adds a **`StorageService` whose backends are genro-storage**
(`gnr/lib/services/storage_genro.py`), with the legacy `StorageNode` unchanged
on top of it. The legacy node therefore keeps its `isinstance` identity, its
`.service`, and the `serve()`, `mkdir()`, `base64`, `internal_url`, `listdir`,
`autocreate`, `copy`/`move` behaviour it already has — including the bridging of
a copy between the two worlds, which `StorageService` does by content on its
own. `GenroStorageHandler` overrides exactly one method, `storage()`: which
service resolves a mount is the single point of variation.

| implementation | with the switch on |
|---|---|
| `local`, `raw`, `aws_s3` | served by genro-storage |
| `symbolic` (`rsrc`, `pkg`, `page`, `conn`, `user`, `temp`, `dojo`, `gnr`, `pages`), `http`, `compressed`, `vol:`, any unknown name | **stay legacy, by design** |
| `relative`, `sftp` | mappable, deferred: stay legacy |

`symbolic` stays legacy permanently and deliberately: it is nine dynamic
resolvers keyed on the mount name, three of them request-scoped, with no
`base_path` at all — things a storage library cannot know. This is the point
#252 got wrong by mapping `symbolic` to `local`; there is an explicit test that
`rsrc:`, `pkg:`, `temp:` and `gnr:` resolve to the very same path as on the
legacy handler with the switch on.

A mount is skipped with a warning, and stays legacy, when it is `readonly`
(genro-storage has no counterpart, and silently dropping the restriction would
be worse), when it has no bucket, or when it is local on a `base_path` that does
not exist yet (genro-storage's local backend requires the directory; the legacy
service creates it on first write — upstream `genropy/genro-storage#75`).

## Dependency

Optional extra `genro_storage` in `gnrpy/pyproject.toml`, plus genro-storage in
`developer` so the tests can import it. `s3fs` is deliberately **not** a base
dependency: it pulls `aiobotocore`, which caps `botocore<1.40.19`, while genropy
declares `boto3` with no upper bound — that is #1079, and making it mandatory
would put it on the critical path of every install.

`pip check` is unchanged by this branch: same five pre-existing lines before and
after (two of them are the `s3fs`/`gcsfs` exact pin on `fsspec`, an environment
matter that predates this work).

## Tests

- `gnrpy/tests/core/gnrstorage_compare_test.py` — one test body per operation,
  run **twice** through a mode fixture, over the whole legacy `StorageNode`
  surface. Real services on a real filesystem, and on a real S3 endpoint when
  `GNR_TEST_S3_ENDPOINT` is set; only the site is stood in for, never a storage
  operation. Where the two worlds legitimately differ, the difference is
  asserted and named rather than smoothed over.
- `gnrpy/tests/web/gnrgenrostoragehandler_test.py` — the switch (off by default,
  and each test sets the value it needs instead of assuming the local
  siteconfig), mount routing, registry sync, and the legacy-stays-legacy
  guarantee.
- `gnrpy/tests/core/gnrstorage_benchmark.py` — the same operations timed in both
  modes, `pytest -s`.
- `projects/gnrcore/packages/test15/webpages/tools/storage_genro.py` — a
  testhandler page that drives the switch through real requests: storage trees
  on both kinds of mount, an inspector over the node surface, a side-by-side of
  the two handlers on the same path, an uploader, a cross-world copy/move, a
  tree on an S3 mount.

Measured on this branch:

| | |
|---|---|
| switch off (the default) | `2469 passed, 169 skipped` — no test went passed→failed, no new skip beyond the S3 ones that skip without an endpoint |
| comparison tests, local | 94 passed, 0 skipped (both modes) |
| comparison tests, MinIO | 188 passed with `GNR_TEST_S3_ENDPOINT` set; 94 passed + 94 skipped, reason naming the variable, without it |
| handler routing | 29 passed, including the nine symbolic mounts and `_http_` |

CI has no S3 endpoint, so that half skips there with an explicit reason.

## Benchmark

Full tables, with the machine and the versions, in
`docs/development/genro-storage-migration.md` §11. The short version: **the
overhead is per call, not per byte**. On a local mount a metadata call goes from
0.002 ms to 0.047 ms (the 22x ratio), while on a 4 MB file the ratio collapses
to ~1. On S3 the writes are faster (a single `PutObject` against smart_open's
multipart), metadata is a wash, and small reads are slower. `md5hash` on S3 is
not a like-for-like comparison: the legacy service gives up on a multipart ETag
and returns `None`.

## Driving it in a real site found two defects

Both fixed here, both with a test:

- `children()` was not sorted, while the legacy local service sorts by basename
  — the order shows up in every tree built on the service.
- `size` and `md5hash` raised on a directory instead of answering `None`, which
  is what the legacy `aws_s3` service already does.

## Before this leaves draft

- `genropy/genro-storage#78` — on S3, `copy_to()` issues 6 API calls where one
  `CopyObject` would do (two of them `ListObjectVersions`, which a copy does not
  need), and `open('rb')` adds a `HeadObject`. The copy does stay server-side,
  so it is round trips and not a transfer, but on a real endpoint it is ~180 ms
  instead of ~30. Our `duplicateNode` could sidestep it by going through the
  backend's `copy()`; not done here, since the upstream fix would make it
  unnecessary.
- #1237 — `StorageNode.open()` runs autocreate even for reads, costing a
  `HeadObject` plus a `ListObjectsV2` per open on S3. Pre-existing and on the
  legacy path too, but it inflates every read on both sides.

Also worth a decision before merging, and written up in the plan document:
whether the hybrid of the table above is the intended end state (this branch
assumes it is), and whether `relative` and `sftp` should come in here or later.

Not yet exercised in a live site: the upload path itself (it needs a file picked
by hand) and multidomain.
