### PR TITLE
fix(web): point the error detail link at the root domain

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -674,7 +674,7 @@ class GnrWebPage(GnrBaseWebPage):
             result = '<div>%s</div>' %str(e)
             if error_id:
                 if self.isDeveloper():
-                    detail_url = '/sys/ep_error?error_code=%s' % error_id
+                    detail_url = '%ssys/ep_error?error_code=%s' % (self.site.rootDomainHomeUri, error_id)
                     result = '%s <br/> Exception Id: <a href="%s" target="_blank">%s</a>' % (result, detail_url, error_id)
                 else:
                     result = '%s <br/> Check Exception Id: %s' % (result, error_id)

--- a/gnrpy/gnr/web/gnrwsgisite.py
+++ b/gnrpy/gnr/web/gnrwsgisite.py
@@ -675,6 +675,17 @@ class GnrWsgiSite(object):
             return f'{self.default_uri}{self.currentDomain}/'
         return self.default_uri
 
+    @property
+    def rootDomainHomeUri(self):
+        """Returns the home URI of the rootDomain.
+
+        In multidomain mode _syspackage records live in the root store,
+        so they are reachable only through the rootDomain.
+        """
+        if self.multidomain:
+            return f'{self.default_uri}{self.rootDomain}/'
+        return self.default_uri
+
     def getSubscribedTables(self,tables):
         domain_proxy = self.domains[self.currentDomain]
         if domain_proxy and domain_proxy._register is not None:

--- a/gnrpy/tests/web/gnrwsgisite_test.py
+++ b/gnrpy/tests/web/gnrwsgisite_test.py
@@ -16,6 +16,15 @@ class TestGnrWsgiSite(BaseGnrDaemonTest):
         assert self.site.remote_edit is None
         assert self.site.locale
         
+    def test_root_domain_home_uri(self, monkeypatch):
+        assert not self.site.multidomain
+        assert self.site.rootDomainHomeUri == self.site.default_uri
+        monkeypatch.setattr(type(self.site.db), 'multidb_config',
+                            property(lambda db: {'multidomain': 'true'}))
+        assert self.site.multidomain
+        assert self.site.rootDomainHomeUri == f'{self.site.default_uri}{self.site.rootDomain}/'
+        assert self.site.rootDomainHomeUri == '/_main_/'
+
     def test_apikeys(self):
         r = self.site.getApiKeys("booger")
         assert r is None

--- a/projects/gnrcore/packages/test/webpages/error_test/03_rpc_server_error.py
+++ b/projects/gnrcore/packages/test/webpages/error_test/03_rpc_server_error.py
@@ -8,7 +8,8 @@ EXPECTED BEHAVIOR:
 - A persistent error toast appears with the error message and a reference code
   in format (ref: YYMMDD-XXXXX).
 - For DEVELOPER users: the toast message includes a clickable link to the
-  error detail page at /sys/ep_error?error_code=<id>.
+  error detail page at sys/ep_error?error_code=<id>, prefixed with /_main_/
+  in multidomain instances, where errors are stored in the root store.
 - For NORMAL users: the toast shows the reference code as plain text.
 - The error is stored in the sys.error table with full context:
   error_code, description, traceback, username, user_ip, user_agent,

--- a/projects/gnrcore/packages/test/webpages/error_test/04_error_detail_page.py
+++ b/projects/gnrcore/packages/test/webpages/error_test/04_error_detail_page.py
@@ -7,7 +7,9 @@ EXPECTED BEHAVIOR:
 - First trigger an error using the button (creates an error record).
 - Then click "Open Error Table" to see sys.error records.
 - The error_code column should be the first column.
-- Click "Detail" link on any row -> opens /sys/ep_error?error_code=<id> in new tab.
+- Click "Detail" link on any row -> opens sys/ep_error?error_code=<id> in new tab
+  (prefixed with /_main_/ in multidomain instances, where errors are stored in
+  the root store).
 - The error detail page shows:
   * Header with error code and description (red left border)
   * Info grid: error type, date, user, IP, RPC method, page ID
