### PR TITLE
feat(siteregister): report whether a data change was actually filed

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -320,9 +320,14 @@ class BaseRegister(BaseRemoteObject):
         return self.update_item(register_item_id, dict(datachanges=list(), datachanges_idx=0))
 
     def set_datachange(self, register_item_id, path, value=None, attributes=None, fired=False, reason=None, replace=False, delete=False):
+        """Queue a client data change on a register item.
+
+        Return True if the change was queued, False if the item is not registered
+        (any more) and the change was therefore dropped.
+        """
         register_item = self.get_item(register_item_id)
         if not register_item:
-            return
+            return False
         datachanges = register_item['datachanges']
         register_item['datachanges_idx'] = register_item.get('datachanges_idx', 0)
         register_item['datachanges_idx'] += 1
@@ -332,6 +337,7 @@ class BaseRegister(BaseRemoteObject):
         if replace and datachange in datachanges:
             datachanges.pop(datachanges.index(datachange))
         datachanges.append(datachange)
+        return True
 
     def drop_datachanges(self, register_item_id, path):
         register_item = self.get_item(register_item_id)
@@ -718,20 +724,29 @@ class PageRegister(BaseRegister):
 
     def setInClientData(self, path, value=None, attributes=None, page_id=None, filters=None,
                         fired=False, reason=None, public=False, replace=False):
+        """Queue one or more client data changes on the target pages.
+
+        Return True if every change was queued, False as soon as one target page is
+        not registered (any more) and its change was therefore dropped. A ``filters``
+        that matches no page returns True: nothing was dropped because nothing was
+        addressed.
+        """
         if filters:
             pages = [p['register_item_id'] for p in self.pages(filters=filters)]
         else:
             pages = [page_id]
+        done = []
         for page_id in pages:
             if isinstance(path, Bag):
                 changeBag = path
                 for changeNode in changeBag:
                     attr = changeNode.attr
-                    self.set_datachange(page_id, path=attr.pop('_client_path'), value=changeNode.value,
-                                        attributes=attr, fired=attr.pop('fired', None))
+                    done.append(self.set_datachange(page_id, path=attr.pop('_client_path'), value=changeNode.value,
+                                                    attributes=attr, fired=attr.pop('fired', None)))
             else:
-                self.set_datachange(page_id, path=path, value=value, reason=reason,
-                                    attributes=attributes, fired=fired)
+                done.append(self.set_datachange(page_id, path=path, value=value, reason=reason,
+                                                attributes=attributes, fired=fired))
+        return all(done)
 
 
 class SiteRegister(BaseRemoteObject):

--- a/gnrpy/tests/web/siteregister_setinclientdata_test.py
+++ b/gnrpy/tests/web/siteregister_setinclientdata_test.py
@@ -1,0 +1,115 @@
+"""Tests for the boolean contract of ``setInClientData``/``set_datachange`` (#1253).
+
+Filing a data change against a page that is no longer registered is a silent no-op: the
+change is dropped and the caller has no way to tell. The register now answers with a
+boolean, so a caller that cares can react instead of assuming delivery.
+
+The page register is taken from a real ``SiteRegister``, built with a stand-in server:
+its constructor only needs ``server.daemon.register`` for the remote-bag handler, so no
+daemon and no Pyro are involved.
+"""
+
+from gnr.core.gnrbag import Bag
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _register():
+    return SiteRegister(_FakeServer(), sitename='testsite').page_register
+
+
+# ---------------------------------------------------------------------------
+# single page
+# ---------------------------------------------------------------------------
+
+
+def test_setinclientdata_on_a_live_page_returns_true():
+    reg = _register()
+    reg.create('p1')
+    assert reg.setInClientData('a.b', value=1, page_id='p1') is True
+    assert [dc.path for dc in reg.get_datachanges('p1')] == ['a.b']
+
+
+def test_setinclientdata_on_an_unknown_page_returns_false():
+    reg = _register()
+    reg.create('p1')
+    assert reg.setInClientData('a.b', value=1, page_id='ghost') is False
+    assert reg.get_datachanges('p1') == []
+
+
+def test_setinclientdata_on_a_dropped_page_returns_false():
+    reg = _register()
+    reg.create('p1')
+    reg.drop('p1')
+    assert reg.setInClientData('a.b', value=1, page_id='p1') is False
+
+
+# ---------------------------------------------------------------------------
+# filters
+# ---------------------------------------------------------------------------
+
+
+def test_setinclientdata_with_filters_matching_live_pages_returns_true():
+    reg = _register()
+    reg.create('p1', pagename='dashboard')
+    reg.create('p2', pagename='dashboard')
+    reg.create('p3', pagename='other')
+    assert reg.setInClientData('a.b', value=1, filters='pagename:dashboard') is True
+    assert len(reg.get_datachanges('p1')) == 1
+    assert len(reg.get_datachanges('p2')) == 1
+    assert reg.get_datachanges('p3') == []
+
+
+def test_setinclientdata_with_filters_matching_nothing_returns_true():
+    # vacuous truth: no page matched, so no change was dropped
+    reg = _register()
+    reg.create('p1', pagename='dashboard')
+    assert reg.setInClientData('a.b', value=1, filters='pagename:nosuchpage') is True
+    assert reg.get_datachanges('p1') == []
+
+
+# ---------------------------------------------------------------------------
+# Bag path
+# ---------------------------------------------------------------------------
+
+
+def _changebag():
+    changes = Bag()
+    changes.setItem('c0', 1, _client_path='a.b')
+    changes.setItem('c1', 2, _client_path='a.c')
+    return changes
+
+
+def test_setinclientdata_with_a_bag_path_on_a_live_page_returns_true():
+    reg = _register()
+    reg.create('p1')
+    assert reg.setInClientData(_changebag(), page_id='p1') is True
+    assert [dc.path for dc in reg.get_datachanges('p1')] == ['a.b', 'a.c']
+
+
+def test_setinclientdata_with_a_bag_path_on_an_unknown_page_returns_false():
+    reg = _register()
+    reg.create('p1')
+    assert reg.setInClientData(_changebag(), page_id='ghost') is False
+
+
+# ---------------------------------------------------------------------------
+# the underlying primitive
+# ---------------------------------------------------------------------------
+
+
+def test_set_datachange_returns_true_when_filed_and_false_when_dropped():
+    reg = _register()
+    reg.create('p1')
+    assert reg.set_datachange('p1', 'a.b', value=1) is True
+    assert reg.set_datachange('ghost', 'a.b', value=1) is False


