### PR TITLE
Add an opt-in fetch transport for asynchronous Dojo requests

### DIFF
--- a/docs/development/dojo-xhr-patch.md
+++ b/docs/development/dojo-xhr-patch.md
@@ -75,7 +75,8 @@ Dojo 1.1 builds. Reloading starts again with original Dojo.
 
 Coverage includes methods and raw bodies, parameter encoding, request and
 response headers, XML attributes, callback order/context, chained Deferreds,
-HTTP and parse errors, recovery, cancellation, timeout, synchronous calls,
+HTTP and parse errors, XML without Content-Type, malformed XML, recovery,
+cancellation, timeout, synchronous calls,
 form serialization, cookies, fallback routing and fetch network failure.
 An explicit assertion verifies that fetch does not enter `dojo._ioWatch`.
 
@@ -114,3 +115,29 @@ The two CSV failures (`test_getCsvDialect_limited_lines` and
 `test_CsvReader_auto_dialect`) also reproduce in isolation without importing
 the modified webpage module. This run does not establish a green full suite.
 Real form/TableHandler validation and the broader benchmark remain pending.
+
+## XML compatibility and instance validation, 2026-09-09
+
+Responses without Content-Type now use XHR's XML default. Explicit text/plain
+responses still have no responseXML. Malformed XML is recognized with both
+the Mozilla and XHTML parser-error namespaces used by browser engines.
+The added contract check first reproduced both regressions, then passed
+after the corrections. The updated suite passed 20 checks on each bundled
+Dojo build in the integrated browser, and on the compact build in Chrome.
+
+The `/test/datastore/dojo_xhr` testhandler page exercises real application
+RPC, the returned Dojo Deferred, callback chaining, Bag results, datachanges,
+error recovery and a province TableHandler. Run it against a disposable
+instance with the transport option enabled. Set the site's `wsgi.debug` to
+`false` to exercise application error callbacks; debug mode can re-raise
+the deliberate exception as HTTP 500.
+
+Validation on the isolated `sandboxpg_fetchmode` PostgreSQL instance passed
+the RPC and datachange checks, HTTP and application error recovery, resource
+loading, and form load/save. A province name was changed through the form,
+verified directly in PostgreSQL, and restored through the form. The runtime
+used Python and JavaScript from the feature worktree. Four Python bootstrap
+and webpage tests passed. After rebasing onto current develop, the full Python
+suite passed with 2,509 passed and 10 skipped (Python 3.13). The compact browser
+contract and application RPC/error-recovery checks also passed after the rebase.
+Broader latency/concurrency measurements remain pending.

