### PR TITLE
fix: portable AFM metrics loading for pip-installed deployments

### DIFF
--- a/gnrpy/gnr/utils/fonts.py
+++ b/gnrpy/gnr/utils/fonts.py
@@ -6,13 +6,18 @@
 # Units are 1/1000 of the font size in points.
 # Example: at 10pt, 'A' in Helvetica = 667/1000 * 10 = 6.67 pt wide.
 #
-# Width data is stored in resources/common/fonts/afm_widths.json and loaded
-# at first use.
+# Width data is stored in the shared resources directory
+# (common/fonts/afm_widths.json) and loaded at first use.
 
 import json
 import os
 
+from gnr.core.gnrsys import expandpath
+from gnr.utils import logger
+
 _AFM_WIDTHS = None
+
+_AFM_RELATIVE_PATH = os.path.join('common', 'fonts', 'afm_widths.json')
 
 _DEFAULT_CHAR_WIDTH = 556  # fallback for unknown chars (avg lowercase Helvetica)
 
@@ -36,17 +41,53 @@ _FONT_ALIASES = {
 }
 
 
+def _afm_widths_candidates():
+    """Yield candidate paths of the metrics file, most authoritative first.
+
+    1. the ``resources`` directories declared in environment.xml, so that a
+       deployment can override the metrics like any other shared resource
+       (the lookup ``resource_name_to_path`` uses)
+    2. ``resources`` inside the ``gnr`` package: a pip-installed genropy ships
+       the shared resources as the ``gnr.resources`` package, so the installed
+       layout resolves even with no resources declared
+    3. the checkout-relative path, for a repository used without installing
+    """
+    # deferred import: gnr.core.gnrconfig imports gnr.core.gnrstring,
+    # which imports this module at load time
+    from gnr.core.gnrconfig import getGnrConfig
+    try:
+        environment_xml = getGnrConfig()['gnr.environment_xml']
+    except Exception:  # getGnrConfig raises a bare Exception when unconfigured
+        environment_xml = None
+    if environment_xml and 'resources' in environment_xml:
+        for path in environment_xml.digest('resources:#a.path'):
+            yield expandpath(os.path.join(path, _AFM_RELATIVE_PATH))
+    package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    yield os.path.join(package_path, 'resources', _AFM_RELATIVE_PATH)
+    yield os.path.normpath(os.path.join(package_path, '..', '..',
+                                        'resources', _AFM_RELATIVE_PATH))
+
+
 def _load_afm_widths():
+    """Return the AFM width maps, loading them from the first readable candidate.
+
+    A metrics problem must never take a print down: when no candidate is
+    usable the widths degrade to the approximate default char width.
+    """
     global _AFM_WIDTHS
     if _AFM_WIDTHS is not None:
         return _AFM_WIDTHS
-    json_path = os.path.join(
-        os.path.dirname(__file__),
-        '..', '..', '..', 'resources', 'common', 'fonts', 'afm_widths.json'
-    )
-    json_path = os.path.normpath(json_path)
-    with open(json_path, 'r', encoding='utf-8') as f:
-        _AFM_WIDTHS = json.load(f)
+    for json_path in _afm_widths_candidates():
+        if not os.path.isfile(json_path):
+            continue
+        try:
+            with open(json_path, 'r', encoding='utf-8') as f:
+                _AFM_WIDTHS = json.load(f)
+            return _AFM_WIDTHS
+        except (ValueError, OSError):
+            logger.warning('Invalid AFM metrics file %s, skipped', json_path)
+    logger.warning('AFM metrics file not found: string widths will be approximate')
+    _AFM_WIDTHS = {'Helvetica': {}}
     return _AFM_WIDTHS
 
 

--- a/gnrpy/tests/utils/fonts_test.py
+++ b/gnrpy/tests/utils/fonts_test.py
@@ -1,5 +1,13 @@
+import importlib
+import importlib.util
+import json
+import os
+import shutil
+from contextlib import contextmanager
+
 import pytest
 
+from gnr.utils import fonts
 from gnr.utils.fonts import resolve_font_name, font_size_pt, string_width
 
 
@@ -75,3 +83,130 @@ def test_font_size_pt_invalid_returns_default():
     assert font_size_pt('large') == 10.0
     assert font_size_pt(None) == 10.0
     assert font_size_pt('large', default=8) == 8.0
