### PR TITLE
fix(siteregister): announce a popped node on its own path, as a delete

### DIFF
--- a/gnrjs/gnr_d11/js/genro_rpc.js
+++ b/gnrjs/gnr_d11/js/genro_rpc.js
@@ -548,7 +548,10 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                     if (stringStartsWith(changepath, serverpath_prefix)) {
                         let clientpath = clientpath_prefix + changepath.slice(serverpath_prefix.length);
                         if (isDelete) {
-                            genro._data.delItem(clientpath);
+                            // mark the removal as the server's, like the write path
+                            // below and the two other server-side pops: an unmarked
+                            // event is echoed back as a client write (genro.js:1621)
+                            genro._data.delItem(clientpath, reason);
                         } else {
                             updater(clientpath, value, attr, reason);
                         }
@@ -556,7 +559,7 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                 }
             }
             else if (isDelete) {
-                genro._data.delItem(changepath);
+                genro._data.delItem(changepath, reason);
             }
             else {
                 updater(changepath, value, attr, reason);

--- a/gnrjs/gnr_d11/js/genro_rpc.js
+++ b/gnrjs/gnr_d11/js/genro_rpc.js
@@ -547,7 +547,11 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                     var serverpath_prefix = genro._serverstore_paths[clientpath_prefix];
                     if (stringStartsWith(changepath, serverpath_prefix)) {
                         let clientpath = clientpath_prefix + changepath.slice(serverpath_prefix.length);
-                        updater(clientpath, value, attr, reason);
+                        if (isDelete) {
+                            genro._data.delItem(clientpath);
+                        } else {
+                            updater(clientpath, value, attr, reason);
+                        }
                     }
                 }
             }

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -185,8 +185,8 @@ class BaseRegister(BaseRemoteObject):
         self.itemsData[register_item_id] = data
 
     def _on_data_trigger(self, node=None, ind=None, evt=None, pathlist=None, register_item=None, **kwargs):
-        if evt == 'ins':
-            pathlist.append(node.label)
+        if evt in ('ins', 'del'):
+            pathlist = pathlist + [node.label]
         path = '.'.join(pathlist)
         if evt != 'del' and node.attr.get('_caching_table'):
             caching_subscribers = self.cached_tables[node.attr['_caching_table']]
@@ -198,7 +198,8 @@ class BaseRegister(BaseRemoteObject):
         for subscribed in register_item['subscribed_paths']:
             if path.startswith(subscribed):
                 register_item['datachanges'].append(
-                    ClientDataChange(path=path, value=node.value, reason='serverChange', attributes=node.attr))
+                    ClientDataChange(path=path, value=node.value, reason='serverChange', attributes=node.attr,
+                                     delete=evt == 'del'))
                 break
 
     def invalidateTableCache(self, table):

