### PR TITLE
fix: create the archive folders only when archive_and_delete writes an archive

### DIFF
--- a/gnrpy/tests/web/archive_and_delete_test.py
+++ b/gnrpy/tests/web/archive_and_delete_test.py
@@ -1,0 +1,144 @@
+"""Real checks on the ``archive_and_delete`` resource action (#836).
+
+The batch is loaded through the site resource loader and its steps are run
+against the ``gnrtest`` instance, so the assertions look at the real
+``export_archive`` tree on disk and at the real records in the database.
+
+``adm.htmltemplate_atc`` is the fixture table: it is an ``AttachmentTable``,
+so it exercises the ``onArchiveExport`` branch of ``step_archive`` on the
+archived table itself, and it carries ``__del_ts``, so it also covers the
+logically deleted records the batch is expected to archive and delete.
+"""
+
+import os
+import shutil
+import sys
+from datetime import datetime
+
+from core.common import BaseGnrTest
+
+from gnr.app.gnrapp import GnrApp
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrlang import getUuid
+from gnr.web.gnrdummysite import GnrDummySite
+
+TABLE = 'adm.htmltemplate_atc'
+RESPATH = 'action/_common/archive_and_delete'
+ARCHIVE_NAME = 'test_archive'
+
+
+class TestArchiveAndDelete(BaseGnrTest):
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        app = GnrApp(cls.test_instance_name)
+        app.db.model.check(applyChanges=True)
+        app.db.commit()
+        cls.site = GnrDummySite(cls.test_instance_name, site_name=cls.test_instance_name)
+        cls.db = cls.site.db
+        cls.tblobj = cls.db.table(TABLE)
+        cls.export_archive = cls.site.getStaticPath('vol:export_archive')
+
+    def setup_method(self):
+        """Start every test from an empty export_archive and one stored attachment"""
+        shutil.rmtree(self.export_archive, ignore_errors=True)
+        letterhead_tbl = self.db.table('adm.htmltemplate')
+        self.letterhead = letterhead_tbl.newrecord(name='letterhead %s' % getUuid())
+        letterhead_tbl.insert(self.letterhead)
+        self.filepath = 'archive_and_delete_test/%s.txt' % getUuid()
+        self.attachment_node = self.site.storageNode('home:%s' % self.filepath)
+        with self.attachment_node.open(mode='w') as attachment:
+            attachment.write('attached content')
+        self.record = self.tblobj.newrecord(filepath=self.filepath, description='attachment',
+                                            maintable_id=self.letterhead['id'])
+        self.tblobj.insert(self.record)
+        self.db.commit()
+
+    def buildBatch(self, **batch_parameters):
+        batch = self.site.loadTableScript(page=self.site.dummyPage, table=TABLE, respath=RESPATH)
+        batch.batch_parameters = batch_parameters
+        batch.selectedPkeys = [self.record['id']]
+        return batch
+
+    def runBatch(self, **batch_parameters):
+        batch = self.buildBatch(**batch_parameters)
+        for step in batch.batch_steps.split(','):
+            getattr(batch, 'step_%s' % step)()
+        return batch
+
+    def sourceFolder(self, name=ARCHIVE_NAME):
+        return os.path.join(self.export_archive, 'source', name)
+
+    def recordExists(self):
+        return self.tblobj.query(where='$%s=:pkey' % self.tblobj.pkey, pkey=self.record['id'],
+                                 excludeLogicalDeleted=False, excludeDraft=False).count()
+
+    def logicalDelete(self):
+        record = self.tblobj.record(pkey=self.record['id'], for_update=True).output('dict')
+        old_record = dict(record)
+        record[self.tblobj.logicalDeletionField] = datetime.now()
+        self.tblobj.update(record, old_record)
+        self.db.commit()
+
+    def test_resource_under_test(self):
+        # the editable install resolves gnr.* to the main checkout, so make sure the
+        # resource being exercised is the one in this working tree
+        checkout = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+        batch = self.buildBatch(mode='D')
+        resource_file = sys.modules[type(batch).__module__].__file__
+        assert resource_file.startswith(checkout + os.sep)
+
+    def test_delete_only_creates_no_folder(self):
+        self.runBatch(mode='D')
+        assert not os.path.exists(self.export_archive)
+
+    def test_delete_only_deletes_the_records(self):
+        self.runBatch(mode='D')
+        assert self.recordExists() == 0
+
+    def test_archive_only_keeps_the_records(self):
+        self.runBatch(mode='A', name=ARCHIVE_NAME)
+        assert self.recordExists() == 1
+
+    def test_archive_writes_the_pickle_beside_no_records_folder(self):
+        self.runBatch(mode='A', name=ARCHIVE_NAME)
+        source_folder = self.sourceFolder()
+        assert os.path.isfile(os.path.join(source_folder, 'records.pik'))
+        # records is the basename of the pickled bag: it must not also exist as a folder
+        assert not os.path.exists(os.path.join(source_folder, 'records'))
+        assert os.path.isfile(os.path.join(self.export_archive, 'results',
+                                           '%s.zip' % ARCHIVE_NAME))
+
+    def test_archive_holds_the_selected_records(self):
+        self.runBatch(mode='A', name=ARCHIVE_NAME)
+        archive = Bag(os.path.join(self.sourceFolder(), 'records.pik'))
+        archived = archive[TABLE.replace('.', '/')]
+        assert [r['id'] for r in archived] == [self.record['id']]
+
+    def test_archive_copies_the_attachments_of_the_archived_table(self):
+        self.runBatch(mode='A', name=ARCHIVE_NAME)
+        copied = os.path.join(self.sourceFolder(), 'files', TABLE, self.record['id'],
+                              os.path.basename(self.filepath))
+        assert os.path.isfile(copied)
+        with open(copied, encoding='utf-8') as attachment:
+            assert attachment.read() == 'attached content'
+
+    def test_missing_attachment_leaves_no_empty_files_folder(self):
+        self.attachment_node.delete()
+        self.runBatch(mode='A', name=ARCHIVE_NAME)
+        assert not os.path.exists(os.path.join(self.sourceFolder(), 'files'))
+
+    def test_logically_deleted_records_are_archived_and_deleted(self):
+        self.logicalDelete()
+        self.runBatch(mode='AD', name=ARCHIVE_NAME)
+        archive = Bag(os.path.join(self.sourceFolder(), 'records.pik'))
+        assert [r['id'] for r in archive[TABLE.replace('.', '/')]] == [self.record['id']]
+        assert self.recordExists() == 0
+
+    def test_result_handler_reports_the_zip_only_when_archiving(self):
+        delete_only = self.runBatch(mode='D')
+        assert delete_only.result_handler() == ('Completed', None)
+        archiving = self.runBatch(mode='A', name=ARCHIVE_NAME)
+        result, result_attr = archiving.result_handler()
+        assert result_attr['url'].endswith('/%s.zip' % ARCHIVE_NAME)

