### PR TITLE
fix(siteregister): drop datachanges on segment boundaries

### DIFF
--- a/gnrpy/gnr/web/daemon/siteregister.py
+++ b/gnrpy/gnr/web/daemon/siteregister.py
@@ -347,7 +347,8 @@ class BaseRegister(BaseRemoteObject):
         if not register_item:
             return
         datachanges = register_item['datachanges']
-        datachanges[:] = [dc for dc in datachanges if not dc.path.startswith(path)]
+        datachanges[:] = [dc for dc in datachanges
+                          if not (dc.path == path or dc.path.startswith(path + '.'))]
 
     def subscribe_path(self, register_item_id, path):
         register_item = self.get_item(register_item_id)

--- a/gnrpy/tests/web/siteregister_drop_datachanges_test.py
+++ b/gnrpy/tests/web/siteregister_drop_datachanges_test.py
@@ -1,0 +1,74 @@
+"""Tests for the segment-aware drop of queued datachanges (#1259).
+
+``BaseRegister.drop_datachanges`` discards the changes a page has not polled yet under a
+subtree root. Matching them by character prefix also discards every pending change on a
+sibling whose name merely begins with the same letters -- dropping ``gnr.batch.sync``
+takes ``gnr.batch.sync_log.x`` with it, and the page never receives it. Same defect as
+#1255/#1258 in the dropping direction, so the same predicate applies.
+
+The register is a real ``SiteRegister`` built with the stand-in server of
+``siteregister_datachanges_test``: its constructor only needs ``server.daemon.register``,
+so no daemon and no Pyro are involved.
+"""
+
+from gnr.web.daemon.siteregister import SiteRegister
+
+
+class _FakeDaemon:
+    def register(self, obj, name):
+        pass
+
+
+class _FakeServer:
+    daemon = _FakeDaemon()
+    gnr_daemon_uri = None
+    hmac_key = None
+
+
+def _page_with_queue(*paths):
+    reg = SiteRegister(_FakeServer(), sitename='testsite').page_register
+    reg.create('p1')
+    for path in paths:
+        reg.set_datachange('p1', path, value=1)
+    return reg
+
+
+def _queued(reg):
+    return [dc.path for dc in reg.get_datachanges('p1')]
+
+
+def test_a_sibling_sharing_a_character_prefix_survives_the_drop():
+    """The regression: 'sync_log' is not under 'sync', it only starts with its letters."""
+    reg = _page_with_queue('gnr.batch.sync', 'gnr.batch.sync.thermo', 'gnr.batch.sync_log.x')
+    reg.drop_datachanges('p1', 'gnr.batch.sync')
+    assert _queued(reg) == ['gnr.batch.sync_log.x']
+
+
+def test_the_dropped_path_itself_is_removed():
+    reg = _page_with_queue('gnr.batch.sync')
+    reg.drop_datachanges('p1', 'gnr.batch.sync')
+    assert _queued(reg) == []
+
+
+def test_the_whole_subtree_under_the_dropped_path_is_removed():
+    reg = _page_with_queue('gnr.batch.sync.thermo', 'gnr.batch.sync.log.line')
+    reg.drop_datachanges('p1', 'gnr.batch.sync')
+    assert _queued(reg) == []
+
+
+def test_an_unrelated_path_is_untouched():
+    reg = _page_with_queue('other.node')
+    reg.drop_datachanges('p1', 'gnr.batch.sync')
+    assert _queued(reg) == ['other.node']
+
+
+def test_a_longer_sibling_segment_survives_the_drop():
+    """'srv.ab' shares every character of 'srv.a' but is a different node."""
+    reg = _page_with_queue('srv.a', 'srv.ab.x')
+    reg.drop_datachanges('p1', 'srv.a')
+    assert _queued(reg) == ['srv.ab.x']
+
+
+def test_dropping_on_a_missing_register_item_does_not_raise():
+    reg = _page_with_queue('gnr.batch.sync')
+    assert reg.drop_datachanges('unknown-page', 'gnr.batch.sync') is None


### PR DESCRIPTION
## Problem / Root cause

`BaseRegister.drop_datachanges` (`gnrpy/gnr/web/daemon/siteregister.py`) discarded the
datachanges a page has not polled yet with a character-prefix test:

```python
datachanges[:] = [dc for dc in datachanges if not dc.path.startswith(path)]
```

`str.startswith` compares characters, not Bag segments, so dropping the queue under
`gnr.batch.sync` also removed every pending change on `gnr.batch.sync_log.*` — the page
never received them and nothing reported it. Every caller passes a subtree root
(`serverbatch.py:115,147,163`, `gnrwebpage.py:2343`, `chat_component.py:168`), so any
sibling sharing a character prefix (`form`/`formats`, `order`/`orders`, `srv.a`/`srv.ab`)
loses its queued changes silently.

Same defect as #1255 in the dropping direction; #1258 (96bcb43c6b) fixed the announcing
leg at `siteregister.py:202`.

## Change

One-line filter change, mirroring the predicate the announcing leg already uses: a change
is dropped only when its path is the dropped path itself or continues after a dot.

## Verification

From `gnrpy`, with `PYTHONPATH` pointing at this worktree (`gnr.__file__` asserted inside it):

- narrow gate: `python3 -m pytest tests/web/siteregister_datachanges_test.py tests/web/siteregister_subscribed_path_test.py tests/web/siteregister_client_test.py tests/web/siteregister_drop_datachanges_test.py -q` → **20 passed**
- the two regression tests (sibling `sync_log.x`, sibling segment `srv.ab`) were confirmed to **fail on the pre-fix line** and pass after it
- `python3 -m pytest tests/ -q --ignore=tests/sql` → **1292 passed**
- full suite via the pre-commit hook → **2456 passed, 10 skipped**
- `flake8` on both touched files → zero errors

New tests in `gnrpy/tests/web/siteregister_drop_datachanges_test.py` run against a real
`SiteRegister` with the `_FakeDaemon`/`_FakeServer` stand-in of
`siteregister_datachanges_test.py` (no mocks of the register itself): exact path, subtree,
sibling character prefix, sibling segment, unrelated path, missing register item.

## Follow-up (out of scope)

`subscription_storechanges` (`siteregister.py` ~1037) matches the same way and is left for
a separate change.

## Related issue

Fixes #1259