--- a/docs/development/dojo-xhr-patch.md
+++ b/docs/development/dojo-xhr-patch.md
@@ -1,0 +1,116 @@
+# Experimental Dojo HTTP transport
+
+The `dojo-xhr-patch` experiment replaces supported asynchronous Dojo HTTP
+requests with native fetch. It applies to `dojo.xhr`, `xhrGet`, `xhrPost`,
+`xhrPut`, `xhrDelete`, `rawXhrPost` and `rawXhrPut`, including callers outside
+`genro.rpc`. Fetch completes the existing Dojo Deferred directly, bypassing
+the legacy 50 ms completion polling interval.
+
+## Configuration and rollback
+
+Add this child to the instance's `instanceconfig.xml`:
+
+```xml
+<experimental-features dojo-xhr-patch="fetch"/>
+```
+
+Restart the instance to reload its configuration, then reload browser pages.
+The server supplies `dojoXhrPatch` at bootstrap; a page request parameter
+cannot override the instance setting. The patch is installed when the client
+is constructed, before application initialization. Requests made before that
+point continue to use the original transport.
+
+To roll back, remove the attribute (or the node if otherwise empty), restart
+the instance, and reload browser pages. Existing pages keep their installed
+transport until reloaded. Only the exact value `fetch` enables the patch;
+absent or other values leave Dojo unchanged.
+
+The patch lives in `genro_patch.js`, so no vendor bundle rebuild is required.
+Deploy the matching Python and JavaScript changes together and refresh any
+deployment-managed static caches.
+
+## Compatibility boundary
+
+Supported requests use same-origin HTTP(S) with existing parameter/form
+serialization, headers, cookies and the built-in Dojo text, JSON, XML and
+JavaScript response handlers. XML/Bag serialization and WebSocket transport
+are unchanged. The experiment targets the application's UTF-8 responses;
+fetch's text decoding does not reproduce XHR decoding for other charsets.
+
+Callbacks retain their context, ordering and transformations, including
+Deferred chaining and errback recovery. `ioArgs.xhr` provides response text,
+XML, status, status text, ready state, response-header access and abort. It is
+an adapter, not an `XMLHttpRequest` instance, and does not implement XHR event
+listeners or intermediate progress events. Callers that directly attach XHR
+listeners after obtaining the Deferred require a separate compatibility
+assessment before enabling the experiment for their instance.
+
+Requests with `sync`, explicit username/password authentication, non-text
+`responseType`, progress/upload options, iframe proxy options, file-input
+forms or nonstandard response handlers retain the original transport.
+Cross-origin and non-HTTP URLs also retain it. Browsers missing the required
+fetch, abort, headers, URL or XML parser APIs do not install the patch.
+Separate iframe/script transports and direct `XMLHttpRequest` calls are
+unaffected. The supported generic methods are GET, POST, PUT, DELETE, PATCH
+and HEAD; other methods retain the original transport.
+
+Timeouts cover response-body consumption as well as receiving headers.
+Cancellation, timeout and completion settle the request once and release
+the timer and pending-request entry. `dojo._ioCancelAll()` covers both
+original requests and fetch requests. Failed fetch requests are never
+automatically retried through XHR, avoiding duplicate writes.
+
+## Reproducible browser checks
+
+From the repository root:
+
+```sh
+python gnrjs/tests/dojo_xhr_server.py
+```
+
+Open `http://127.0.0.1:8765/gnrjs/tests/dojo_xhr.html`. The page runs the same
+contract checks against original Dojo and patched Dojo using real HTTP
+requests. Add `?build=source` or `?build=release` to exercise the other bundled
+Dojo 1.1 builds. Reloading starts again with original Dojo.
+
+Coverage includes methods and raw bodies, parameter encoding, request and
+response headers, XML attributes, callback order/context, chained Deferreds,
+HTTP and parse errors, recovery, cancellation, timeout, synchronous calls,
+form serialization, cookies, fallback routing and fetch network failure.
+An explicit assertion verifies that fetch does not enter `dojo._ioWatch`.
+
+The page also reports a local smoke benchmark: 12 warm-up requests followed
+by 50 sequential calls per transport, client p50/p95 and median server time
+from `X-GnrTime`. The original transport runs first, followed by fetch. This
+fixture demonstrates completion latency; it is not an application throughput
+benchmark or evidence of a general application speedup.
+
+Before broad adoption, run a real form/TableHandler flow with error and
+recovery, datachanges and resource loading. Extend measurement to alternating
+transport rounds, WSK, representative payload sizes, serialization time and
+controlled latency/concurrency. TYTX/NBag integration remains separate work
+under issues #1274 and #329; this first transport experiment does not enable
+or implement that codec.
+
+## First validation, 2026-09-09
+
+The browser contract passed on the compact, source and release Dojo 1.1
+builds. The final compact-build run passed 18 checks, including the added
+response-body timeout check. Its 50-call smoke benchmark reported:
+
+| Transport | Client p50 | Client p95 | Server p50 |
+| --- | ---: | ---: | ---: |
+| Original Dojo | 51.60 ms | 52.00 ms | 0.11 ms |
+| Dojo with fetch | 1.10 ms | 5.30 ms | 0.05 ms |
+
+Three configuration tests and the existing webpage regression test passed.
+JavaScript syntax checks and the Python lint selection used by CI passed;
+new Python files also passed the default flake8 checks.
+
+The full Python suite reported 1,564 passed, 86 skipped, 759 setup errors and
+two failures. PostgreSQL initialization encountered exhausted system shared
+memory resources (`shmget: No space left on device`, not disk exhaustion).
+The two CSV failures (`test_getCsvDialect_limited_lines` and
+`test_CsvReader_auto_dialect`) also reproduce in isolation without importing
+the modified webpage module. This run does not establish a green full suite.
+Real form/TableHandler validation and the broader benchmark remain pending.

