### PR TITLE
Preserve explicit document versions after cache invalidation

### DIFF
--- a/gnrpy/tests/app/test_document_endpoint.py
+++ b/gnrpy/tests/app/test_document_endpoint.py
@@ -1,0 +1,122 @@
+"""Document endpoints keep explicit storage versions after cache invalidation."""
+
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gnr.core.gnrlang import gnrImport
+from gnr.lib.services.storage import StorageNode
+
+
+ENDPOINT_PATH = (Path(__file__).resolve().parents[3] / 'projects' / 'gnrcore'
+                 / 'packages' / 'sys' / 'webpages' / 'ep_table.py')
+endpoint = gnrImport(str(ENDPOINT_PATH), avoidDup=True)
+
+
+class VersionedStorage:
+    is_versioned = True
+
+    def __init__(self, folder):
+        self.folder = folder
+
+    def expandpath(self, path):
+        return path
+
+    def fullpath(self, path):
+        return path
+
+    def exists(self, path):
+        return (self.folder / 'latest').exists()
+
+    def autocreate(self, path, autocreate=None):
+        return
+
+    def open(self, path, mode='rb', version_id=None):
+        return (self.folder / (version_id or 'latest')).open(mode)
+
+    def versions(self, path):
+        return [dict(VersionId='previous', IsLatest=False, LastModified=datetime(2026, 1, 1)),
+                dict(VersionId='current', IsLatest=True, LastModified=datetime(2026, 2, 1))]
+
+
+@pytest.fixture
+def document(db_sqlite, tmp_path):
+    table = db_sqlite.table('invc.invoice')
+    pkey = table.query(columns='$id', limit=1).fetch()[0]['id']
+    storage = VersionedStorage(tmp_path)
+    (tmp_path / 'previous').write_bytes(b'previous document')
+    (tmp_path / 'latest').write_bytes(b'current document')
+    generated = []
+
+    def generate(record_id, **kwargs):
+        generated.append(record_id)
+        (tmp_path / 'latest').write_bytes(b'regenerated document')
+        return f'archive:{record_id}.pdf'
+
+    generate.tags = False
+    generate.pathTemplate = 'archive:{0[id]}.pdf'
+    generate.outdatedWatermark = 'Version of {localized_date}'
+    page = endpoint.GnrCustomWebPage()
+    page.db = db_sqlite
+    page.site = SimpleNamespace(
+        storageNode=lambda path, version=None: StorageNode(service=storage, path=path, version=version),
+        register=SimpleNamespace(page=lambda *args, **kwargs: None))
+    page.getPublicMethod = lambda *args: generate
+    page.toText = lambda value, **kwargs: value.date().isoformat()
+    page._ = lambda value: value
+    return SimpleNamespace(page=page, table=table, pkey=pkey, folder=tmp_path,
+                           generate=generate, generated=generated)
+
+
+@pytest.mark.parametrize('latest_exists', [True, False])
+def test_explicit_version_returns_historical_bytes(document, latest_exists):
+    if not latest_exists:
+        (document.folder / 'latest').unlink()
+    node = document.page._get_documentNode(document.table, pkey=document.pkey,
+                                           source='document', version='previous')
+    with node.open() as source:
+        assert source.read() == b'previous document'
+    assert node.version == 'previous'
+    assert node.watermark == 'Version of 2026-01-01'
+    assert document.generated == []
+    assert (document.folder / 'latest').exists() is latest_exists
+
+
+@pytest.mark.parametrize('version', [None, '_latest_'])
+@pytest.mark.parametrize('latest_exists', [True, False])
+def test_latest_uses_cache_or_regenerates(document, version, latest_exists):
+    if not latest_exists:
+        (document.folder / 'latest').unlink()
+    node = document.page._get_documentNode(document.table, pkey=document.pkey,
+                                           source='document', version=version)
+    with node.open() as source:
+        assert source.read() == (b'current document' if latest_exists else b'regenerated document')
+    assert node.version is None
+    assert node.watermark is None
+    assert document.generated == ([] if latest_exists else [document.pkey])
+
+
+def test_missing_version_never_falls_back_to_latest(document):
+    (document.folder / 'latest').unlink()
+    node = document.page._get_documentNode(document.table, pkey=document.pkey,
+                                           source='document', version='missing')
+    with pytest.raises(FileNotFoundError):
+        node.open()
+    assert document.generated == []
+
+
+def test_version_without_path_does_not_generate(document):
+    document.generate.pathTemplate = None
+    assert document.page._get_documentNode(document.table, pkey=document.pkey,
+                                           source='document', version='previous') is None
+    assert document.generated == []
+
+
+def test_historical_version_still_requires_permission(document):
+    document.generate.tags = 'admin'
+    with pytest.raises(endpoint.NotAllowedError):
+        document.page._get_documentNode(document.table, pkey=document.pkey,
+                                       source='document', version='previous')
+    assert document.generated == []

--- a/projects/gnrcore/packages/sys/webpages/ep_table.py
+++ b/projects/gnrcore/packages/sys/webpages/ep_table.py
@@ -101,11 +101,13 @@ class GnrCustomWebPage(object):
         clientRecordUpdater = Bag()
         if documentPath:
             documentNode = self.site.storageNode(documentPath,version=version) 
-            if documentNode and not documentNode.exists:
+            if documentNode and not version and not documentNode.exists:
                 documentNode = None
-        if handler and not documentNode:
+        if handler and not documentNode and not version:
             documentPath = handler(pkey,documentPath=documentPath,**kwargs)
             documentNode = self.site.storageNode(documentPath)
+        if not documentNode:
+            return
         if documentNode and isCachedInField and record[source] != documentNode.fullpath:
             with tblobj.recordToUpdate(pkey,raw=True) as rec:
                 rec[source] = documentNode.fullpath
@@ -158,4 +160,3 @@ class GnrCustomWebPage(object):
             'image/svg+xml'
         }
         return storageNode.mimetype.lower() in INLINE_MIME_TYPES
-


### PR DESCRIPTION
An explicit document version could return newly generated content carrying the watermark of an older version. After cache invalidation deletes the current storage object, `StorageNode.exists` checks that current object even when a historical version was requested. The endpoint then discarded the requested version and regenerated the current PDF.

Preserve explicit versions without testing the current object's existence, and restrict generation to requests for the current document. A historical request without a document path returns no document; an unavailable stored version never falls back to current content. Permission checks remain in place.

This is the framework prerequisite for the cache invalidation change in softwellsrl/pansotti#87.

Validation:
- Nine endpoint tests use the existing SQLite invoice fixture and temporary versioned storage. They cover historical content with and without a current object, current cache hits and regeneration, unavailable versions, missing paths, and permission denial.
- Replacing the endpoint with the original implementation makes the three regression cases fail.
- Full GenroPy suite: 2,524 passed, 10 skipped.
- Flake8 and diff checks pass on the changed files.