@@ -15,7 +17,7 @@ EXPECTED BEHAVIOR:
   * Traceback section: expandable frames with module, line, function,
     file hash (gray badge), locals count (blue badge)
   * Expandable locals table per frame
-- Test 404: navigating to /sys/ep_error?error_code=INVALID shows "Not Found".
+- Test 404: navigating to sys/ep_error?error_code=INVALID shows "Not Found".
 - Test auth: page requires _DEV_ or admin tags.
 
 VERIFY:
@@ -53,7 +55,8 @@ class GnrCustomWebPage(object):
     def test_2_test_404(self, pane):
         """Open error detail page with invalid code - should show 'Not Found'"""
         pane.button('Open Invalid Error Page',
-                     action="window.open('/sys/ep_error?error_code=INVALID_CODE_999', '_blank');")
+                     action="window.open('%ssys/ep_error?error_code=INVALID_CODE_999', '_blank');"
+                            % self.site.rootDomainHomeUri)
 
     def test_3_open_latest_error(self, pane):
         """After generating an error, open the latest error detail page.
@@ -64,4 +67,5 @@ class GnrCustomWebPage(object):
         fb.textbox(value='^.error_code_input', lbl='Error code',
                     width='15em', placeholder='YYMMDD-XXXXX')
         fb.button('Open Detail Page',
-                   action="window.open('/sys/ep_error?error_code=' + GET .error_code_input, '_blank');")
+                   action="window.open('%ssys/ep_error?error_code=' + GET .error_code_input, '_blank');"
+                          % self.site.rootDomainHomeUri)


### PR DESCRIPTION
## Problem

On a multidomain instance the developer link shown on an rpc exception is a dead
link: `https://<host>/sys/ep_error?error_code=260904-HN6HT` returns 404.

Two facts add up:

- `sys.error` rows are always written in the root store: `sys.error.errorHandler`
  opens `tempEnv(connectionName='system', storename=db.rootstore)` explicitly,
  because in multidomain the redirect of `_syspackage` tables to the root store
  is skipped (`gnrsql/execute.py`, `if not self.multidomain`).
- The link was a literal `/sys/ep_error?error_code=...`, with no domain segment.
  In multidomain the first path segment must be a domain (`_main_` or a
  workspace), otherwise `DbStoreRouter.route()` fails and the dispatcher returns
  `NotFound`. Even with a workspace prefix it would read that store's own
  `sys.error`, where the row does not exist.

So the link has to point at the root domain: `/_main_/sys/ep_error?error_code=...`,
which is what the `detail_url` formula column of the model already emits.

## Change

- New `site.rootDomainHomeUri`, next to `current_home_uri`: the home URI of the
  root domain, where the records of the `_syspackage` tables live. It also
  honours the configured `home_uri`, which the old literal ignored.
- The developer link in `_rpcDispatcher` is built through it.
- Same prefix in the `error_test` pages, whose `window.open` calls had the same
  literal.

Single-domain instances are unaffected: the property returns `default_uri`.

## Not in this PR

- `request_host` is stored as `request.host_url`, which ends with a slash, so
  the `detail_url` of the grid comes out with a double slash
  (`https://host//_main_/sys/...`). It works, the path is normalised on parsing,
  but it is one `rstrip('/')` away from being clean.
- From a workspace domain `/<workspace>/sys/th_error` shows that store's own
  `sys.error`, which is always empty. Fixing that means making `_syspackage`
  tables read from the root store in multidomain too: a design change, worth its
  own issue.

## Test plan

- New `test_root_domain_home_uri` in `gnrpy/tests/web/gnrwsgisite_test.py`,
  covering both modes on the real site object.
- Full suite: 2351 passed, 10 skipped.
- flake8 clean on the touched files.