### PR TITLE
fix(siteregister): report serverstore changes for an unknown page

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -1037,8 +1037,10 @@ class SiteRegister(BaseRemoteObject):
         if not page_item:
             return False
         catalog = self.catalog
-        if _serverstore_changes:
-            self.set_serverstore_changes(page_id, _serverstore_changes)
+        if _serverstore_changes and not self.set_serverstore_changes(page_id, _serverstore_changes):
+            # refresh answered above, so the page went while this ping travelled
+            logger.warning('page %s vanished from the register: serverstore changes discarded (%s)',
+                           page_id, ','.join(sorted(_serverstore_changes)))
         if _children_pages_info:
             for k, v in list(_children_pages_info.items()):
                 child_lastUserEventTs = v.pop('_lastUserEventTs', None)
@@ -1081,13 +1083,27 @@ class SiteRegister(BaseRemoteObject):
         return result
 
     def set_serverstore_changes(self, page_id=None, datachanges=None):
+        """File the client's serverstore changes on the page's register item.
+
+        Answers whether they were filed. `get_item_data` builds a detached Bag
+        for an id it does not know, so without the guard the changes went into
+        an object that died with the call - and the client has already dropped
+        its own buffer by then, so there is nothing to recover: the only
+        available answer is to report. Whether absence is exceptional depends on
+        the caller, so this one does not log.
+
+        `exists` rather than `get_item`: the latter stamps `itemsTS` before
+        testing, which would leak a timestamp for a page that never existed.
+
+        :param page_id: id of the target page
+        :param datachanges: the changes to file, as sent by the client
+        :returns: True when filed, False when the page is not in the register"""
         if not self.page_register.exists(page_id):
-            logger.warning('page %s not existing in register: serverstore changes discarded (%s)',
-                           page_id, ','.join(sorted(datachanges or {})))
-            return
+            return False
         page_item_data = self.page_register.get_item_data(page_id)
         for k, v in list(datachanges.items()):
             page_item_data.setItem(k, self._parse_change_value(v))
+        return True
 
     def _parse_change_value(self, change_value):
         if isinstance(change_value, (bytes, str)):

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -1081,6 +1081,10 @@ class SiteRegister(BaseRemoteObject):
         return result
 
     def set_serverstore_changes(self, page_id=None, datachanges=None):
+        if not self.page_register.exists(page_id):
+            logger.warning('page %s not existing in register: serverstore changes discarded (%s)',
+                           page_id, ','.join(sorted(datachanges or {})))
+            return
         page_item_data = self.page_register.get_item_data(page_id)
         for k, v in list(datachanges.items()):
             page_item_data.setItem(k, self._parse_change_value(v))

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -641,8 +641,11 @@ class GnrWebPage(GnrBaseWebPage):
         self._lastUserEventTs = kwargs.pop('_lastUserEventTs', None)
         self._lastRpc = kwargs.pop('_lastRpc', None)
         self._pageProfilers = kwargs.pop('_pageProfilers', None)
-        if _serverstore_changes:
-            self.site.register.set_serverstore_changes(self.page_id, _serverstore_changes)
+        if _serverstore_changes and not self.site.register.set_serverstore_changes(
+                self.page_id, _serverstore_changes):
+            # the page passed _check_page_id in __init__, so this is the cleanup race
+            logger.warning('page %s vanished from the register: serverstore changes discarded (%s)',
+                           self.page_id, ','.join(sorted(_serverstore_changes)))
         auth = AUTH_OK
         if method not in ('doLogin', 'onClosePage'):
             auth = self._checkAuth(method=method, **kwargs)

--- a/gnrpy/tests/web/siteregister_serverstore_changes_test.py
+++ b/gnrpy/tests/web/siteregister_serverstore_changes_test.py
@@ -1,0 +1,42 @@
+"""Tests for ``SiteRegister.set_serverstore_changes`` on a page the register lost (#1231).
+
+``get_item_data`` returns a detached ``Bag()`` on a cache miss, so writing the client's
+``_serverstore_changes`` into it used to drop them with no error and no log. The page can
+only be missing because cleanup raced the request, which is exactly the case that has to
+be visible.
+
+The register is a real ``SiteRegister`` built with a stand-in server -- its constructor
+only needs ``server.daemon.register`` -- as in ``subscribed_tables_index_test.py``.
+"""
+
+import logging
+
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def test_serverstore_changes_for_an_unknown_page_are_reported(caplog):
+    sr = SiteRegister(_FakeServer(), sitename='testsite')
+    with caplog.at_level(logging.WARNING):
+        sr.set_serverstore_changes('ghost', {'rootenv.language': 'en'})
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any('ghost' in msg and 'rootenv.language' in msg for msg in messages)
+
+
+def test_serverstore_changes_for_a_known_page_are_stored(caplog):
+    sr = SiteRegister(_FakeServer(), sitename='testsite')
+    sr.page_register.create('p1')
+    with caplog.at_level(logging.WARNING):
+        sr.set_serverstore_changes('p1', {'rootenv.language': 'en'})
+    assert sr.page_register.get_item_data('p1')['rootenv.language'] == 'en'
+    assert not caplog.records

