### PR TITLE
fix(print): honour a string pdf path in TableTemplateToHtml

### DIFF
--- a/gnrpy/gnr/web/gnrbaseclasses.py
+++ b/gnrpy/gnr/web/gnrbaseclasses.py
@@ -320,11 +320,12 @@ class TableTemplateToHtml(BagToHtmlWeb):
         if not htmlContent:
             htmlContent = self.contentFromTemplate(record,template=template,locale=locale)
             record = self.record
+        callingPdfPath = pdf if isinstance(pdf,str) else None
         if pdf :
             filepath = filepath or self.getHtmlPath(f'{self.getDocName()}.html')
         result = super(TableTemplateToHtml, self).__call__(record=record,htmlContent=htmlContent,filepath=filepath,**kwargs)
-        if pdf is True:
-            return self.writePdf()
+        if pdf:
+            return self.writePdf(pdfpath=callingPdfPath)
         return result
     
     def getDocName(self):

--- a/gnrpy/tests/web/gnrbaseclasses_test.py
+++ b/gnrpy/tests/web/gnrbaseclasses_test.py
@@ -3,16 +3,24 @@
 ``sys.batch_log`` is the fixture table: its ``caption_field`` is the formula
 column ``log_caption``, the shape that made every record of a table print to
 the same file name.
