### PR TITLE
fix(flatfiles): CsvReader with an explicit delimiter, and rows lost to doubled line terminators

### DIFF
--- a/gnrpy/gnr/core/flatfiles.py
+++ b/gnrpy/gnr/core/flatfiles.py
@@ -396,6 +396,8 @@ class CsvReader(BaseReader):
 
     def __call__(self):
         for r in self.rows:
+            if not r:
+                continue
             yield GnrNamedList(self.index, r)
         if self._owns_filecsv:
             self.filecsv.close()

--- a/gnrpy/gnr/core/flatfiles.py
+++ b/gnrpy/gnr/core/flatfiles.py
@@ -379,13 +379,14 @@ class CsvReader(BaseReader):
         for _ in range(start_at_line):
             next(self.filecsv)
 
-        # Delimiter argument has priority over dialect in clevercsv.reader
-        if delimiter:
+        # Delimiter argument has priority over dialect in clevercsv.reader,
+        # which rejects dialect=None where the stdlib csv accepts it
+        if dialect and delimiter:
             self.rows = csv.reader(self.filecsv, dialect=dialect, delimiter=delimiter)
         elif dialect:
             self.rows = csv.reader(self.filecsv, dialect=dialect)
         else:
-            self.rows = csv.reader(self.filecsv, delimiter=',')
+            self.rows = csv.reader(self.filecsv, delimiter=delimiter or ',')
 
         self.headers = next(self.rows)
         name = docname if isinstance(docname, str) else (getattr(docname, 'name', None) or '<file-like>')

--- a/gnrpy/tests/core/flatfiles_test.py
+++ b/gnrpy/tests/core/flatfiles_test.py
@@ -572,6 +572,27 @@ def test_CsvReader_auto_dialect():
         assert last_row[9] == expected_description
 
 
+
+def test_CsvReader_delimiter_without_dialect():
+    """Test CsvReader and getReader with an explicit delimiter and no dialect.
+
+    clevercsv rejects dialect=None where the stdlib csv accepts it, so the
+    delimiter has to be passed on its own.
+    """
+    test_file = os.path.join(DATA_DIR, 'test_CsvAuto_SemiColon.csv')
+
+    reader = CsvReader(test_file, delimiter=';', encoding='utf-8')
+    assert reader.ncols == 11
+    assert reader.headers[0] == 'Data contabile'
+    rows = list(reader())
+    assert len(rows) == 6
+    assert rows[5][2] == '-50,00'
+
+    reader = getReader(test_file, delimiter=';', encoding='utf-8')
+    assert reader.ncols == 11
+    assert len(list(reader())) == 6
+
+
 ### ported from gnrlist_test
 def test_getReader():
 

--- a/gnrpy/tests/core/flatfiles_test.py
+++ b/gnrpy/tests/core/flatfiles_test.py
@@ -593,6 +593,28 @@ def test_CsvReader_delimiter_without_dialect():
     assert len(list(reader())) == 6
 
 
+
+def test_CsvReader_doubled_line_terminators():
+    """Test CsvReader on a file whose records end with CR CR LF.
+
+    Some Windows exporters emit a doubled CR, which every csv reader (clevercsv
+    and the stdlib alike, in text mode and with newline='') splits into an extra
+    zero-field row per record.
+    """
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False, newline='') as f:
+        csv_file = f.name
+        f.write('id;name\r\r\n1;Alice\r\r\n2;Bob\r\r\n')
+
+    try:
+        reader = CsvReader(csv_file, delimiter=';')
+        assert reader.headers == ['id', 'name']
+        rows = list(reader())
+        assert len(rows) == 2
+        assert [r['name'] for r in rows] == ['Alice', 'Bob']
+    finally:
+        os.unlink(csv_file)
+
+
 ### ported from gnrlist_test
 def test_getReader():
 


### PR DESCRIPTION
Fixes #1270

Two independent defects in `CsvReader`, one commit each.

**1. `ValueError: Unknown dialect type: None` (regression)**

`CsvReader` forwarded `dialect=None` to `clevercsv.reader` whenever an explicit
`delimiter` was passed, and clevercsv rejects it where the stdlib `csv` accepts
it — so every `CsvReader(path, delimiter=';')` / `getReader(sn, delimiter=';')`
died at construction, before reading a single row.

The guard is `dialect and delimiter` on the first branch; the `else` now carries
`delimiter or ','`, so an explicit delimiter still wins over the dialect's own
and the plain no-argument case is unchanged.

Regression from ef436e8b84 (#935), which swapped this module's `csv` for
clevercsv while leaving `dialect=dialect` in the delimiter branch. `develop`
only: `master` still imports the stdlib `csv` here, so no released version is
affected and no hotfix is needed there.

**2. `IndexError: list index out of range` on doubled line terminators**

Records ending with `\r\r\n` — some Windows exporters emit that — are split by
every csv reader into an extra zero-field row per record, verified identically
with clevercsv and the stdlib, in text mode and with `newline=''`. Those were
yielded as `GnrNamedList(index, [])`, so any consumer touching a column got an
IndexError. A blank physical line carries no data in any CSV, so `__call__` now
skips it and no caller loses information. Not a regression: long-standing, and
the same crash happens on `master`.

**Tests:** one per defect, each covering a branch nothing exercised — every
existing `CsvReader` test passes either an explicit dialect or neither argument,
and none feeds a malformed terminator. Both are red on `develop` (with the
ValueError and the IndexError above) and green with this change; the full `gnrpy`
suite passes (2419 passed, 10 skipped).

Verified on the case that surfaced this: a 58-record semicolon payroll CSV with
doubled terminators, which now reads back its 57 data rows through
`getReader(sn, delimiter=';', detect_encoding=True)`.