--- a/resources/common/tables/_default/action/_common/archive_and_delete.py
+++ b/resources/common/tables/_default/action/_common/archive_and_delete.py
@@ -22,52 +22,62 @@ class Main(BaseResourceAction):
 
     def step_get_dependencies(self):
         "Get dependencies"
-        self.curr_records = self.tblobj.query(where=f'${self.tblobj.pkey} IN :pkeys',pkeys=self.get_selection_pkeys(),addPkeyColumns=False,
-                                    excludeLogicalDelete=False,excludeDraft=False,subtable='*').fetch()
-        name = self.batch_parameters.get('name') or 'archive_for_%s' %self.tblobj.fullname.replace('.','_')
-        self.source_folder = self.page.site.getStaticPath('vol:export_archive','source',name)
-        self.archive_path = self.page.site.getStaticPath('vol:export_archive','source',name,'records',autocreate=True)
-        self.files_to_copy = self.page.site.getStaticPath('vol:export_archive','source',name,'files',autocreate=True)
-        self.result_path = self.page.site.getStaticPath('vol:export_archive','results','%s.zip' %name,autocreate=-1)
-        self.result_url = self.page.site.getStaticUrl('vol:export_archive','results','%s.zip' %name)
+        self.mode = self.batch_parameters.get('mode')
+        self.curr_records = self.tblobj.query(where=f'${self.tblobj.pkey} IN :pkeys',pkeys=self.get_selection_pkeys(),addPkeyColumn=False,
+                                    excludeLogicalDeleted=False,excludeDraft=False,subtable='*').fetch()
+        self.archive_name = self.batch_parameters.get('name') or 'archive_for_%s' %self.tblobj.fullname.replace('.','_')
+        #the archive paths are computed by step_archive: in delete only mode none is needed
+        self.result_url = None
         self.tableDependencies = self.tblobj.dependenciesTree(self.curr_records)
         self.index_tables = list(self.db.tablesMasterIndex(hard=True)['_index_'].keys())
