### PR TITLE
fix(siteregister): do not announce autocreated parents to the client

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -184,7 +184,10 @@ class BaseRegister(BaseRemoteObject):
         data.subscribe('datachanges', any=lambda **kwargs: self._on_data_trigger(register_item=register_item, **kwargs))
         self.itemsData[register_item_id] = data
 
-    def _on_data_trigger(self, node=None, ind=None, evt=None, pathlist=None, register_item=None, **kwargs):
+    def _on_data_trigger(self, node=None, ind=None, evt=None, pathlist=None, register_item=None,
+                         reason=None, **kwargs):
+        if reason == 'autocreate':
+            return
         if evt == 'ins':
             pathlist.append(node.label)
         path = '.'.join(pathlist)

--- a/gnrpy/tests/web/siteregister_datachanges_test.py
+++ b/gnrpy/tests/web/siteregister_datachanges_test.py
@@ -1,0 +1,63 @@
+"""Tests for the datachanges a page store announces to the client (#1230).
+
+A ``setItem('a.b.c', 1)`` on a Bag whose ``a`` and ``a.b`` do not exist yet makes the Bag
+insert the parents on the fly (``reason='autocreate'``). Those parents carry an empty Bag,
+and the client rewrites whatever it holds under that path whenever the value differs
+(``genro_rpc.js:setDatachangesInData``), so announcing them wipes the client-side subtree
+an instant before the leaf arrives. Writing the leaf recreates the parents anyway.
+
+``_on_data_trigger`` lives on ``BaseRegister``, so the filter covers the page, user,
+connection and global stores at once. ``gnrasync._on_data_trigger`` already filters the
+identical event.
+
+The register is a real ``SiteRegister`` built with a stand-in server -- its constructor
+only needs ``server.daemon.register`` -- as in ``subscribed_tables_index_test.py``.
+"""
+
+from gnr.core.gnrbag import Bag
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _subscribed_page():
+    reg = SiteRegister(_FakeServer(), sitename='testsite').page_register
+    reg.create('p1')
+    reg.subscribe_path('p1', 'a')
+    return reg
+
+
+def test_autocreated_parents_are_not_announced_as_server_changes():
+    reg = _subscribed_page()
+    reg.get_item_data('p1').setItem('a.b.c', 1)
+    changes = reg.get_datachanges('p1')
+    assert [c.path for c in changes] == ['a.b.c']
+    assert changes[0].reason == 'serverChange'
+
+
+def test_an_explicitly_written_empty_bag_still_travels():
+    reg = _subscribed_page()
+    reg.get_item_data('p1').setItem('a.sub', Bag())
+    changes = reg.get_datachanges('p1')
+    assert [c.path for c in changes] == ['a.sub']
+
+
+def test_attributes_and_rewrites_of_a_leaf_still_travel():
+    reg = _subscribed_page()
+    data = reg.get_item_data('p1')
+    data.setItem('a.b.c', 1)
+    data.setItem('a.b.c', 2)
+    data.setItem('a.x', 'v', mode='wide')
+    changes = reg.get_datachanges('p1')
+    assert [c.path for c in changes] == ['a.b.c', 'a.b.c', 'a.x']
+    assert [c.value for c in changes] == [1, 2, 'v']
+    assert changes[2].attributes == dict(mode='wide')


### PR DESCRIPTION
## Problem

A `setItem('a.b.c', 1)` on a page store whose `a` and `a.b` do not exist yet announced
THREE changes to the client: `a` (an empty Bag), `a.b` (an empty Bag), then `a.b.c`, all
with `reason='serverChange'`. The two parents add nothing — writing the leaf recreates
them — and when the client holds its own children under `a`, the `a = Bag()` change wipes
that subtree an instant before the leaf arrives: `setDatachangesInData` → `updater` writes
whenever the value differs, with no guard.

## Root cause

`_on_data_trigger` did not look at the Bag event's `reason`, while the on-the-fly parents
are emitted as `reason='autocreate'` by `Bag._onNodeInserted`.

## Change

`_on_data_trigger` takes `reason` and returns immediately on `autocreate`, so only
explicitly written nodes travel. This is the filter `gnrasync._on_data_trigger` already
applies to the identical event, and the whole client side already ignores
`reason == 'autocreate'` — the daemon was the odd one out. The ASGI bridge filters them
too, so the two behaviours stay aligned.

The method lives on `BaseRegister`, so the guard covers the page, user, connection and
global stores at once. Nothing legitimate is dropped: a parent can only match a
`subscribed_paths` prefix if the leaf written under it matches too, so the leaf that
recreates the parents is always announced.

## Verification

- `gnrpy/tests/web/siteregister_datachanges_test.py` (new): the issue's case, plus the two
  counter-cases that pin down what must still travel — an empty Bag written explicitly,
  and a leaf's rewrites and attributes. All three red before the change, green after.
- `pytest gnrpy/tests/ -q`: 2351 passed, 10 skipped.
- flake8 clean on both touched files.

## Related issue

Fixes #1230