--- a/gnrjs/gnr_d11/js/genro.js
+++ b/gnrjs/gnr_d11/js/genro.js
@@ -61,6 +61,7 @@ dojo.declare('gnr.GenroClient', null, {
         this.domRootName = kwargs.domRootName || 'mainWindow';
         this.page_id = kwargs.page_id;
         this.startArgs = kwargs.startArgs || {};
+        genropatches.dojoXhr(this.startArgs.dojoXhrPatch);
         this.debuglevel = kwargs.startArgs.debug || null;
         this.debug_sql = kwargs.startArgs.debug_sql;
         dojo.subscribe('gnrServerLog', this, 'serverLog');

--- a/gnrjs/gnr_d11/js/genro_patch.js
+++ b/gnrjs/gnr_d11/js/genro_patch.js
@@ -1,6 +1,181 @@
 
 
 var genropatches = {};
+genropatches.dojoXhr = function(transport){
+    if(transport !== 'fetch' || genropatches.dojoXhr.installed ||
+            !window.fetch || !window.AbortController || !window.DOMParser ||
+            !window.URL || !window.Headers){
+        return;
+    }
+    var original = {xhr: dojo.xhr, rawXhrPost: dojo.rawXhrPost,
+                    rawXhrPut: dojo.rawXhrPut, cancelAll: dojo._ioCancelAll};
+    var pending = new Set();
+    var handlers = ['text', 'json', 'xml', 'javascript',
+                    'json-comment-filtered', 'json-comment-optional'];
+
+    function supported(args){
+        if(args.sync || args.user || args.password || args.responseType ||
+                args.onprogress || args.upload || args.iframeProxyUrl ||
+                handlers.indexOf(args.handleAs || 'text') < 0){
+            return false;
+        }
+        var form = args.form && dojo.byId(args.form);
+        if(form && form.querySelector('input[type="file"]')){
+            return false;
+        }
+        try{
+            var url = new URL(args.url || (form && form.getAttribute('action')),
+                              document.baseURI);
+            return /^https?:$/.test(url.protocol) && !url.username && !url.password &&
+                   url.origin === window.location.origin;
+        }catch(error){
+            return false;
+        }
+    }
+
+    function request(method, args, hasBody, rawField){
+        var controller = new AbortController();
+        var finished = false;
+        var timer;
+        var responseHeaders;
+        function cleanup(){
+            finished = true;
+            clearTimeout(timer);
+            pending.delete(dfd);
+        }
+        var dfd = dojo._ioSetArgs(args, function(deferred){
+            deferred.canceled = true;
+            cleanup();
+            controller.abort();
+            xhr.readyState = 0;
+            xhr.status = 0;
+            xhr.statusText = '';
+            responseHeaders = null;
+            var error = new Error('xhr cancelled');
+            error.dojoType = 'cancel';
+            return error;
+        }, function(deferred){
+            return dojo._contentHandlers[deferred.ioArgs.handleAs](xhr);
+        }, function(error){
+            return error;
+        });
+        var ioArgs = dfd.ioArgs;
+        // Preserve the response surface used by Dojo handlers and RPC bookkeeping.
+        var xhr = ioArgs.xhr = {
+            readyState: 1, status: 0, statusText: '', responseText: '', responseXML: null,
+            getResponseHeader: function(name){
+                return responseHeaders ? responseHeaders.get(name) : null;
+            },
+            getAllResponseHeaders: function(){
+                var result = '';
+                if(responseHeaders){
+                    responseHeaders.forEach(function(value, name){
+                        result += name + ': ' + value + '\r\n';
+                    });
+                }
+                return result;
+            },
+            abort: function(){ dfd.cancel(); }
+        };
+        function fail(error){
+            if(finished){ return; }
+            if(!error.status){
+                xhr.readyState = 4;
+                xhr.status = 0;
+                xhr.statusText = '';
+                responseHeaders = null;
+            }
+            cleanup();
+            dfd.errback(error);
+        }
+        if(rawField){
+            if(rawField === 'postData' || args.putData){
+                ioArgs.query = args[rawField];
+            }
+            if(rawField === 'putData' && args.putData){
+                args.putData = null;
+            }
+        }else if(!hasBody){
+            dojo._ioAddQueryToUrl(ioArgs);
+        }
+        pending.add(dfd);
+        try{
+            var headers = new Headers(args.headers || {});
+            if(args.contentType || !headers.has('Content-Type')){
+                headers.set('Content-Type', args.contentType || 'application/x-www-form-urlencoded');
+            }
+            if(!headers.has('X-Requested-With')){
+                headers.set('X-Requested-With', 'XMLHttpRequest');
+            }
+            if(args.timeout){
+                dfd.startTime = Date.now();
+                timer = setTimeout(function(){
+                    if(finished){ return; }
+                    controller.abort();
+                    var error = new Error('timeout exceeded');
+                    error.dojoType = 'timeout';
+                    fail(error);
+                }, args.timeout);
+            }
+            window.fetch(ioArgs.url, {
+                method: method, headers: headers, body: hasBody ? ioArgs.query : null,
+                credentials: 'same-origin', signal: controller.signal
+            }).then(function(response){
+                if(finished){ return; }
+                xhr.status = response.status;
+                xhr.statusText = response.statusText;
+                xhr.readyState = 2;
+                responseHeaders = response.headers;
+                return response.text().then(function(text){
+                    if(finished){ return; }
+                    xhr.responseText = text;
+                    xhr.readyState = 4;
+                    if(/(?:\/|\+)xml(?:\s*;|$)/i.test(xhr.getResponseHeader('Content-Type') || '')){
+                        var xml = new DOMParser().parseFromString(text, 'application/xml');
+                        var parseErrors = xml.getElementsByTagNameNS(
+                            'http://www.mozilla.org/newlayout/xml/parsererror.xml', 'parsererror');
+                        xhr.responseXML = parseErrors.length ? null : xml;
+                    }
+                    if(!dojo._isDocumentOk(xhr)){
+                        var error = new Error('Unable to load ' + ioArgs.url + ' status:' + xhr.status);
+                        error.status = xhr.status;
+                        error.responseText = text;
+                        fail(error);
+                        return;
+                    }
+                    cleanup();
+                    dfd.callback(dfd);
+                });
+            }).catch(fail);
+        }catch(error){
+            // Keep setup failures asynchronous, like other fetch failures.
+            Promise.resolve().then(function(){ fail(error); });
+        }
+        return dfd;
+    }
+
+    dojo.xhr = function(method, args, hasBody){
+        if(!supported(args) || (hasBody && (method === 'GET' || method === 'HEAD')) ||
+                ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD'].indexOf(method) < 0){
+            return original.xhr.apply(dojo, arguments);
+        }
+        return request(method, args, hasBody);
+    };
+    dojo.rawXhrPost = function(args){
+        return supported(args) ? request('POST', args, true, 'postData') :
+                                original.rawXhrPost.apply(dojo, arguments);
+    };
+    dojo.rawXhrPut = function(args){
+        return supported(args) ? request('PUT', args, true, 'putData') :
+                                original.rawXhrPut.apply(dojo, arguments);
+    };
+    dojo._ioCancelAll = function(){
+        Array.from(pending).forEach(function(dfd){ dfd.cancel(); });
+        return original.cancelAll.apply(dojo, arguments);
+    };
+    genropatches.dojoXhr.installed = true;
+};
+
 genropatches.places = function(){
     var placeOnScreenAroundElement = dijit.placeOnScreenAroundElement;
     dijit.placeOnScreenAroundElement = function(

--- a/gnrjs/gnr_d11/js/genro_patch.js
+++ b/gnrjs/gnr_d11/js/genro_patch.js
@@ -130,11 +130,12 @@ genropatches.dojoXhr = function(transport){
                     if(finished){ return; }
                     xhr.responseText = text;
                     xhr.readyState = 4;
-                    if(/(?:\/|\+)xml(?:\s*;|$)/i.test(xhr.getResponseHeader('Content-Type') || '')){
+                    if(/(?:\/|\+)xml(?:\s*;|$)/i.test(xhr.getResponseHeader('Content-Type') || 'text/xml')){
                         var xml = new DOMParser().parseFromString(text, 'application/xml');
                         var parseErrors = xml.getElementsByTagNameNS(
-                            'http://www.mozilla.org/newlayout/xml/parsererror.xml', 'parsererror');
-                        xhr.responseXML = parseErrors.length ? null : xml;
+                            'http://www.mozilla.org/newlayout/xml/parsererror.xml', 'parsererror').length ||
+                            xml.getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'parsererror').length;
+                        xhr.responseXML = parseErrors ? null : xml;
                     }
                     if(!dojo._isDocumentOk(xhr)){
                         var error = new Error('Unable to load ' + ioArgs.url + ' status:' + xhr.status);

--- a/gnrjs/tests/dojo_xhr.html
+++ b/gnrjs/tests/dojo_xhr.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Dojo HTTP transport contract</title>
+<script>var djConfig = {isDebug: false, usePlainJson: true};</script>
+<script>
+var builds = {compact: 'dojo', source: 'dojo_src', release: 'dojo_release'};
+var build = builds[new URLSearchParams(location.search).get('build')] || 'dojo';
+document.write('<script src="/dojo_libs/dojo_11/' + build + '/dojo/dojo.js"><\/script>');
+</script>
+<script src="/gnrjs/gnr_d11/js/genro_patch.js"></script>
+<h1>Dojo HTTP transport contract</h1>
+<p>Real HTTP requests using the bundled Dojo runtime. Reload to repeat.</p>
+<pre id="results">Running...</pre>
+<script src="dojo_xhr_test.js"></script>
+</html>

--- a/gnrjs/tests/dojo_xhr_server.py
+++ b/gnrjs/tests/dojo_xhr_server.py
@@ -1,0 +1,71 @@
+"""Serve the browser transport contract tests against real HTTP endpoints.
+
+Run from the repository root: python gnrjs/tests/dojo_xhr_server.py
+Open http://127.0.0.1:8765/gnrjs/tests/dojo_xhr.html
+"""
+
+import json
+import time
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(ROOT), **kwargs)
+
+    def do_GET(self):
+        parsed = urlsplit(self.path)
+        if not parsed.path.startswith('/transport-test/'):
+            if parsed.path.startswith(('/gnrjs/', '/dojo_libs/')):
+                return super().do_GET()
+            self.send_error(404)
+            return
+        started = time.perf_counter()
+        query = parse_qs(parsed.query)
+        delay = min(float(query.get('delay', ['0'])[0]), 2)
+        time.sleep(delay)
+        body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
+        status = int(query.get('status', ['200'])[0])
+        content_type = 'application/json'
+        result = json.dumps(dict(
+            method=self.command, query=query, body=body.decode(),
+            headers=dict(self.headers))).encode()
+        if parsed.path.endswith('/xml'):
+            content_type = 'application/xml'
+            result = b'<GenRoBag><result answer="yes">hello</result></GenRoBag>'
+        elif parsed.path.endswith('/invalid-json'):
+            result = b'{broken'
+        elif parsed.path.endswith('/close'):
+            self.close_connection = True
+            self.connection.close()
+            return
+        self.send_response(status)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Content-Length', str(len(result)))
+        self.send_header('X-GnrTime', str(time.perf_counter() - started))
+        self.end_headers()
+        if parsed.path.endswith('/slow-body'):
+            self.wfile.flush()
+            time.sleep(0.12)
+        try:
+            self.wfile.write(result)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    do_POST = do_GET
+    do_PUT = do_GET
+    do_DELETE = do_GET
+    do_PATCH = do_GET
+
+    def log_message(self, format, *args):
+        pass
+
+
+if __name__ == '__main__':
+    print('Open http://127.0.0.1:8765/gnrjs/tests/dojo_xhr.html', flush=True)
+    ThreadingHTTPServer(('127.0.0.1', 8765), Handler).serve_forever()

--- a/gnrjs/tests/dojo_xhr_server.py
+++ b/gnrjs/tests/dojo_xhr_server.py
@@ -35,9 +35,16 @@ class Handler(SimpleHTTPRequestHandler):
         result = json.dumps(dict(
             method=self.command, query=query, body=body.decode(),
             headers=dict(self.headers))).encode()
-        if parsed.path.endswith('/xml'):
+        if parsed.path.endswith(('/xml', '/xml-no-content-type',
+                                 '/xml-invalid', '/xml-text')):
             content_type = 'application/xml'
             result = b'<GenRoBag><result answer="yes">hello</result></GenRoBag>'
+            if parsed.path.endswith('/xml-no-content-type'):
+                content_type = None
+            elif parsed.path.endswith('/xml-invalid'):
+                result = b'<GenRoBag><result></GenRoBag>'
+            elif parsed.path.endswith('/xml-text'):
+                content_type = 'text/plain'
         elif parsed.path.endswith('/invalid-json'):
             result = b'{broken'
         elif parsed.path.endswith('/close'):
@@ -45,7 +52,8 @@ class Handler(SimpleHTTPRequestHandler):
             self.connection.close()
             return
         self.send_response(status)
-        self.send_header('Content-Type', content_type)
+        if content_type:
+            self.send_header('Content-Type', content_type)
         self.send_header('Content-Length', str(len(result)))
         self.send_header('X-GnrTime', str(time.perf_counter() - started))
         self.end_headers()

--- a/gnrjs/tests/dojo_xhr_test.js
+++ b/gnrjs/tests/dojo_xhr_test.js
@@ -64,6 +64,19 @@
             assert(await wait(dfd) === 42, 'Transformed result');
             assert(order.join(',') === 'load,handle,callback', 'Callback ordering');
         });
+        await test(transport + ': XML MIME defaults and invalid documents', async function(){
+            for(const name of ['xml', 'xml-no-content-type', 'xml-invalid', 'xml-text']){
+                const dfd = dojo.xhrGet({url: '/transport-test/' + name, handleAs: 'xml'});
+                assert(dfd instanceof dojo.Deferred, 'XML request returns a Dojo Deferred');
+                const xml = await wait(dfd);
+                if(name === 'xml' || name === 'xml-no-content-type'){
+                    assert(xml && xml.documentElement.nodeName === 'GenRoBag', name + ' XML document');
+                }else{
+                    assert(xml === null, name + ' has no XML document: ' +
+                        (xml && xml.documentElement.outerHTML));
+                }
+            }
+        });
         await test(transport + ': empty raw PUT retains legacy content and Deferred chaining', async function(){
             const dfd = dojo.rawXhrPut({url: endpoint, handleAs: 'json', putData: '',
                 content: {value: 'preserved'}});

--- a/gnrjs/tests/dojo_xhr_test.js
+++ b/gnrjs/tests/dojo_xhr_test.js
@@ -1,0 +1,189 @@
+/* Browser contract tests: real Dojo, native fetch/XHR and a local HTTP server. */
+(async function(){
+    const output = document.getElementById('results');
+    const lines = [];
+    function assert(value, message){
+        if(!value){ throw new Error(message); }
+    }
+    function report(message){
+        lines.push(message);
+        output.textContent = lines.join('\n');
+    }
+    function wait(dfd){
+        return new Promise(function(resolve, reject){
+            dfd.addCallbacks(function(value){ resolve(value); return value; },
+                             function(error){ reject(error); return error; });
+        });
+    }
+    const pause = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const endpoint = '/transport-test/echo';
+    async function test(name, run){
+        await run();
+        report('PASS ' + name);
+    }
+    async function contract(transport){
+        await test(transport + ': methods, encoding, raw bodies and headers', async function(){
+            for(const name of ['xhrGet', 'xhrPost', 'xhrPut', 'xhrDelete', 'rawXhrPost', 'rawXhrPut']){
+                const args = {url: endpoint, handleAs: 'json',
+                    content: {text: 'caffè & tea', multi: ['a', 'b']},
+                    headers: {'X-Test': 'transport'}, preventCache: true,
+                    postData: 'raw=post&untouched', putData: 'raw=put&untouched'};
+                const dfd = dojo[name](args);
+                assert(dfd instanceof dojo.Deferred, 'Real Deferred required');
+                const result = await wait(dfd);
+                const expected = name.includes('Get') ? 'GET' : name.includes('Delete') ? 'DELETE' :
+                                 name.includes('Put') ? 'PUT' : 'POST';
+                assert(result.method === expected, name + ' method');
+                const headers = Object.fromEntries(Object.entries(result.headers).map(([k, v]) => [k.toLowerCase(), v]));
+                assert(headers['x-test'] === 'transport', 'Custom header');
+                assert(headers['x-requested-with'] === 'XMLHttpRequest', 'Legacy request header');
+                if(name.startsWith('raw')){
+                    assert(result.body === (name === 'rawXhrPost' ? 'raw=post&untouched' : 'raw=put&untouched'), 'Raw body');
+                }else{
+                    const params = ['GET', 'DELETE'].includes(expected) ? result.query :
+                        Object.fromEntries(new URLSearchParams(result.body));
+                    assert(String(params.text) === 'caffè & tea', 'Parameter encoding');
+                    assert(params['dojo.preventCache'], 'Cache prevention');
+                }
+                assert(dfd.ioArgs.xhr.getResponseHeader('X-GnrTime') !== null, 'Timing header');
+                assert(dfd.ioArgs.xhr.getAllResponseHeaders().toLowerCase().includes('x-gnrtime:'), 'All headers');
+            }
+        });
+        await test(transport + ': XML and callback transformation', async function(){
+            const order = [];
+            const args = {url: '/transport-test/xml', handleAs: 'xml',
+                load: function(xml, io){
+                    assert(this === args && io.args === args, 'Callback context');
+                    assert(xml.documentElement.nodeName === 'GenRoBag', 'XML document');
+                    assert(xml.getElementsByTagName('result')[0].getAttribute('answer') === 'yes', 'XML attributes');
+                    order.push('load');
+                    return 40;
+                }, handle: function(value){ order.push('handle'); return value + 1; }};
+            const dfd = dojo.xhrGet(args);
+            dfd.addCallback(function(value){ order.push('callback'); return value + 1; });
+            assert(await wait(dfd) === 42, 'Transformed result');
+            assert(order.join(',') === 'load,handle,callback', 'Callback ordering');
+        });
+        await test(transport + ': empty raw PUT retains legacy content and Deferred chaining', async function(){
+            const dfd = dojo.rawXhrPut({url: endpoint, handleAs: 'json', putData: '',
+                content: {value: 'preserved'}});
+            dfd.addCallback(function(result){
+                assert(result.body === 'value=preserved', 'Empty raw PUT body');
+                return dojo.xhrGet({url: endpoint, handleAs: 'text'});
+            });
+            assert(JSON.parse(await wait(dfd)).method === 'GET', 'Returned Deferred is awaited');
+        });
+        await test(transport + ': HTTP error, parser error and recovery', async function(){
+            let recovered = false;
+            const dfd = dojo.xhrGet({url: endpoint + '?status=500', handleAs: 'json',
+                error: function(error, io){
+                    assert(error.status === 500 && io.xhr.status === 500, 'HTTP status');
+                    assert(error.responseText.includes('GET'), 'Error response');
+                    recovered = true;
+                    return 'recovered';
+                }});
+            assert(await wait(dfd) === 'recovered' && recovered, 'Errback recovery');
+            try{
+                await wait(dojo.xhrGet({url: '/transport-test/invalid-json', handleAs: 'json'}));
+                throw new Error('Parser must reject');
+            }catch(error){ assert(error instanceof SyntaxError, 'JSON parse error'); }
+            assert((await wait(dojo.xhrGet({url: endpoint, handleAs: 'json'}))).method === 'GET', 'Recovery request');
+        });
+        await test(transport + ': timeout and cancellation complete once', async function(){
+            for(const mode of ['timeout', 'cancel', 'abort', 'all']){
+                let completions = 0;
+                const dfd = dojo.xhrGet({url: endpoint + '?delay=0.12', handleAs: 'json',
+                    timeout: mode === 'timeout' ? 15 : 0,
+                    handle: function(value){ completions++; return value; }});
+                const result = wait(dfd).catch(error => error);
+                if(mode === 'cancel'){ dfd.cancel(); }
+                if(mode === 'abort'){ dfd.ioArgs.xhr.abort(); }
+                if(mode === 'all'){ dojo._ioCancelAll(); }
+                // Direct native XHR.abort() does not complete the legacy Deferred.
+                if(mode === 'abort' && transport === 'legacy'){ dfd.cancel(); }
+                const error = await result;
+                assert(error.dojoType === (mode === 'timeout' ? 'timeout' : 'cancel'), mode + ' classification');
+                await pause(150);
+                assert(completions === 1, mode + ' completed once');
+            }
+        });
+        await test(transport + ': synchronous calls retain native XHR', function(){
+            let value;
+            const dfd = dojo.xhrGet({url: endpoint, sync: true, handleAs: 'json',
+                load: function(result){ value = result; }});
+            assert(value.method === 'GET', 'Synchronous callback');
+            assert(dfd.ioArgs.xhr instanceof XMLHttpRequest, 'Native synchronous XHR');
+        });
+        await test(transport + ': timeout while reading response body', async function(){
+            const dfd = dojo.xhrGet({url: '/transport-test/slow-body', timeout: 30});
+            const error = await wait(dfd).catch(error => error);
+            assert(error.dojoType === 'timeout', 'Timeout covers body consumption');
+        });
+        await test(transport + ': form fields and same-origin cookies', async function(){
+            document.cookie = 'dojo_transport_test=present; path=/; SameSite=Lax';
+            const form = document.createElement('form');
+            form.action = endpoint;
+            form.innerHTML = '<input name="field" value="from form">';
+            document.body.appendChild(form);
+            try{
+                const result = await wait(dojo.xhrPost({form: form, handleAs: 'json'}));
+                assert(new URLSearchParams(result.body).get('field') === 'from form', 'Form serialization');
+                const headers = Object.fromEntries(Object.entries(result.headers).map(([k, v]) => [k.toLowerCase(), v]));
+                assert(headers.cookie.includes('dojo_transport_test=present'), 'Session cookie');
+            }finally{
+                form.remove();
+                document.cookie = 'dojo_transport_test=; Max-Age=0; path=/';
+            }
+        });
+    }
+    async function benchmark(){
+        for(let i = 0; i < 12; i++){
+            await wait(dojo.xhrGet({url: endpoint, handleAs: 'json', preventCache: true}));
+        }
+        const client = [], server = [];
+        for(let i = 0; i < 50; i++){
+            const start = performance.now();
+            const dfd = dojo.xhrGet({url: endpoint, handleAs: 'json', preventCache: true});
+            await wait(dfd);
+            client.push(performance.now() - start);
+            server.push(Number(dfd.ioArgs.xhr.getResponseHeader('X-GnrTime')) * 1000);
+        }
+        const percentile = (values, p) => values.sort((a, b) => a - b)[Math.ceil(values.length * p) - 1].toFixed(2);
+        return {calls: 50, client_p50_ms: percentile(client, 0.5), client_p95_ms: percentile(client, 0.95),
+                server_p50_ms: percentile(server, 0.5)};
+    }
+    try{
+        const original = dojo.xhr;
+        genropatches.dojoXhr();
+        genropatches.dojoXhr('disabled');
+        assert(dojo.xhr === original, 'Disabled configuration leaves Dojo unchanged');
+        await contract('legacy');
+        const legacy = await benchmark();
+        genropatches.dojoXhr('fetch');
+        assert(dojo.xhr !== original, 'Patch installed');
+        const patched = dojo.xhr;
+        genropatches.dojoXhr('fetch');
+        assert(dojo.xhr === patched, 'Idempotent installation');
+        await contract('fetch');
+        await test('fetch: async completion bypasses polling', async function(){
+            const watch = dojo._ioWatch;
+            let watched = 0;
+            dojo._ioWatch = function(){ watched++; return watch.apply(dojo, arguments); };
+            try{
+                await wait(dojo.xhrGet({url: endpoint, handleAs: 'json'}));
+                assert(watched === 0, 'No polling for fetch');
+                await wait(dojo.xhrGet({url: endpoint, handleAs: 'json', onprogress: function(){}}));
+                assert(watched === 1, 'Unsupported options use original transport');
+            }finally{ dojo._ioWatch = watch; }
+        });
+        await test('fetch: network failure completes the Deferred', async function(){
+            const error = await wait(dojo.xhrGet({url: '/transport-test/close'})).catch(error => error);
+            assert(error instanceof Error, 'Network failure');
+        });
+        const fetched = await benchmark();
+        report('BENCHMARK ' + JSON.stringify({legacy: legacy, fetch: fetched}, null, 2));
+        report('ALL TESTS PASSED');
+    }catch(error){
+        report('FAIL ' + error.stack);
+    }
+})();

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -1345,6 +1345,8 @@ class GnrWebPage(GnrBaseWebPage):
         kwargs['servertime'] = datetime.datetime.now()
         kwargs['websockets_url'] = '/websocket' if self.wsk_enabled else None
         kwargs['websockets_endpoint'] = self.async_endpoint if self.wsk_enabled else None
+        kwargs['dojoXhrPatch'] = self.application.config.getItem(
+            'experimental-features?dojo-xhr-patch') or ''
         self.getPwaIntegration(arg_dict)
         self.getSquareLogoUrl(arg_dict)
         self.getCoverLogoUrl(arg_dict)

--- a/gnrpy/tests/web/test_dojo_xhr_config.py
+++ b/gnrpy/tests/web/test_dojo_xhr_config.py
@@ -1,0 +1,45 @@
+"""The instance configuration owns the HTTP transport bootstrap option."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrclasses import GnrClassCatalog
+from gnr.web.gnrwebpage import GnrWebPage
+
+
+@pytest.mark.parametrize('transport', [None, 'fetch', 'disabled'])
+def test_transport_bootstrap_uses_instance_configuration(transport):
+    config = Bag()
+    if transport:
+        config.setItem('experimental-features', None,
+                       _attributes={'dojo-xhr-patch': transport})
+    static = SimpleNamespace(url=lambda *args: '/static/')
+    page = SimpleNamespace(
+        application=SimpleNamespace(config=config),
+        site=SimpleNamespace(
+            storage=lambda name: static, debug=False, debugpy=False,
+            home_uri='/', compressedJsPath='/client.js', config=Bag()),
+        frontend=SimpleNamespace(
+            frontend_arg_dict=lambda args: None,
+            gnrjs_frontend=lambda: []),
+        catalog=GnrClassCatalog(), gnrjsversion='gnr_d11',
+        _htmlHeaders=[], charset='utf-8', pagename='test', page_id='test',
+        wsk_enabled=False, debug_sql=False, debug_py=False, isMobile=False,
+        isDeveloper=lambda: False, deviceScreenSize='desktop', extraFeatures={},
+        connection=SimpleNamespace(is_cordova=False, electron_static=False),
+        getPwaIntegration=lambda args: None,
+        getSquareLogoUrl=lambda args: None,
+        getCoverLogoUrl=lambda args: None,
+        getGoogleFonts=lambda args: None,
+        getSentryJs=lambda args: None,
+        get_bodyclasses=lambda: '', get_css_genro=lambda: {}, js_requires=[],
+        get_css_path=lambda: ([], {}))
+
+    # Request arguments must neither enable nor disable the instance switch.
+    supplied = 'disabled' if transport == 'fetch' else 'fetch'
+    result = GnrWebPage.build_arg_dict(page, dojoXhrPatch=supplied)
+    start_args = json.loads(result['startArgs'])
+    assert start_args['dojoXhrPatch'] == (transport or '')

--- a/projects/gnrcore/packages/test/webpages/datastore/dojo_xhr.py
+++ b/projects/gnrcore/packages/test/webpages/datastore/dojo_xhr.py
@@ -1,0 +1,56 @@
+"""Dojo HTTP transport integration."""
+
+from gnr.core.gnrbag import Bag
+from gnr.core.gnrdecorator import public_method
+from gnr.core.gnrlang import GnrException
+
+
+class GnrCustomWebPage(object):
+    py_requires = ('gnrcomponents/testhandler:TestHandlerFull,'
+                   'th/th:TableHandler')
+    maintable = 'glbl.provincia'
+
+    def test_0_deferred(self, pane):
+        """Check the active transport and the public Deferred contract."""
+        pane.button('Check Deferred', action="""
+            var dfd = genro.serverCall('transport_echo', {}, function(result){
+                genro.setData('transport.echo', result.getItem('message'));
+            });
+            SET .contract = dfd instanceof dojo.Deferred ? 'Dojo Deferred' : 'FAIL';
+            SET .transport = dfd.ioArgs.xhr instanceof XMLHttpRequest ? 'XHR' : 'fetch';
+            dfd.addCallback(function(result){
+                genro.setData('transport.chain', 'Callback chain completed');
+                return result;
+            });
+        """)
+        pane.div('^.contract')
+        pane.div('^.transport')
+        pane.div('^transport.echo')
+        pane.div('^transport.chain')
+        pane.div('^transport.datachange')
+
+    def test_1_recovery(self, pane):
+        """An expected RPC error must leave subsequent calls usable."""
+        pane.button('Expected RPC error').dataRpc(
+            '.result', self.transport_error,
+            _onError="SET .status = 'Expected RPC error received';")
+        pane.button('Recover with RPC').dataRpc(
+            '.result', self.transport_echo,
+            _onResult="SET .status = result.getItem('message');")
+        pane.div('^.status')
+
+    def test_2_tablehandler(self, pane):
+        """Load and save a province in the dedicated test database."""
+        pane.borderContainer(height='400px').contentPane(
+            region='center').dialogTableHandler(
+                table='glbl.provincia', view_store_onStart=True,
+                dialog_height='300px', dialog_width='450px')
+
+    @public_method
+    def transport_echo(self):
+        self.setInClientData('transport.datachange', 'Datachange received')
+        return Bag(dict(message='RPC completed'))
+
+    @public_method
+    def transport_error(self):
+        raise GnrException('Expected transport test error')


### PR DESCRIPTION
## Summary

Supported asynchronous Dojo HTTP requests currently wait for the legacy 50 ms completion polling loop. Add an instance-controlled fetch transport that completes the existing `dojo.Deferred` directly, preserving callback chaining, parameter serialization, XML/Bag responses and RPC bookkeeping.

Enable explicitly in `instanceconfig.xml`:

```xml
<experimental-features dojo-xhr-patch="fetch"/>
```

Absent or other values preserve the original transport. The switch wraps the shared Dojo HTTP entry points for the enabled instance, including supported callers outside `genro.rpc`. Synchronous, cross-origin and unsupported requests retain XHR. Fetch failures are never retried through XHR, avoiding duplicate writes. Remove the switch, restart the instance and reload pages to roll back.

`ioArgs.xhr` is a compatibility adapter, not a native XMLHttpRequest; XHR event/progress listeners are outside its supported surface. Preserve native XML behavior for missing Content-Type and malformed documents across browser parser-error namespaces.

Related to #1275: this implements the initial HTTP transport experiment. TYTX/NBag integration (#1274, #329), broader network/concurrency measurements and any default change remain separate work. The parent issue remains open for those acceptance criteria.

## Validation

- Rebased onto current `develop` before final validation.
- Full Python suite: **2,509 passed, 10 skipped**, Python 3.13; temporary PostgreSQL test databases.
- Configured flake8 checks pass on all changed Python files; new Python files also pass default flake8. JavaScript syntax and `git diff --check` pass.
- Real HTTP contract: **20 checks per bundled Dojo build** (compact/source/release) in the integrated browser; compact also passed in Chrome. The new XML test reproduced both regressions before their fixes.
- Verified methods, encoding, raw bodies, headers/cookies, real Dojo Deferred type, callbacks/chaining, HTTP/parse errors, recovery, timeout through body consumption, cancellation, fallback and bypass of `_ioWatch`.
- Dedicated **sandboxpg_fetchmode** instance/database, fetch enabled and Python/static resources resolved from the feature worktree. Verified RPC, Bag results, callback chaining, datachanges, resource loading, HTTP/application error recovery and a TableHandler form save. Confirmed the changed province name directly in PostgreSQL, then restored it through the form and verified restoration.
- Compact contract and application RPC/error recovery repeated successfully after rebase.

Reproduce the transport contract with `python gnrjs/tests/dojo_xhr_server.py`, then open `/gnrjs/tests/dojo_xhr.html` on port 8765. The application testhandler is `/test/datastore/dojo_xhr`; use a disposable instance/database. Configuration and compatibility details are in `docs/development/dojo-xhr-patch.md`.

## Local benchmarks

Measured on 2026-09-09 using the real HTTP fixture, 12 warm-up requests followed by 50 sequential requests per transport. Original Dojo runs first, fetch second. Server time is read from `X-GnrTime`; all values are milliseconds.

| Browser / build | Transport | Client p50 | Client p95 | Server p50 |
| --- | --- | ---: | ---: | ---: |
| Chrome / compact | Original Dojo | 52.00 | 52.50 | 0.19 |
| Chrome / compact | Fetch | 3.90 | 5.70 | 0.13 |
| Integrated browser / compact, after rebase | Original Dojo | 51.70 | 52.60 | 0.13 |
| Integrated browser / compact, after rebase | Fetch | 0.50 | 0.70 | 0.03 |

These measurements demonstrate removal of the local completion-polling delay, not equivalent application-wide speedups. The fixture is a lightweight local HTTP server, not the TableHandler workload. SQL, application logic, serialization cost, payload size, latency, concurrency and alternating transport rounds need separate measurement. No throughput claim is made.