-        self.mode = self.batch_parameters.get('mode')
+
+    def prepareArchiveFolders(self):
+        """Compute the archive paths and create the folders that will actually be written.
+        Called from step_archive only, so a delete only run leaves no empty folder behind"""
+        name = self.archive_name
+        site = self.page.site
+        self.source_folder = site.getStaticPath('vol:export_archive','source',name)
+        #records is the basename of the pickled bag (records.pik), not a folder: autocreate its parent only
+        self.archive_path = site.getStaticPath('vol:export_archive','source',name,'records',autocreate=-1)
+        #step_archive creates the files subfolders one per table and pkey, only when there is something to copy
+        self.files_to_copy = site.getStaticPath('vol:export_archive','source',name,'files')
+        self.result_path = site.getStaticPath('vol:export_archive','results','%s.zip' %name,autocreate=-1)
+        self.result_url = site.getStaticUrl('vol:export_archive','results','%s.zip' %name)
 
     def step_archive(self):
         "Prepare Archive file"
         if self.mode == 'D':
             return
+        self.prepareArchiveFolders()
         archive = Bag()
         for t in self.index_tables:
             tablename = t.replace('/','.')
+            archivingTable = self.db.table(tablename)
             if tablename==self.tblobj.fullname:
                 archive[t] = self.curr_records
             else:
                 d = self.tableDependencies.get(tablename)
                 if d:
                     pkeys = d['one'].union(d['many'])
