### PR TITLE
fix(web): tagged public methods accept the page session again

### DIFF
--- a/gnrpy/gnr/web/gnrwebpage.py
+++ b/gnrpy/gnr/web/gnrwebpage.py
@@ -110,6 +110,7 @@ class GnrUserNotAllowed(GnrException):
 
 class GnrBasicAuthenticationError(GnrException):
     code = 'AUTH-901'
+    caption = "!!Error code %(code)s : %(msg)s."
 
 EXCEPTIONS = {
     'user_not_allowed': GnrUserNotAllowed,
@@ -1281,7 +1282,7 @@ class GnrWebPage(GnrBaseWebPage):
                 raise GnrException('Verifier wrong class')
         elif getattr(handler, 'tags',None):
             verifier = AuthorizationBaseTagsVerifier(self)
-            verifier_error = verifier(tags=handler.tags)
+            verifier_error = verifier(tags=handler.tags, method=method)
         if verifier_error:
             raise verifier_error                
         return handler

--- a/gnrpy/gnr/web/verifiers.py
+++ b/gnrpy/gnr/web/verifiers.py
@@ -60,12 +60,26 @@ class AuthorizationBearerVerifier(GnrVerifier):
 
 
 class AuthorizationBaseTagsVerifier(GnrVerifier):
-    """Verifier for HTTP Basic Authentication with tag-based authorization.
+    """Verifier for tag-based authorization.
 
-    Decodes Basic Auth credentials, authenticates the user via getAvatar,
-    and checks resource permissions against the handler's required tags."""
+    Checks the handler's required tags against the tags of the logged in
+    user. A caller with no session is authenticated through HTTP Basic
+    Authentication first, so the same handler serves both a browser page
+    and an external client."""
 
-    def verify(self,tags=None,**kwargs):
+    def verify(self,tags=None,method=None,**kwargs):
+        userTags = self.page.userTags
+        if not userTags:
+            error = self.basicAuthenticate()
+            if error:
+                return error
+            userTags = self.page.avatar.user_tags
+        if not self.page.application.checkResourcePermission(tags, userTags):
+            return self.page.exception('user_not_allowed', method=method)
+
+    def basicAuthenticate(self):
+        """Authenticate the caller through the Basic Authorization header,
+        setting page.avatar. Returns an exception instance on failure."""
         authorization = self.page.request.headers.get('Authorization')
         if not authorization:
             return self.page.exception('basic_authentication',msg='Missing Basic Authorization')
@@ -79,6 +93,3 @@ class AuthorizationBaseTagsVerifier(GnrVerifier):
         self.page.avatar = self.page.application.getAvatar(user, pwd, authenticate=True)
         if not self.page.avatar:
             return self.page.exception('basic_authentication', msg='Wrong Authorization Login')
-        userTags = self.page.userTags or self.page.avatar.user_tags
-        if not self.page.application.checkResourcePermission(tags, userTags):
-            return self.page.exception('basic_authentication', msg='User not allowed')

--- a/gnrpy/tests/web/verifiers_test.py
+++ b/gnrpy/tests/web/verifiers_test.py
@@ -1,0 +1,68 @@
+from base64 import b64encode
+
+from gnr.web.verifiers import AuthorizationBaseTagsVerifier
+
+
+class _RequestStub(object):
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+class _AvatarStub(object):
+    user_tags = 'pos'
+
+
+class _ApplicationStub(object):
+    def __init__(self, avatar=None):
+        self.avatar = avatar
+
+    def getAvatar(self, user, pwd, authenticate=None):
+        return self.avatar
+
+    def checkResourcePermission(self, tags, userTags):
+        tags = set((tags or '').split(','))
+        return bool(tags & set((userTags or '').split(',')))
+
+
+class _PageStub(object):
+    def __init__(self, userTags=None, headers=None, avatar=None):
+        self.userTags = userTags
+        self.request = _RequestStub(headers)
+        self.application = _ApplicationStub(avatar)
+        self.avatar = None
+        self.raised = None
+
+    def exception(self, exception, **kwargs):
+        self.raised = (exception, kwargs)
+        return Exception(exception)
+
+
+def test_session_tags_need_no_basic_authorization():
+    """A logged in user calling a tagged public method must not be asked
+    for a Basic Authorization header."""
+    page = _PageStub(userTags='pos,user')
+    assert AuthorizationBaseTagsVerifier(page).verify(tags='pos,admin') is None
+    assert page.raised is None
+
+
+def test_session_tags_not_matching_gives_user_not_allowed():
+    page = _PageStub(userTags='user')
+    assert AuthorizationBaseTagsVerifier(page).verify(tags='pos,admin', method='doit')
+    assert page.raised == ('user_not_allowed', dict(method='doit'))
+
+
+def test_missing_session_still_requires_basic_authorization():
+    page = _PageStub()
+    assert AuthorizationBaseTagsVerifier(page).verify(tags='pos')
+    assert page.raised[0] == 'basic_authentication'
+    assert page.raised[1]['msg'] == 'Missing Basic Authorization'
+
+
+def test_basic_authorization_tags_are_checked():
+    credentials = b64encode(b'mario:secret').decode()
+    page = _PageStub(headers={'Authorization': 'Basic %s' % credentials},
+                     avatar=_AvatarStub())
+    assert AuthorizationBaseTagsVerifier(page).verify(tags='pos') is None
+    assert page.avatar is not None
+    assert AuthorizationBaseTagsVerifier(page).verify(tags='admin', method='doit')
+    assert page.raised == ('user_not_allowed', dict(method='doit'))


### PR DESCRIPTION
## Problem

`AuthorizationBaseTagsVerifier` asks for the `Authorization` header before
looking at the page session, so **every** `@public_method(tags=...)` called
from a logged in browser fails with `AUTH-901`. It surfaced on an ECR emulator
call from a sale page, but it hits any tagged handler reached through
`genro.serverCall` / `dataRpc`.

The check regressed in 4ecc2f8 (#700), which moved the inline logic into the
verifier module. Before that move `getPublicMethod` read:

```python
userTags = self.userTags or self.basicAuthenticationTags()
if not self.application.checkResourcePermission(handler.tags, userTags):
    raise self.exception(GnrUserNotAllowed, method=method)
```

Session tags first, Basic Authentication only for a caller with no session.
The verifier dropped that order, so the fallback became mandatory. It went
unnoticed because the tagged handlers in use are external endpoints that do
send Basic credentials.

## Change

- `verify()` checks `page.userTags` first and only falls back to
  `basicAuthenticate()` when there is no session, restoring the pre-refactor
  order. Tags that do not match give `user_not_allowed` (AUTH-001) again
  instead of an authentication error.
- The Basic Authorization decoding moves to `basicAuthenticate()`, unchanged in
  behaviour and error codes, so the same handler still serves both a browser
  page and an external client.
- `method` reaches the verifier, so the AUTH-001 caption names the method again.
- `GnrBasicAuthenticationError` gets a caption: the base one renders only code
  and description, so the `msg` kwarg never reached the user and the dialog
  showed just `AUTH-901` plus a `file:line`.

## Verification

`gnrpy/tests/web/verifiers_test.py` covers the four paths: session tags pass
with no header, non matching session tags give `user_not_allowed`, a caller
with no session still needs the header, and Basic credentials are still checked
against the required tags. Full suite green (2454 passed, 10 skipped).