+
+TestTableTemplatePdfPath covers issue #1264 on the sibling base class
+TableTemplateToHtml: a string ``pdf`` argument is the requested output path,
+the meaning TableScriptToHtml already gives it. The PDF cases render through
+the real htmltopdf service and are skipped when weasyprint or pymupdf are not
+importable (same guard as tests/core/htmltopdf_test.py).
 """
 
 import os
 import re
 
+import pytest
+
 from core.common import BaseGnrTest
 
 from gnr.app.gnrapp import GnrApp
 from gnr.web import gnrbaseclasses
-from gnr.web.gnrbaseclasses import TableScriptToHtml
+from gnr.web.gnrbaseclasses import TableScriptToHtml, TableTemplateToHtml
 from gnr.web.gnrdummysite import GnrDummySite
 
 
@@ -108,3 +116,59 @@ class TestTableScriptOutputName(BaseGnrTest):
         assert len(set(names)) == len(self.pkeys)
         for pkey, name in zip(self.pkeys, names):
             assert name.endswith('%s.html' % re.sub(r'\W', '_', pkey))
+
+
+class TestTableTemplatePdfPath(BaseGnrTest):
+    """``adm.user`` and its ``homepage`` template resource are the fixture: the
+    template prints the username, so the rendered document can be recognized."""
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        app = GnrApp(cls.test_instance_name)
+        app.db.model.check(applyChanges=True)
+        app.db.commit()
+        cls.site = GnrDummySite(cls.test_instance_name, site_name=cls.test_instance_name)
+        cls.tblobj = cls.site.db.table('adm.user')
+        record = cls.tblobj.newrecord(username='tpluser')
+        cls.tblobj.insert(record)
+        cls.site.db.commit()
+        cls.pkey = record[cls.tblobj.pkey]
+
+    def buildScript(self):
+        page = self.site.dummyPage
+
+        def loadTemplate(template_address, **kwargs):
+            # adm.userobject is empty on the sqlite test instance and querying it
+            # raises (#1165): go straight to the resource the address points at
+            table, tplname = template_address.split(':', 1)
+            data, _dataInfo = page.templateFromResource(table=table, tplname=tplname)
+            return data['compiled']
+        page.loadTemplate = loadTemplate
+        return TableTemplateToHtml(page=page, table=self.tblobj, record_template='homepage')
+
+    def pdfText(self, pdfpath):
+        fitz = pytest.importorskip('fitz')
+        with fitz.open(pdfpath) as doc:
+            return '\n'.join(page.get_text() for page in doc)
+
+    def test_a_string_pdf_is_the_output_path(self, tmp_path):
+        pytest.importorskip('weasyprint')
+        target = str(tmp_path / 'badge.pdf')
+        script = self.buildScript()
+        assert script(record=self.pkey, pdf=target) == target
+        assert os.path.getsize(target) > 0
+        assert 'tpluser' in self.pdfText(target)
+
+    def test_pdf_true_still_writes_beside_the_html(self):
+        pytest.importorskip('weasyprint')
+        script = self.buildScript()
+        result = script(record=self.pkey, pdf=True)
+        assert result == script.filepath.replace('.html', '.pdf')
+        assert os.path.getsize(result) > 0
+
+    def test_no_pdf_returns_the_html(self):
+        script = self.buildScript()
+        result = script(record=self.pkey)
+        assert result.startswith('<!DOCTYPE html')
+        assert 'tpluser' in result


### PR DESCRIPTION
## Problem / Root cause

`TableTemplateToHtml.__call__` guarded the same `pdf` argument twice with
different predicates:

```python
if pdf :                 # truthy: a string passes
    filepath = filepath or self.getHtmlPath(f'{self.getDocName()}.html')
result = super(TableTemplateToHtml, self).__call__(...)
if pdf is True:          # identity: a string fails
    return self.writePdf()
return result
```

A string path therefore passed the first guard (the html was written as if a
PDF were coming) and failed the second, so `writePdf()` never ran:
`script(record=pkey, pdf='/tmp/badge.pdf')` returned the rendered HTML string,
wrote nothing at the requested path and raised nothing.

The sibling base class `TableScriptToHtml.__call__` already gives a string
`pdf` the meaning of an output path (`callingPdfPath = pdf if isinstance(pdf,str) else None`,
forwarded as `pdfpath` to `writePdf`), so the two table-script base classes
disagreed on the same argument.

## Change

One method, `gnrpy/gnr/web/gnrbaseclasses.py` `TableTemplateToHtml.__call__`:
copy-adapt the `TableScriptToHtml` idiom — keep the string as `callingPdfPath`
and make the second guard `if pdf: return self.writePdf(pdfpath=callingPdfPath)`.
`BagToHtmlWeb.writePdf` already honours an explicit `pdfpath`, so neither
`writePdf` nor `getPdfPath` needed a change.

Behaviour: a string `pdf` is written at the requested path and returned;
`pdf=True` still writes the PDF beside the html and returns its path;
`pdf=None` still returns the html.

Tests in `gnrpy/tests/web/gnrbaseclasses_test.py` (`TestTableTemplatePdfPath`),
following the `TestTableScriptOutputName` pattern: `BaseGnrTest` + `GnrApp` +
a real `GnrDummySite` over the `gnrtest` instance, a real `adm.user` record and
the real `homepage` template resource, `page.loadTemplate` stubbed to
`page.templateFromResource` (the #1165 sqlite workaround, `adm.userobject` is
empty on the test instance). The PDF is rendered by the real htmltopdf service
and read back with pymupdf to check the record's own content is in it; the two
PDF cases carry the `weasyprint`/`pymupdf` `importorskip` guard of
`gnrpy/tests/core/htmltopdf_test.py`.

## Verification

Run in this session, from `gnrpy/`, with `PYTHONPATH` pointing at this
worktree (asserted by `test_module_under_test`):

- Narrow gate: `python3 -m pytest tests/web/gnrbaseclasses_test.py tests/web/gnrtablescript_test.py tests/web/gnrtablescript_new_test.py -q` — **12 passed**. weasyprint and pymupdf are both installed on this machine, so **the two PDF cases actually ran, they were not skipped**.
- Regression proof: with the fix reverted and the new tests in place, `test_a_string_pdf_is_the_output_path` fails (**1 failed, 11 passed**) — it returns the HTML instead of the path.
- `python3 -m pytest core web app xtnd -q` from `gnrpy/tests` — **1233 passed**.
- `python3 -m pytest tests/ -q --ignore=tests/sql` — 1288 passed, 1 failed: `tests/web/gnrasync_test.py::test_wsproxy_push` (TimeoutError), which passes on its own (`7 passed`) and is unrelated to this change.
- `flake8 gnrpy/gnr/web/gnrbaseclasses.py gnrpy/tests/web/gnrbaseclasses_test.py` — zero errors.
- `tests/sql` was not run: `testing.postgresql` cannot boot on this machine right now (`shmget: No space left on device`). Nothing in this change touches SQL.

## Note for #1045

PR #1045 (`feat/123-generic-template-print-resource`) rewrites this same
`__call__`, so it will need a small adjacent-line rebase on top of this.

## Related issue

Fixes #1264
