### PR TITLE
fix(stores): fetchItemByIdentity keeps a stale reply out of the node's validation state

### DIFF
--- a/gnrjs/gnr_d11/js/genro_widgets.js
+++ b/gnrjs/gnr_d11/js/genro_widgets.js
@@ -4999,15 +4999,6 @@ dojo.declare("gnr.widgets.DynamicBaseCombo", gnr.widgets.BaseCombo, {
                 this.setValue(null,false);
                 this.store.fetchItemByIdentity({identity:currvalue,onItem:function(){
                     if(self.sourceNode.getRelativeData(vpath) != currvalue){
-                        // the stale reply may have flagged a value that is no longer
-                        // there. fetchItemByIdentity clears _lastQueryError before
-                        // the call, so a value here belongs to this reply: without
-                        // one there is nothing of ours to undo, and the node may
-                        // meanwhile hold the current value's own error or required
-                        if(self._lastQueryError){
-                            delete self._lastQueryError;
-                            self.sourceNode.resetValidationError();
-                        }
                         return;
                     }
                     self.setValue(currvalue,false);

--- a/gnrjs/gnr_d11/js/gnrstores.js
+++ b/gnrjs/gnr_d11/js/gnrstores.js
@@ -641,10 +641,15 @@ dojo.declare("gnr.GnrStoreQuery", gnr.GnrStoreBag, {
             }
             var finalize = dojo.hitch(this, function(r) {
                 var scope = request.scope ? request.scope : dojo.global;
-                if(r.attr.errors){
-                    this._parentSourceNode.widget._lastQueryError = r.attr.errors;
-                    
-                    this._parentSourceNode.setValidationError({error:r.attr.errors});
+                var sn = this._parentSourceNode;
+                // the reply's error belongs to the identity it asked about: the datastore
+                // may have moved to another value, and setValidationError is wholesale
+                var stale = sn && sn.attr.value && request.identity != sn.getRelativeData(sn.attr.value);
+                if(r.attr.errors && sn && sn.widget && !stale){
+                    sn.widget._lastQueryError = r.attr.errors;
+                    sn.setValidationError({error:r.attr.errors,
+                                           warnings:sn.getValidationWarnings(),
+                                           required:sn.isValidationRequired()});
                 }
                 var result = r.getValue();
                 if (result instanceof gnr.GnrBag) {

--- a/projects/gnrcore/packages/test/webpages/inputfields/dbselect.py
+++ b/projects/gnrcore/packages/test/webpages/inputfields/dbselect.py
@@ -100,7 +100,24 @@ class GnrCustomWebPage(object):
                     lbl='DbSelect',width='25em',nodeId='dbselect_condition_null')
         fb.div('^.sigla',lbl='Datastore value')
         fb.button('Set LOM / null',action="SET .regione='LOM'; SET .sigla=null;")
-        
+
+    def test_10_condition_race_validation(self,pane):
+        "A stale condition reply must not overwrite the validation state of the newer value"
+        pane.data('.regione','VAL')
+        pane.data('.sigla','AO')
+        fb = pane.formbuilder(cols=2, border_spacing='4px')
+        fb.dbSelect(table='glbl.regione',value='^.regione',lbl='Regione',width='25em')
+        fb.dbSelect(table='glbl.provincia',value='^.sigla',method=self.delayedDbSelect,
+                    condition='$regione=:regione',condition_regione='^.regione',
+                    lbl='DbSelect',width='25em',validate_notnull=True,
+                    validate_notnull_error='Manca il valore',
+                    nodeId='dbselect_race_validation')
+        fb.div('^.sigla',lbl='Datastore value')
+        pane.dataRpc('.race_province',self.raceProvince,regione='^.regione',
+                     _if="regione=='LOM'",_else='null')
+        pane.dataController("SET .sigla=province;",province='^.race_province',_if='province')
+        fb.button('Set LOM / MI',action="SET .regione='LOM';")
+
     def test_2_clientmethod(self,pane):
         "Manually set what to display with callbackSelect"
         fb = pane.formbuilder(cols=1, border_spacing='4px')


### PR DESCRIPTION
## Problem / Root cause

`GnrStoreQuery.fetchItemByIdentity`'s `finalize` (`gnrjs/gnr_d11/js/gnrstores.js`) raised a node-level validation error for a reply whose currency it never checked:

- it set `widget._lastQueryError` and called `setValidationError({error:r.attr.errors})` unconditionally, with no comparison between `request.identity` and the value the datastore actually holds now;
- `finalize` runs **before** `request.onItem`, so a consumer callback could only normalise state that was already lost;
- `setValidationError` is wholesale (`gnrdomsource.js`), and the store was the only caller passing a partial literal, so `warnings` and `required` became `undefined`;
- it dereferenced `._parentSourceNode.widget` without the `.widget` guard used a few lines above on the same path.

The result: on any `dbSelect` / `dbComboBox` with a bound `condition_*`, a late identity reply installed the resolver error of a value the widget no longer holds, and blanked the two other validation fields. The consumer guard added by #1057 could clear the stale error but could not restore `warnings` and `required`.

## Change

`gnrstores.js` — `finalize` compares `request.identity` with the node's live bound value (`sn.getRelativeData(sn.attr.value)`, the same comparison `DynamicBaseCombo.mixin_setCondition` makes). When the reply is stale it writes neither `_lastQueryError` nor the validation state; `cached_values` and `request.onItem` are untouched, so caching and consumers behave exactly as before. When the reply is current it now passes a complete validation object — `{error, warnings: sn.getValidationWarnings(), required: sn.isValidationRequired()}` — so the node's own `warnings` and `required` survive the error write. The missing `.widget` guard is added.

`genro_widgets.js` — `mixin_setCondition` loses the now-dead `_lastQueryError` repair branch: a stale reply no longer sets the flag, so there is nothing left to undo. The plain stale `return` stays.

`projects/gnrcore/packages/test/webpages/inputfields/dbselect.py` — new `test_10_condition_race_validation`: `test_8`'s race fixture (`method=self.delayedDbSelect` sleeping on `_id=='AO'`, plus the `dataRpc`/`dataController` pair that writes `MI` in the same tick as the condition change) with `validate_notnull=True` on the raced node, so the node carries `required`/`warnings` state before the stale reply lands.

The request-token alternative discussed on the issue (a monotonic counter on `GnrStoreQuery`) was deliberately not taken: it adds state to a store shared by every `dbSelect` to cover the narrower overlapping-`setCondition` case, which the issue itself records as a residual rather than a tracked defect. `gnrdomsource.js` is untouched — the fix preserves `warnings`/`required` at the store call site rather than making `setValidationError` partial-safe.

## Verification

Run in this session, from the worktree (`gnr` imports asserted to resolve inside it):

- `flake8` on `projects/gnrcore/packages/test/webpages/inputfields/dbselect.py` — zero errors.
- `node --check` on both touched JS files (`gnrstores.js`, `genro_widgets.js`) — both parse. There is no JS test infrastructure in the repo.
- `python3 -m pytest tests/ -q --ignore=tests/sql` — **1286 passed**.
- The repo's own pre-commit gate (`pytest core sql web app xtnd` from `gnrpy/tests`) ran on the commit — **2450 passed, 10 skipped**.

**Still owed, and the reason this PR is a draft:** the browser pass on the testhandler page `/test/inputfields/dbselect` has NOT been run. It needs a served instance and was left to the operator. It must cover:

- `test_10` (the new case): press *Set LOM / MI*, then after settle assert the widget caption and the datapath are both `MI`, `_validations.error` is null, `_validations.warnings` is still an array, `_validations.required` is unchanged, and the `gnrrequired` class is still on the `focusNode`;
- `test_8` — a stale reply still neither restores nor invalidates the newer value;
- `test_9` — condition change plus `SET null` in the same tick: caption clears, no validation error;
- `test_7` — the single-option branch still updates both widgets;
- `test_1_condition` — a **current** reply that does not fit the condition still raises the error (the guard must not suppress that one).

## Related issue

Fixes #1273