-                    reltblobj = self.db.table(tablename)
-                    archive[t] = reltblobj.query(where='$%s IN :pkeys' %reltblobj.pkey,
+                    archive[t] = archivingTable.query(where='$%s IN :pkeys' %archivingTable.pkey,
                                                 pkeys=list(pkeys),
                                                 addPkeyColumn=False,bagFields=True,
                                                 excludeDraft=False,excludeLogicalDeleted=False,
                                                 subtable='*').fetch()
-            archivingTable = self.db.table(tablename)         
             if hasattr(archivingTable,'onArchiveExport') and (t in archive):
                 files = defaultdict(list)
-                reltblobj.onArchiveExport(archive[t],files=files)
+                archivingTable.onArchiveExport(archive[t],files=files)
                 for pkey,pathlist in list(files.items()):
                     destfolder = os.path.join(self.files_to_copy,tablename,pkey)
-                    if not os.path.exists(destfolder):
-                        os.makedirs(destfolder)
                     for sn in pathlist:
                         if not sn.exists:
                             continue
-                        basename = sn.basename
-                        destpath = os.path.join(destfolder,basename)
+                        #created here and not before the loop: a record whose files are all
+                        #missing must not leave an empty folder in the archive
+                        if not os.path.exists(destfolder):
+                            os.makedirs(destfolder)
+                        destpath = os.path.join(destfolder,sn.basename)
                         sn.copy(destpath)
-                        #shutil.copy(sn,destpath)        
         archive.makePicklable()
         archive.pickle('%s.pik' %self.archive_path)
         self.page.site.zipFiles(self.source_folder,self.result_path)


### PR DESCRIPTION
Fixes #836

## Problem

`archive_and_delete` computed the `export_archive` paths in `step_get_dependencies` with `autocreate`, regardless of the selected mode. In delete-only mode (`D`) `step_archive` returns immediately, so every launch left an empty directory tree behind:

```
export_archive/source/archive_for_<pkg>_<table>/records/
export_archive/source/archive_for_<pkg>_<table>/files/
export_archive/results/
```

Reproduced on a `gnrtest` instance before the fix — all four folders created, all empty, no zip.

## Fix

Path computation moved to `prepareArchiveFolders`, called from `step_archive` **after** the mode guard, so a delete-only run touches nothing under `export_archive`. This also settles point 2 of the issue: the generic `archive_for_<table>` fallback name is still computed (it is the archive filename for `A`/`AD`) but no longer names a folder on a pure delete.

Two further corrections in the same area, both of which were making folders that stayed empty even while archiving:

- `records` is the basename of the pickled bag (`records.pik`), not a folder, so `autocreate=True` was creating a `records/` directory that was never written to. It now autocreates its parent only (`autocreate=-1`), which is what the `records.pik` write needs.
- the `files/<table>/<pkey>/` folder was created before checking `sn.exists`, so a record whose attachment file is missing left an empty folder in the archive. It is now created while copying, only when there is a file to copy.

## Also in scope — points 3 and 4 of the issue

Both were verified against a real instance and both are real defects:

**Point 3 — `reltblobj` scoping.** `step_archive` called `onArchiveExport` on `reltblobj`, which is only bound inside the dependencies branch. Archiving an attachment table itself (`tablename == self.tblobj.fullname`) raised:

```
UnboundLocalError: cannot access local variable 'reltblobj' where it is not associated with a value
```

The table object is now resolved once per iteration as `archivingTable` and used for both the dependencies query and the export hook — `archivingTable` was already being computed for exactly this purpose and then not used.

**Point 4 — query kwarg spelling.** The query layer honours `excludeLogicalDeleted`; the misspelling `excludeLogicalDelete` on line 26 was the only occurrence in the whole repository. `SqlQuery.__init__` collects unknown kwargs into `self.sqlparams`, so it was silently swallowed and the default `excludeLogicalDeleted=True` applied: a logically deleted record produced `curr_records == 0`, and the batch archived and deleted nothing for it. Same class of typo on `addPkeyColumns` (correct name: `addPkeyColumn`), fixed alongside — the effect is that the extra aliased `pkey` column is no longer added to the archived records, which matches both the original intent and the related-tables query a few lines below.

## Test case

`gnrpy/tests/web/archive_and_delete_test.py` — 10 tests, no mocks of the framework. The batch is loaded through the real site resource loader and its steps are run against the `gnrtest` instance, so the assertions look at the real `export_archive` tree on disk and at the real records in the database.

`adm.htmltemplate_atc` is the fixture table: it is an `AttachmentTable`, so it exercises the `onArchiveExport` branch on the archived table itself, and it carries `__del_ts`, so it also covers the logically deleted case.

Coverage:

- delete-only creates no folder at all, and still deletes the records
- archive-only writes `records.pik` and the zip, keeps the records, and creates no `records/` folder
- the pickled archive holds the selected records
- the attachment of the archived table is copied under `files/<table>/<pkey>/` with its content
- a missing attachment file leaves no empty `files/` folder
- a logically deleted record is archived and deleted
- `result_handler` reports the zip url only when archiving

Against the pre-fix resource 8 of these 10 fail (the other two are non-regression guards). Full `gnrpy` suite: 2473 passed, 10 skipped. flake8 clean on both files.

## Follow-up worth its own issue

Not changed here, but found while reviewing: the selected-records query does not pass `bagFields=True`, while the related-tables query a few lines below does. Bag (`X`) columns of the very records being archived are therefore missing from the archive — for example `adm.htmltemplate.data`. On an archive-then-delete that is silent data loss. Happy to open a separate issue for it.
