### PR TITLE
Opt-in WebSocket provider and client for the ASGI bridge

### DIFF
--- a/docs/development/websocket_provider.md
+++ b/docs/development/websocket_provider.md
@@ -1,0 +1,26 @@
+# Optional WebSocket provider
+
+Classic installations continue to use the existing WebSocket handler and client.
+Installing an alternative provider does not activate it. Selection is explicit:
+`GNR_WEBSOCKET_PROVIDER` must name a distribution or module exporting a
+`gnr.web` entry point called `websockethandler`.
+
+The provider must export a handler class with `checkSocket` and
+`sendCommandToPage`. An explicitly selected missing, ambiguous or invalid provider
+raises ImportError at import time rather than silently falling back. Set the
+variable before importing the site; provider selection is process-wide, not a
+per-request switch.
+
+A selected handler can declare `client_module`; this replaces the
+`gnrwebsocket` entry in the frontend's JavaScript imports. Without selection,
+the frontend imports are untouched. A selected handler without this attribute
+keeps the original client. Normal site WebSocket enablement is still required.
+
+The supplied `gnrwebsocket_asgi` client implements the initial genropy-asgi
+request/response contract: open an owned page channel, send correlated WSK calls,
+and process ordinary legacy XML/JSON RPC results. It requires the corresponding
+bridge adapter (genropy/genropy-asgi#22). It does not provide full gnrasync
+compatibility: unsolicited push, shared objects, automatic reconnection and
+cookie-changing authentication flows are outside this increment.
+
+The provider variable does not need to be set for ordinary WSGI deployments.

--- a/docs/development/websocket_provider.md
+++ b/docs/development/websocket_provider.md
@@ -1,9 +1,10 @@
 # Optional WebSocket provider
 
 Classic installations continue to use the existing WebSocket handler and client.
-Installing an alternative provider does not activate it. Selection is explicit:
-`GNR_WEBSOCKET_PROVIDER` must name a distribution or module exporting a
-`gnr.web` entry point called `websockethandler`.
+Installing an alternative provider does not activate it. Selection reuses
+`GNR_DAEMON_PROVIDER`, the existing daemon selector; there is no separate
+WebSocket switch. The selected provider also exports a `gnr.web` entry point
+called `websockethandler`. The bridge selects `genropy-asgi` for both interfaces.
 
 The provider must export a handler class with `checkSocket` and
 `sendCommandToPage`. An explicitly selected missing, ambiguous or invalid provider

--- a/gnrjs/gnr_d11/js/gnrwebsocket_asgi.js
+++ b/gnrjs/gnr_d11/js/gnrwebsocket_asgi.js
@@ -1,0 +1,150 @@
+/* WSX transport for ordinary ephemeral-page RPC calls. */
+dojo.declare('gnr.GnrWebSocketHandler', null, {
+    constructor: function(application, wsroot, options) {
+        this.application = application;
+        this.wsroot = wsroot;
+        this.pending = {};
+        this.counter = 0;
+        this.channelReady = null;
+        this.url = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') +
+                   window.location.host + (wsroot || '/websocket');
+    },
+
+    create: function() {
+        if (!this.wsroot || this.channelReady) { return; }
+        var that = this;
+        this.channelReady = new Promise(function(resolve, reject) {
+            that.socket = new WebSocket(that.url);
+            that.socket.onmessage = function(event) { that.onmessage(event); };
+            that.socket.onopen = function() {
+                that.request('/_wsx/openchannel', {parameters: {sequential: true}})
+                    .then(resolve, reject);
+            };
+            that.socket.onerror = function() { reject(new Error('WSX connection failed')); };
+            that.socket.onclose = function() {
+                var error = new Error('WSX connection closed');
+                reject(error);
+                Object.keys(that.pending).forEach(function(id) {
+                    clearTimeout(that.pending[id].timer);
+                    that.pending[id].reject(error);
+                });
+                that.pending = {};
+            };
+        });
+        // Bootstrap can open the channel before the first application call.
+        this.channelReady.catch(function(error) { console.error(error); });
+    },
+
+    request: function(path, payload) {
+        var that = this;
+        return new Promise(function(resolve, reject) {
+            var id = 'wsx_' + (++that.counter);
+            var timer = setTimeout(function() {
+                delete that.pending[id];
+                reject(new Error('WSX reply timeout'));
+            }, 15000);
+            that.pending[id] = {resolve: resolve, reject: reject, timer: timer};
+            try {
+                // Initial payloads use the JSON subset of TYTX transport.
+                that.socket.send('WSX://' + JSON.stringify({
+                    id: id, method: 'WSK', path: path,
+                    page_id: that.application.page_id,
+                    data: '"' + JSON.stringify(payload) + '"'
+                }));
+            } catch (error) {
+                clearTimeout(timer);
+                delete that.pending[id];
+                reject(error);
+            }
+        });
+    },
+
+    onmessage: function(event) {
+        if (typeof event.data !== 'string' || event.data.indexOf('WSX://') !== 0) { return; }
+        var envelope;
+        try { envelope = JSON.parse(event.data.slice(6)); }
+        catch (error) { console.error('Invalid WSX envelope', error); return; }
+        var pending = this.pending[envelope.id];
+        if (!pending) { return; }
+        clearTimeout(pending.timer);
+        delete this.pending[envelope.id];
+        try {
+            var encoded = envelope.data;
+            var result = encoded == null ? null : JSON.parse(encoded.slice(1, -1));
+            if (envelope.status >= 400) {
+                throw new Error('WSX request failed (' + envelope.status + ')');
+            }
+            pending.resolve(result);
+        } catch (error) { pending.reject(error); }
+    },
+
+    call: function(kw, omitSerialize, cb) {
+        var deferred = new dojo.Deferred();
+        var that = this;
+        this.create();
+        if (!this.channelReady) {
+            deferred.errback(new Error('WSX is disabled'));
+            return deferred;
+        }
+        var rpc = this.application.rpc;
+        var parameters = objectUpdate({}, kw);
+        objectPop(parameters, '_onResult');
+        objectPop(parameters, '_onError');
+        objectPop(parameters, '_sourceNode');
+        parameters.mode = parameters.mode || 'bag';
+        parameters.page_id = this.application.page_id;
+        if (this.application._serverstore_changes) {
+            parameters._serverstore_changes = this.application._serverstore_changes;
+            this.application._serverstore_changes = null;
+        }
+        var call = {content: parameters};
+        rpc.register_call(call);
+        var registered = true;
+        function unregister() {
+            if (registered) {
+                registered = false;
+                rpc.unregister_call({args: call});
+            }
+        }
+        this.channelReady.then(function() {
+            var serialized = omitSerialize ? parameters :
+                rpc.serializeParameters(that.application.src.dynamicParameters(parameters));
+            var form = Object.keys(serialized).map(function(key) {
+                return encodeURIComponent(key) + '=' + encodeURIComponent(serialized[key]);
+            }).join('&');
+            return that.request(rpc.pageIndexUrl(), {form: form});
+        }).then(function(reply) {
+            var result;
+            if (parameters.mode === 'json') {
+                unregister();
+                result = JSON.parse(reply.body);
+            } else {
+                var xml = new DOMParser().parseFromString(reply.body, 'text/xml');
+                var ioArgs = {args: call, url: rpc.pageIndexUrl(), xhr: {
+                    getResponseHeader: function(name) {
+                        return reply.headers[name.toLowerCase()] || null;
+                    }
+                }};
+                registered = false; // resultHandler performs unregister_call.
+                result = rpc.resultHandler(xml, ioArgs);
+            }
+            deferred.callback(result);
+        }).catch(function(error) {
+            unregister();
+            deferred.errback(error);
+        });
+        if (kw._onResult) { deferred.addCallback(kw._onResult); }
+        if (kw._onError) { deferred.addErrback(kw._onError); }
+        return deferred;
+    },
+
+    errorHandler: function(error) {
+        console.error(error);
+        return error;
+    },
+
+    send: function(command, parameters) {
+        // Legacy events are deliberately not forwarded during reception-only work.
+        console.debug('WSX event not enabled:', command);
+    }
+});

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -1382,6 +1382,10 @@ class GnrWebPage(GnrBaseWebPage):
         arg_dict['bodyclasses'] = self.get_bodyclasses()
         arg_dict['gnrModulePath'] = gnrModulePath
         gnrimports = self.frontend.gnrjs_frontend()
+        if os.environ.get('GNR_WEBSOCKET_PROVIDER'):
+            websocket_client = getattr(self.wsk, 'client_module', 'gnrwebsocket')
+            gnrimports = [websocket_client if name == 'gnrwebsocket' else name
+                          for name in gnrimports]
         if localroot:
             arg_dict['genroJsImport'] = [gnr_static_handler.url(self.gnrjsversion, 'js', '%s.js' % f, _localroot=localroot) for f in gnrimports]
         elif _nodebug is False and (self.isDeveloper()):

--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -1382,7 +1382,7 @@ class GnrWebPage(GnrBaseWebPage):
         arg_dict['bodyclasses'] = self.get_bodyclasses()
         arg_dict['gnrModulePath'] = gnrModulePath
         gnrimports = self.frontend.gnrjs_frontend()
-        if os.environ.get('GNR_WEBSOCKET_PROVIDER'):
+        if os.environ.get('GNR_DAEMON_PROVIDER'):
             websocket_client = getattr(self.wsk, 'client_module', 'gnrwebsocket')
             gnrimports = [websocket_client if name == 'gnrwebsocket' else name
                           for name in gnrimports]

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrwebsockethandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrwebsockethandler.py
@@ -171,7 +171,7 @@ class HTTPSocketConnection(http.client.HTTPConnection):
 
 def _select_websocket_handler():
     """Select an explicitly requested handler without changing classic installs."""
-    provider = os.environ.get('GNR_WEBSOCKET_PROVIDER')
+    provider = os.environ.get('GNR_DAEMON_PROVIDER')
     if not provider:
         return WsgiWebSocketHandler
     entries = importlib.metadata.entry_points(
@@ -180,7 +180,7 @@ def _select_websocket_handler():
                 if provider in (entry.module, getattr(entry.dist, 'name', None))]
     if len(matching) != 1:
         raise ImportError(
-            f'GNR_WEBSOCKET_PROVIDER={provider!r} matches {len(matching)} '
+            f'GNR_DAEMON_PROVIDER={provider!r} matches {len(matching)} '
             'gnr.web:websockethandler entry points; expected exactly one')
     handler = matching[0].load()
     if not isinstance(handler, type) or not all(

--- a/gnrpy/gnr/web/gnrwsgisite_proxy/gnrwebsockethandler.py
+++ b/gnrpy/gnr/web/gnrwsgisite_proxy/gnrwebsockethandler.py
@@ -21,6 +21,7 @@
 #Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import os
+import importlib.metadata
 import http.client
 import socket
 import urllib.request, urllib.parse, urllib.error
@@ -166,3 +167,28 @@ class HTTPSocketConnection(http.client.HTTPConnection):
     def close(self):
         if hasattr(self,'sock') and self.sock:
             self.sock.close()
+
+
+def _select_websocket_handler():
+    """Select an explicitly requested handler without changing classic installs."""
+    provider = os.environ.get('GNR_WEBSOCKET_PROVIDER')
+    if not provider:
+        return WsgiWebSocketHandler
+    entries = importlib.metadata.entry_points(
+        group='gnr.web', name='websockethandler')
+    matching = [entry for entry in entries
+                if provider in (entry.module, getattr(entry.dist, 'name', None))]
+    if len(matching) != 1:
+        raise ImportError(
+            f'GNR_WEBSOCKET_PROVIDER={provider!r} matches {len(matching)} '
+            'gnr.web:websockethandler entry points; expected exactly one')
+    handler = matching[0].load()
+    if not isinstance(handler, type) or not all(
+            callable(getattr(handler, name, None))
+            for name in ('checkSocket', 'sendCommandToPage')):
+        raise ImportError('WebSocket provider must export a handler class with '
+                          'checkSocket and sendCommandToPage methods')
+    return handler
+
+
+WsgiWebSocketHandler = _select_websocket_handler()

--- a/gnrpy/tests/web/test_websocket_provider.py
+++ b/gnrpy/tests/web/test_websocket_provider.py
@@ -28,9 +28,9 @@ class Handler:
         pass
 ''')
         env = os.environ.copy()
-        env.pop('GNR_WEBSOCKET_PROVIDER', None)
+        env.pop('GNR_DAEMON_PROVIDER', None)
         if provider:
-            env['GNR_WEBSOCKET_PROVIDER'] = provider
+            env['GNR_DAEMON_PROVIDER'] = provider
         env['PYTHONPATH'] = os.pathsep.join([directory, str(SOURCE)])
         return subprocess.run([sys.executable, '-c', code], env=env,
                               capture_output=True, text=True, timeout=20)

--- a/gnrpy/tests/web/test_websocket_provider.py
+++ b/gnrpy/tests/web/test_websocket_provider.py
@@ -1,0 +1,74 @@
+"""Explicit provider selection must leave classic installations untouched."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+SOURCE = Path(__file__).resolve().parents[2]
+
+
+def run_import(provider, code, provider_source=None):
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        metadata = root / 'wsk_test_provider-1.0.dist-info'
+        metadata.mkdir()
+        (metadata / 'METADATA').write_text(
+            'Metadata-Version: 2.1\nName: wsk-test-provider\nVersion: 1.0\n')
+        (metadata / 'entry_points.txt').write_text(
+            '[gnr.web]\nwebsockethandler = wsk_test_provider:Handler\n')
+        (root / 'wsk_test_provider.py').write_text(provider_source or '''
+class Handler:
+    client_module = 'gnrwebsocket_asgi'
+    def checkSocket(self):
+        return True
+    def sendCommandToPage(self, *args):
+        pass
+''')
+        env = os.environ.copy()
+        env.pop('GNR_WEBSOCKET_PROVIDER', None)
+        if provider:
+            env['GNR_WEBSOCKET_PROVIDER'] = provider
+        env['PYTHONPATH'] = os.pathsep.join([directory, str(SOURCE)])
+        return subprocess.run([sys.executable, '-c', code], env=env,
+                              capture_output=True, text=True, timeout=20)
+
+
+def test_installed_provider_is_not_discovered_without_explicit_selection():
+    result = run_import(None, '''
+import importlib.metadata
+from unittest.mock import patch
+with patch.object(importlib.metadata, 'entry_points', side_effect=AssertionError('discovery')):
+    from gnr.web.gnrwsgisite_proxy.gnrwebsockethandler import WsgiWebSocketHandler, WebSocketHandler
+assert WsgiWebSocketHandler.__module__ == 'gnr.web.gnrwsgisite_proxy.gnrwebsockethandler'
+assert issubclass(WsgiWebSocketHandler, WebSocketHandler)
+assert not hasattr(WsgiWebSocketHandler, 'client_module')
+''')
+    assert result.returncode == 0, result.stderr
+
+
+def test_explicit_provider_selects_its_handler():
+    result = run_import('wsk-test-provider', '''
+from gnr.web.gnrwsgisite_proxy.gnrwebsockethandler import WsgiWebSocketHandler
+from wsk_test_provider import Handler
+assert WsgiWebSocketHandler is Handler
+''')
+    assert result.returncode == 0, result.stderr
+
+
+def test_unknown_provider_fails_explicitly():
+    result = run_import('missing-provider', '''
+from gnr.web.gnrwsgisite_proxy.gnrwebsockethandler import WsgiWebSocketHandler
+''')
+    assert result.returncode != 0
+    assert 'matches 0' in result.stderr
+
+
+def test_invalid_provider_fails_explicitly():
+    result = run_import('wsk-test-provider', '''
+from gnr.web.gnrwsgisite_proxy.gnrwebsockethandler import WsgiWebSocketHandler
+''', provider_source='Handler = object\n')
+    assert result.returncode != 0
+    assert 'must export a handler class' in result.stderr


### PR DESCRIPTION
## Explicit opt-in for the ASGI bridge

Allow the bridge to replace the old async.sock handler and load its WSX client, while ordinary WSGI installations retain the existing handler and JavaScript imports.

`GNR_DAEMON_PROVIDER`, the existing daemon selector, also selects exactly one `gnr.web:websockethandler` entry point. Without the variable, provider discovery is not run, an installed provider is ignored, and the added page-import branch is skipped entirely. A selected provider can name its `client_module`; without that attribute, the classic client remains selected. Selection is process-wide and must happen before site imports. Invalid explicit selections fail clearly.

Includes `gnrwebsocket_asgi.js` for the bounded legacy WSK request/response path. It retains legacy parameter serialization and result processing and requires the bridge adapter in https://github.com/genropy/genropy-asgi/pull/22. No default configuration changes, automatic provider activation or version bump.

Unsolicited push, shared objects, resident-page redesign, automatic reconnection and cookie-changing authentication flows are outside scope.

There is no separate WebSocket selector. The bridge sets only GNR_DAEMON_PROVIDER=genropy-asgi for both interfaces.

## Validation

- Four new isolated-process tests pass: installed-but-unselected provider, explicit selection, missing provider and invalid provider.
- Configured flake8 passes on all changed Python files; Node syntax check and git diff check pass.
- Full suite on this branch: **1759 passed, 10 skipped, 751 setup errors**.
- Full suite on an exported, unmodified develop at `64ea463f7c`: **1754 passed, 10 skipped, 751 setup errors, 1 additional failure**. The sets of 751 error test IDs are identical; PostgreSQL initdb cannot allocate shared memory in this environment. The baseline-only failure is GnrAppInsights inspecting Git history in the exported tree, which has no .git directory. No added error test IDs on this branch.
- Earlier live bridge checks: 12 targeted WebSocket tests passed; original legacy WSK/RPC buttons returned the same result; dbSelect search and selection worked through WSK. Full bridge suite: 282 passed, 2 optional tests skipped.

The unchanged-deployment protection is explicit in both the Python provider and JavaScript import paths. The environment-limited database suite is documented rather than represented as fully green.

After selector unification, the full run had 1758 passed, 10 skipped, the same 751 baseline setup errors, and one Git-insights timeout under the 15-second test limit. The timed-out test passed in isolation with a 60-second limit (9.75 seconds). The bridge full suite remained 282 passed, 2 skipped.