--- a/gnrpy/tests/web/siteregister_datachanges_del_test.py
+++ b/gnrpy/tests/web/siteregister_datachanges_del_test.py
@@ -1,0 +1,179 @@
+"""Tests for the datachanges a register announces to the client (#1249).
+
+``BaseRegister._on_data_trigger`` appended ``node.label`` only for ``evt == 'ins'``, so a
+``pop('a.b.c')`` was announced on the PARENT path ``a.b`` carrying the removed value and
+``delete=False``: the client wrote that value over the parent node -- siblings included --
+and the deletion never reached it. ``gnrasync._on_data_trigger`` appends the label for
+both events; the daemon now does the same and marks the change ``delete``.
+
+The trigger lives on ``BaseRegister``, so every store built on it (page, user, connection,
+global) is covered by the same code path -- the user register is exercised here for that
+reason.
+
+The register is a real ``SiteRegister`` built with a stand-in server -- its constructor
+only needs ``server.daemon.register`` -- as in ``subscribed_tables_index_test.py``.
+
+The fixture creates the subscribed root explicitly and clears the changes it produced, so
+what each test asserts is only the event it fires: the parents a ``setItem`` autocreates
+are announced too, which is a separate defect (#1230) and not what these tests measure.
+"""
+
+from gnr.core.gnrbag import Bag
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _site_register():
+    return SiteRegister(_FakeServer(), sitename='testsite')
+
+
+def _subscribed_page(sr=None):
+    reg = (sr or _site_register()).page_register
+    reg.create('p1')
+    reg.subscribe_path('p1', 'a')
+    reg.get_item_data('p1').setItem('a', Bag())
+    reg.get_datachanges('p1', reset=True)
+    return reg
+
+
+def _paths(changes):
+    return [(c.path, c.value, c.delete) for c in changes]
+
+
+# ---------------------------------------------------------------------------
+# what a write announces
+# ---------------------------------------------------------------------------
+
+def test_a_written_leaf_is_announced_on_its_own_path():
+    reg = _subscribed_page()
+    reg.get_item_data('p1').setItem('a.b', 1)
+    changes = reg.get_datachanges('p1')
+    assert _paths(changes) == [('a.b', 1, False)]
+    assert changes[0].reason == 'serverChange'
+
+
+def test_overwriting_a_leaf_keeps_the_leaf_path():
+    reg = _subscribed_page()
+    data = reg.get_item_data('p1')
+    data.setItem('a.b', 1)
+    data.setItem('a.b', 2)
+    assert _paths(reg.get_datachanges('p1')) == [('a.b', 1, False), ('a.b', 2, False)]
+
+
+def test_a_write_outside_the_subscribed_paths_is_ignored():
+    reg = _subscribed_page()
+    reg.get_item_data('p1').setItem('z.b', 1)
+    assert reg.get_datachanges('p1') == []
+
+
+# ---------------------------------------------------------------------------
+# what a pop announces -- the defect
+# ---------------------------------------------------------------------------
+
+def test_a_popped_leaf_is_announced_on_its_own_path_as_a_delete():
+    reg = _subscribed_page()
+    data = reg.get_item_data('p1')
+    data.setItem('a.b', 1)
+    reg.get_datachanges('p1', reset=True)
+    data.pop('a.b')
+    assert _paths(reg.get_datachanges('p1')) == [('a.b', 1, True)]
+
+
+def test_a_pop_does_not_announce_the_parent_path():
+    reg = _subscribed_page()
+    data = reg.get_item_data('p1')
+    data.setItem('a.b.c', 1)
+    data.setItem('a.b.d', 2)
+    reg.get_datachanges('p1', reset=True)
+    data.pop('a.b.c')
+    changes = reg.get_datachanges('p1')
+    assert [c.path for c in changes] == ['a.b.c']
+    assert data['a.b.d'] == 2
+
+
+def test_popping_a_subtree_announces_the_subtree_path():
+    reg = _subscribed_page()
+    data = reg.get_item_data('p1')
+    data.setItem('a.b.c', 1)
+    reg.get_datachanges('p1', reset=True)
+    data.pop('a.b')
+    changes = reg.get_datachanges('p1')
+    assert [(c.path, c.delete) for c in changes] == [('a.b', True)]
+    assert isinstance(changes[0].value, Bag)
+
+
+def test_a_pop_outside_the_subscribed_paths_is_ignored():
+    reg = _subscribed_page()
+    data = reg.get_item_data('p1')
+    data.setItem('z.b', 1)
+    reg.get_datachanges('p1', reset=True)
+    data.pop('z.b')
+    assert reg.get_datachanges('p1') == []
+
+
+# ---------------------------------------------------------------------------
+# the flag has to reach the client
+# ---------------------------------------------------------------------------
+
+def test_the_delete_flag_travels_in_the_client_envelope():
+    sr = _site_register()
+    reg = _subscribed_page(sr)
+    data = reg.get_item_data('p1')
+    data.setItem('a.b', 1)
+    reg.get_datachanges('p1', reset=True)
+    data.pop('a.b')
+    envelope = sr.handle_ping_get_datachanges('p1')
+    nodes = envelope.getNodes()
+    assert [n.attr['change_path'] for n in nodes] == ['a.b']
+    assert nodes[0].attr['change_delete'] is True
+
+
+def test_a_write_travels_in_the_client_envelope_without_the_delete_flag():
+    sr = _site_register()
+    reg = _subscribed_page(sr)
+    reg.get_item_data('p1').setItem('a.b', 1)
+    nodes = sr.handle_ping_get_datachanges('p1').getNodes()
+    assert [n.attr['change_path'] for n in nodes] == ['a.b']
+    assert nodes[0].attr['change_delete'] is False
+
+
+# ---------------------------------------------------------------------------
+# the trigger is BaseRegister's, so every store shares it
+# ---------------------------------------------------------------------------
+
+def test_the_user_store_announces_a_pop_the_same_way():
+    reg = _site_register().user_register
+    reg.create('u1')
+    reg.subscribe_path('u1', 'a')
+    data = reg.get_item_data('u1')
+    data.setItem('a', Bag())
+    data.setItem('a.b', 1)
+    reg.get_datachanges('u1', reset=True)
+    data.pop('a.b')
+    assert _paths(reg.get_datachanges('u1')) == [('a.b', 1, True)]
+
+
+# ---------------------------------------------------------------------------
+# the trigger must not consume the pathlist the Bag shares with its subscribers
+# ---------------------------------------------------------------------------
+
+def test_the_trigger_leaves_the_event_pathlist_to_the_other_subscribers():
+    reg = _subscribed_page()
+    data = reg.get_item_data('p1')
+    seen = []
+    data.subscribe('probe', any=lambda node=None, pathlist=None, **kwargs:
+                   seen.append('.'.join(pathlist + [node.label])))
+    data.setItem('a.b', 1)
+    data.pop('a.b')
+    assert seen == ['a.b', 'a.b']
+    assert [c.path for c in reg.get_datachanges('p1')] == ['a.b', 'a.b']


