### PR TITLE
fix(slotbar): updateSlotsAttr rebuilds only the slots it addresses

### DIFF
--- a/gnrpy/gnr/web/gnrwebstruct/base.py
+++ b/gnrpy/gnr/web/gnrwebstruct/base.py
@@ -151,7 +151,25 @@ class GnrDomSrc(GnrStructData):
         :param nodeId: the :ref:`nodeid`"""
         assert nodeId not in self.register_nodeId,'%s is duplicated' %nodeId
         self.page._register_nodeId[nodeId] = self
-        
+
+    def unregisterNodeIds(self, childname):
+        """Remove from the :ref:`nodeid` register every :ref:`nodeid` declared
+        inside a child subtree, so that the child can be rebuilt
+
+        :param childname: the :ref:`childname` of the subtree"""
+        childnode = self.getNode(childname)
+        if childnode is None:
+            return
+        register = self.register_nodeId
+        nodes = [childnode]
+        childvalue = childnode.getStaticValue()
+        if isinstance(childvalue, Bag):
+            nodes += list(childvalue.traverse())
+        for node in nodes:
+            nodeId = node.attr.get('nodeId')
+            if nodeId:
+                register.pop(nodeId, None)
+
     @property
     def register_nodeId(self):
         """TODO"""

--- a/gnrpy/gnr/web/gnrwebstruct/dojo11.py
+++ b/gnrpy/gnr/web/gnrwebstruct/dojo11.py
@@ -723,6 +723,7 @@ class GnrDomSrc_dojo_11(GnrDomSrc):
         namespace = namespace or self.parent.attributes.get('namespace')
         tb = self.child('slotBar',slotbarCode=slotbarCode,slots=slots,childname=childname,**kwargs)
         toolbarArgs = tb.attributes
+        tb._slotArgs = dict(toolbarArgs) #_addSlot consumes the slot parameters out of the attributes
         slots = gnrstring.splitAndStrip(str(slots))
         frame = self.parent
         frameCode = self.getInheritedAttributes().get('frameCode')
@@ -734,7 +735,17 @@ class GnrDomSrc_dojo_11(GnrDomSrc):
         
         #se ritorni la toolbar hai una toolbar vuota 
     
+    def _extractSlotArgs(self,slot,args):
+        slotName = slot.split('@')[0]
+        slotPrefix = '%s_' %slot.replace('@','_')
+        return dict([(k,v) for k,v in list(args.items())
+                        if k==slotName or k.startswith(slotPrefix)])
+
     def slotbar_updateslotsattr(self,**kwargs):
+        slotArgs = getattr(self,'_slotArgs',None)
+        if slotArgs is None:
+            slotArgs = self._slotArgs = dict()
+        slotArgs.update(kwargs)
         self.attributes.update(kwargs)
         toolbarArgs = self.attributes
         slotstr = toolbarArgs['slots']
@@ -746,9 +757,14 @@ class GnrDomSrc_dojo_11(GnrDomSrc):
         frame = self.parent.parent
         prefix = slotbarCode or frameCode
         for slot in slots:
-            if slot!='*' and slot!='|' and not slot.isdigit():
-                self.pop(slot)
-                self._addSlot(slot,prefix=prefix,frame=frame,frameCode=frameCode,namespace=namespace,toolbarArgs=toolbarArgs)
+            if slot=='*' or slot=='|' or slot.isdigit():
+                continue
+            if not self._extractSlotArgs(slot,kwargs):
+                continue
+            toolbarArgs.update(self._extractSlotArgs(slot,slotArgs))
+            self.unregisterNodeIds(slot)
+            self.pop(slot)
+            self._addSlot(slot,prefix=prefix,frame=frame,frameCode=frameCode,namespace=namespace,toolbarArgs=toolbarArgs)
 
     def slotbar_replaceslots(self, toReplace, replaceStr,**kwargs):
         """Allow to redefine the preset bars of the :ref:`slotBars <slotbar>` and the

