### PR TITLE
fix(frm): accept silent record pushes as server baselines

### DIFF
--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -1,0 +1,16 @@
+name: JavaScript tests
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node --test gnrjs/tests/*.test.js

--- a/gnrjs/gnr_d11/js/genro_frm.js
+++ b/gnrjs/gnr_d11/js/genro_frm.js
@@ -1516,7 +1516,14 @@ dojo.declare("gnr.GnrFrmHandler", null, {
     },
 
     externalChange:function(field,value,triggerChanges){
-        this.sourceNode.setRelativeData(this.formDatapath+'.'+field,value,triggerChanges?{}:{_loadedValue:value});
+        if(!triggerChanges){
+            this.resetChangesAtPath(field);
+        }
+        this.sourceNode.setRelativeData(this.formDatapath+'.'+field,value,{},null,
+                                       triggerChanges?null:'externalChange',null,{_updattr:true});
+        if(!triggerChanges){
+            this.updateStatus();
+        }
     },
 
     getFormData: function() {
@@ -1775,6 +1782,9 @@ dojo.declare("gnr.GnrFrmHandler", null, {
             }
             return;
         }
+        if(kw.reason == 'externalChange'){
+            return;
+        }
         var allowed = !this.isDisabled();
         if(this.disabledStatus()=='unlocked_readOnly'){
             allowed = !this._protectedNode(kw.node);
@@ -1794,7 +1804,9 @@ dojo.declare("gnr.GnrFrmHandler", null, {
                         n.attr.to = newvalue;
                     }
                 }else{
-                    changes.setItem(changekey,null,{_valuelabel:kw.reason.getElementLabel?kw.reason.getElementLabel():cattr,from:oldvalue,to:newvalue,allowed:allowed});
+                    changes.setItem(changekey,null,{_valuelabel:kw.reason.getElementLabel?kw.reason.getElementLabel():cattr,
+                                                   _dataPath:kw.pathlist.join('.')+'?'+cattr,
+                                                   from:oldvalue,to:newvalue,allowed:allowed});
                 }
                 this.updateStatus();
             }
@@ -1819,6 +1831,7 @@ dojo.declare("gnr.GnrFrmHandler", null, {
                 }
                 if (changed!==false) {
                     changes.setItem(changekey, null,{_valuelabel:kw.reason.getElementLabel?kw.reason.getElementLabel():kw.node.label,
+                                                    _dataPath:kw.pathlist.join('.'),
                                                     from:kw.node.attr._loadedValue,to:kw.value,allowed:allowed});
                 } else {
                     changes.pop(changekey);
@@ -1839,7 +1852,7 @@ dojo.declare("gnr.GnrFrmHandler", null, {
             return;
         }
         ;
-        if (kw.reason == 'autocreate' || kw.reason == '_removedRow') { // || kw.reason==true){
+        if (kw.reason == 'autocreate' || kw.reason == '_removedRow' || kw.reason == 'externalChange') {
             return;
         }
         var changes = this.getChangesLogger();
@@ -1847,7 +1860,7 @@ dojo.declare("gnr.GnrFrmHandler", null, {
             kw.node.attr._loadedValue = null;
         }
         var changekey = this.getChangeKey(kw.node);
-        changes.setItem(changekey, null, {isNewNode: true});
+        changes.setItem(changekey, null, {isNewNode: true, _dataPath:kw.pathlist.join('.')});
         this.updateStatus();
         //this.updateInvalidField(kw.reason, changekey);
     },
@@ -1857,7 +1870,7 @@ dojo.declare("gnr.GnrFrmHandler", null, {
         if (changes.getAttr(changekey, 'isNewNode')) {
             changes.pop(changekey);
         } else {
-            changes.setItem(changekey, null);
+            changes.setItem(changekey, null, {_dataPath:kw.pathlist.join('.')});
         }
         dojo.forEach(changes.getNodes(),function(n){
             if((changekey!=n.label) && (n.label.indexOf(changekey)==0)){
@@ -2174,6 +2187,24 @@ dojo.declare("gnr.GnrFrmHandler", null, {
     resetChangesLogger:function(){
         this.getControllerData().setItem('changesLogger',new gnr.GnrBag());
         this.updateStatus();
+    },
+
+    resetChangesAtPath:function(path){
+        var node = this.getFormData().getNode(path);
+        if(node){
+            delete node.attr._loadedValue;
+            var value = node.getValue('static');
+            if(value instanceof gnr.GnrBag){
+                value.walk(function(n){delete n.attr._loadedValue;},'static');
+            }
+        }
+        var changes = this.getChangesLogger();
+        changes.getNodes().forEach(function(n){
+            var dataPath = n.attr._dataPath;
+            if(dataPath == path || (dataPath && dataPath.indexOf(path+'.') == 0)){
+                changes.popNode(n.label);
+            }
+        });
     },
 
     hasChangesAtPath:function(path) {

--- a/gnrjs/tests/external_change.test.js
+++ b/gnrjs/tests/external_change.test.js
@@ -1,0 +1,233 @@
+const assert = require('node:assert/strict');
+const {readFileSync} = require('node:fs');
+const path = require('node:path');
+const {test} = require('node:test');
+const vm = require('node:vm');
+
+function createForm() {
+    const context = {console, File: function() {}, gnr: {}, genro: {}};
+    context.dojo = {
+        Deferred: function() {},
+        eval,
+        hitch: (object, method) => (typeof method === 'string' ? object[method] : method).bind(object),
+        forEach: (items, callback) => Array.prototype.forEach.call(items || [], callback),
+        some: (items, callback) => Array.prototype.some.call(items || [], callback),
+        toJson: JSON.stringify,
+        declare(name, base, members) {
+            function Declared(...args) {
+                if (base) base.apply(this, args);
+                if (Object.hasOwn(members, 'constructor')) members.constructor.apply(this, args);
+            }
+            Declared.prototype = Object.assign(Object.create(base ? base.prototype : Object.prototype), members);
+            Declared.prototype.constructor = Declared;
+            const names = name.split('.');
+            let namespace = context;
+            for (const part of names.slice(0, -1)) namespace = namespace[part] ||= {};
+            namespace[names.at(-1)] = Declared;
+            return Declared;
+        }
+    };
+    vm.createContext(context);
+    const sourceDir = process.env.GNR_JS_SOURCE || path.join(__dirname, '../gnr_d11/js');
+    for (const filename of ['gnrlang.js', 'gnrbag.js', 'gnrdomsource.js', 'genro_frm.js']) {
+        vm.runInContext(readFileSync(path.join(sourceDir, filename), 'utf8'), context, {filename});
+    }
+    const Bag = context.gnr.GnrBag;
+    const data = new Bag();
+    const record = new Bag();
+    data.setItem('form.record', record, {_pkey: 'MI'});
+    data.setItem('form.controller', new Bag());
+    data.setItem('form.pkey', 'MI');
+    data.setBackRef();
+    context.genro._data = data;
+    const sourceNode = Object.create(context.gnr.GnrDomSourceNode.prototype);
+    sourceNode.absDatapath = value => value;
+    const form = Object.create(context.gnr.GnrFrmHandler.prototype);
+    Object.assign(form, {
+        sourceNode,
+        formDatapath: 'form.record',
+        controllerPath: 'form.controller',
+        pkeyPath: 'form.pkey',
+        gridEditors: {},
+        _status_list: [],
+        isValid: () => true,
+        isDisabled: () => false,
+        disabledStatus: () => null,
+        isProtectWrite: () => false,
+        isNewRecord: () => false,
+        publish: () => {},
+        applyDisabledStatus: () => {}
+    });
+    form.resetChanges();
+    function initial(field, value, attributes = {}) {
+        record.setItem(field, value, attributes, {doTrigger: false});
+    }
+    function edit(field, value) {
+        sourceNode.setRelativeData('form.record.' + field, value, null);
+    }
+    function fields() {
+        return Array.from(form.getFormChanges().getItem('record').keys());
+    }
+    function assertClean() {
+        assert.equal(form.hasChanges(), false);
+        assert.equal(form.status, 'ok');
+        assert.equal(form.getChangesLogger().len(), 0);
+        assert.equal(record.getNodeByAttr('_loadedValue') == null, true);
+        assert.deepEqual(fields(), []);
+    }
+    return {form, record, data, Bag, initial, edit, fields, assertClean};
+}
+
+for (const virtual of [false, true]) {
+    for (const [name, before, after] of [
+        ['equal', false, false],
+        ['changed', true, false],
+        ['to null', 10, null],
+        ['from null', null, 10],
+        ['to zero', 10, 0],
+        ['to blank', 'text', '']
+    ]) {
+        test(`silent ${virtual ? 'virtual' : 'physical'} push: ${name}`, () => {
+            const s = createForm();
+            const attributes = {dtype: 'B', caption: 'Flag'};
+            if (virtual) attributes.virtual_column = true;
+            s.initial('flag', before, attributes);
+            s.form.externalChange('flag', after);
+            s.form.externalChange('flag', after);
+            assert.equal(s.record.getItem('flag'), after);
+            assert.deepEqual({...s.record.getNode('flag').attr}, attributes);
+            s.assertClean();
+        });
+    }
+}
+
+for (const value of [false, null, 0, '']) {
+    test(`silent push creates a clean node for ${JSON.stringify(value)}`, () => {
+        const s = createForm();
+        s.form.externalChange('flag', value);
+        assert.ok(s.record.getNode('flag'));
+        assert.equal(s.record.getItem('flag'), value);
+        s.assertClean();
+    });
+}
+
+for (const serverValue of [11, 12]) {
+    test(`silent push acknowledges an edited field with value ${serverValue}`, () => {
+        const s = createForm();
+        s.initial('amount', 10, {dtype: 'L'});
+        s.edit('amount', 11);
+        assert.equal(s.form.hasChanges(), true);
+        s.form.externalChange('amount', serverValue);
+        s.assertClean();
+        s.edit('amount', 13);
+        assert.equal(s.record.getNode('amount').attr._loadedValue, serverValue);
+        assert.deepEqual(s.fields(), ['amount']);
+        s.edit('amount', serverValue);
+        s.assertClean();
+    });
+}
+
+test('a silent push preserves unrelated local edits', () => {
+    const s = createForm();
+    s.initial('name', 'before');
+    s.edit('name', 'after');
+    s.form.externalChange('flag', false);
+    assert.equal(s.form.hasChanges(), true);
+    assert.equal(s.record.getNode('name').attr._loadedValue, 'before');
+    assert.deepEqual(s.fields(), ['name']);
+});
+
+test('bindings receive one changed-value notification and no duplicate on an equal push', () => {
+    const s = createForm();
+    s.initial('flag', true, {virtual_column: true});
+    const values = [];
+    s.data.subscribe('binding', {any: kw => {
+        if (kw.node.label === 'flag') values.push(kw.node.getValue());
+    }});
+    s.form.externalChange('flag', false);
+    s.form.externalChange('flag', false);
+    assert.deepEqual(values, [false]);
+    s.assertClean();
+});
+
+test('a reactive write to another field is still a local edit', () => {
+    const s = createForm();
+    s.initial('derived', 1);
+    s.data.subscribe('controller', {any: kw => {
+        if (kw.node.label === 'amount') s.edit('derived', 2);
+    }});
+    s.form.externalChange('amount', 12);
+    assert.equal(s.record.getNode('derived').attr._loadedValue, 1);
+    assert.deepEqual(s.fields(), ['derived']);
+});
+
+test('a reactive write to the pushed field uses the server value as its baseline', () => {
+    const s = createForm();
+    s.initial('amount', 10);
+    s.data.subscribe('controller', {any: kw => {
+        if (kw.node.label === 'amount' && kw.node.getValue() === 12) s.edit('amount', 13);
+    }});
+    s.form.externalChange('amount', 12);
+    assert.equal(s.record.getItem('amount'), 13);
+    assert.equal(s.record.getNode('amount').attr._loadedValue, 12);
+    assert.deepEqual(s.fields(), ['amount']);
+});
+
+test('non-silent pushes keep normal change tracking and preserve attributes', () => {
+    const s = createForm();
+    s.initial('amount', 10, {dtype: 'L'});
+    s.form.externalChange('amount', 12, true);
+    assert.equal(s.form.hasChanges(), true);
+    assert.equal(s.record.getNode('amount').attr.dtype, 'L');
+    assert.equal(s.record.getNode('amount').attr._loadedValue, 10);
+    assert.deepEqual(s.fields(), ['amount']);
+});
+
+test('a non-silent insertion is still tracked', () => {
+    const s = createForm();
+    s.form.externalChange('amount', 12, true);
+    assert.equal(s.form.hasChanges(), true);
+    assert.deepEqual(s.fields(), ['amount']);
+});
+
+for (const change of ['none', 'update', 'insert', 'delete']) {
+    test(`a silent Bag replacement clears its ${change} changes`, () => {
+        const s = createForm();
+        s.initial('payload', new s.Bag({a: 1, b: 2}), {dtype: 'X'});
+        if (change === 'update') s.edit('payload.a', 3);
+        if (change === 'insert') s.edit('payload.c', 3);
+        if (change === 'delete') s.record.popNode('payload.a');
+        s.form.externalChange('payload', new s.Bag({a: 4}));
+        assert.equal(s.record.getItem('payload.a'), 4);
+        assert.equal(s.record.getNode('payload').attr.dtype, 'X');
+        s.assertClean();
+    });
+}
+
+test('a Bag replacement preserves a sibling whose name shares its prefix', () => {
+    const s = createForm();
+    s.initial('payload', new s.Bag({a: 1}), {dtype: 'X'});
+    s.initial('payload_extra', 1);
+    s.edit('payload_extra', 2);
+    s.edit('payload.a', 3);
+    s.form.externalChange('payload', new s.Bag({a: 4}));
+    assert.deepEqual(s.fields(), ['payload_extra']);
+    assert.equal(s.form.getChangesLogger().len(), 1);
+    assert.equal(s.record.getNode('payload_extra').attr._loadedValue, 1);
+});
+
+test('an equal Bag snapshot acknowledges child changes', () => {
+    const s = createForm();
+    s.initial('payload', new s.Bag({a: 1}), {dtype: 'X'});
+    s.edit('payload.a', 2);
+    s.form.externalChange('payload', s.record.getItem('payload'));
+    s.assertClean();
+});
+
+test('a silent push acknowledges a previously deleted field', () => {
+    const s = createForm();
+    s.initial('amount', 10);
+    s.record.popNode('amount');
+    s.form.externalChange('amount', 12);
+    s.assertClean();
+});

--- a/projects/gnrcore/packages/test15/webpages/gnrwdg/external_change.py
+++ b/projects/gnrcore/packages/test15/webpages/gnrwdg/external_change.py
@@ -1,0 +1,83 @@
+"""Server pushes must preserve bindings without staging silent changes."""
+
+from gnr.core.gnrdecorator import public_method
+
+
+class GnrCustomWebPage(object):
+    py_requires = (
+        'gnrcomponents/testhandler:TestHandlerFull,'
+        'gnrcomponents/formhandler:FormHandler'
+    )
+
+    def test_0_silent_push(self, pane):
+        """Push loaded and unloaded virtuals, then edit Name and save."""
+        pane.div(
+            'Silent pushes must leave the form unchanged. '
+            'Edit Name before a push: that edit must survive and save. '
+            'A non-silent push must mark Code as changed.',
+            margin='10px'
+        )
+        form = pane.frameForm(
+            frameCode='prov_push', datapath='.form',
+            height='360px', width='1000px', border='1px solid silver'
+        )
+        store = form.formStore(
+            table='glbl.provincia', storeType='Item',
+            handler='recordCluster', startKey='MI'
+        )
+        store.handler('load', virtual_columns='numero_abitanti')
+        bar = form.top.slotToolbar(
+            '5,loaded,unloaded,tracked,inspect,*,semaphore,|,formcommands,5'
+        )
+        bar.loaded.slotButton('Push loaded virtual').dataRpc(
+            self.pushTotals, pkey='=#FORM.record.sigla',
+            virtual_column='numero_abitanti'
+        )
+        bar.unloaded.slotButton('Push unloaded virtual').dataRpc(
+            self.pushTotals, pkey='=#FORM.record.sigla',
+            virtual_column='tot_superficie'
+        )
+        bar.tracked.slotButton('Push non-silent').dataRpc(
+            self.pushTotals, pkey='=#FORM.record.sigla', silent=False
+        )
+        bar.inspect.slotButton('Inspect changes', action="""
+            var record = this.form.getFormData();
+            var state = {changed:this.form.hasChanges(),
+                         changeSet:this.form.getFormChanges().getItem('record').keys(),
+                         fields:{}};
+            ['codice','numero_abitanti','tot_superficie'].forEach(function(field){
+                var node = record.getNode(field);
+                state.fields[field] = node?{value:node.getValue(),
+                    dtype:node.attr.dtype,virtual_column:node.attr.virtual_column,
+                    hasLoadedValue:'_loadedValue' in node.attr}:null;
+            });
+            this.form.sourceNode.setRelativeData('.verification',JSON.stringify(state,null,2));
+        """)
+        fb = form.center.contentPane(datapath='.record').formbuilder(
+            cols=2, border_spacing='4px'
+        )
+        fb.field('nome', lbl='Name')
+        fb.field('codice', lbl='Code')
+        fb.numberTextBox(
+            value='^.numero_abitanti', lbl='Population (loaded virtual)',
+            readOnly=True
+        )
+        form.bottom.contentPane(height='170px').simpleTextArea(
+            value='^.verification', height='160px', width='100%', readOnly=True
+        )
+
+    @public_method
+    def pushTotals(self, pkey=None, virtual_column=None, silent=True):
+        tbl = self.db.table('glbl.provincia')
+        with tbl.recordToUpdate(pkey) as record:
+            record['codice'] = (record['codice'] or 0) + 1
+        self.db.commit()
+        fields = 'codice'
+        if virtual_column:
+            record[virtual_column] = tbl.readColumns(
+                columns=f'${virtual_column}', pkey=pkey
+            )
+            fields += f',{virtual_column}'
+        self.setInClientRecord(
+            tblobj=tbl, record=record, fields=fields, silent=silent
+        )


### PR DESCRIPTION
Silent server pushes can leave a form dirty or stage pushed fields for saving, including virtual columns that were not loaded initially. Accept silent values as the new baseline so a later user edit compares against the server value.

Use a dedicated change reason to skip form tracking while preserving reactive notifications and node attributes. Clear prior changes only for the pushed field or Bag subtree; retain unrelated edits and track writes made by reactive controllers normally. Store the original data path in change-log entries so subtree cleanup does not confuse dotted paths with underscore-containing field names. Explicit non-silent pushes retain normal change tracking. Virtual-column names and the default `silent=True` remain unchanged.

Supersedes #1291. Refs #1287. Client confirmation in Pansotti is still pending; this PR does not close that issue automatically.

Validation:
- 31 JavaScript regression tests pass using the real Bag, source-node and form-handler code. The same tests expose 28 failures on develop and 20 on #1291. A dedicated GitHub Actions job runs them.
- Full Python suite: 2515 passed, 10 skipped. The added test page passes flake8; JavaScript syntax checks and `git diff --check` pass.
- Real-browser check at `test15/gnrwdg/external_change`, backed by PostgreSQL: loaded and initially absent virtual pushes stay clean; an unrelated Name edit survives the pushes and saves to the database; `silent=False` is tracked; an equal silent push acknowledges a local edit. No console errors or failed HTTP requests observed. Test-row values restored afterward.