--- a/gnrpy/tests/web/siteregister_serverstore_changes_test.py
+++ b/gnrpy/tests/web/siteregister_serverstore_changes_test.py
@@ -1,9 +1,16 @@
 """Tests for ``SiteRegister.set_serverstore_changes`` on a page the register lost (#1231).
 
 ``get_item_data`` returns a detached ``Bag()`` on a cache miss, so writing the client's
-``_serverstore_changes`` into it used to drop them with no error and no log. The page can
-only be missing because cleanup raced the request, which is exactly the case that has to
-be visible.
+``_serverstore_changes`` into it used to drop them with no error. The client has already
+nulled its own buffer by then (``genro_rpc.js:306-308``), so the changes are
+unrecoverable at the moment the server notices: the only available answer is to report.
+
+The call answers a boolean and does not log, the convention #1253 sets for its sibling
+``set_datachange``: whether a missing page is exceptional is the caller's to know. Two of
+the three callers reach it after a check that the page existed, so absence there is the
+cleanup race and worth a line; the third is the children loop of ``handle_ping``, whose
+ids come from the browser's own walk over ``window.frames`` with no check at all, and
+whose absence repeats on every ping carrying changes for a dead child.
 
 The register is a real ``SiteRegister`` built with a stand-in server -- its constructor
 only needs ``server.daemon.register`` -- as in ``subscribed_tables_index_test.py``.
@@ -25,18 +32,28 @@ class _FakeServer:
     hmac_key = None
 
 
-def test_serverstore_changes_for_an_unknown_page_are_reported(caplog):
+def test_serverstore_changes_for_an_unknown_page_answer_false(caplog):
     sr = SiteRegister(_FakeServer(), sitename='testsite')
     with caplog.at_level(logging.WARNING):
-        sr.set_serverstore_changes('ghost', {'rootenv.language': 'en'})
-    messages = [rec.getMessage() for rec in caplog.records]
-    assert any('ghost' in msg and 'rootenv.language' in msg for msg in messages)
+        assert sr.set_serverstore_changes('ghost', {'rootenv.language': 'en'}) is False
+    assert not caplog.records, 'the callee does not know whether absence is exceptional'
 
 
 def test_serverstore_changes_for_a_known_page_are_stored(caplog):
     sr = SiteRegister(_FakeServer(), sitename='testsite')
     sr.page_register.create('p1')
     with caplog.at_level(logging.WARNING):
-        sr.set_serverstore_changes('p1', {'rootenv.language': 'en'})
+        assert sr.set_serverstore_changes('p1', {'rootenv.language': 'en'}) is True
     assert sr.page_register.get_item_data('p1')['rootenv.language'] == 'en'
     assert not caplog.records
+
+
+def test_asking_about_a_ghost_leaves_no_timestamp_behind():
+    """``get_item`` calls ``updateTS`` before testing whether the item is there, and
+    ``itemsTS`` is only popped in ``drop_item``, which never runs for an id that was
+    never registered -- and it is pickled into the freeze. The children loop is where
+    ghost ids come from, so the guard has to be ``exists``."""
+    sr = SiteRegister(_FakeServer(), sitename='testsite')
+    sr.set_serverstore_changes('ghost', {'rootenv.language': 'en'})
+    assert 'ghost' not in sr.page_register.itemsTS
+    assert 'ghost' not in sr.page_register.itemsData


### PR DESCRIPTION
## Problem

`SiteRegister.set_serverstore_changes(page_id, datachanges)` wrote the client's
`_serverstore_changes` into a Bag attached to nothing when the register no longer held the
page: no error, no log, the changes lost. The page can only be missing because cleanup
raced the request (`_check_page_id` rejects an unknown page in `__init__`, before the
dispatch), which is exactly the case that has to be visible.

## Root cause

`PageRegister.get_item_data` returns a fresh `Bag()` on a cache miss without inserting it
into `self.itemsData`, so the object the caller writes into is detached and dies with the
method. Fixing `get_item_data` itself would regress `handle_ping`, which chains
`get_item_data(user).getItem(...)` with no guard — so the guard belongs in the caller.

## Change

`set_serverstore_changes` checks `page_register.exists(page_id)` first and, when the page
is gone, logs a `WARNING` naming the page and the discarded paths, then returns. Behaviour
for a live page is unchanged. Same level and same lazy `%s` style as
`gnrasync.registerPage`, which already reports this condition; the ASGI bridge logs a
WARNING in the same case, so the two stay aligned.

## Verification

- `gnrpy/tests/web/siteregister_serverstore_changes_test.py` (new): the unknown page is
  reported, and a known page still stores its changes with no warning. Red before the
  change (the first test emits no record), green after.
- `pytest gnrpy/tests/ -q`: 2291 passed, 69 skipped.
- flake8 clean on both touched files.

## Related issue

Fixes #1231