### PR TITLE
fix(core): keep BagResolver instances out of tracebackBag locals

### DIFF
--- a/gnrpy/gnr/core/gnrerror.py
+++ b/gnrpy/gnr/core/gnrerror.py
@@ -5,7 +5,7 @@ import linecache
 import json
 
 from gnr.core.gnrstructures import GnrStructData
-from gnr.core.gnrbag import Bag
+from gnr.core.gnrbag import Bag, BagResolver
 
 
 def _is_library_frame(filename):
@@ -61,6 +61,8 @@ def tracebackBag(limit=None, full_stack=False):
                     v = '*STRUCTURE*'
                 elif isinstance(v,Bag):
                     v = '*BAG*'
+                elif isinstance(v,BagResolver):
+                    v = '*RESOLVER* %s' % v.__class__.__name__
                 elif isinstance(v,(dict,list,tuple)):
 
                     json.dumps(v)

--- a/gnrpy/tests/app/test_error_handler.py
+++ b/gnrpy/tests/app/test_error_handler.py
@@ -1,0 +1,66 @@
+"""Tests for GnrApp.errorHandler persistence into sys.error.
+
+Uses the shared test_invoice fixture (``db_sqlite``), whose instance
+includes ``gnrcore:sys``.
+"""
+
+from core.common import BaseGnrTest
+
+from gnr.core.gnrbag import Bag, BagResolver
+
+
+def setup_module(module):
+    BaseGnrTest.setup_class()
+
+
+def teardown_module(module):
+    BaseGnrTest.teardown_class()
+
+
+class FailingResolver(BagResolver):
+    classKwargs = {'cacheTime': 0, 'readOnly': True}
+    classArgs = []
+
+    def load(self):
+        raise RuntimeError('resolver failure')
+
+
+def _handle(app, exc):
+    return app.errorHandler(exception=exc, error_type='rpc_exception',
+                            traceback=True, notify_user=True,
+                            rpc_method='m', rpc_kwargs=Bag(a=1))
+
+
+def _error_rows(db, error_id):
+    db.closeConnection()
+    return db.table('sys.error').query(
+        columns='$description,$error_type,$rpc_method,$error_data',
+        where='$error_code=:c', c=error_id).fetch()
+
+
+class TestErrorHandlerPersistence:
+
+    def test_plain_exception_is_written(self, db_sqlite):
+        app = db_sqlite.application
+        try:
+            raise ValueError('plain failure')
+        except ValueError as e:
+            error_id = _handle(app, e)
+        rows = _error_rows(db_sqlite, error_id)
+        assert len(rows) == 1
+        assert rows[0]['description'] == 'plain failure'
+        assert rows[0]['error_type'] == 'rpc_exception'
+        assert rows[0]['rpc_method'] == 'm'
+
+    def test_exception_inside_resolver_is_written(self, db_sqlite):
+        app = db_sqlite.application
+        bag = Bag()
+        bag.setItem('root', FailingResolver())
+        try:
+            bag['root']
+        except RuntimeError as e:
+            error_id = _handle(app, e)
+        rows = _error_rows(db_sqlite, error_id)
+        assert len(rows) == 1
+        assert rows[0]['description'] == 'resolver failure'
+        assert '*RESOLVER* FailingResolver' in str(rows[0]['error_data'])

--- a/gnrpy/tests/core/gnrlang_test.py
+++ b/gnrpy/tests/core/gnrlang_test.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import threading
 from gnr.core import gnrlang as gl
-from gnr.core.gnrbag import Bag
+from gnr.core.gnrbag import Bag, BagResolver
 from gnr.core.gnrerror import tracebackBag
 
 class TestGnrLang():
@@ -130,6 +130,28 @@ class TestGnrLang():
     def test_tracebackBag(self):
         r = tracebackBag()
         #FIXME: how to test this properly?
+
+    def test_tracebackBag_resolver_locals(self):
+        calls = []
+
+        class FailingResolver(BagResolver):
+            classKwargs = {'cacheTime': 0, 'readOnly': True}
+            classArgs = []
+
+            def load(self):
+                calls.append(1)
+                raise ValueError('resolver failure')
+
+        b = Bag()
+        b.setItem('root', FailingResolver())
+        try:
+            b['root']
+        except ValueError:
+            r = tracebackBag()
+        assert calls == [1]
+        xml = r.toXml()
+        assert calls == [1]
+        assert '*RESOLVER* FailingResolver' in xml
 
     def test_thlocal(self):
         r = gl.thlocal()


### PR DESCRIPTION
## Summary

Errors raised inside (or in a frame holding) a `BagResolver` were shown to the user with an `Exception Id` but never persisted in `sys.error`. Reported on the storage tree of an S3 service with a custom endpoint (`SignatureDoesNotMatch` from `ListObjectsV2`).

Fixes #1261

## Root cause

`tracebackBag()` copies each frame's `f_locals` into a `Bag`. `Bag` and `GnrStructData` values are replaced by placeholders, `BagResolver` instances are not: `Bag.setItem` stores them as lazy nodes. When `sys.error.errorHandler` inserts the record, the adapter serializes `error_data` with `toXml()`, the lazy node is resolved, `load()` runs again and raises the same exception inside the insert. `sys` `Package.errorHandler` logs `sys.errorHandler: failed to write to sys.error` and swallows it, while `GnrApp.errorHandler` has already returned the error id.

## Change

- `gnrpy/gnr/core/gnrerror.py`: `BagResolver` locals are stored as `*RESOLVER* <class name>`, like `Bag` locals.

## Tests

- `gnrpy/tests/core/gnrlang_test.py`: `tracebackBag()` on an exception raised inside `BagResolver.load()` must not run `load()` again when serialized and must carry the placeholder.
- `gnrpy/tests/app/test_error_handler.py`: real-DB tests on the `test_invoice` sqlite fixture (`gnrcore:sys` included): `GnrApp.errorHandler` writes the `sys.error` row for a plain exception and for an exception raised inside a resolver, checked after `closeConnection()` as `site.cleanup()` does.

Both new tests fail on `develop` without the fix and pass with it. flake8 clean on touched files; `pytest core web app sql xtnd`: 2353 passed, 10 skipped.