### PR TITLE
fix(siteregister): match subscribed_paths on segment boundaries

### DIFF
--- a/gnrjs/gnr_d11/js/genro_rpc.js
+++ b/gnrjs/gnr_d11/js/genro_rpc.js
@@ -546,8 +546,10 @@ dojo.declare("gnr.GnrRpcHandler", null, {
                 for (var clientpath_prefix in genro._serverstore_paths) {
                     var serverpath_prefix = genro._serverstore_paths[clientpath_prefix];
                     if (stringStartsWith(changepath, serverpath_prefix)) {
-                        let clientpath = clientpath_prefix + changepath.slice(serverpath_prefix.length);
-                        updater(clientpath, value, attr, reason);
+                        let inner = changepath.slice(serverpath_prefix.length);
+                        if (!inner || inner[0] == '.') {
+                            updater(clientpath_prefix + inner, value, attr, reason);
+                        }
                     }
                 }
             }

--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -196,7 +196,7 @@ class BaseRegister(BaseRemoteObject):
             else:
                 caching_subscribers[register_item_id].add(path)
         for subscribed in register_item['subscribed_paths']:
-            if path.startswith(subscribed):
+            if path == subscribed or path.startswith(subscribed + '.'):
                 register_item['datachanges'].append(
                     ClientDataChange(path=path, value=node.value, reason='serverChange', attributes=node.attr))
                 break

--- a/gnrpy/tests/web/siteregister_subscribed_path_test.py
+++ b/gnrpy/tests/web/siteregister_subscribed_path_test.py
@@ -1,0 +1,81 @@
+"""Tests for the segment-aware matching of ``subscribed_paths`` (#1255).
+
+``BaseRegister._on_data_trigger`` filters a page store write against the paths the page
+subscribed. Matching them by character prefix announces every write under ``formats.*``
+to a page subscribed to ``form``; the client then rebuilds the client path by slicing off
+the server prefix, so the change lands on a path nothing reads. A subscription must match
+whole path segments only.
+
+The page register is taken from a real ``SiteRegister`` built with the stand-in server of
+``subscribed_tables_index_test``: its constructor only needs ``server.daemon.register``,
+so no daemon and no Pyro are involved.
+"""
+
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _register():
+    return SiteRegister(_FakeServer(), sitename='testsite').page_register
+
+
+def _announced(reg, page_id='page-1'):
+    return [dc.path for dc in reg.get_datachanges(page_id)]
+
+
+def _subscribed_page(subscribed='form'):
+    reg = _register()
+    reg.create('page-1')
+    reg.subscribe_path('page-1', subscribed)
+    return reg, reg.get_item_data('page-1')
+
+
+def test_a_sibling_sharing_a_character_prefix_is_not_announced():
+    """The regression: 'formats' is not under 'form', it only starts with its letters."""
+    reg, data = _subscribed_page()
+    data.setItem('form.name', 'Ada')
+    data.setItem('formats.date', 'dmy')
+    announced = _announced(reg)
+    assert not [p for p in announced if p == 'formats' or p.startswith('formats.')]
+
+
+def test_the_subscribed_subtree_is_still_announced():
+    reg, data = _subscribed_page()
+    data.setItem('form.name', 'Ada')
+    data.setItem('formats.date', 'dmy')
+    assert 'form.name' in _announced(reg)
+
+
+def test_a_write_on_the_subscribed_path_itself_is_announced():
+    reg, data = _subscribed_page()
+    data.setItem('form', 'Ada')
+    assert 'form' in _announced(reg)
+
+
+def test_a_deeper_write_under_the_subscription_is_announced():
+    reg, data = _subscribed_page()
+    data.setItem('form.address.city', 'Turin')
+    assert 'form.address.city' in _announced(reg)
+
+
+def test_an_unrelated_path_is_never_announced():
+    reg, data = _subscribed_page()
+    data.setItem('other.name', 'Ada')
+    assert _announced(reg) == []
+
+
+def test_a_segment_subscription_does_not_match_a_longer_sibling_segment():
+    """'srv.ab' shares every character of 'srv.a' but is a different node."""
+    reg, data = _subscribed_page(subscribed='srv.a')
+    data.setItem('srv.ab.x', 1)
+    assert not [p for p in _announced(reg) if p.startswith('srv.ab')]


### PR DESCRIPTION
## Problem

A page subscribed to the server path `form` is announced every write under `formats.*` as
well. On the client the same match rebuilds the client path by slicing off the server
prefix, so a change on `formats.date` with `form -> cliente.dati` is written to
`cliente.datiats.date` — a path nothing reads, with no error anywhere.

It takes only two server paths on one page where one is a character prefix of the other:
`form`/`formats`, `order`/`orders`, `srv.a`/`srv.ab`.

## Root cause

Both legs of the datachange mechanism match a subscription by characters instead of by
path segments:

- `BaseRegister._on_data_trigger` (`gnrpy/gnr/web/daemon/siteregister.py`) filtered the
  write with `path.startswith(subscribed)`.
- `setDatachangesInData` (`gnrjs/gnr_d11/js/genro_rpc.js`) matched with
  `stringStartsWith(changepath, serverpath_prefix)` and then sliced the prefix off
  unconditionally.

The upload leg of the very same mechanism is already segment-aware: `genro.js` accepts a
registered path only when the remainder is empty or starts with `'.'`. Download and upload
disagreed.

## Change

Both legs now apply that same rule:

- server: `if path == subscribed or path.startswith(subscribed + '.')`
- client: compute the remainder after the prefix and update only when it is empty or
  starts with `'.'`, mirroring the `genro.js` precedent.

The client loop over `genro._serverstore_paths` keeps its shape — no `break` added: two
distinct client prefixes may legitimately mirror overlapping server subtrees, and stopping
at the first match would drop a real update. That is orthogonal to this fix.

`drop_datachanges` carries the same character-prefix defect and is deliberately left out
of this PR; a twin issue is opened for it (linked below).

## Verification

- New `gnrpy/tests/web/siteregister_subscribed_path_test.py`, built on the stand-in
  server fixture of `subscribed_tables_index_test.py` (real `SiteRegister`, no daemon, no
  Pyro): 6 tests, red before the change (`['formats', 'formats.date']` announced to a page
  subscribed to `form`), green after.
- `pytest gnrpy/tests/ -q` — 2356 passed, 10 skipped.
- `flake8` on the touched Python files — zero errors.
- The client leg has **no JS test harness in this repository** (no jest/karma/mocha, no
  `package.json`), so it was verified by reading against the `genro.js` precedent plus a
  `node --check` parse. No JS test was run, and none is claimed.

Note on the assertion the issue proposes: `== ['form.name']` stays red even with this fix,
because the autocreated parent `form` is still announced — that is #1230, not this bug.
The test here asserts the segment rule without depending on #1230.

## Related issues

Fixes #1255

Twin defect in `drop_datachanges`, out of scope here: see the linked follow-up issue.

Two PRs are already open on the same file, and the three will need a merge order —
textual conflict with #1248 is likely, since it touches the same `_on_data_trigger`:

- #1248 (`fix/1230-autocreate-serverchange`) — same function
- #1252 (`fix/1249-del-datachange-path`) — same file
