### PR TITLE
fix(crud): compare only physical columns in the optimistic-lock merge test

### DIFF
--- a/gnrpy/gnr/sql/gnrsqltable/crud.py
+++ b/gnrpy/gnr/sql/gnrsqltable/crud.py
@@ -546,7 +546,9 @@ class CrudMixin(SqlTableBaseMixin):
                 )
                 for fnode in main_changeSet:
                     fname = fnode.label
-                    if testForMerge:
+                    # only physical columns carry conflict information: a
+                    # virtual one is absent from old_record and never written
+                    if testForMerge and fname in self.model.columns:
                         incompatible = False
                         if fnode.getAttr('_gnrbag'):
                             pass

--- a/gnrpy/tests/sql/writerecordcluster_merge_test.py
+++ b/gnrpy/tests/sql/writerecordcluster_merge_test.py
@@ -1,0 +1,69 @@
+"""Optimistic-lock merge test of writeRecordCluster (issue #1287).
+
+The changeSet a form sends back can carry a virtual column: it is absent
+from the record ``writeRecordCluster`` reloads for the comparison, so it
+used to read as ``None`` and be reported as modified by another user.
+"""
+
+import pytest
+
+from core.common import BaseGnrTest
+
+from gnr.core.gnrbag import Bag
+
+
+def setup_module(module):
+    BaseGnrTest.setup_class()
+
+
+def teardown_module(module):
+    BaseGnrTest.teardown_class()
+
+
+def changeset(**fields):
+    """A main changeSet as the client sends it: value plus loaded oldValue."""
+    result = Bag()
+    for fname, (value, oldValue) in fields.items():
+        result.setItem(fname, value, dict(oldValue=oldValue))
+    return result
+
+
+class TestWriteRecordClusterMerge:
+
+    def customer(self, db):
+        """A committed customer, with the pkey and the virtual values it has."""
+        tblobj = db.table('invc.customer')
+        record = tblobj.newrecord(
+            account_name='Merge Test', street_address='1 Test Road',
+            suburb='Testville', notes='before',
+        )
+        tblobj.insert(record)
+        db.commit()
+        return tblobj, record['id']
+
+    def test_virtual_column_is_not_a_conflict(self, db_sqlite):
+        # no lastTS in the cluster arms testForMerge (crud.py:543); the
+        # virtual fields carry the value the form loaded, unchanged
+        tblobj, pkey = self.customer(db_sqlite)
+        tblobj.writeRecordCluster(
+            changeset(notes=('after', 'before'),
+                      has_invoices=(False, False),
+                      full_address=('1 Test Road, Testville',
+                                    '1 Test Road, Testville'),
+                      state_name=('Nowhere', 'Nowhere')),
+            dict(_pkey=pkey),
+        )
+        db_sqlite.commit()
+        assert tblobj.record(pkey).output('dict')['notes'] == 'after'
+
+    def test_physical_column_still_conflicts(self, db_sqlite):
+        tblobj, pkey = self.customer(db_sqlite)
+        with pytest.raises(Exception) as err:
+            tblobj.writeRecordCluster(
+                changeset(account_name=('Mine', 'Stale Value')),
+                dict(_pkey=pkey),
+            )
+        assert 'Incompatible changes' in str(err.value)
+        assert 'account_name' in str(err.value)
+        db_sqlite.rollback()
+        assert tblobj.record(pkey).output('dict')['account_name'] == 'Merge Test'


### PR DESCRIPTION
## Problem / Root cause

`writeRecordCluster` (`gnrpy/gnr/sql/gnrsqltable/crud.py:497`) runs its optimistic-lock merge test over every field of the client changeSet, comparing each against a record it reloads at `crud.py:521`:

```python
old_record = self.record(pkey, for_update=True, bagFields=True).output('bag', ...)
main_record = old_record.deepcopy()
```

`record()` takes a `virtual_columns` parameter (`gnrpy/gnr/sql/gnrsqltable/record.py:311`) and the caller does not pass it; the bare `*` expansion adds only *static* virtual columns (`gnrpy/gnr/sql/gnrsqlmodel/table.py:485-490`). So a virtual column is simply not in that bag, `main_record[fname]` reads `None`, and the comparison at `crud.py:552-556` can only conclude that somebody else changed the field:

```
Incompatible changes: another user modified field has_invoices from False to None
```

with nobody else on the record. Every save that follows a table method which both writes the record and pushes derived fields to the client fails.

## Change

One line: compare only the physical columns of the table.

No variant of virtual column is writable, so a difference on one carries no information about a write conflict:

- `prepareRecordData` drops every key `in tblobj.virtual_columns` before `insert`/`update` build their SQL (`gnrpy/gnr/sql/adapters/_gnrbaseadapter.py:738-740`);
- a virtual name never enters `sqlnamemapper` either — its only writer is `DbColumnObj.doInit` (`gnrpy/gnr/sql/gnrsqlmodel/columns.py:223`), and `DbVirtualColumnObj` is a sibling under `DbBaseColumnObj`, not a subclass (`columns.py:194`, `:255`). Every factory (`aliasColumn`, `joinColumn`, `compositeColumn`, `bagItemColumn`, `toolColumn`, `subQueryColumn`, `formulaColumn`, `pyColumn`) routes through `virtual_column()` (`gnrpy/gnr/sql/gnrsqlmodel/model.py:955-1243`).

The rest of the framework already applies this rule; `crud.py` was the layer where it was missing. The client drops a node whose label starts with `$` or which carries a `virtual_column` attr (`gnrjs/gnr_d11/js/genro_frm.js:1667`), and the web layer pops the declared virtual columns out of the recordCluster before calling `writeRecordCluster` (`gnrpy/gnr/web/_gnrbasewebpage.py:506-509`) — but only those in `pageStore 'tables.<table>.virtual_columns'`, so not the `always` ones added server-side (`gnr/web/gnrwebpage_proxy/apphandler/get_record.py:189-192`) and not non-web callers.

The predicate is "compare only what is physical" rather than "skip what is virtual": the two differ for a key that is neither, and only the former is exercised by the tests. `main_record[fname] = fnode.value` at `:569` is left as it was — virtual fields there are inert, since `prepareRecordData` drops them.

## Verification

From `gnrpy`, `PYTHONPATH` into this worktree (`gnr.__file__` asserted inside it):

- new file, on this branch → `pytest tests/sql/writerecordcluster_merge_test.py -q` → **2 passed**
- same file copied onto `origin/develop` → **1 failed, 1 passed**: the virtual-column test fails with `Incompatible changes: another user modified field has_invoices from False to None`, and the physical-column test passes there too, so the guard does not disarm the lock
- `pytest tests/ -q --ignore=tests/sql` → **1291 passed**
- `pytest tests/sql -q -k "not pg"` → **1032 passed, 10 skipped** (postgres deliberately not exercised, to leave a running instance alone)
- full suite through the pre-commit hook → **2457 passed, 10 skipped**
- `flake8` on both touched files → zero errors

The new tests use the existing `db_sqlite` fixture (`gnrpy/tests/sql/conftest.py:110`) on the real `test_invoice` database and call `writeRecordCluster` directly, with no mocks: `invc.customer` carries a `formulaColumn` with an `exists=` (`has_invoices`), one with a `sql_formula` (`full_address`) and an `aliasColumn` (`state_name`). `lastTS` is omitted from the cluster attributes, which is what arms `testForMerge` (`crud.py:543`). No test covered `writeRecordCluster` before this one.

## Follow-up (out of scope)

`setInClientRecord` is what plants a bare-named node carrying `oldValue` in the form record in the first place: server side it writes the plain column name (`gnrpy/gnr/web/gnrwebpage.py:2228`), client side it discards the node's attributes (`gnrjs/gnr_d11/js/genro_frm.js:1467`) and `externalChange` stamps `_loadedValue` (`:1514`), which is the condition on which `_getRecordCluster` includes the node (`:1720`) and gives it an `oldValue` (`:1726`). Routing virtual columns to `$<field>`, the way a field does, is worth a change of its own and is discussed on the issue.

## Related issue

Fixes #1287