--- a/gnrpy/gnr/web/gnrwebstruct/dojo11.py
+++ b/gnrpy/gnr/web/gnrwebstruct/dojo11.py
@@ -775,6 +775,7 @@ class GnrDomSrc_dojo_11(GnrDomSrc):
         :param replaceStr: MANDATORY. A string with the list of the slots to add
         """
         self.attributes.update(kwargs)
+        self._slotArgs = dict(getattr(self,'_slotArgs',None) or dict(),**kwargs) #_addSlot consumes the slot parameters out of the attributes
         toolbarArgs = self.attributes
         slotstr = toolbarArgs['slots']
         slotbarCode= toolbarArgs.get('slotbarCode')

--- a/gnrpy/tests/web/gnrwebstruct_test.py
+++ b/gnrpy/tests/web/gnrwebstruct_test.py
@@ -544,3 +544,118 @@ def test_hidden_group_member_targets_its_own_label_cell():
     assert "this.attributeOwnerNode('tag','td')" in memberNode.attr['onCreated']
     labelCell = _hiddenFieldLabelCell(root, '^.gamma')
     assert labelCell.attr['innerHTML'] == 'Gamma'
+
+
+# ---------------------------------------------------------------------------
+# nodeId register: unregisterNodeIds
+# ---------------------------------------------------------------------------
+
+def test_unregisterNodeIds_clears_a_nested_subtree():
+    """Every nodeId declared inside the subtree leaves the register, so the
+    same subtree can be built again."""
+    page = _PageStub()
+    root = _make_root(page=page)
+    box = root.child('div', childname='box', nodeId='box_id')
+    box.child('div', childname='inner').child('div', childname='leaf',
+                                              nodeId='leaf_id')
+    assert sorted(page._register_nodeId) == ['box_id', 'leaf_id']
+    root.unregisterNodeIds('box')
+    assert page._register_nodeId == {}
+    root.pop('box')
+    root.child('div', childname='box', nodeId='box_id')
+    assert list(page._register_nodeId) == ['box_id']
+
+
+def test_unregisterNodeIds_on_a_missing_child_is_a_noop():
+    page = _PageStub()
+    root = _make_root(page=page)
+    root.child('div', childname='box', nodeId='box_id')
+    root.unregisterNodeIds('nowhere')
+    assert list(page._register_nodeId) == ['box_id']
+
+
+# ---------------------------------------------------------------------------
+# slotBar: updateSlotsAttr rebuilds only the slots it addresses
+# ---------------------------------------------------------------------------
+
+def _slotbar(slots='withid,plain,*', **kwargs):
+    """Build a real slotBar with two slots: `withid`, whose handler assigns a
+    fixed nodeId (as the table handler query menu does), and `plain`."""
+
+    @struct_method('slotbar_withid')
+    def _withid_slot(struct, withid=None, frameCode=None, **slotkw):
+        struct.div(childname='content', nodeId='fixed_id', **slotkw)
+
+    @struct_method('slotbar_plain')
+    def _plain_slot(struct, plain=None, frameCode=None, **slotkw):
+        struct.div(childname='content', **slotkw)
+
+    page = _PageStub()
+    page._withid_slot = _withid_slot
+    page._plain_slot = _plain_slot
+    pane = _make_root(page=page).child('div', childname='frame') \
+                               .child('div', childname='pane')
+    return page, pane.slotBar(slots, **kwargs)
+
+
+def _slotContentAttr(bar, slot):
+    return bar.getNode(slot).value.getNode('content').attr
+
+
+def test_slotbar_builds_its_slots_with_their_parameters():
+    page, bar = _slotbar(withid_label='hello')
+    assert _slotContentAttr(bar, 'withid')['label'] == 'hello'
+    assert list(page._register_nodeId) == ['fixed_id']
+
+
+def test_updateslotsattr_does_not_duplicate_registered_nodeids():
+    """Rebuilding a sibling slot must not walk over the slot holding a
+    nodeId: that is the `... is duplicated` assertion of the issue."""
+    page, bar = _slotbar(withid_label='hello')
+    bar.updateSlotsAttr(plain_x='zz')
+    assert _slotContentAttr(bar, 'plain')['x'] == 'zz'
+    assert list(page._register_nodeId) == ['fixed_id']
+
+
+def test_updateslotsattr_keeps_the_parameters_of_untouched_slots():
+    page, bar = _slotbar(withid_label='hello')
+    withidSlot = bar.getNode('withid').value
+    bar.updateSlotsAttr(plain_x='zz')
+    assert _slotContentAttr(bar, 'withid')['label'] == 'hello'
+    # not addressed by the call, hence not rebuilt at all
+    assert bar.getNode('withid').value is withidSlot
+
+
+def test_updateslotsattr_rebuilds_the_addressed_slot_only():
+    page, bar = _slotbar(withid_label='hello')
+    plainSlot = bar.getNode('plain').value
+    bar.updateSlotsAttr(withid_label='world')
+    assert _slotContentAttr(bar, 'withid')['label'] == 'world'
+    assert bar.getNode('plain').value is plainSlot
+    # the register points at the rebuilt subtree, not at the discarded one
+    assert list(page._register_nodeId) == ['fixed_id']
+    assert page._register_nodeId['fixed_id'] is bar.getNode('withid').value
+
+
+def test_updateslotsattr_accumulates_over_repeated_calls():
+    page, bar = _slotbar(withid_label='hello')
+    bar.updateSlotsAttr(withid_label='world')
+    bar.updateSlotsAttr(withid_extra='x')
+    attr = _slotContentAttr(bar, 'withid')
+    assert attr['label'] == 'world'
+    assert attr['extra'] == 'x'
+    assert list(page._register_nodeId) == ['fixed_id']
+
+
+def test_updateslotsattr_still_updates_the_bar_attributes():
+    page, bar = _slotbar(withid_label='hello')
+    bar.updateSlotsAttr(_class='mybar')
+    assert bar.attributes['_class'] == 'mybar'
+
+
+def test_replaceslots_adds_the_new_slot_with_its_parameters():
+    page, bar = _slotbar(slots='withid,*')
+    bar.replaceSlots('*', 'plain,*', plain_x='zz')
+    assert bar.attributes['slots'] == 'withid,plain,*'
+    assert _slotContentAttr(bar, 'plain')['x'] == 'zz'
+    assert list(page._register_nodeId) == ['fixed_id']

--- a/gnrpy/tests/web/gnrwebstruct_test.py
+++ b/gnrpy/tests/web/gnrwebstruct_test.py
@@ -659,3 +659,15 @@ def test_replaceslots_adds_the_new_slot_with_its_parameters():
     assert bar.attributes['slots'] == 'withid,plain,*'
     assert _slotContentAttr(bar, 'plain')['x'] == 'zz'
     assert list(page._register_nodeId) == ['fixed_id']
+
+
+def test_updateslotsattr_keeps_the_parameters_added_by_replaceslots():
+    """`replaceSlots` parameters must survive a later `updateSlotsAttr` on the
+    same slot: `_addSlot` consumes them out of the bar attributes, so the
+    snapshot has to see them too."""
+    page, bar = _slotbar(slots='withid,*')
+    bar.replaceSlots('*', 'plain,*', plain_x='zz')
+    bar.updateSlotsAttr(plain_y='ww')
+    attr = _slotContentAttr(bar, 'plain')
+    assert attr['x'] == 'zz'
+    assert attr['y'] == 'ww'


### PR DESCRIPTION
## Problem / Root cause

`slotbar_updateslotsattr` popped and re-added **every** slot of the bar so that new attributes could reach the slot handlers. Two independent faults followed.

1. **nodeId leak.** `Bag.pop` only detaches the node: nothing removes the nodeIds its subtree registered in `page._register_nodeId` (written only by `GnrDomSrc.checkNodeId`). The rebuild therefore hit the `checkNodeId` assertion. On a table handler view bar the query menu declares `nodeId='<th_root>_searchMenu_a'` (`resources/common/th/th_view.py:1544`), so a `th_top_custom` calling `top.bar.updateSlotsAttr(...)` broke the page build with `Server Error: V_<pkg>_<table>_searchMenu_a is duplicated`.
2. **Parameter loss.** `_addSlot` consumes the slot parameters out of the bar attributes (`toolbarArgs.pop` + `dictExtract(..., pop=True)`), so the rebuild-all loop re-added every *other* slot with an empty parameter dict, silently dropping its original arguments.

## Change

- `gnrpy/gnr/web/gnrwebstruct/base.py`: new `GnrDomSrc.unregisterNodeIds(childname)` next to `checkNodeId`, which walks the child subtree and removes its nodeIds from the register.
- `gnrpy/gnr/web/gnrwebstruct/dojo11.py`: `slotBar` snapshots the slot parameters (`tb._slotArgs`) before the consuming `_addSlot` loop; `slotbar_updateslotsattr` now rebuilds **only** the slots addressed by the incoming kwargs, re-injecting that slot's remembered arguments and unregistering its nodeIds before `pop` + `_addSlot`. Incoming kwargs are merged into the snapshot, so repeated calls accumulate. Bar-level attributes keep being updated as before.

Scope kept minimal on purpose: `Bag.pop` is untouched, no generic `pop` override on `GnrDomSrc`, `slotbar_replaceslots` untouched. Every other `pop` of a struct subtree keeps its current behaviour; widening the unregistration to all removals would need its own regression pass (`th.py:369`, `th_picker.py:21`).

Slot order is unaffected: the client builds the bar from the `slots` attribute and looks children up by name (`gnrjs/gnr_d11/js/genro_components.js`, `createContent_horizontal`), not from child order.

No JS changes.

## Verification

Run in this session, from `gnrpy` with `PYTHONPATH` on this worktree (`gnr.__file__` asserted inside it):

- `python3 -m pytest tests/web/gnrwebstruct_test.py -q` → **66 passed** (57 before, 9 added).
- Regression proof: with the two source files reverted and the new tests in place, **7 of the 9 new tests fail** (`fixed_id is duplicated` among them); the two that pass without the fix cover pre-existing `slotBar` / `replaceSlots` behaviour.
- `python3 -m pytest tests/ -q --ignore=tests/sql` → **1295 passed**; the pre-commit hook ran the whole suite: **2459 passed, 10 skipped**.
- `flake8` on the three touched files → zero errors.

New tests (real structs via `GnrDomSrc_dojo_11.makeRoot(_PageStub())`, two `@struct_method` slot handlers, one of which assigns a fixed nodeId like the query menu): nodeId register cleared for a nested subtree and a no-op on a missing child; `updateSlotsAttr` on a sibling slot no longer duplicates the nodeId; untouched slots keep their parameters and are not rebuilt at all; the addressed slot is rebuilt with the register pointing at the new subtree; repeated calls accumulate; bar attributes still updated; `replaceSlots` still adds the missing slot with its parameters.

## Related issue

Fixes #1269