### PR DESCRIPTION
## Problem

`BaseRegister._on_data_trigger` appended `node.label` to the path only for `evt == 'ins'`.
A `pop('a.b.c')` was therefore announced on the parent path `a.b`, carrying the **removed
value**, with `delete=False`. Two effects on the client: the parent node was overwritten
with that value — the surviving siblings under `a.b` wiped with it — and the deletion
itself never arrived.

## Root cause

Two halves, one behaviour:

- `gnrpy/gnr/web/daemon/siteregister.py` — the label was appended for `ins` only, and the
  `ClientDataChange` was built with the default `delete=False` whatever the event was.
- `gnrjs/gnr_d11/js/genro_rpc.js` — `setDatachangesInData` tests `reason == 'serverChange'`
  **before** `isDelete`, so for a store change the flag was ignored and the `updater`
  branch ran regardless. Fixing the daemon alone would have stopped the sibling wipe but
  still not deleted anything on the client.

`gnrasync._on_data_trigger` already appends the label for both `ins` and `del` on the
identical trigger signature.

## Change

- The label is appended for `del` too, and the change is marked `delete=evt == 'del'`.
- The serverChange branch of `setDatachangesInData` calls `genro._data.delItem` on the
  mapped client path when the change is a delete, instead of writing the value.
- The label is appended to a **copy** of `pathlist`. The Bag hands the same list object to
  every subscriber of the event and then to its parent (`Bag._onNodeInserted`,
  `_onNodeDeleted`), so mutating it in place was a latent corruption of the paths seen by
  anything else subscribed to that store. No behaviour change for a single subscriber at
  the root — which is why nothing showed today — and one test pins it down.

The trigger lives on `BaseRegister`, so the page, user, connection and global stores are
all fixed by the same lines.

## Verification

`gnrpy/tests/web/siteregister_datachanges_del_test.py` (new, 11 tests). The daemon side of
this defect had **zero** coverage before: no test in the suite named `get_datachanges`,
`set_datachange`, `_on_data_trigger` or `subscribe_path`. The file covers the whole
observable surface of the trigger:

- a written leaf is announced on its own path, an overwrite keeps that path, a write
  outside the subscribed paths is ignored;
- a popped leaf is announced on its own path with `delete=True`; a pop does **not** announce
  the parent, and the sibling survives; popping a subtree announces the subtree path; a pop
  outside the subscribed paths is ignored;
- the flag reaches the client: `handle_ping_get_datachanges` carries `change_delete` true
  for a pop and false for a write;
- the user store behaves identically, as the trigger is `BaseRegister`'s;
- the trigger leaves the event's `pathlist` intact for the other subscribers of the Bag.

6 of the 11 are red on `develop` and green with the change; the other 5 are the regression
guards on the write path. Full suite: 2359 passed, 10 skipped. flake8 clean on both Python
files.

The JS half is **not** covered by an automated test: there is no test harness for `gnrjs`
in this repo (only the vendored dojo suites). It needs a manual check — a server-side `pop`
on a subscribed subtree, with a sibling under the same parent, must remove exactly the
popped node in the client store.

## Note for whoever merges

This touches `_on_data_trigger` two lines away from #1248, so the two conflict in git
(verified with `git merge-tree`). The resolution is mechanical — the changes stack, the
`autocreate` guard first and the label append after — but whichever merges second needs a
rebase.

## Related issue

Fixes #1249