### PR TITLE
fix(frm): keep a silent setInClientRecord push out of the changeSet

### DIFF
--- a/gnrjs/gnr_d11/js/genro_frm.js
+++ b/gnrjs/gnr_d11/js/genro_frm.js
@@ -1516,7 +1516,12 @@ dojo.declare("gnr.GnrFrmHandler", null, {
     },
 
     externalChange:function(field,value,triggerChanges){
-        this.sourceNode.setRelativeData(this.formDatapath+'.'+field,value,triggerChanges?{}:{_loadedValue:value});
+        var path = this.formDatapath+'.'+field;
+        if(!triggerChanges && isEqual(this.sourceNode.getRelativeData(path),value)){
+            return;
+        }
+        this.sourceNode.setRelativeData(path,value,triggerChanges?{}:{_loadedValue:value},
+                                        null,null,null,{_updattr:true});
     },
 
     getFormData: function() {

--- a/projects/gnrcore/packages/test15/webpages/gnrwdg/external_change.py
+++ b/projects/gnrcore/packages/test15/webpages/gnrwdg/external_change.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+"""setInClientRecord: a silent server push must not stage a change"""
+
+from gnr.core.gnrdecorator import public_method
+
+
+class GnrCustomWebPage(object):
+    py_requires = "gnrcomponents/testhandler:TestHandlerFull,gnrcomponents/formhandler:FormHandler"
+
+    def test_0_silent_push(self, pane):
+        """Push twice, then save: no pushed field may reach the changeSet.
+
+        numero_abitanti is a formulaColumn loaded with the record. Before the fix
+        the first push wiped the node attributes (dtype, virtual_column) and the
+        second push, same value, left _loadedValue on it: the save then raised
+        'Incompatible changes: another user modified field numero_abitanti'.
+        Expected now: the form stays unchanged after both pushes and the save
+        has nothing to send."""
+        form = pane.frameForm(frameCode='prov_push', datapath='.form',
+                              height='160px', width='600px', border='1px solid silver')
+        store = form.formStore(table='glbl.provincia', storeType='Item',
+                               handler='recordCluster', startKey='MI')
+        store.handler('load', virtual_columns='numero_abitanti')
+        tb = form.top.slotToolbar('5,pusher,*,semaphore,|,formcommands,5')
+        tb.pusher.slotButton('Push totals (silent)').dataRpc(self.pushTotals,
+                                                             pkey='=#FORM.record.sigla')
+        fb = form.center.contentPane(datapath='.record').formbuilder(cols=2, border_spacing='4px')
+        fb.field('nome')
+        fb.field('codice')
+        fb.numberTextBox(value='^.numero_abitanti', lbl='N.Abitanti (formula)', readOnly=True)
+
+    @public_method
+    def pushTotals(self, pkey=None):
+        tbl = self.db.table('glbl.provincia')
+        with tbl.recordToUpdate(pkey) as record:
+            record['codice'] = (record['codice'] or 0) + 1
+        self.db.commit()
+        record['numero_abitanti'] = tbl.readColumns(columns='$numero_abitanti', pkey=pkey)
+        self.setInClientRecord(tblobj=tbl, record=record, fields='codice,numero_abitanti')


### PR DESCRIPTION
## Problem / Root cause

A `setInClientRecord` push is delivered by `externalChange` (`gnrjs/gnr_d11/js/genro_frm.js:1518`), which wrote the value with `{_loadedValue: value}` and no `_updattr`. Two consequences, both read in `gnrbag.js` and then measured (see Verification):

- **Attributes were replaced, not merged.** `setValue` → `setAttr(attrs, false, undefined)` does `this.attr = attr` (`gnrbag.js:462-466`), so the node lost `dtype` and `virtual_column`. That second attribute is what keeps a formula column out of the change logger (`genro_frm.js:1765`) and out of `_getRecordCluster` (`:1671`): after the first push a virtual column became an ordinary field. This is the point @genro measured in the #1288 review.
- **A push of the value the node already holds left the marker behind.** `setRelativeData` always passes `lazySet:true`; with an equal value and *changed attributes* `Bag.set` takes its attribute-only branch (`gnrbag.js:1825-1835`): `node.setAttr(...)` writes `_loadedValue` and fires an `upd` without `updvalue`, which `triggerUPD` treats as "changed attributes" and ignores (`genro_frm.js:1832`). Nothing removes the marker afterwards, and presence of `_loadedValue` is exactly what puts a node in the changeSet (`:1723`). The closing comment on #1290 said an identical push assigns nothing: true only when the attributes are equal too.

At save the field travels with `oldValue` set; `writeRecordCluster` reloads the record without virtual columns, reads `None`, and raises `Incompatible changes: another user modified field <formula column> from X to None`. Physical columns in the same push are in the changeSet as well and survive only because the server has just written them.

Report: softwellsrl/pansotti#83 (`ciak.ordine_acquisto.ricalcolaTotali` pushing `ha_righe_invalide` after each row autosave).

## Change

`externalChange`:

- a **silent** push of the value the node already holds returns without touching the node;
- otherwise the value is written with `{_updattr: true}`, so attributes merge and `dtype` / `virtual_column` survive; the silent variant still carries `{_loadedValue: value}`.

Two deliberate differences from the variant sketched in the #1288 review:

- `_loadedValue` is kept, no new `_serverChange` attribute. On a clean physical node with a different value the change logger, finding no marker, *creates* one from `oldvalue` and marks the field changed (`genro_frm.js:1809-1811`); the marker equal to the value is what makes it delete instead (`:1811-1813`). Without it a silent push would stage a change on every physical column it touches. The Node probe in that review loaded `gnrbag.js` without `genro_frm.js`, so the logger was not in the picture.
- `_updattr: true`, not `'*'`. With `'*'` a null value would delete `_loadedValue` instead of setting it to `null`, and the logger's null/blank rule (`:1811`) would not apply.

Still true after the change, on purpose: on a **virtual** node the logger returns early, so a silent push with a different value leaves `_loadedValue` on it. Inert — the node is excluded from the cluster by `virtual_column`, which now survives — and out of the reported case. The absent-node path (`triggerINS` keeping a marker already present) is also unchanged: the reported case never reaches it, the nodes were present.

Test page `test15/gnrwdg/external_change`: a `glbl.provincia` form with `numero_abitanti` (formulaColumn) loaded, a button that writes `codice` server-side and pushes `codice,numero_abitanti` silently.

## Verification

- Node harness (real `gnrlang.js`, `gnrbag.js`, `genro_frm.js`, logger wired as at `:517`), record with a physical and two virtual nodes, two silent pushes of the same values.
  Before: after the 2nd push all three nodes carry `_loadedValue`, all three are in the changeSet with `oldValue`, `imponibile` typed `::L` because `dtype` was lost.
  After: attributes intact, changeSet empty after both pushes.
- Browser, `sandboxpg` served from this branch, page `test15/gnrwdg/external_change`, Milano loaded.
  With `develop`'s `genro_frm.js`: first push (equal value) already leaves `numero_abitanti` with attrs `{_loadedValue: 3156694}` and in the changeSet; editing `nome` and saving raises `GnrSqlSaveException: ... Incompatible changes: another user modified field numero_abitanti from 3156694 to None` (`crud.py:559`).
  With this branch: two pushes, attributes unchanged (`dtype`, `virtual_column` kept), changeSet empty; editing `nome` and saving sends `nome` only and succeeds.
- `flake8 --select=F401,E9,F63,F7,F82` clean on the test page; pre-commit hook ran `gnrpy/tests`: 2455 passed, 10 skipped.
- Not verified: `gnr_d20` has no `externalChange`; no other caller in `gnrpy`, `projects`, `resources`.

## Related issue

Fixes #1287