+
+
+# ---------- metrics file resolution (#978) ----------
+
+@contextmanager
+def gnr_environment(config_dir):
+    """Point the genro configuration at *config_dir* and reload font metrics."""
+    old = os.environ.get('GENRO_GNRFOLDER')
+    os.environ['GENRO_GNRFOLDER'] = str(config_dir)
+    try:
+        importlib.reload(fonts)
+        yield fonts
+    finally:
+        if old is None:
+            del os.environ['GENRO_GNRFOLDER']
+        else:
+            os.environ['GENRO_GNRFOLDER'] = old
+        importlib.reload(fonts)
+
+
+def make_config(tmp_path, resources_path=None):
+    """Build a minimal genro config folder with an environment.xml."""
+    config_dir = tmp_path / 'etc' / 'gnr'
+    config_dir.mkdir(parents=True)
+    resources_tag = ''
+    if resources_path is not None:
+        resources_tag = '<resources><test path="%s"/></resources>' % resources_path
+    (config_dir / 'environment.xml').write_text(
+        '<?xml version="1.0"?><GenRoBag>%s</GenRoBag>' % resources_tag)
+    return config_dir
+
+
+def write_metrics(resources_path, widths):
+    fonts_dir = resources_path / 'common' / 'fonts'
+    fonts_dir.mkdir(parents=True)
+    (fonts_dir / 'afm_widths.json').write_text(json.dumps(widths))
+
+
+def load_module_copy(tmp_dir, module_name):
+    """Load a copy of fonts.py from *tmp_dir*, simulating an installed layout."""
+    module_path = tmp_dir / 'fonts.py'
+    shutil.copy(fonts.__file__.rstrip('c'), str(module_path))
+    spec = importlib.util.spec_from_file_location(module_name, str(module_path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_no_declaration_finds_shipped_metrics(tmp_path):
+    # without a resources declaration the loader still finds the metrics
+    # shipped with the code, through the package or the checkout path
+    config_dir = make_config(tmp_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(6.67)
+
+
+def test_config_resources_priority(tmp_path):
+    # metrics declared in environment.xml win over the ones shipped
+    # with the code, like any other overridden shared resource
+    resources_path = tmp_path / 'my_resources'
+    write_metrics(resources_path, {'Helvetica': {'A': 1000}})
+    config_dir = make_config(tmp_path, resources_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(10.0)
+
+
+def test_config_resources_without_file_skipped(tmp_path):
+    # a declared resources dir without the metrics file is skipped
+    # and the next candidate wins
+    resources_path = tmp_path / 'my_resources'
+    resources_path.mkdir()
+    config_dir = make_config(tmp_path, resources_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(6.67)
+
+
+def test_invalid_metrics_file_skipped(tmp_path):
+    # an unreadable metrics file must never break prints:
+    # the next candidate wins
+    resources_path = tmp_path / 'my_resources'
+    fonts_dir = resources_path / 'common' / 'fonts'
+    fonts_dir.mkdir(parents=True)
+    (fonts_dir / 'afm_widths.json').write_text('{not valid json')
+    config_dir = make_config(tmp_path, resources_path)
+    with gnr_environment(config_dir) as fonts_mod:
+        assert fonts_mod.string_width('A', 'Helvetica', 10) == pytest.approx(6.67)
+
+
+def test_installed_layout_unconfigured(tmp_path):
+    # regression test for #978: on a pip-installed deployment fonts.py lives
+    # in site-packages/gnr/utils and the metrics in site-packages/gnr/resources,
+    # with no checkout-relative path and nothing declared in environment.xml
+    utils_dir = tmp_path / 'site-packages' / 'gnr' / 'utils'
+    utils_dir.mkdir(parents=True)
+    resources_path = tmp_path / 'site-packages' / 'gnr' / 'resources'
+    write_metrics(resources_path, {'Helvetica': {'A': 500}})
+    config_dir = make_config(tmp_path)
+    with gnr_environment(config_dir):
+        installed_fonts = load_module_copy(utils_dir, 'installed_unconfigured_fonts')
+        assert installed_fonts.string_width('A', 'Helvetica', 10) == pytest.approx(5.0)
+
+
+def test_installed_layout_declared_resources_win(tmp_path):
+    # the same installed layout, with metrics declared elsewhere:
+    # the declaration wins over the ones shipped in the package
+    utils_dir = tmp_path / 'site-packages' / 'gnr' / 'utils'
+    utils_dir.mkdir(parents=True)
+    write_metrics(tmp_path / 'site-packages' / 'gnr' / 'resources',
+                  {'Helvetica': {'A': 500}})
+    declared_path = tmp_path / 'my_resources'
+    write_metrics(declared_path, {'Helvetica': {'A': 800}})
+    config_dir = make_config(tmp_path, declared_path)
+    with gnr_environment(config_dir):
+        installed_fonts = load_module_copy(utils_dir, 'installed_declared_fonts')
+        assert installed_fonts.string_width('A', 'Helvetica', 10) == pytest.approx(8.0)
+
+
+def test_metrics_file_missing_never_raises(tmp_path):
+    # worst case of #978: no usable metrics anywhere — string widths must
+    # degrade to approximate values instead of raising FileNotFoundError
+    utils_dir = tmp_path / 'site-packages' / 'gnr' / 'utils'
+    utils_dir.mkdir(parents=True)
+    config_dir = make_config(tmp_path)
+    with gnr_environment(config_dir):
+        installed_fonts = load_module_copy(utils_dir, 'unconfigured_fonts')
+        # every char falls back to the default width: 556/1000 * 10pt
+        assert installed_fonts.string_width('A', 'Helvetica', 10) == pytest.approx(5.56)


### PR DESCRIPTION
## Motivation

`_load_afm_widths()` in `gnr/utils/fonts.py` resolved `afm_widths.json` by climbing three directory levels from the module to the repository root. That layout only exists in a development checkout: on a pip-installed genropy the shared `resources/` directory is packaged as the `gnr.resources` package inside site-packages, so the lookup pointed at a non-existent path and any print measuring text crashed with `FileNotFoundError`. This broke invoice printing in a production deployment and forced a revert of the row-height migration on genromed.

Since #981 landed on develop, `auto_row_height` is on by default in `GnrBagHtmlBuilder`: `calcRowHeight` now reaches the metrics on **every grid print**, not only on the reports that explicitly overrode `getRowWrapField()`. The bug went from latent to systematic on every non-editable install, which is why the fix belongs here rather than on the hotfix branch this replaces.

Fixes #978. Replaces #979, which targeted `master`, where the AFM path is still strictly opt-in and no stock print reaches it.

## Solution

The metrics file is resolved through an ordered list of candidates, first readable one wins:

1. every path declared under `resources` in `environment.xml` — the same `resources:#a.path` lookup used by `resource_name_to_path` in `gnrwsgisite.py` and `gnrresourceloader.py`, so a deployment can override the metrics like any other shared resource
2. `resources` inside the `gnr` package — on an installed layout this is exactly where `MANIFEST.in`/`pyproject.toml` put the file (`site-packages/gnr/resources/common/fonts/afm_widths.json`), so it resolves with no configuration at all
3. the former checkout-relative path, for a repository used without installing (CI)

Candidate 2 is what makes the fix independent of configuration: `build_environment_xml` in `gnrdeploy.py` does write `resources.genropy` pointing at `<genropy_home>/resources` in both layouts, but a deployment with a hand-written or stale `environment.xml` would otherwise silently lose the real metrics.

If no candidate is readable, string widths degrade to approximate values (average char width) with a logged warning instead of raising — a metrics problem can never take a print down again.

The `getGnrConfig` import is deferred inside the resolver to break the `gnrstring → fonts → gnrconfig → gnrstring` import cycle.

## Tests

Seven tests added to `gnrpy/tests/utils/fonts_test.py`, all end-to-end with real files and real configuration (no mocks), driving resolution through the public `GENRO_GNRFOLDER` entry point:

- `test_no_declaration_finds_shipped_metrics`: no `resources` declaration → the metrics shipped with the code are still found
- `test_config_resources_priority`: metrics declared in `environment.xml` win over the shipped ones
- `test_config_resources_without_file_skipped`: a declared resources dir without the file is skipped
- `test_invalid_metrics_file_skipped`: a corrupt metrics file is skipped without raising
- `test_installed_layout_unconfigured`: regression test for #978 — module copy loaded from a simulated `site-packages/gnr/utils`, metrics in `site-packages/gnr/resources`, **nothing declared in `environment.xml`**
- `test_installed_layout_declared_resources_win`: same layout, declaration overrides the packaged metrics
- `test_metrics_file_missing_never_raises`: worst case, no usable metrics anywhere → approximate widths, no `FileNotFoundError`

Both new resolution candidates were mutation-checked: removing the package candidate fails `test_installed_layout_unconfigured`, removing the config candidates fails `test_config_resources_priority` and `test_installed_layout_declared_resources_win`.

Suite on this branch: 1302 passed excluding `gnrpy/tests/sql`, which errors locally only for a missing postgres binary (`initdb: program "postgres" is needed`), unrelated to this change. flake8 clean on both modified files.