### PR DESCRIPTION
Fixes #1253

## Motivation

Filing a client data change against a page that is no longer registered is a silent
no-op. `BaseRegister.set_datachange` did a bare `return` when `get_item` found nothing
and returned nothing when it appended either, and `PageRegister.setInClientData` looped
over its targets ignoring every outcome. A caller had no way to distinguish a delivered
change from one dropped on the floor.

This is a missing contract, not a defect: no caller reads the return value today (all
call sites checked), so nothing changes behaviourally — the register simply starts
answering the question.

## Change

Scope stops at the register.

- `BaseRegister.set_datachange` returns `True` when the change is queued and `False`
  when the register item is not (or no longer) registered. Same shape as the existing
  `lock_item` in the same class.
- `PageRegister.setInClientData` collects the outcomes of the `set_datachange` calls it
  makes — one per target page, or one per node for a `Bag` path — and returns `all(...)`.
- Docstrings on both state what the boolean means.

The remote plumbing already propagates a return value (`siteregister_client.py`
`ServerStore.set_datachange`), so nothing there needed touching.

**`WebPage.setInClientData` is deliberately not touched** (third bullet of the issue).
Its websocket branch (`gnrwebsockethandler.py`) posts and forgets and cannot answer the
same question, so returning a boolean there would mean a three-valued contract in which
`if not page.setInClientData(...)` is a false alarm on any `wsk_enabled` site. Better to
leave the page-level API alone than to ship a boolean that lies on half the deployments.

### The one point to confirm

A `filters` that matches **zero** pages returns `True` — the vacuous `all([])`: nothing
was addressed, so nothing was dropped. It is documented in the docstring and covered by
a test. The alternative reading is that "nothing matched" is itself a non-delivery and
should be `False`. Happy to flip it if you prefer that reading; it is a contract call,
not an implementation one.

## Verification

New `gnrpy/tests/web/siteregister_setinclientdata_test.py`, on the `_FakeDaemon` /
`_FakeServer` stand-in already used by `subscribed_tables_index_test.py`: a real
`SiteRegister`, no mocks of the register internals. Covers live page, unknown page,
dropped page, `filters` matching pages, `filters` matching nothing, `Bag` path on a live
and on an unknown page, and the `set_datachange` primitive directly.

All 8 tests are red before the change (both primary assertions return `None`) and green
after.

```
pytest gnrpy/tests/web/siteregister_setinclientdata_test.py -q   ->  8 passed
pytest gnrpy/tests/ -q --ignore=gnrpy/tests/sql                  ->  1194 passed
pytest gnrpy/tests/ -q  (pre-commit hook, full)                  ->  2358 passed, 10 skipped
flake8 on both touched files                                     ->  clean
```

## Related issues

- Merge order: `gnrpy/gnr/web/daemon/siteregister.py` is also touched by #1258
  (issue #1255, `_on_data_trigger`) and by the open PRs #1248 and #1252. The hunks here
  (`set_datachange`, `PageRegister.setInClientData`) are disjoint from all three, so the
  order does not matter, but it is worth knowing they overlap in the file.
- Coherence: the closest sibling, #1231 / PR #1247, answered the same class of silent
  drop with a **WARNING** log instead of a return value. The two answers should end up
  coherent — a boolean here plus a warning there is defensible (different layers), but
  that is a reviewer call worth making explicitly.
