### PR TITLE
Let a templateChunk opt into the Parameters tab (#1283)

### DIFF
--- a/gnrjs/gnr_d11/js/genro_components.js
+++ b/gnrjs/gnr_d11/js/genro_components.js
@@ -3801,7 +3801,7 @@ dojo.declare("gnr.widgets.TemplateChunk", gnr.widgets.gnrwdg, {
         genro.setData(paletteRoot+'.status','info');
     },
 
-    openTemplatePalette:function(chunkNode,editorConstrain,showLetterhead){
+    openTemplatePalette:function(chunkNode,editorConstrain,showLetterhead,showParameters){
         let componentNode = chunkNode.getParentNode();
         var paletteCode = componentNode.getAttributeFromDatasource('paletteCode');
         if(!paletteCode){
@@ -3821,6 +3821,7 @@ dojo.declare("gnr.widgets.TemplateChunk", gnr.widgets.gnrwdg, {
             var table = componentNode.getAttributeFromDatasource('table');
             var remote_datasourcepath = chunkNode.attr.datasource? chunkNode.absDatapath(chunkNode.attr.datasource):null;
             showLetterhead = typeof(showLetterhead) == 'string' ? chunkNode.getRelativeData(showLetterhead) : showLetterhead;
+            showParameters = typeof(showParameters) == 'string' ? chunkNode.getRelativeData(showParameters) : showParameters;
             var kw = {'paletteCode':paletteCode,'dockTo':'dommyDock:open',
                     title:'Template Edit '+table?table.split('.')[1]:'',width:'750px',
                     maxable:true,
@@ -3833,6 +3834,7 @@ dojo.declare("gnr.widgets.TemplateChunk", gnr.widgets.gnrwdg, {
                     remote_resource_mode:!table || (templateHandler.dataInfo && templateHandler.dataInfo.respath!=null),
                     remote_datasourcepath:remote_datasourcepath,
                     remote_showLetterhead:showLetterhead,
+                    remote_showParameters:showParameters,
                     remote_editorConstrain: editorConstrain
                     };  
            //kw.remote__onRemote = function(){
@@ -3946,6 +3948,7 @@ dojo.declare("gnr.widgets.TemplateChunk", gnr.widgets.gnrwdg, {
         var tplpars = objectExtract(kw,'template,editable');
         var editorConstrain = objectExtract(kw,'constrain_*',null,true);
         var showLetterhead = objectPop(kw, 'showLetterhead');
+        var showParameters = objectPop(kw, 'showParameters');
         if(paletteCode && (paletteCode[0]=='^' || paletteCode[0]=='=')){
             paletteCode = paletteCode[0]+sourceNode.absDatapath(paletteCode);
         }
@@ -3960,6 +3963,9 @@ dojo.declare("gnr.widgets.TemplateChunk", gnr.widgets.gnrwdg, {
         }
         if(typeof(showLetterhead)=='string'){
             showLetterhead = sourceNode.absDatapath(showLetterhead);
+        }
+        if(typeof(showParameters)=='string'){
+            showParameters = sourceNode.absDatapath(showParameters);
         }
         var record_id = objectPop(kw, 'record_id');
         if(record_id){
@@ -3992,11 +3998,11 @@ dojo.declare("gnr.widgets.TemplateChunk", gnr.widgets.gnrwdg, {
         var handler = this;
         if(tplpars.editable){
             kw.selfsubscribe_openTemplatePalette = function(){
-                handler.openTemplatePalette(this,editorConstrain,showLetterhead);
+                handler.openTemplatePalette(this,editorConstrain,showLetterhead,showParameters);
             }
             kw.connect_ondblclick = function(evt){
                 if(tplpars.editable===true || evt.shiftKey){
-                    handler.openTemplatePalette(this,editorConstrain,showLetterhead);
+                    handler.openTemplatePalette(this,editorConstrain,showLetterhead,showParameters);
                 }
            };
         }

--- a/gnrpy/tests/web/tpleditor_chunk_parameters_test.py
+++ b/gnrpy/tests/web/tpleditor_chunk_parameters_test.py
@@ -1,0 +1,116 @@
+"""Structural checks on the templateChunk palette editor (issue #1283).
+
+Every pane here is built through the same entry point the browser uses --
+``remoteBuilder`` -> ``te_chunkEditorPane`` -- on a real site: the component
+under test is the one in this working tree and no struct object is faked.
+"""
+
+import inspect
+import os
+
+from core.common import BaseGnrTest
+
+from gnr.app.gnrapp import GnrApp
+from gnr.core.gnrbag import Bag
+from gnr.web.gnrdummysite import GnrDummySite
+
+CHUNK_COMPONENT = 'gnrcomponents/tpleditor:ChunkEditor'
+CHUNK_TABLE = 'adm.htmltemplate'
+GRID_DATAPATHS = ('.varsgrid', '.parametersgrid')
+
+
+def struct_nodes(struct):
+    """Depth first walk of a built struct, yielding every node in it."""
+    for node in struct.nodes:
+        yield node
+        if isinstance(node.value, Bag):
+            yield from struct_nodes(node.value)
+
+
+class TestChunkEditorParameters(BaseGnrTest):
+    """No daemon is started for this class: nothing here may need one."""
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        app = GnrApp(cls.test_instance_name)
+        app.db.model.check(applyChanges=True)
+        app.db.commit()
+        cls.site = GnrDummySite(cls.test_instance_name, site_name=cls.test_instance_name)
+
+    def chunk_editor_page(self):
+        page = self.site.dummyPage
+        page.mixinComponent(CHUNK_COMPONENT)
+        return page
+
+    def chunk_editor_pane(self, **kwargs):
+        return self.site.dummyPage.remoteBuilder(handler='te_chunkEditorPane',
+                                                 py_requires=CHUNK_COMPONENT,
+                                                 table=CHUNK_TABLE,
+                                                 paletteId='tpl_editor_floating',
+                                                 **kwargs)
+
+    def metadata_grids(self, pane):
+        """Region and store of every bagGrid of the Metadata tab, by datapath."""
+        result = {}
+        for node in struct_nodes(pane):
+            datapath = node.attr.get('datapath')
+            if datapath in GRID_DATAPATHS:
+                stores = [n.attr['storepath'] for n in struct_nodes(node.value)
+                          if n.attr.get('tag') == 'BagStore']
+                result[datapath] = dict(region=node.attr.get('region'),
+                                        height=node.attr.get('height'),
+                                        storepath=stores[0] if stores else None)
+        return result
+
+    def save_buttons(self, pane):
+        """The save buttons of the palette bars, the ones compiling the chunk."""
+        return [node for node in struct_nodes(pane)
+                if node.attr.get('tag') == 'SlotButton'
+                and 'te_compileTemplate' in (node.attr.get('action') or '')]
+
+    def test_component_under_test(self):
+        # the editable install resolves gnr.* to the main checkout, so make sure
+        # the component being exercised is the one in this working tree
+        mixined = self.site.dummyPage.mixinComponent(CHUNK_COMPONENT)
+        component_file = inspect.getsourcefile(mixined._te_frameChunkInfo)
+        assert component_file == os.path.join(self.test_genro_root, 'resources',
+                                             'common', 'gnrcomponents', 'tpleditor.py')
+
+    def test_parameters_hidden_by_default(self):
+        grids = self.metadata_grids(self.chunk_editor_pane())
+        assert '.parametersgrid' not in grids
+        # the variables grid keeps the whole Metadata tab, as before #1283
+        assert grids['.varsgrid']['region'] == 'center'
+        assert grids['.varsgrid']['height'] is None
+
+    def test_parameters_shown_on_request(self):
+        grids = self.metadata_grids(self.chunk_editor_pane(showParameters=True))
+        assert grids['.parametersgrid']['storepath'] == '#ANCHOR.data.parameters'
+        assert grids['.parametersgrid']['region'] == 'center'
+        # the variables grid makes room for it, as in the full template editor
+        assert grids['.varsgrid']['region'] == 'bottom'
+        assert grids['.varsgrid']['height'] == '60%'
+
+    def test_save_button_forwards_the_parameters(self):
+        for pane in (self.chunk_editor_pane(), self.chunk_editor_pane(showParameters=True)):
+            buttons = self.save_buttons(pane)
+            assert buttons
+            for button in buttons:
+                # .data.parametersbag was a dangling path: nothing ever wrote it
+                assert button.attr['pb'] == '=.data.parameters'
+                assert button.attr['vb'] == '=.data.varsbag'
+
+    def test_parameter_formats_reach_the_compiled_template(self):
+        parameters = Bag()
+        parameters.setItem('r_0', Bag(dict(code='occurrences', format='#,##0')))
+        parameters.setItem('r_1', Bag(dict(code='notification_url', mask='%s/detail')))
+        compiled = self.chunk_editor_page().te_compileTemplate(
+            table=CHUNK_TABLE,
+            datacontent='<p>$occurrences</p><p>$notification_url</p>',
+            varsbag=Bag(), parametersbag=parameters)['compiled']
+        attributes = compiled.getAttr('main')
+        assert attributes['formats']['occurrences'] == '#,##0'
+        assert attributes['masks']['notification_url'] == '%s/detail'
+        # parameters are not columns of the template table
+        assert 'occurrences' not in attributes['columns']

--- a/resources/common/gnrcomponents/tpleditor.py
+++ b/resources/common/gnrcomponents/tpleditor.py
@@ -665,9 +665,11 @@ class PaletteTemplateEditor(TemplateEditor):
 class ChunkEditor(PaletteTemplateEditor):
     @public_method
     def te_chunkEditorPane(self,pane,table=None,resource_mode=None,paletteId=None,
-                            datasourcepath=None,showLetterhead=False,editorConstrain=None,plainText=False,emailChunk=False,**kwargs):
+                            datasourcepath=None,showLetterhead=False,showParameters=False,
+                            editorConstrain=None,plainText=False,emailChunk=False,**kwargs):
         sc = self._te_mainstack(pane,table=table)
-        self._te_frameChunkInfo(sc.framePane(title='!!Metadata',pageName='info',childname='info'),table=table,datasourcepath=datasourcepath)
+        self._te_frameChunkInfo(sc.framePane(title='!!Metadata',pageName='info',childname='info'),table=table,
+                                datasourcepath=datasourcepath,showParameters=showParameters)
         bar = sc.info.top.bar
         if table:
             bar.replaceSlots('#','#,customres,menutemplates,savetpl,5')
@@ -716,14 +718,16 @@ class ChunkEditor(PaletteTemplateEditor):
 
         
         
-    def _te_frameChunkInfo(self,frame,table=None,datasourcepath=None):
+    def _te_frameChunkInfo(self,frame,table=None,datasourcepath=None,showParameters=False):
         frame.top.slotToolbar('5,parentStackButtons,*',parentStackButtons_font_size='8pt')
         bc = frame.center.borderContainer()
-        self._te_info_vars(bc,table=table,region='center',
+        vars_layout = dict(region='bottom',height='60%') if showParameters else dict(region='center')
+        self._te_info_vars(bc,table=table,
                             datasourcepath=datasourcepath,
                             fieldsTree_currRecordPath=datasourcepath,
-                            fieldsTree_explorerPath='#ANCHOR.dbexplorer')
-        #self._te_info_parameters(bc,region='center')
+                            fieldsTree_explorerPath='#ANCHOR.dbexplorer',**vars_layout)
+        if showParameters:
+            self._te_info_parameters(bc,region='center')
     
     def _te_framePreviewChunk(self,frame,table=None,datasourcepath=None):
         bar = frame.top.slotToolbar('5,parentStackButtons,10,fb,*',parentStackButtons_font_size='8pt')                   
@@ -752,7 +756,7 @@ class ChunkEditor(PaletteTemplateEditor):
                             email_meta='=.data.metadata.email',
                             content_css='=.data.content_css',
                             letterhead_id='=.preview.letterhead_id',
-                            vb='=.data.varsbag',pb='=.data.parametersbag',data='=.data')
+                            vb='=.data.varsbag',pb='=.data.parameters',data='=.data')
         
     
         


### PR DESCRIPTION
## Problem

Template **parameters** — the editor's registry for variables that are *not* columns of the template's table — could never be reached from the `templateChunk` palette editor (#1283). Two independent defects:

1. `_te_frameChunkInfo` had `self._te_info_parameters(bc,region='center')` commented out, so the grid was never instantiated in the chunk variant (the full `te_templateEditor` was fine).
2. The chunk Save button read `pb='=.data.parametersbag'`, a dangling datapath. Every other site uses `.data.parameters` (the grid store, the compile `dataRpc`, the save helpers), so `te_compileTemplate` received an empty bag and the `formats`/`masks` of those codes were dropped from the compiled chunk — even for a template that already carried parameters in its stored bag. As a side effect, reading that path materialised a junk `parametersbag` node in saved templates (visible in several `tpl/*.xml` under `projects/`).

## Solution

Instead of switching the tab on for every chunk, `templateChunk` now accepts a **`showParameters`** kwarg, defaulted to `False` and plumbed exactly like the existing `showLetterhead`:

- `createContent` pops it, resolving a `^`/`=` datapath to an absolute one;
- `openTemplatePalette` evaluates it and forwards it as `remote_showParameters`;
- `te_chunkEditorPane` passes it to `_te_frameChunkInfo`, which adds the Parameters grid at `region='center'` and moves the Variables grid to `region='bottom', height='60%'` — the same layout the full editor uses.

With the default, the Metadata tab is byte-for-byte what it is today; with `showParameters=True` the grid appears and round-trips through save.

The dangling `pb` path is fixed unconditionally: it is a bug on its own, and without it the opt-in would still compile to an empty parameters bag.

```python
pane.templateChunk(template='mytemplate', table='pkg.mytable',
                   editable=True, showParameters=True)
```

## Test case

New `gnrpy/tests/web/tpleditor_chunk_parameters_test.py` — 5 tests, no mocks: each pane is built on a real `GnrDummySite` through the same entry point the browser uses (`remoteBuilder` → `te_chunkEditorPane`), and assertions run on the real struct.

- `test_component_under_test` — the component exercised is the one in the working tree
- `test_parameters_hidden_by_default` — no `.parametersgrid`, Variables still owns the whole tab
- `test_parameters_shown_on_request` — grid present on `#ANCHOR.data.parameters`, Variables moved to `bottom`/`60%`
- `test_save_button_forwards_the_parameters` — every compile button carries `pb='=.data.parameters'`
- `test_parameter_formats_reach_the_compiled_template` — a `parametersbag` lands in the compiled `formats`/`masks` without polluting `columns`

The two behavioural tests fail on `develop` and pass on this branch. Full `gnrpy/tests` suite green: 2511 passed, 10 skipped.

Manual check: put `templateChunk(..., editable=True, showParameters=True)` on a form, double-click it, add a parameter row in Metadata, drag its `$code` from the Parameters folder of the Edit tab, save, reopen — the row is still there and the format applies in the preview.

Fixes #1283